### PR TITLE
GitHub App Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ github:
         contents: read
         issues: write
       events: [push, pull_request]
+      webhook_url: "http://localhost:3000/webhooks/github"
+      webhook_secret: "my-secret"
       installations:
         - installation_id: 100
           account: my-org
@@ -211,6 +213,10 @@ github:
 ```
 
 JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's private key (RS256). The emulator verifies the signature and resolves the app.
+
+**App webhook delivery**: When events occur on repos where a GitHub App is installed, the emulator mirrors real GitHub behavior:
+- All webhook payloads (including repo and org hooks) include an `installation` field with `{ id, node_id }`.
+- If the app has a `webhook_url`, the emulator delivers the event there with the `installation` field and (if configured) an `X-Hub-Signature-256` header signed with `webhook_secret`.
 
 ## Vercel API
 

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -33,6 +33,24 @@ github:
       description: An organization repository
       language: TypeScript
       auto_init: true
+  apps:
+    - app_id: 12345
+      slug: my-github-app
+      name: My GitHub App
+      private_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        ...your PEM key...
+        -----END RSA PRIVATE KEY-----
+      permissions:
+        contents: read
+        issues: write
+      events: [push, pull_request, issues]
+      webhook_url: http://localhost:3000/webhooks/github
+      webhook_secret: my-webhook-secret
+      installations:
+        - installation_id: 100
+          account: octocat
+          repository_selection: all
   oauth_apps:
     - client_id: emu_github_client_id
       client_secret: emu_github_client_secret

--- a/packages/@internal/github/src/__tests__/webhook-installation.test.ts
+++ b/packages/@internal/github/src/__tests__/webhook-installation.test.ts
@@ -1,0 +1,395 @@
+import { createHmac } from "crypto";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import { Store, WebhookDispatcher } from "@internal/core";
+import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@internal/core";
+import { githubPlugin, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4000";
+
+function createTestApp(seedConfig?: Parameters<typeof seedFromConfig>[2]) {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("test-token", { login: "octocat", id: 1, scopes: ["repo", "user", "admin:org", "admin:repo_hook"] });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap));
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, seedConfig ?? {
+    users: [{ login: "octocat" }],
+    repos: [{ owner: "octocat", name: "hello-world" }],
+  });
+
+  return { app, store, webhooks, tokenMap };
+}
+
+function authHeaders(): HeadersInit {
+  return { Authorization: "Bearer test-token" };
+}
+
+describe("webhook installation enrichment", () => {
+  const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("includes installation in webhook payload when an app is installed on the repo", async () => {
+    const { app, webhooks } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [{
+        app_id: 100,
+        slug: "test-app",
+        name: "Test App",
+        private_key: "fake-key",
+        events: ["issues"],
+        installations: [{
+          installation_id: 42,
+          account: "octocat",
+          repository_selection: "all",
+        }],
+      }],
+    });
+
+    webhooks.register({
+      url: "https://hooks.example/receiver",
+      events: ["issues"],
+      active: true,
+      owner: "octocat",
+      repo: "hello-world",
+    });
+
+    await app.request(`${base}/repos/octocat/hello-world/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Test issue" }),
+    });
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.installation).toBeDefined();
+    expect(body.installation.id).toBe(42);
+    expect(body.installation.node_id).toBeTruthy();
+  });
+
+  it("does not include installation when no app is installed", async () => {
+    const { app, webhooks } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+    });
+
+    webhooks.register({
+      url: "https://hooks.example/receiver",
+      events: ["issues"],
+      active: true,
+      owner: "octocat",
+      repo: "hello-world",
+    });
+
+    await app.request(`${base}/repos/octocat/hello-world/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "No app issue" }),
+    });
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.installation).toBeUndefined();
+  });
+
+  it("skips installation when the app does not subscribe to the event", async () => {
+    const { app, webhooks } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [{
+        app_id: 200,
+        slug: "push-only-app",
+        name: "Push Only",
+        private_key: "fake-key",
+        events: ["push"],
+        installations: [{
+          installation_id: 77,
+          account: "octocat",
+          repository_selection: "all",
+        }],
+      }],
+    });
+
+    webhooks.register({
+      url: "https://hooks.example/receiver",
+      events: ["issues"],
+      active: true,
+      owner: "octocat",
+      repo: "hello-world",
+    });
+
+    await app.request(`${base}/repos/octocat/hello-world/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Not subscribed" }),
+    });
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.installation).toBeUndefined();
+  });
+
+  it("includes installation in pull_request webhook on merge", async () => {
+    const { app, webhooks } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [{
+        app_id: 300,
+        slug: "pr-app",
+        name: "PR App",
+        private_key: "fake-key",
+        events: ["pull_request"],
+        installations: [{
+          installation_id: 1,
+          account: "octocat",
+          repository_selection: "all",
+        }],
+      }],
+    });
+
+    webhooks.register({
+      url: "https://hooks.example/receiver",
+      events: ["pull_request"],
+      active: true,
+      owner: "octocat",
+      repo: "hello-world",
+    });
+
+    const createRes = await app.request(`${base}/repos/octocat/hello-world/pulls`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "feat: test", head: "feature", base: "main" }),
+    });
+    expect(createRes.status).toBe(201);
+
+    mockFetch.mockClear();
+
+    const prData = (await createRes.json()) as { number: number };
+    const mergeRes = await app.request(
+      `${base}/repos/octocat/hello-world/pulls/${prData.number}/merge`,
+      {
+        method: "PUT",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(mergeRes.status).toBe(200);
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.action).toBe("closed");
+    expect(body.pull_request.merged).toBe(true);
+    expect(body.installation).toBeDefined();
+    expect(body.installation.id).toBe(1);
+  });
+
+  it("respects selected repository_selection", async () => {
+    const { app, store, webhooks } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [
+        { owner: "octocat", name: "included-repo" },
+        { owner: "octocat", name: "excluded-repo" },
+      ],
+      apps: [{
+        app_id: 400,
+        slug: "selective-app",
+        name: "Selective App",
+        private_key: "fake-key",
+        events: ["issues"],
+        installations: [{
+          installation_id: 88,
+          account: "octocat",
+          repository_selection: "selected",
+          repositories: ["included-repo"],
+        }],
+      }],
+    });
+
+    webhooks.register({
+      url: "https://hooks.example/included",
+      events: ["issues"],
+      active: true,
+      owner: "octocat",
+      repo: "included-repo",
+    });
+    webhooks.register({
+      url: "https://hooks.example/excluded",
+      events: ["issues"],
+      active: true,
+      owner: "octocat",
+      repo: "excluded-repo",
+    });
+
+    await app.request(`${base}/repos/octocat/hello-world/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "noop" }),
+    });
+    mockFetch.mockClear();
+
+    await app.request(`${base}/repos/octocat/included-repo/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Included" }),
+    });
+
+    const includedCall = mockFetch.mock.calls.find(
+      (c) => c[0] === "https://hooks.example/included",
+    );
+    expect(includedCall).toBeDefined();
+    const includedBody = JSON.parse((includedCall![1] as RequestInit).body as string);
+    expect(includedBody.installation).toBeDefined();
+    expect(includedBody.installation.id).toBe(88);
+
+    mockFetch.mockClear();
+
+    await app.request(`${base}/repos/octocat/excluded-repo/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Excluded" }),
+    });
+
+    const excludedCall = mockFetch.mock.calls.find(
+      (c) => c[0] === "https://hooks.example/excluded",
+    );
+    expect(excludedCall).toBeDefined();
+    const excludedBody = JSON.parse((excludedCall![1] as RequestInit).body as string);
+    expect(excludedBody.installation).toBeUndefined();
+  });
+});
+
+describe("app webhook_url delivery", () => {
+  const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("delivers to app webhook_url with installation in payload", async () => {
+    const { app } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [{
+        app_id: 500,
+        slug: "webhook-app",
+        name: "Webhook App",
+        private_key: "fake-key",
+        events: ["issues"],
+        webhook_url: "https://app.example/webhook",
+        installations: [{
+          installation_id: 55,
+          account: "octocat",
+          repository_selection: "all",
+        }],
+      }],
+    });
+
+    await app.request(`${base}/repos/octocat/hello-world/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "App webhook test" }),
+    });
+
+    const appCall = mockFetch.mock.calls.find(
+      (c) => c[0] === "https://app.example/webhook",
+    );
+    expect(appCall).toBeDefined();
+
+    const headers = (appCall![1] as RequestInit).headers as Record<string, string>;
+    expect(headers["X-GitHub-Event"]).toBe("issues");
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse((appCall![1] as RequestInit).body as string);
+    expect(body.installation).toBeDefined();
+    expect(body.installation.id).toBe(55);
+  });
+
+  it("signs app webhook delivery with webhook_secret", async () => {
+    const secret = "app-webhook-secret";
+    const { app } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [{
+        app_id: 600,
+        slug: "signed-app",
+        name: "Signed App",
+        private_key: "fake-key",
+        events: ["issues"],
+        webhook_url: "https://signed.example/webhook",
+        webhook_secret: secret,
+        installations: [{
+          installation_id: 66,
+          account: "octocat",
+          repository_selection: "all",
+        }],
+      }],
+    });
+
+    await app.request(`${base}/repos/octocat/hello-world/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Signed webhook test" }),
+    });
+
+    const appCall = mockFetch.mock.calls.find(
+      (c) => c[0] === "https://signed.example/webhook",
+    );
+    expect(appCall).toBeDefined();
+
+    const headers = (appCall![1] as RequestInit).headers as Record<string, string>;
+    const rawBody = (appCall![1] as RequestInit).body as string;
+    const expectedHmac = createHmac("sha256", secret).update(rawBody).digest("hex");
+    expect(headers["X-Hub-Signature-256"]).toBe(`sha256=${expectedHmac}`);
+  });
+
+  it("does not deliver to app when webhook_url is null", async () => {
+    const { app } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [{
+        app_id: 700,
+        slug: "no-url-app",
+        name: "No URL App",
+        private_key: "fake-key",
+        events: ["issues"],
+        installations: [{
+          installation_id: 77,
+          account: "octocat",
+          repository_selection: "all",
+        }],
+      }],
+    });
+
+    await app.request(`${base}/repos/octocat/hello-world/issues`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "No URL test" }),
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@internal/github/src/entities.ts
+++ b/packages/@internal/github/src/entities.ts
@@ -492,6 +492,7 @@ export interface GitHubApp extends Entity {
   permissions: Record<string, string>;
   events: string[];
   webhook_url: string | null;
+  webhook_secret: string | null;
   description: string | null;
 }
 

--- a/packages/@internal/github/src/index.ts
+++ b/packages/@internal/github/src/index.ts
@@ -1,6 +1,9 @@
+import { createHmac } from "crypto";
 import type { Hono } from "hono";
 import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@internal/core";
 import { getGitHubStore } from "./store.js";
+import type { GitHubStore } from "./store.js";
+import type { GitHubAppInstallation } from "./entities.js";
 import { generateNodeId, generateSha } from "./helpers.js";
 import { usersRoutes } from "./routes/users.js";
 import { reposRoutes } from "./routes/repos.js";
@@ -68,6 +71,7 @@ export interface GitHubSeedConfig {
     permissions?: Record<string, string>;
     events?: string[];
     webhook_url?: string;
+    webhook_secret?: string;
     description?: string;
     installations?: Array<{
       installation_id: number;
@@ -330,6 +334,7 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
         permissions: a.permissions ?? {},
         events: a.events ?? [],
         webhook_url: a.webhook_url ?? null,
+        webhook_secret: a.webhook_secret ?? null,
         description: a.description ?? null,
       });
 
@@ -373,9 +378,115 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
   }
 }
 
+function findInstallationsForRepo(
+  gh: GitHubStore,
+  ownerLogin: string,
+  repoName: string | undefined,
+  event: string,
+): GitHubAppInstallation[] {
+  const ownerEntity =
+    gh.users.findOneBy("login", ownerLogin) ?? gh.orgs.findOneBy("login", ownerLogin);
+  if (!ownerEntity) return [];
+
+  const repoEntity = repoName
+    ? gh.repos.findOneBy("full_name", `${ownerLogin}/${repoName}`)
+    : null;
+
+  const results: GitHubAppInstallation[] = [];
+  for (const inst of gh.appInstallations.all()) {
+    if (inst.account_id !== ownerEntity.id) continue;
+    if (inst.suspended_at) continue;
+
+    const ghApp = gh.apps.all().find((a) => a.app_id === inst.app_id);
+    if (!ghApp) continue;
+    if (!ghApp.events.includes(event) && !ghApp.events.includes("*")) continue;
+
+    if (repoEntity && inst.repository_selection === "selected") {
+      if (!inst.repository_ids.includes(repoEntity.id)) continue;
+    }
+
+    results.push(inst);
+  }
+  return results;
+}
+
+function enrichPayloadWithInstallation(
+  payload: unknown,
+  installation: GitHubAppInstallation,
+): unknown {
+  if (!payload || typeof payload !== "object") return payload;
+  return {
+    ...(payload as Record<string, unknown>),
+    installation: {
+      id: installation.installation_id,
+      node_id: generateNodeId("Installation", installation.installation_id),
+    },
+  };
+}
+
+async function deliverToAppWebhookUrls(
+  gh: GitHubStore,
+  event: string,
+  action: string | undefined,
+  payload: unknown,
+  ownerLogin: string,
+  repoName: string | undefined,
+): Promise<void> {
+  const installations = findInstallationsForRepo(gh, ownerLogin, repoName, event);
+
+  for (const inst of installations) {
+    const ghApp = gh.apps.all().find((a) => a.app_id === inst.app_id);
+    if (!ghApp?.webhook_url) continue;
+
+    const enriched = enrichPayloadWithInstallation(payload, inst);
+    const body = JSON.stringify(enriched);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-GitHub-Event": event,
+      "X-GitHub-Delivery": String(Date.now()),
+    };
+    if (ghApp.webhook_secret) {
+      const hmac = createHmac("sha256", ghApp.webhook_secret).update(body).digest("hex");
+      headers["X-Hub-Signature-256"] = `sha256=${hmac}`;
+    }
+
+    try {
+      await fetch(ghApp.webhook_url, {
+        method: "POST",
+        headers,
+        body,
+        signal: AbortSignal.timeout(10000),
+      });
+    } catch {
+      // Best-effort delivery
+    }
+  }
+}
+
 export const githubPlugin: ServicePlugin = {
   name: "github",
   register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const gh = getGitHubStore(store);
+
+    const originalDispatch = webhooks.dispatch.bind(webhooks);
+    webhooks.dispatch = async (
+      event: string,
+      action: string | undefined,
+      payload: unknown,
+      owner: string,
+      repo?: string,
+    ): Promise<void> => {
+      const installations = findInstallationsForRepo(gh, owner, repo, event);
+
+      const enrichedPayload = installations.length > 0
+        ? enrichPayloadWithInstallation(payload, installations[0])
+        : payload;
+
+      await originalDispatch(event, action, enrichedPayload, owner, repo);
+      await deliverToAppWebhookUrls(gh, event, action, payload, owner, repo);
+    };
+
     const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
     usersRoutes(ctx);
     reposRoutes(ctx);


### PR DESCRIPTION
## Enhance GitHub App support: webhook delivery, installation payload, and signing

### Summary

This PR improves how the GitHub emulator behaves for **GitHub Apps**: webhook payloads now include **installation** metadata (matching real GitHub), and apps can optionally receive events at a configured **`webhook_url`** with **`X-Hub-Signature-256`** when a **`webhook_secret`** is set.

### What changed

- **`webhook_secret`** on seeded GitHub apps (`GitHubSeedConfig`, `GitHubApp` entity, seeding) so secrets persist like `webhook_url`.
- **Installation-aware dispatch**: wraps the webhook dispatcher so payloads passed through the normal path are enriched with `installation: { id, node_id }` when at least one matching installation exists (first installation wins for enrichment).
- **App webhook delivery**: for each installation that matches the repo/org, subscribed events, and non-suspended state, POSTs JSON to the app’s `webhook_url` with `X-GitHub-Event`, `X-GitHub-Delivery`, and optional HMAC `X-Hub-Signature-256` (SHA-256 over the body). Delivery is best-effort (errors swallowed, 10s timeout).
- **Matching logic**: respects account, app event list (or `*`), suspension, and `repository_selection` / `repository_ids` for **selected** repos.
- **Docs & examples**: README documents app webhook behavior; `emulate.config.example.yaml` shows `webhook_url` and `webhook_secret`.
- **Tests**: `webhook-installation.test.ts` covers installation enrichment and delivery behavior.

### Configuration

In seed YAML under `github.apps`:

- `webhook_url` — where the emulator POSTs app events  
- `webhook_secret` — optional; enables `X-Hub-Signature-256` verification on the receiver  
