### PR TITLE
Add Apple Auth emulator

### DIFF
--- a/packages/@internal/apple/package.json
+++ b/packages/@internal/apple/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@internal/apple",
+  "version": "0.2.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@internal/core": "workspace:*",
+    "hono": "^4",
+    "jose": "^6"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7"
+  }
+}

--- a/packages/@internal/apple/src/__tests__/apple.test.ts
+++ b/packages/@internal/apple/src/__tests__/apple.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@internal/core";
+import { applePlugin, seedFromConfig } from "../index.js";
+import { decodeJwt } from "jose";
+
+const base = "http://localhost:4000";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+
+  const app = new Hono();
+  app.use("*", authMiddleware(tokenMap));
+  applePlugin.register(app as any, store, webhooks, base, tokenMap);
+  applePlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ email: "testuser@example.com", name: "Test User" }],
+  });
+
+  return { app, store, webhooks, tokenMap };
+}
+
+async function getAuthCode(
+  app: Hono,
+  options: {
+    email?: string;
+    client_id?: string;
+    redirect_uri?: string;
+    scope?: string;
+    state?: string;
+    nonce?: string;
+    response_mode?: string;
+  } = {},
+): Promise<{ code: string; state: string; userJson?: string }> {
+  const email = options.email ?? "testuser@example.com";
+  const redirect_uri = options.redirect_uri ?? "http://localhost:3000/callback";
+  const scope = options.scope ?? "openid email name";
+  const state = options.state ?? "test-state";
+  const nonce = options.nonce ?? "test-nonce";
+  const client_id = options.client_id ?? "test-client";
+  const response_mode = options.response_mode ?? "query";
+
+  const formData = new URLSearchParams({
+    email,
+    redirect_uri,
+    scope,
+    state,
+    nonce,
+    client_id,
+    response_mode,
+  });
+
+  const res = await app.request(`${base}/auth/authorize/callback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: formData.toString(),
+  });
+
+  if (response_mode === "form_post") {
+    const html = await res.text();
+    const codeMatch = html.match(/name="code" value="([^"]+)"/);
+    const stateMatch = html.match(/name="state" value="([^"]+)"/);
+    const userMatch = html.match(/name="user" value="([^"]+)"/);
+    return {
+      code: codeMatch?.[1] ?? "",
+      state: stateMatch?.[1] ?? "",
+      userJson: userMatch ? decodeHtmlEntities(userMatch[1]) : undefined,
+    };
+  }
+
+  const location = res.headers.get("location") ?? "";
+  const url = new URL(location);
+  return {
+    code: url.searchParams.get("code") ?? "",
+    state: url.searchParams.get("state") ?? "",
+    userJson: url.searchParams.get("user") ?? undefined,
+  };
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'");
+}
+
+async function exchangeCode(
+  app: Hono,
+  code: string,
+  options: {
+    client_id?: string;
+    redirect_uri?: string;
+  } = {},
+): Promise<Response> {
+  const formData = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    client_id: options.client_id ?? "test-client",
+    client_secret: "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0ZWFtLWlkIiwiYXVkIjoiaHR0cHM6Ly9hcHBsZWlkLmFwcGxlLmNvbSIsInN1YiI6InRlc3QtY2xpZW50In0.fake",
+    redirect_uri: options.redirect_uri ?? "http://localhost:3000/callback",
+  });
+
+  return app.request(`${base}/auth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: formData.toString(),
+  });
+}
+
+describe("Apple plugin integration", () => {
+  let app: Hono;
+  let store: Store;
+
+  beforeEach(() => {
+    const testApp = createTestApp();
+    app = testApp.app;
+    store = testApp.store;
+  });
+
+  // --- OIDC Discovery ---
+
+  it("GET /.well-known/openid-configuration returns Apple OIDC discovery document", async () => {
+    const res = await app.request(`${base}/.well-known/openid-configuration`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.issuer).toBe(base);
+    expect(body.authorization_endpoint).toBe(`${base}/auth/authorize`);
+    expect(body.token_endpoint).toBe(`${base}/auth/token`);
+    expect(body.revocation_endpoint).toBe(`${base}/auth/revoke`);
+    expect(body.jwks_uri).toBe(`${base}/auth/keys`);
+    expect(body.response_types_supported).toEqual(["code"]);
+    expect(body.response_modes_supported).toEqual(["query", "fragment", "form_post"]);
+    expect(body.subject_types_supported).toEqual(["pairwise"]);
+    expect(body.id_token_signing_alg_values_supported).toEqual(["RS256"]);
+    expect(body.scopes_supported).toEqual(["openid", "email", "name"]);
+    expect(body.token_endpoint_auth_methods_supported).toEqual(["client_secret_post"]);
+    expect(body.claims_supported).toContain("is_private_email");
+    expect(body.claims_supported).toContain("real_user_status");
+    expect(body.claims_supported).toContain("nonce_supported");
+  });
+
+  // --- JWKS ---
+
+  it("GET /auth/keys returns JWKS with proper RSA key structure", async () => {
+    const res = await app.request(`${base}/auth/keys`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { keys: Array<Record<string, unknown>> };
+    expect(body.keys).toHaveLength(1);
+    const key = body.keys[0];
+    expect(key.kty).toBe("RSA");
+    expect(key.kid).toBe("emulate-apple-1");
+    expect(key.use).toBe("sig");
+    expect(key.alg).toBe("RS256");
+    expect(key.n).toBeDefined();
+    expect(key.e).toBe("AQAB");
+  });
+
+  // --- Authorization page ---
+
+  it("GET /auth/authorize returns an HTML sign-in page", async () => {
+    const url = `${base}/auth/authorize?client_id=test-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=openid%20email%20name`;
+    const res = await app.request(url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    const html = await res.text();
+    expect(html.length).toBeGreaterThan(0);
+    expect(html).toMatch(/Sign in/i);
+  });
+
+  // --- Full OAuth flow ---
+
+  it("completes full OAuth authorization_code flow", async () => {
+    const { code, state } = await getAuthCode(app);
+    expect(code).toBeTruthy();
+    expect(state).toBe("test-state");
+
+    const tokenRes = await exchangeCode(app, code);
+    expect(tokenRes.status).toBe(200);
+    const tokenBody = await tokenRes.json() as Record<string, unknown>;
+    expect(tokenBody.access_token).toBeDefined();
+    expect((tokenBody.access_token as string).startsWith("apple_")).toBe(true);
+    expect(tokenBody.refresh_token).toBeDefined();
+    expect((tokenBody.refresh_token as string).startsWith("r_apple_")).toBe(true);
+    expect(tokenBody.token_type).toBe("Bearer");
+    expect(tokenBody.expires_in).toBe(3600);
+    expect(tokenBody.id_token).toBeDefined();
+
+    // Decode and verify id_token claims
+    const claims = decodeJwt(tokenBody.id_token as string);
+    expect(claims.iss).toBe(base);
+    expect(claims.aud).toBe("test-client");
+    expect(claims.sub).toBeDefined();
+    expect(claims.email).toBe("testuser@example.com");
+    // CRITICAL: email_verified and is_private_email must be STRINGS
+    expect(claims.email_verified).toBe("true");
+    expect(typeof claims.email_verified).toBe("string");
+    expect(typeof claims.is_private_email).toBe("string");
+    expect(claims.nonce_supported).toBe(true);
+    expect(claims.nonce).toBe("test-nonce");
+    expect(claims.real_user_status).toBe(2);
+    expect(claims.auth_time).toBeDefined();
+  });
+
+  // --- Refresh token flow ---
+
+  it("exchanges refresh_token for new access_token without new refresh_token", async () => {
+    const { code } = await getAuthCode(app);
+    const tokenRes = await exchangeCode(app, code);
+    const tokenBody = await tokenRes.json() as Record<string, unknown>;
+    const refreshToken = tokenBody.refresh_token as string;
+
+    const refreshFormData = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: "test-client",
+      client_secret: "eyJhbGciOiJFUzI1NiJ9.fake.fake",
+    });
+
+    const refreshRes = await app.request(`${base}/auth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: refreshFormData.toString(),
+    });
+
+    expect(refreshRes.status).toBe(200);
+    const refreshBody = await refreshRes.json() as Record<string, unknown>;
+    expect(refreshBody.access_token).toBeDefined();
+    expect((refreshBody.access_token as string).startsWith("apple_")).toBe(true);
+    expect(refreshBody.id_token).toBeDefined();
+    expect(refreshBody.token_type).toBe("Bearer");
+    expect(refreshBody.expires_in).toBe(3600);
+    // No new refresh_token in refresh grant
+    expect(refreshBody.refresh_token).toBeUndefined();
+  });
+
+  // --- Token revocation ---
+
+  it("POST /auth/revoke returns 200", async () => {
+    const formData = new URLSearchParams({
+      client_id: "test-client",
+      client_secret: "eyJhbGciOiJFUzI1NiJ9.fake.fake",
+      token: "some-token",
+      token_type_hint: "access_token",
+    });
+
+    const res = await app.request(`${base}/auth/revoke`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData.toString(),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  // --- Authorization code is single-use ---
+
+  it("rejects second use of authorization code", async () => {
+    const { code } = await getAuthCode(app);
+
+    // First exchange succeeds
+    const res1 = await exchangeCode(app, code);
+    expect(res1.status).toBe(200);
+
+    // Second exchange fails
+    const res2 = await exchangeCode(app, code);
+    expect(res2.status).toBe(400);
+    const body = await res2.json() as Record<string, unknown>;
+    expect(body.error).toBe("invalid_grant");
+  });
+
+  // --- User JSON blob only on first auth ---
+
+  it("sends user JSON blob only on first authorization per user+client pair", async () => {
+    // First auth should include user blob
+    const first = await getAuthCode(app, { response_mode: "query" });
+    expect(first.userJson).toBeDefined();
+    const parsed = JSON.parse(first.userJson!);
+    expect(parsed.name.firstName).toBe("Test");
+    expect(parsed.name.lastName).toBe("User");
+    expect(parsed.email).toBe("testuser@example.com");
+
+    // Second auth for same user+client should NOT include user blob
+    const second = await getAuthCode(app, { response_mode: "query" });
+    expect(second.userJson).toBeUndefined();
+  });
+
+  // --- form_post response mode ---
+
+  it("returns auto-submit form for form_post response mode", async () => {
+    const result = await getAuthCode(app, { response_mode: "form_post" });
+    expect(result.code).toBeTruthy();
+    expect(result.state).toBe("test-state");
+  });
+
+  // --- Unsupported grant type ---
+
+  it("rejects unsupported grant type", async () => {
+    const formData = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: "test-client",
+      client_secret: "eyJhbGciOiJFUzI1NiJ9.fake.fake",
+    });
+
+    const res = await app.request(`${base}/auth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData.toString(),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("unsupported_grant_type");
+  });
+});

--- a/packages/@internal/apple/src/entities.ts
+++ b/packages/@internal/apple/src/entities.ts
@@ -1,0 +1,21 @@
+import type { Entity } from "@internal/core";
+
+export interface AppleUser extends Entity {
+  uid: string;
+  email: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  email_verified: boolean;
+  is_private_email: boolean;
+  private_relay_email: string | null;
+  real_user_status: number;
+}
+
+export interface AppleOAuthClient extends Entity {
+  client_id: string;
+  team_id: string;
+  key_id: string;
+  name: string;
+  redirect_uris: string[];
+}

--- a/packages/@internal/apple/src/helpers.ts
+++ b/packages/@internal/apple/src/helpers.ts
@@ -1,0 +1,19 @@
+import { randomBytes } from "crypto";
+
+/**
+ * Generate a pairwise subject ID in Apple's format: "XXXXXX.hex32.XXXX"
+ */
+export function generateAppleUid(): string {
+  const prefix = randomBytes(3).toString("hex").toUpperCase();
+  const middle = randomBytes(16).toString("hex");
+  const suffix = randomBytes(2).toString("hex").toUpperCase();
+  return `${prefix}.${middle}.${suffix}`;
+}
+
+/**
+ * Generate a private relay email address.
+ */
+export function generatePrivateRelayEmail(): string {
+  const id = randomBytes(12).toString("hex");
+  return `${id}@privaterelay.appleid.com`;
+}

--- a/packages/@internal/apple/src/index.ts
+++ b/packages/@internal/apple/src/index.ts
@@ -1,0 +1,94 @@
+import type { Hono } from "hono";
+import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@internal/core";
+import { getAppleStore } from "./store.js";
+import { generateAppleUid, generatePrivateRelayEmail } from "./helpers.js";
+import { oauthRoutes } from "./routes/oauth.js";
+
+export { getAppleStore, type AppleStore } from "./store.js";
+export * from "./entities.js";
+
+export interface AppleSeedConfig {
+  users?: Array<{
+    email: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
+    is_private_email?: boolean;
+  }>;
+  oauth_clients?: Array<{
+    client_id: string;
+    team_id: string;
+    key_id?: string;
+    name: string;
+    redirect_uris: string[];
+  }>;
+}
+
+function seedDefaults(store: Store, _baseUrl: string): void {
+  const as = getAppleStore(store);
+
+  as.users.insert({
+    uid: generateAppleUid(),
+    email: "testuser@icloud.com",
+    name: "Test User",
+    given_name: "Test",
+    family_name: "User",
+    email_verified: true,
+    is_private_email: false,
+    private_relay_email: null,
+    real_user_status: 2,
+  });
+}
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: AppleSeedConfig): void {
+  const as = getAppleStore(store);
+
+  if (config.users) {
+    for (const u of config.users) {
+      const existing = as.users.findOneBy("email", u.email);
+      if (existing) continue;
+
+      const nameParts = (u.name ?? "").split(/\s+/);
+      const isPrivate = u.is_private_email ?? false;
+
+      as.users.insert({
+        uid: generateAppleUid(),
+        email: u.email,
+        name: u.name ?? u.email.split("@")[0],
+        given_name: u.given_name ?? nameParts[0] ?? "",
+        family_name: u.family_name ?? nameParts.slice(1).join(" ") ?? "",
+        email_verified: true,
+        is_private_email: isPrivate,
+        private_relay_email: isPrivate ? generatePrivateRelayEmail() : null,
+        real_user_status: 2,
+      });
+    }
+  }
+
+  if (config.oauth_clients) {
+    for (const client of config.oauth_clients) {
+      const existing = as.oauthClients.findOneBy("client_id", client.client_id);
+      if (existing) continue;
+      as.oauthClients.insert({
+        client_id: client.client_id,
+        team_id: client.team_id,
+        key_id: client.key_id ?? "TESTKEY001",
+        name: client.name,
+        redirect_uris: client.redirect_uris,
+      });
+    }
+  }
+}
+
+export const applePlugin: ServicePlugin = {
+  name: "apple",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    oauthRoutes(ctx);
+  },
+  seed(store: Store, baseUrl: string): void {
+    seedDefaults(store, baseUrl);
+  },
+};
+
+export default applePlugin;

--- a/packages/@internal/apple/src/routes/oauth.ts
+++ b/packages/@internal/apple/src/routes/oauth.ts
@@ -1,0 +1,392 @@
+import { randomBytes } from "crypto";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
+import type { RouteContext } from "@internal/core";
+import {
+  escapeHtml,
+  escapeAttr,
+  renderCardPage,
+  renderErrorPage,
+  renderUserButton,
+  matchesRedirectUri,
+  bodyStr,
+  debug,
+} from "@internal/core";
+import { getAppleStore } from "../store.js";
+import type { AppleUser } from "../entities.js";
+import type { Store } from "@internal/core";
+
+// RSA key pair generated at module load for signing id_tokens
+const keyPairPromise = generateKeyPair("RS256");
+const KID = "emulate-apple-1";
+
+type PendingCode = {
+  email: string;
+  scope: string;
+  redirectUri: string;
+  clientId: string;
+  nonce: string | null;
+  responseMode: string;
+  created_at: number;
+};
+
+type StoredRefreshToken = {
+  email: string;
+  clientId: string;
+  scope: string;
+  nonce: string | null;
+};
+
+const PENDING_CODE_TTL_MS = 5 * 60 * 1000;
+
+function getPendingCodes(store: Store): Map<string, PendingCode> {
+  let map = store.getData<Map<string, PendingCode>>("apple.oauth.pendingCodes");
+  if (!map) {
+    map = new Map();
+    store.setData("apple.oauth.pendingCodes", map);
+  }
+  return map;
+}
+
+function getRefreshTokens(store: Store): Map<string, StoredRefreshToken> {
+  let map = store.getData<Map<string, StoredRefreshToken>>("apple.oauth.refreshTokens");
+  if (!map) {
+    map = new Map();
+    store.setData("apple.oauth.refreshTokens", map);
+  }
+  return map;
+}
+
+function getFirstAuthTracker(store: Store): Set<string> {
+  let set = store.getData<Set<string>>("apple.oauth.firstAuthTracker");
+  if (!set) {
+    set = new Set();
+    store.setData("apple.oauth.firstAuthTracker", set);
+  }
+  return set;
+}
+
+function isPendingCodeExpired(p: PendingCode): boolean {
+  return Date.now() - p.created_at > PENDING_CODE_TTL_MS;
+}
+
+const SERVICE_LABEL = "Apple";
+
+async function createIdToken(
+  user: AppleUser,
+  clientId: string,
+  nonce: string | null,
+  baseUrl: string,
+): Promise<string> {
+  const { privateKey } = await keyPairPromise;
+
+  const email = user.is_private_email && user.private_relay_email
+    ? user.private_relay_email
+    : user.email;
+
+  const now = Math.floor(Date.now() / 1000);
+
+  const builder = new SignJWT({
+    sub: user.uid,
+    email,
+    email_verified: String(user.email_verified),
+    is_private_email: String(user.is_private_email),
+    real_user_status: user.real_user_status,
+    nonce_supported: true,
+    auth_time: now,
+    ...(nonce ? { nonce } : {}),
+  })
+    .setProtectedHeader({ alg: "RS256", kid: KID, typ: "JWT" })
+    .setIssuer(baseUrl)
+    .setAudience(clientId)
+    .setIssuedAt(now)
+    .setExpirationTime("1h");
+
+  return builder.sign(privateKey);
+}
+
+export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): void {
+  const as = getAppleStore(store);
+
+  // ---------- OIDC Discovery ----------
+
+  app.get("/.well-known/openid-configuration", (c) => {
+    return c.json({
+      issuer: baseUrl,
+      authorization_endpoint: `${baseUrl}/auth/authorize`,
+      token_endpoint: `${baseUrl}/auth/token`,
+      revocation_endpoint: `${baseUrl}/auth/revoke`,
+      jwks_uri: `${baseUrl}/auth/keys`,
+      response_types_supported: ["code"],
+      response_modes_supported: ["query", "fragment", "form_post"],
+      subject_types_supported: ["pairwise"],
+      id_token_signing_alg_values_supported: ["RS256"],
+      scopes_supported: ["openid", "email", "name"],
+      token_endpoint_auth_methods_supported: ["client_secret_post"],
+      claims_supported: [
+        "aud", "email", "email_verified", "exp", "iat",
+        "is_private_email", "iss", "nonce", "nonce_supported",
+        "real_user_status", "sub", "transfer_sub",
+      ],
+    });
+  });
+
+  // ---------- JWKS ----------
+
+  app.get("/auth/keys", async (c) => {
+    const { publicKey } = await keyPairPromise;
+    const jwk = await exportJWK(publicKey);
+    return c.json({
+      keys: [{
+        ...jwk,
+        kid: KID,
+        use: "sig",
+        alg: "RS256",
+      }],
+    });
+  });
+
+  // ---------- Authorization page ----------
+
+  app.get("/auth/authorize", (c) => {
+    const client_id = c.req.query("client_id") ?? "";
+    const redirect_uri = c.req.query("redirect_uri") ?? "";
+    const scope = c.req.query("scope") ?? "";
+    const state = c.req.query("state") ?? "";
+    const nonce = c.req.query("nonce") ?? "";
+    const response_mode = c.req.query("response_mode") ?? "query";
+
+    const clientsConfigured = as.oauthClients.all().length > 0;
+    let clientName = "";
+    if (clientsConfigured) {
+      const client = as.oauthClients.findOneBy("client_id", client_id);
+      if (!client) {
+        return c.html(
+          renderErrorPage("Application not found", `The client_id '${client_id}' is not registered.`, SERVICE_LABEL),
+          400,
+        );
+      }
+      if (redirect_uri && !matchesRedirectUri(redirect_uri, client.redirect_uris)) {
+        return c.html(
+          renderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", SERVICE_LABEL),
+          400,
+        );
+      }
+      clientName = client.name;
+    }
+
+    const subtitleText = clientName
+      ? `Sign in to <strong>${escapeHtml(clientName)}</strong> with your Apple ID.`
+      : "Choose a seeded user to continue.";
+
+    const users = as.users.all();
+    const userButtons = users
+      .map((user) => {
+        return renderUserButton({
+          letter: (user.email[0] ?? "?").toUpperCase(),
+          login: user.email,
+          name: user.name,
+          email: user.email,
+          formAction: "/auth/authorize/callback",
+          hiddenFields: {
+            email: user.email,
+            redirect_uri,
+            scope,
+            state,
+            nonce,
+            client_id,
+            response_mode,
+          },
+        });
+      })
+      .join("\n");
+
+    const body = users.length === 0
+      ? '<p class="empty">No users in the emulator store.</p>'
+      : userButtons;
+
+    return c.html(renderCardPage("Sign in with Apple", subtitleText, body, SERVICE_LABEL));
+  });
+
+  // ---------- Authorization callback ----------
+
+  app.post("/auth/authorize/callback", async (c) => {
+    const body = await c.req.parseBody();
+    const email = bodyStr(body.email);
+    const redirect_uri = bodyStr(body.redirect_uri);
+    const scope = bodyStr(body.scope);
+    const state = bodyStr(body.state);
+    const client_id = bodyStr(body.client_id);
+    const nonce = bodyStr(body.nonce);
+    const response_mode = bodyStr(body.response_mode) || "query";
+
+    const code = randomBytes(20).toString("hex");
+
+    getPendingCodes(store).set(code, {
+      email,
+      scope,
+      redirectUri: redirect_uri,
+      clientId: client_id,
+      nonce: nonce || null,
+      responseMode: response_mode,
+      created_at: Date.now(),
+    });
+
+    debug("apple.oauth", `[Apple callback] code=${code.slice(0, 8)}... email=${email}`);
+
+    // Track first authorization per user+client pair
+    const tracker = getFirstAuthTracker(store);
+    const pairKey = `${email}:${client_id}`;
+    const isFirstAuth = !tracker.has(pairKey);
+    if (isFirstAuth) {
+      tracker.add(pairKey);
+    }
+
+    // Build user JSON blob (only on first auth)
+    let userJson: string | undefined;
+    if (isFirstAuth) {
+      const user = as.users.findOneBy("email", email as AppleUser["email"]);
+      if (user) {
+        userJson = JSON.stringify({
+          name: { firstName: user.given_name, lastName: user.family_name },
+          email: user.email,
+        });
+      }
+    }
+
+    if (response_mode === "form_post") {
+      // Return auto-submit form that POSTs to redirect_uri
+      const html = `<!DOCTYPE html>
+<html>
+<head><title>Submit</title></head>
+<body onload="document.forms[0].submit()">
+<form method="POST" action="${escapeAttr(redirect_uri)}">
+<input type="hidden" name="code" value="${escapeAttr(code)}" />
+<input type="hidden" name="state" value="${escapeAttr(state)}" />${userJson ? `\n<input type="hidden" name="user" value="${escapeAttr(userJson)}" />` : ""}
+</form>
+</body>
+</html>`;
+      return c.html(html);
+    }
+
+    // Default: query mode redirect
+    const url = new URL(redirect_uri);
+    url.searchParams.set("code", code);
+    if (state) url.searchParams.set("state", state);
+    if (userJson) url.searchParams.set("user", userJson);
+
+    return c.redirect(url.toString(), 302);
+  });
+
+  // ---------- Token exchange ----------
+
+  app.post("/auth/token", async (c) => {
+    const rawText = await c.req.text();
+    const body = Object.fromEntries(new URLSearchParams(rawText));
+
+    const grant_type = body.grant_type ?? "";
+    const code = body.code ?? "";
+    const client_id = body.client_id ?? "";
+    const refresh_token = body.refresh_token ?? "";
+
+    if (grant_type === "authorization_code") {
+      const pendingMap = getPendingCodes(store);
+      const pending = pendingMap.get(code);
+      if (!pending) {
+        return c.json({ error: "invalid_grant", error_description: "The code is incorrect or expired." }, 400);
+      }
+      if (isPendingCodeExpired(pending)) {
+        pendingMap.delete(code);
+        return c.json({ error: "invalid_grant", error_description: "The code is incorrect or expired." }, 400);
+      }
+
+      // Single-use: delete immediately
+      pendingMap.delete(code);
+
+      const user = as.users.findOneBy("email", pending.email as AppleUser["email"]);
+      if (!user) {
+        return c.json({ error: "invalid_grant", error_description: "User not found." }, 400);
+      }
+
+      const accessToken = "apple_" + randomBytes(20).toString("base64url");
+      const refreshToken = "r_apple_" + randomBytes(20).toString("base64url");
+      const scopes = pending.scope ? pending.scope.split(/\s+/).filter(Boolean) : [];
+
+      if (tokenMap) {
+        tokenMap.set(accessToken, { login: user.email, id: user.id, scopes });
+      }
+
+      // Store refresh token
+      getRefreshTokens(store).set(refreshToken, {
+        email: user.email,
+        clientId: pending.clientId,
+        scope: pending.scope,
+        nonce: pending.nonce,
+      });
+
+      const idToken = await createIdToken(user, pending.clientId, pending.nonce, baseUrl);
+
+      debug("apple.oauth", `[Apple token] issued token for ${user.email}`);
+
+      return c.json({
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: 3600,
+        refresh_token: refreshToken,
+        id_token: idToken,
+      });
+    }
+
+    if (grant_type === "refresh_token") {
+      const refreshMap = getRefreshTokens(store);
+      const stored = refreshMap.get(refresh_token);
+      if (!stored) {
+        return c.json({ error: "invalid_grant", error_description: "The refresh_token is invalid." }, 400);
+      }
+
+      const user = as.users.findOneBy("email", stored.email as AppleUser["email"]);
+      if (!user) {
+        return c.json({ error: "invalid_grant", error_description: "User not found." }, 400);
+      }
+
+      const accessToken = "apple_" + randomBytes(20).toString("base64url");
+      const scopes = stored.scope ? stored.scope.split(/\s+/).filter(Boolean) : [];
+
+      if (tokenMap) {
+        tokenMap.set(accessToken, { login: user.email, id: user.id, scopes });
+      }
+
+      const idToken = await createIdToken(user, stored.clientId || client_id, stored.nonce, baseUrl);
+
+      debug("apple.oauth", `[Apple refresh] issued new token for ${user.email}`);
+
+      // No new refresh_token for refresh grant
+      return c.json({
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: 3600,
+        id_token: idToken,
+      });
+    }
+
+    return c.json({ error: "unsupported_grant_type", error_description: "Only authorization_code and refresh_token are supported." }, 400);
+  });
+
+  // ---------- Token revocation ----------
+
+  app.post("/auth/revoke", async (c) => {
+    const rawText = await c.req.text();
+    const params = new URLSearchParams(rawText);
+    const token = params.get("token") ?? "";
+
+    if (token && tokenMap) {
+      tokenMap.delete(token);
+    }
+
+    // Also check refresh tokens
+    if (token) {
+      getRefreshTokens(store).delete(token);
+    }
+
+    return c.body(null, 200);
+  });
+}

--- a/packages/@internal/apple/src/store.ts
+++ b/packages/@internal/apple/src/store.ts
@@ -1,0 +1,14 @@
+import { Store, type Collection } from "@internal/core";
+import type { AppleUser, AppleOAuthClient } from "./entities.js";
+
+export interface AppleStore {
+  users: Collection<AppleUser>;
+  oauthClients: Collection<AppleOAuthClient>;
+}
+
+export function getAppleStore(store: Store): AppleStore {
+  return {
+    users: store.collection<AppleUser>("apple.users", ["uid", "email"]),
+    oauthClients: store.collection<AppleOAuthClient>("apple.oauth_clients", ["client_id"]),
+  };
+}

--- a/packages/@internal/apple/tsconfig.json
+++ b/packages/@internal/apple/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@internal/apple/tsup.config.ts
+++ b/packages/@internal/apple/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+});

--- a/packages/@internal/apple/vitest.config.ts
+++ b/packages/@internal/apple/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@internal/core": "workspace:*",
     "@internal/github": "workspace:*",
+    "@internal/apple": "workspace:*",
     "@internal/google": "workspace:*",
     "@internal/vercel": "workspace:*",
     "tsup": "^8",

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -2,12 +2,14 @@ import { createServer, type AppKeyResolver, type AuthFallback, type Store } from
 import { vercelPlugin, seedFromConfig as seedVercel, type VercelSeedConfig } from "@internal/vercel";
 import { githubPlugin, seedFromConfig as seedGitHub, getGitHubStore, type GitHubSeedConfig } from "@internal/github";
 import { googlePlugin, seedFromConfig as seedGoogle, type GoogleSeedConfig } from "@internal/google";
+import { applePlugin, seedFromConfig as seedApple, type AppleSeedConfig } from "@internal/apple";
 import { serve } from "@hono/node-server";
 
 const SERVICE_PLUGINS = {
   vercel: vercelPlugin,
   github: githubPlugin,
   google: googlePlugin,
+  apple: applePlugin,
 } as const;
 
 export type ServiceName = keyof typeof SERVICE_PLUGINS;
@@ -17,6 +19,7 @@ export interface SeedConfig {
   vercel?: VercelSeedConfig;
   github?: GitHubSeedConfig;
   google?: GoogleSeedConfig;
+  apple?: AppleSeedConfig;
 }
 
 export interface EmulatorOptions {
@@ -76,6 +79,9 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
   } else if (service === "google") {
     const firstEmail = seedConfig?.google?.users?.[0]?.email ?? "testuser@gmail.com";
     fallbackUser = { login: firstEmail, id: 1, scopes: ["openid", "email", "profile"] };
+  } else if (service === "apple") {
+    const firstEmail = seedConfig?.apple?.users?.[0]?.email ?? "testuser@icloud.com";
+    fallbackUser = { login: firstEmail, id: 1, scopes: ["openid", "email", "name"] };
   }
 
   const { app, store } = createServer(plugin, { port, baseUrl, tokens, appKeyResolver, fallbackUser });
@@ -86,6 +92,7 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
     if (service === "vercel" && seedConfig?.vercel) seedVercel(store, baseUrl, seedConfig.vercel);
     if (service === "github" && seedConfig?.github) seedGitHub(store, baseUrl, seedConfig.github);
     if (service === "google" && seedConfig?.google) seedGoogle(store, baseUrl, seedConfig.google);
+    if (service === "apple" && seedConfig?.apple) seedApple(store, baseUrl, seedConfig.apple);
   };
   seed();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^3.0.118
-        version: 3.0.118(react@19.2.4)(zod@4.3.6)
+        version: 3.0.118(react@19.2.4)(zod@3.25.76)
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1
@@ -43,10 +43,10 @@ importers:
         version: 1.37.0
       ai:
         specifier: ^6.0.116
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@3.25.76)
       bash-tool:
         specifier: ^1.3.15
-        version: 1.3.15(ai@6.0.116(zod@4.3.6))(just-bash@2.14.0)
+        version: 1.3.15(ai@6.0.116(zod@3.25.76))(just-bash@2.14.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -55,7 +55,7 @@ importers:
         version: 2.1.1
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.2.0(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.7.0(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       just-bash:
         specifier: ^2.14.0
         version: 2.14.0
@@ -119,7 +119,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.0
-        version: 16.2.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -177,12 +177,31 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.0
-        version: 16.2.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
       typescript:
         specifier: ^5
+        version: 5.9.3
+
+  packages/@internal/apple:
+    dependencies:
+      '@internal/core':
+        specifier: workspace:*
+        version: link:../core
+      hono:
+        specifier: ^4
+        version: 4.12.8
+      jose:
+        specifier: ^6
+        version: 6.2.2
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7
         version: 5.9.3
 
   packages/@internal/core:
@@ -270,6 +289,9 @@ importers:
         specifier: ^2
         version: 2.8.2
     devDependencies:
+      '@internal/apple':
+        specifier: workspace:*
+        version: link:../@internal/apple
       '@internal/core':
         specifier: workspace:*
         version: link:../@internal/core
@@ -5950,28 +5972,28 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.66(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
       '@vercel/oidc': 3.1.0
-      zod: 4.3.6
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 3.25.76
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.118(react@19.2.4)(zod@4.3.6)':
+  '@ai-sdk/react@3.0.118(react@19.2.4)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      ai: 6.0.116(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      ai: 6.0.116(zod@3.25.76)
       react: 19.2.4
       swr: 2.4.1(react@19.2.4)
       throttleit: 2.1.0
@@ -8211,13 +8233,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.116(zod@4.3.6):
+  ai@6.0.116(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.66(zod@3.25.76)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
+      zod: 3.25.76
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -8359,9 +8381,9 @@ snapshots:
 
   baseline-browser-mapping@2.10.9: {}
 
-  bash-tool@1.3.15(ai@6.0.116(zod@4.3.6))(just-bash@2.14.0):
+  bash-tool@1.3.15(ai@6.0.116(zod@3.25.76))(just-bash@2.14.0):
     dependencies:
-      ai: 6.0.116(zod@4.3.6)
+      ai: 6.0.116(zod@3.25.76)
       fast-glob: 3.3.3
       gray-matter: 4.0.3
       zod: 3.25.76
@@ -9606,7 +9628,7 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  geist@1.7.0(next@16.2.0(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  geist@1.7.0(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       next: 16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 


### PR DESCRIPTION
## Summary
- Adds a new `@internal/apple` package implementing a production-fidelity Apple Sign in with Apple emulator
- Implements all 5 OIDC/OAuth endpoints: discovery, JWKS (real RS256 keys via jose), authorization, token exchange (auth code + refresh), and revocation
- Emulates Apple-specific quirks: string-typed `email_verified`/`is_private_email`, pairwise `sub` format (`XXXXXX.hex32.XXXX`), `user` JSON blob only on first authorization, `form_post` response mode, no PKCE, `name` scope (not `profile`)
- 10 integration tests covering full OAuth flow, token refresh, single-use codes, first-auth-only user blob

## Test plan
- [x] All 10 integration tests pass (`pnpm test` in `packages/@internal/apple`)
- [x] Full monorepo build passes (`pnpm build`)
- [ ] Manual test: wire up a Sign in with Apple client library against the emulator and verify the full auth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)