### PR TITLE
Add Gmail messages, threads, and labels APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ google:
       client_secret: GOCSPX-secret
       redirect_uris:
         - http://localhost:3000/api/auth/callback/google
+  labels:
+    - id: Label_ops
+      user_email: testuser@example.com
+      name: Ops/Review
+      color_background: "#DDEEFF"
+      color_text: "#111111"
+  messages:
+    - id: msg_welcome
+      user_email: testuser@example.com
+      from: welcome@example.com
+      to: testuser@example.com
+      subject: Welcome to the Gmail emulator
+      body_text: You can now test Gmail messages, threads, and labels locally.
+      label_ids: [INBOX, UNREAD, CATEGORY_UPDATES]
 ```
 
 ## OAuth & Integrations
@@ -387,15 +401,29 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /zen` - random zen phrase
 - `GET /versions` - API versions
 
-## Google API
+## Google OAuth + Gmail API
 
-OAuth 2.0 and OpenID Connect emulation.
+OAuth 2.0, OpenID Connect, and a mutable Gmail surface for local inbox flows.
+This stays under a single `google:` service because the Gmail API is used by both consumer Google accounts and Google Workspace accounts. A separate Workspace-specific service would only make sense once we add admin or tenant-level APIs that do not belong in the basic Google/Gmail emulator.
 
 - `GET /o/oauth2/v2/auth` - authorization endpoint
-- `POST /oauth2/v4/token` - token exchange
+- `POST /oauth2/token` - token exchange
 - `GET /oauth2/v2/userinfo` - get user info
 - `GET /.well-known/openid-configuration` - OIDC discovery document
 - `GET /oauth2/v3/certs` - JSON Web Key Set (JWKS)
+- `GET /gmail/v1/users/:userId/messages` - list messages with `q`, `labelIds`, `maxResults`, and `pageToken`
+- `GET /gmail/v1/users/:userId/messages/:id` - fetch a Gmail-style message payload in `full`, `metadata`, `minimal`, or `raw` formats
+- `POST /gmail/v1/users/:userId/messages/send` - create sent mail from `raw` MIME or structured fields
+- `POST /gmail/v1/users/:userId/messages/import` - import inbox mail
+- `POST /gmail/v1/users/:userId/messages` - insert a message directly
+- `POST /gmail/v1/users/:userId/messages/:id/modify` - add/remove labels on one message
+- `POST /gmail/v1/users/:userId/messages/batchModify` - add/remove labels across many messages
+- `POST /gmail/v1/users/:userId/messages/:id/trash` and `POST /gmail/v1/users/:userId/messages/:id/untrash`
+- `POST /gmail/v1/users/:userId/threads/:id/modify` - add/remove labels across a thread
+- `GET /gmail/v1/users/:userId/threads` and `GET /gmail/v1/users/:userId/threads/:id`
+- `GET /gmail/v1/users/:userId/labels`, `POST /gmail/v1/users/:userId/labels`, `PATCH /gmail/v1/users/:userId/labels/:id`, `DELETE /gmail/v1/users/:userId/labels/:id`
+
+The Google plugin still does not cover the entire Gmail API, but messages, threads, and labels can now be created and mutated through the API itself, so large seed configs are optional rather than required.
 
 ## Architecture
 
@@ -406,7 +434,7 @@ packages/
     core/           # HTTP server, in-memory store, plugin interface, middleware
     vercel/         # Vercel API service
     github/         # GitHub API service
-    google/         # Google OAuth 2.0 / OIDC
+    google/         # Google OAuth 2.0 / OIDC + Gmail APIs for consumer and Workspace accounts
 apps/
   web/              # Documentation site (Next.js)
 ```

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -89,3 +89,21 @@ google:
       name: Code App (Google)
       redirect_uris:
         - http://localhost:3000/api/auth/callback/google
+  labels:
+    - id: Label_ops
+      user_email: testuser@gmail.com
+      name: Ops/Review
+      color_background: "#DDEEFF"
+      color_text: "#111111"
+  messages:
+    - id: msg_welcome
+      user_email: testuser@gmail.com
+      from: welcome@example.com
+      to: testuser@gmail.com
+      subject: Welcome to the Gmail emulator
+      body_text: You can now test Gmail messages, threads, and labels locally.
+      label_ids:
+        - INBOX
+        - UNREAD
+        - CATEGORY_UPDATES
+      date: 2025-01-04T10:00:00.000Z

--- a/packages/@internal/google/src/__tests__/google.test.ts
+++ b/packages/@internal/google/src/__tests__/google.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { Hono } from "hono";
-import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@internal/core";
+import {
+  Store,
+  WebhookDispatcher,
+  authMiddleware,
+  createApiErrorHandler,
+  createErrorHandler,
+  type TokenMap,
+} from "@internal/core";
 import { googlePlugin, seedFromConfig } from "../index.js";
+import { buildRawMessage } from "../helpers.js";
 
 const base = "http://localhost:4000";
 
@@ -16,18 +24,106 @@ function createTestApp() {
   });
 
   const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
   app.use("*", authMiddleware(tokenMap));
   googlePlugin.register(app as any, store, webhooks, base, tokenMap);
   googlePlugin.seed?.(store, base);
   seedFromConfig(store, base, {
     users: [{ email: "testuser@example.com", name: "Test User" }],
+    labels: [
+      {
+        id: "Label_ops",
+        user_email: "testuser@example.com",
+        name: "Ops/Review",
+        color_background: "#DDEEFF",
+        color_text: "#111111",
+      },
+    ],
+    messages: [
+      {
+        id: "msg_support_1",
+        thread_id: "thread_support",
+        user_email: "testuser@example.com",
+        from: "Support <support@example.com>",
+        to: "testuser@example.com",
+        subject: "Your support ticket has been updated",
+        body_text: "We have an update on your ticket.",
+        label_ids: ["INBOX", "UNREAD", "Label_ops"],
+        date: "2025-01-04T10:00:00.000Z",
+      },
+      {
+        id: "msg_support_2",
+        thread_id: "thread_support",
+        user_email: "testuser@example.com",
+        from: "testuser@example.com",
+        to: "Support <support@example.com>",
+        subject: "Re: Your support ticket has been updated",
+        body_text: "Thanks for the update.",
+        label_ids: ["SENT"],
+        date: "2025-01-04T11:00:00.000Z",
+        references: "<msg_support_1@emulate.google.local>",
+        in_reply_to: "<msg_support_1@emulate.google.local>",
+      },
+      {
+        id: "msg_invoice",
+        thread_id: "thread_billing",
+        user_email: "testuser@example.com",
+        from: "Billing <billing@example.com>",
+        to: "testuser@example.com",
+        subject: "Invoice ready for review",
+        body_text: "Your January invoice is ready to review.",
+        label_ids: ["INBOX", "CATEGORY_UPDATES"],
+        date: "2025-01-03T10:00:00.000Z",
+      },
+      {
+        id: "msg_release",
+        thread_id: "thread_release",
+        user_email: "testuser@example.com",
+        from: "Releases <release@example.com>",
+        to: "testuser@example.com",
+        subject: "Release notes available",
+        body_html: "<p>The latest release is ready.</p>",
+        label_ids: ["INBOX", "UNREAD", "CATEGORY_UPDATES"],
+        date: "2025-01-02T10:00:00.000Z",
+      },
+      {
+        id: "msg_draft",
+        thread_id: "thread_draft",
+        user_email: "testuser@example.com",
+        from: "testuser@example.com",
+        to: "partner@example.com",
+        subject: "Draft follow-up",
+        body_text: "This draft should only appear when not filtered.",
+        label_ids: ["DRAFT"],
+        date: "2025-01-01T10:00:00.000Z",
+      },
+    ],
   });
 
-  return { app, store, webhooks, tokenMap };
+  return { app };
 }
 
-function authHeaders(): HeadersInit {
-  return { Authorization: "Bearer test-token" };
+function authHeaders(extra?: HeadersInit): HeadersInit {
+  return { Authorization: "Bearer test-token", ...extra };
+}
+
+async function jsonRequest(
+  app: Hono,
+  path: string,
+  init?: RequestInit & { body?: unknown },
+) {
+  const headers = authHeaders({ "Content-Type": "application/json", ...(init?.headers ?? {}) });
+  const body =
+    init?.body === undefined || typeof init.body === "string"
+      ? (init?.body as BodyInit | undefined)
+      : JSON.stringify(init.body);
+
+  return app.request(`${base}${path}`, {
+    ...init,
+    headers,
+    body,
+  });
 }
 
 describe("Google plugin integration", () => {
@@ -37,41 +133,268 @@ describe("Google plugin integration", () => {
     app = createTestApp().app;
   });
 
-  it("GET /oauth2/v2/userinfo returns user info for a valid token", async () => {
+  it("returns user info for a valid token", async () => {
     const res = await app.request(`${base}/oauth2/v2/userinfo`, { headers: authHeaders() });
     expect(res.status).toBe(200);
+
     const body = (await res.json()) as {
       sub: string;
       email: string;
       email_verified: boolean;
       name: string;
     };
+
     expect(body.sub).toBeDefined();
     expect(body.email).toBe("testuser@example.com");
     expect(body.email_verified).toBe(true);
     expect(body.name).toBe("Test User");
   });
 
-  it("GET /.well-known/openid-configuration returns OpenID Connect discovery document", async () => {
-    const res = await app.request(`${base}/.well-known/openid-configuration`);
+  it("lists paginated messages with Gmail-style filters", async () => {
+    const res = await app.request(
+      `${base}/gmail/v1/users/me/messages?maxResults=2&q=${encodeURIComponent("-label:DRAFT in:inbox")}`,
+      { headers: authHeaders() },
+    );
+
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      issuer: string;
-      authorization_endpoint: string;
-      userinfo_endpoint: string;
+      messages: Array<{ id: string; threadId: string }>;
+      nextPageToken?: string;
+      resultSizeEstimate: number;
     };
-    expect(body.issuer).toBe(base);
-    expect(body.authorization_endpoint).toContain("/o/oauth2/v2/auth");
-    expect(body.userinfo_endpoint).toContain("/oauth2/v2/userinfo");
+
+    expect(body.messages).toEqual([
+      { id: "msg_support_1", threadId: "thread_support" },
+      { id: "msg_invoice", threadId: "thread_billing" },
+    ]);
+    expect(body.nextPageToken).toBe("2");
+    expect(body.resultSizeEstimate).toBe(3);
   });
 
-  it("GET /o/oauth2/v2/auth returns an HTML sign-in page", async () => {
-    const url = `${base}/o/oauth2/v2/auth?client_id=test-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=openid%20email`;
-    const res = await app.request(url);
-    expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toMatch(/text\/html/);
-    const html = await res.text();
-    expect(html.length).toBeGreaterThan(0);
-    expect(html).toMatch(/Sign in/i);
+  it("returns message payloads in metadata and raw formats", async () => {
+    const metadataRes = await app.request(
+      `${base}/gmail/v1/users/me/messages/msg_release?format=metadata&metadataHeaders=Subject&metadataHeaders=From`,
+      { headers: authHeaders() },
+    );
+
+    expect(metadataRes.status).toBe(200);
+    const metadataBody = (await metadataRes.json()) as {
+      payload: { headers: Array<{ name: string; value: string }>; body: { size: number } };
+    };
+
+    expect(metadataBody.payload.headers).toEqual([
+      { name: "From", value: "Releases <release@example.com>" },
+      { name: "Subject", value: "Release notes available" },
+    ]);
+    expect(metadataBody.payload.body.size).toBe(0);
+
+    const rawRes = await app.request(`${base}/gmail/v1/users/me/messages/msg_release?format=raw`, {
+      headers: authHeaders(),
+    });
+    const rawBody = (await rawRes.json()) as { raw?: string };
+    expect(rawBody.raw).toBeDefined();
+  });
+
+  it("creates sent messages and appends them to existing threads", async () => {
+    const raw = buildRawMessage({
+      from: "testuser@example.com",
+      to: "Support <support@example.com>",
+      subject: "Re: Your support ticket has been updated",
+      body_text: "Closing the loop from the emulator.",
+      message_id: "<outbound-1@example.com>",
+      in_reply_to: "<msg_support_1@emulate.google.local>",
+      references: "<msg_support_1@emulate.google.local>",
+    });
+
+    const sendRes = await jsonRequest(app, "/gmail/v1/users/me/messages/send", {
+      method: "POST",
+      body: {
+        threadId: "thread_support",
+        raw,
+      },
+    });
+
+    expect(sendRes.status).toBe(200);
+    const sent = (await sendRes.json()) as {
+      id: string;
+      threadId: string;
+      labelIds: string[];
+    };
+
+    expect(sent.threadId).toBe("thread_support");
+    expect(sent.labelIds).toContain("SENT");
+
+    const threadRes = await app.request(`${base}/gmail/v1/users/me/threads/thread_support`, {
+      headers: authHeaders(),
+    });
+    expect(threadRes.status).toBe(200);
+    const thread = (await threadRes.json()) as {
+      messages: Array<{ id: string }>;
+    };
+    expect(thread.messages).toHaveLength(3);
+  });
+
+  it("modifies, batches, trashes, and deletes messages", async () => {
+    const labelRes = await jsonRequest(app, "/gmail/v1/users/me/labels", {
+      method: "POST",
+      body: { name: "Projects/Alpha" },
+    });
+    const label = (await labelRes.json()) as { id: string };
+
+    const modifyRes = await jsonRequest(app, "/gmail/v1/users/me/messages/msg_invoice/modify", {
+      method: "POST",
+      body: { addLabelIds: [label.id], removeLabelIds: ["INBOX"] },
+    });
+    expect(modifyRes.status).toBe(200);
+    const modified = (await modifyRes.json()) as { labelIds: string[] };
+    expect(modified.labelIds).toContain(label.id);
+    expect(modified.labelIds).not.toContain("INBOX");
+
+    const batchModifyRes = await jsonRequest(app, "/gmail/v1/users/me/messages/batchModify", {
+      method: "POST",
+      body: { ids: ["msg_support_1", "msg_release"], addLabelIds: ["STARRED"], removeLabelIds: ["UNREAD"] },
+    });
+    expect(batchModifyRes.status).toBe(204);
+
+    const supportRes = await app.request(`${base}/gmail/v1/users/me/messages/msg_support_1`, {
+      headers: authHeaders(),
+    });
+    const support = (await supportRes.json()) as { labelIds: string[] };
+    expect(support.labelIds).toContain("STARRED");
+    expect(support.labelIds).not.toContain("UNREAD");
+
+    const trashRes = await jsonRequest(app, "/gmail/v1/users/me/messages/msg_release/trash", {
+      method: "POST",
+    });
+    const trashed = (await trashRes.json()) as { labelIds: string[] };
+    expect(trashed.labelIds).toContain("TRASH");
+    expect(trashed.labelIds).not.toContain("INBOX");
+
+    const untrashRes = await jsonRequest(app, "/gmail/v1/users/me/messages/msg_release/untrash", {
+      method: "POST",
+    });
+    const untrashed = (await untrashRes.json()) as { labelIds: string[] };
+    expect(untrashed.labelIds).toContain("INBOX");
+    expect(untrashed.labelIds).not.toContain("TRASH");
+
+    const batchDeleteRes = await jsonRequest(app, "/gmail/v1/users/me/messages/batchDelete", {
+      method: "POST",
+      body: { ids: ["msg_draft"] },
+    });
+    expect(batchDeleteRes.status).toBe(204);
+
+    const deletedRes = await app.request(`${base}/gmail/v1/users/me/messages/msg_draft`, {
+      headers: authHeaders(),
+    });
+    expect(deletedRes.status).toBe(404);
+  });
+
+  it("lists, gets, and mutates threads", async () => {
+    const listRes = await app.request(
+      `${base}/gmail/v1/users/me/threads?maxResults=10&q=${encodeURIComponent("-label:DRAFT")}`,
+      { headers: authHeaders() },
+    );
+    expect(listRes.status).toBe(200);
+
+    const listBody = (await listRes.json()) as {
+      threads: Array<{ id: string; snippet: string; historyId: string }>;
+    };
+    expect(listBody.threads.map((thread) => thread.id)).toEqual([
+      "thread_support",
+      "thread_billing",
+      "thread_release",
+    ]);
+
+    const modifyRes = await jsonRequest(app, "/gmail/v1/users/me/threads/thread_support/modify", {
+      method: "POST",
+      body: { addLabelIds: ["IMPORTANT"], removeLabelIds: ["UNREAD"] },
+    });
+    expect(modifyRes.status).toBe(200);
+
+    const thread = (await modifyRes.json()) as {
+      messages: Array<{ labelIds: string[] }>;
+    };
+    expect(thread.messages.every((message) => message.labelIds.includes("IMPORTANT"))).toBe(true);
+    expect(thread.messages.some((message) => message.labelIds.includes("UNREAD"))).toBe(false);
+
+    const trashRes = await jsonRequest(app, "/gmail/v1/users/me/threads/thread_support/trash", {
+      method: "POST",
+    });
+    expect(trashRes.status).toBe(200);
+
+    const hiddenListRes = await app.request(`${base}/gmail/v1/users/me/threads`, {
+      headers: authHeaders(),
+    });
+    const hiddenList = (await hiddenListRes.json()) as { threads: Array<{ id: string }> };
+    expect(hiddenList.threads.some((threadItem) => threadItem.id === "thread_support")).toBe(false);
+
+    const untrashRes = await jsonRequest(app, "/gmail/v1/users/me/threads/thread_support/untrash", {
+      method: "POST",
+    });
+    expect(untrashRes.status).toBe(200);
+
+    const deleteRes = await app.request(`${base}/gmail/v1/users/me/threads/thread_billing`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleteRes.status).toBe(204);
+  });
+
+  it("creates, updates, and deletes user labels", async () => {
+    const createRes = await jsonRequest(app, "/gmail/v1/users/me/labels", {
+      method: "POST",
+      body: {
+        name: "Inbox Zero/Follow Up",
+        messageListVisibility: "show",
+        labelListVisibility: "labelShow",
+        color: {
+          backgroundColor: "#ABCDEF",
+          textColor: "#123456",
+        },
+      },
+    });
+
+    expect(createRes.status).toBe(200);
+    const created = (await createRes.json()) as { id: string; name: string; color?: { backgroundColor?: string } };
+    expect(created.name).toBe("Inbox Zero/Follow Up");
+    expect(created.color?.backgroundColor).toBe("#ABCDEF");
+
+    await jsonRequest(app, "/gmail/v1/users/me/messages/msg_invoice/modify", {
+      method: "POST",
+      body: { addLabelIds: [created.id] },
+    });
+
+    const patchRes = await jsonRequest(app, `/gmail/v1/users/me/labels/${created.id}`, {
+      method: "PATCH",
+      body: {
+        name: "Inbox Zero/Done",
+        color: {
+          backgroundColor: "#FEDCBA",
+          textColor: "#654321",
+        },
+      },
+    });
+    expect(patchRes.status).toBe(200);
+    const patched = (await patchRes.json()) as { name: string; color?: { backgroundColor?: string } };
+    expect(patched.name).toBe("Inbox Zero/Done");
+    expect(patched.color?.backgroundColor).toBe("#FEDCBA");
+
+    const getRes = await app.request(`${base}/gmail/v1/users/me/labels/${created.id}`, {
+      headers: authHeaders(),
+    });
+    const fetched = (await getRes.json()) as { messagesTotal: number };
+    expect(fetched.messagesTotal).toBe(1);
+
+    const deleteRes = await app.request(`${base}/gmail/v1/users/me/labels/${created.id}`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleteRes.status).toBe(204);
+
+    const messageRes = await app.request(`${base}/gmail/v1/users/me/messages/msg_invoice`, {
+      headers: authHeaders(),
+    });
+    const message = (await messageRes.json()) as { labelIds: string[] };
+    expect(message.labelIds).not.toContain(created.id);
   });
 });

--- a/packages/@internal/google/src/entities.ts
+++ b/packages/@internal/google/src/entities.ts
@@ -17,3 +17,37 @@ export interface GoogleOAuthClient extends Entity {
   name: string;
   redirect_uris: string[];
 }
+
+export interface GoogleMessage extends Entity {
+  gmail_id: string;
+  thread_id: string;
+  user_email: string;
+  history_id: string;
+  internal_date: string;
+  raw: string | null;
+  label_ids: string[];
+  snippet: string;
+  subject: string;
+  from: string;
+  to: string;
+  cc: string | null;
+  bcc: string | null;
+  reply_to: string | null;
+  message_id: string;
+  references: string | null;
+  in_reply_to: string | null;
+  date_header: string;
+  body_text: string | null;
+  body_html: string | null;
+}
+
+export interface GoogleLabel extends Entity {
+  gmail_id: string;
+  user_email: string;
+  name: string;
+  type: "system" | "user";
+  message_list_visibility: string | null;
+  label_list_visibility: string | null;
+  color_background: string | null;
+  color_text: string | null;
+}

--- a/packages/@internal/google/src/helpers.ts
+++ b/packages/@internal/google/src/helpers.ts
@@ -1,6 +1,1008 @@
 import { randomBytes } from "crypto";
+import type { Context } from "hono";
+import type { GoogleLabel, GoogleMessage } from "./entities.js";
+import type { GoogleStore } from "./store.js";
+
+export type GmailMessageFormat = "full" | "metadata" | "minimal" | "raw";
+
+export interface GoogleMessageInput {
+  gmail_id?: string;
+  thread_id?: string;
+  user_email: string;
+  raw?: string | null;
+  from?: string;
+  to?: string;
+  cc?: string | null;
+  bcc?: string | null;
+  reply_to?: string | null;
+  subject?: string;
+  snippet?: string;
+  body_text?: string | null;
+  body_html?: string | null;
+  label_ids?: string[];
+  date?: string;
+  internal_date?: string;
+  message_id?: string;
+  references?: string | null;
+  in_reply_to?: string | null;
+}
+
+export interface GoogleLabelInput {
+  gmail_id?: string;
+  user_email: string;
+  name: string;
+  type?: "system" | "user";
+  message_list_visibility?: string | null;
+  label_list_visibility?: string | null;
+  color_background?: string | null;
+  color_text?: string | null;
+}
+
+type ParsedRawMessage = {
+  raw: string;
+  from: string;
+  to: string;
+  cc: string | null;
+  bcc: string | null;
+  reply_to: string | null;
+  subject: string;
+  message_id: string | null;
+  references: string | null;
+  in_reply_to: string | null;
+  date_header: string | null;
+  body_text: string | null;
+  body_html: string | null;
+};
+
+const SYSTEM_LABELS: Array<{
+  gmail_id: string;
+  name: string;
+  message_list_visibility: string | null;
+  label_list_visibility: string | null;
+}> = [
+  { gmail_id: "INBOX", name: "INBOX", message_list_visibility: "show", label_list_visibility: "labelShow" },
+  { gmail_id: "SENT", name: "SENT", message_list_visibility: "show", label_list_visibility: "labelShow" },
+  { gmail_id: "UNREAD", name: "UNREAD", message_list_visibility: "show", label_list_visibility: "labelShow" },
+  { gmail_id: "STARRED", name: "STARRED", message_list_visibility: "show", label_list_visibility: "labelShow" },
+  { gmail_id: "IMPORTANT", name: "IMPORTANT", message_list_visibility: "show", label_list_visibility: "labelShow" },
+  { gmail_id: "TRASH", name: "TRASH", message_list_visibility: "show", label_list_visibility: "labelShow" },
+  { gmail_id: "SPAM", name: "SPAM", message_list_visibility: "show", label_list_visibility: "labelShow" },
+  { gmail_id: "DRAFT", name: "DRAFT", message_list_visibility: "hide", label_list_visibility: "labelHide" },
+  {
+    gmail_id: "CATEGORY_PERSONAL",
+    name: "CATEGORY_PERSONAL",
+    message_list_visibility: "hide",
+    label_list_visibility: "labelHide",
+  },
+  {
+    gmail_id: "CATEGORY_SOCIAL",
+    name: "CATEGORY_SOCIAL",
+    message_list_visibility: "hide",
+    label_list_visibility: "labelHide",
+  },
+  {
+    gmail_id: "CATEGORY_PROMOTIONS",
+    name: "CATEGORY_PROMOTIONS",
+    message_list_visibility: "hide",
+    label_list_visibility: "labelHide",
+  },
+  {
+    gmail_id: "CATEGORY_UPDATES",
+    name: "CATEGORY_UPDATES",
+    message_list_visibility: "hide",
+    label_list_visibility: "labelHide",
+  },
+  {
+    gmail_id: "CATEGORY_FORUMS",
+    name: "CATEGORY_FORUMS",
+    message_list_visibility: "hide",
+    label_list_visibility: "labelHide",
+  },
+];
+
+const SYSTEM_LABEL_IDS = new Set(SYSTEM_LABELS.map((label) => label.gmail_id));
+
+const LABEL_ALIASES: Record<string, string> = {
+  inbox: "INBOX",
+  sent: "SENT",
+  draft: "DRAFT",
+  drafts: "DRAFT",
+  unread: "UNREAD",
+  starred: "STARRED",
+  important: "IMPORTANT",
+  spam: "SPAM",
+  trash: "TRASH",
+  personal: "CATEGORY_PERSONAL",
+  social: "CATEGORY_SOCIAL",
+  promotions: "CATEGORY_PROMOTIONS",
+  updates: "CATEGORY_UPDATES",
+  forums: "CATEGORY_FORUMS",
+};
 
 export function generateUid(prefix = ""): string {
   const id = randomBytes(12).toString("base64url").slice(0, 20);
   return prefix ? `${prefix}_${id}` : id;
+}
+
+export function generateHistoryId(): string {
+  return `${Date.now()}${randomBytes(2).toString("hex")}`;
+}
+
+export function getAuthenticatedEmail(c: Context): string | null {
+  const authUser = c.get("authUser");
+  return authUser?.login ?? null;
+}
+
+export function matchesRequestedUser(userId: string, authEmail: string): boolean {
+  return userId === "me" || userId === authEmail;
+}
+
+export function gmailError(
+  c: Context,
+  code: number,
+  message: string,
+  reason: string,
+  status: string,
+) {
+  return c.json(
+    {
+      error: {
+        code,
+        message,
+        errors: [
+          {
+            message,
+            domain: "global",
+            reason,
+          },
+        ],
+        status,
+      },
+    },
+    code as 400 | 401 | 404,
+  );
+}
+
+export function parseFormat(value: string | null): GmailMessageFormat {
+  if (value === "metadata" || value === "minimal" || value === "raw") return value;
+  return "full";
+}
+
+export function parseOffset(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return 0;
+  return parsed;
+}
+
+export function normalizeLimit(value: string | null | undefined, fallback: number, max = 500): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) return fallback;
+  return Math.max(1, Math.min(max, parsed));
+}
+
+export function parseBooleanParam(value: string | null | undefined): boolean {
+  return value === "true" || value === "1";
+}
+
+export function ensureSystemLabels(gs: GoogleStore, userEmail: string): void {
+  for (const label of SYSTEM_LABELS) {
+    const existing = gs.labels
+      .findBy("user_email", userEmail)
+      .find((row) => row.gmail_id === label.gmail_id);
+    if (existing) continue;
+
+    gs.labels.insert({
+      gmail_id: label.gmail_id,
+      user_email: userEmail,
+      name: label.name,
+      type: "system",
+      message_list_visibility: label.message_list_visibility,
+      label_list_visibility: label.label_list_visibility,
+      color_background: null,
+      color_text: null,
+    });
+  }
+}
+
+export function ensureCustomLabel(
+  gs: GoogleStore,
+  userEmail: string,
+  labelId: string,
+  name = labelId,
+): GoogleLabel {
+  ensureSystemLabels(gs, userEmail);
+
+  const existing = findLabelById(gs, userEmail, labelId);
+  if (existing) return existing;
+
+  return gs.labels.insert({
+    gmail_id: labelId,
+    user_email: userEmail,
+    name,
+    type: "user",
+    message_list_visibility: "show",
+    label_list_visibility: "labelShow",
+    color_background: null,
+    color_text: null,
+  });
+}
+
+export function createLabelRecord(gs: GoogleStore, input: GoogleLabelInput): GoogleLabel {
+  ensureSystemLabels(gs, input.user_email);
+
+  const labelId = input.gmail_id ?? `Label_${randomBytes(8).toString("hex")}`;
+
+  return gs.labels.insert({
+    gmail_id: labelId,
+    user_email: input.user_email,
+    name: input.name,
+    type: input.type ?? "user",
+    message_list_visibility: input.message_list_visibility ?? "show",
+    label_list_visibility: input.label_list_visibility ?? "labelShow",
+    color_background: input.color_background ?? null,
+    color_text: input.color_text ?? null,
+  });
+}
+
+export function updateLabelRecord(
+  gs: GoogleStore,
+  label: GoogleLabel,
+  input: Partial<GoogleLabelInput>,
+): GoogleLabel {
+  return (
+    gs.labels.update(label.id, {
+      name: input.name !== undefined ? input.name : label.name,
+      message_list_visibility:
+        input.message_list_visibility !== undefined
+          ? input.message_list_visibility
+          : label.message_list_visibility,
+      label_list_visibility:
+        input.label_list_visibility !== undefined
+          ? input.label_list_visibility
+          : label.label_list_visibility,
+      color_background:
+        input.color_background !== undefined ? input.color_background : label.color_background,
+      color_text: input.color_text !== undefined ? input.color_text : label.color_text,
+    }) ?? label
+  );
+}
+
+export function isSystemLabelId(labelId: string): boolean {
+  return SYSTEM_LABEL_IDS.has(labelId);
+}
+
+export function findLabelById(gs: GoogleStore, userEmail: string, labelId: string): GoogleLabel | undefined {
+  return gs.labels.findBy("user_email", userEmail).find((label) => label.gmail_id === labelId);
+}
+
+export function findLabelByName(gs: GoogleStore, userEmail: string, name: string): GoogleLabel | undefined {
+  const normalized = name.trim().toLowerCase();
+  return gs.labels.findBy("user_email", userEmail).find((label) => label.name.trim().toLowerCase() === normalized);
+}
+
+export function listLabelsForUser(gs: GoogleStore, userEmail: string): GoogleLabel[] {
+  ensureSystemLabels(gs, userEmail);
+  return gs.labels
+    .findBy("user_email", userEmail)
+    .sort((a, b) => {
+      if (a.type !== b.type) return a.type === "system" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+export function formatLabelResource(gs: GoogleStore, label: GoogleLabel) {
+  const messages = gs.messages
+    .findBy("user_email", label.user_email)
+    .filter((message) => message.label_ids.includes(label.gmail_id));
+
+  const threadIds = new Set(messages.map((message) => message.thread_id));
+  const unreadMessages = messages.filter((message) => message.label_ids.includes("UNREAD"));
+  const unreadThreadIds = new Set(unreadMessages.map((message) => message.thread_id));
+
+  return {
+    id: label.gmail_id,
+    name: label.name,
+    type: label.type === "system" ? "system" : "user",
+    messageListVisibility: label.message_list_visibility ?? undefined,
+    labelListVisibility: label.label_list_visibility ?? undefined,
+    messagesTotal: messages.length,
+    messagesUnread: unreadMessages.length,
+    threadsTotal: threadIds.size,
+    threadsUnread: unreadThreadIds.size,
+    color:
+      label.color_background || label.color_text
+        ? {
+            backgroundColor: label.color_background ?? undefined,
+            textColor: label.color_text ?? undefined,
+          }
+        : undefined,
+  };
+}
+
+export function normalizeLabelQuery(value: string): string {
+  const cleaned = cleanToken(value);
+  const alias = LABEL_ALIASES[cleaned.toLowerCase()];
+  return alias ?? cleaned;
+}
+
+export function findMissingLabelIds(gs: GoogleStore, userEmail: string, labelIds: string[]): string[] {
+  ensureSystemLabels(gs, userEmail);
+  return labelIds.filter((labelId) => !findLabelById(gs, userEmail, labelId));
+}
+
+export function dedupeLabelIds(labelIds: string[]): string[] {
+  return [...new Set(labelIds.filter(Boolean))];
+}
+
+export function createStoredMessage(
+  gs: GoogleStore,
+  input: GoogleMessageInput,
+  options?: {
+    defaultLabelIds?: string[];
+    createMissingCustomLabels?: boolean;
+  },
+): GoogleMessage {
+  ensureSystemLabels(gs, input.user_email);
+
+  const parsedRaw = input.raw ? parseRawMessage(input.raw) : null;
+  const merged = {
+    raw: input.raw ?? null,
+    from: input.from ?? parsedRaw?.from ?? "",
+    to: input.to ?? parsedRaw?.to ?? "",
+    cc: input.cc ?? parsedRaw?.cc ?? null,
+    bcc: input.bcc ?? parsedRaw?.bcc ?? null,
+    reply_to: input.reply_to ?? parsedRaw?.reply_to ?? null,
+    subject: input.subject ?? parsedRaw?.subject ?? "",
+    body_text: input.body_text ?? parsedRaw?.body_text ?? null,
+    body_html: input.body_html ?? parsedRaw?.body_html ?? null,
+    message_id: input.message_id ?? parsedRaw?.message_id ?? null,
+    references: input.references ?? parsedRaw?.references ?? null,
+    in_reply_to: input.in_reply_to ?? parsedRaw?.in_reply_to ?? null,
+    date_header: input.date ?? parsedRaw?.date_header ?? null,
+  };
+
+  const internalDateMs = resolveInternalDate(input.internal_date ?? input.date ?? parsedRaw?.date_header ?? undefined);
+  const gmailId = input.gmail_id ?? generateUid("msg");
+  const threadId = resolveThreadId(gs, input.user_email, input.thread_id, merged.in_reply_to, merged.references);
+  const messageId = merged.message_id ?? `<${gmailId}@emulate.google.local>`;
+  const labelIds = dedupeLabelIds(input.label_ids ?? options?.defaultLabelIds ?? []);
+
+  if (options?.createMissingCustomLabels) {
+    for (const labelId of labelIds.filter((labelId) => !isSystemLabelId(labelId))) {
+      ensureCustomLabel(gs, input.user_email, labelId);
+    }
+  }
+
+  const snippet = (input.snippet?.trim() || deriveSnippet(merged.body_text ?? merged.body_html ?? merged.subject)) || merged.subject;
+  const raw = merged.raw ?? buildRawMessage({
+    from: merged.from,
+    to: merged.to,
+    cc: merged.cc,
+    bcc: merged.bcc,
+    reply_to: merged.reply_to,
+    subject: merged.subject,
+    body_text: merged.body_text,
+    body_html: merged.body_html,
+    message_id: messageId,
+    references: merged.references,
+    in_reply_to: merged.in_reply_to,
+    date_header: new Date(internalDateMs).toUTCString(),
+  });
+
+  return gs.messages.insert({
+    gmail_id: gmailId,
+    thread_id: threadId,
+    user_email: input.user_email,
+    history_id: generateHistoryId(),
+    internal_date: String(internalDateMs),
+    raw,
+    label_ids: labelIds,
+    snippet,
+    subject: merged.subject,
+    from: merged.from,
+    to: merged.to,
+    cc: merged.cc,
+    bcc: merged.bcc,
+    reply_to: merged.reply_to,
+    message_id: messageId,
+    references: merged.references,
+    in_reply_to: merged.in_reply_to,
+    date_header: new Date(internalDateMs).toUTCString(),
+    body_text: merged.body_text,
+    body_html: merged.body_html,
+  });
+}
+
+function resolveInternalDate(value: string | undefined): number {
+  if (!value) return Date.now();
+
+  if (/^\d+$/.test(value)) {
+    const parsed = Number.parseInt(value, 10);
+    if (String(parsed).length >= 13) return parsed;
+    return parsed * 1000;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function resolveThreadId(
+  gs: GoogleStore,
+  userEmail: string,
+  explicitThreadId: string | undefined,
+  inReplyTo: string | null,
+  references: string | null,
+): string {
+  if (explicitThreadId) return explicitThreadId;
+
+  const linkedIds = [inReplyTo, references]
+    .flatMap((value) => (value ? value.split(/\s+/) : []))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  for (const headerMessageId of linkedIds) {
+    const linkedMessage = gs.messages
+      .findBy("user_email", userEmail)
+      .find((message) => message.message_id === headerMessageId);
+    if (linkedMessage) return linkedMessage.thread_id;
+  }
+
+  return generateUid("thr");
+}
+
+export function getMessageById(gs: GoogleStore, userEmail: string, messageId: string): GoogleMessage | undefined {
+  return gs.messages
+    .findBy("user_email", userEmail)
+    .find((message) => message.gmail_id === messageId);
+}
+
+export function listMessagesForUser(
+  gs: GoogleStore,
+  userEmail: string,
+  options?: {
+    labelIds?: string[];
+    query?: string;
+    includeSpamTrash?: boolean;
+  },
+): GoogleMessage[] {
+  let messages = gs.messages.findBy("user_email", userEmail);
+
+  if (!options?.includeSpamTrash) {
+    messages = messages.filter(
+      (message) => !message.label_ids.includes("TRASH") && !message.label_ids.includes("SPAM"),
+    );
+  }
+
+  if (options?.labelIds?.length) {
+    messages = messages.filter((message) => options.labelIds!.every((labelId) => message.label_ids.includes(labelId)));
+  }
+
+  if (options?.query) {
+    const matcher = buildMessageQueryMatcher(gs, userEmail, options.query);
+    messages = messages.filter(matcher);
+  }
+
+  return sortMessagesByDateDesc(messages);
+}
+
+export function groupThreads(messages: GoogleMessage[]): Array<{
+  id: string;
+  snippet: string;
+  historyId: string;
+  messages: GoogleMessage[];
+}> {
+  const threadMap = new Map<string, GoogleMessage[]>();
+
+  for (const message of messages) {
+    const existing = threadMap.get(message.thread_id);
+    if (existing) existing.push(message);
+    else threadMap.set(message.thread_id, [message]);
+  }
+
+  return Array.from(threadMap.entries())
+    .map(([threadId, entries]) => {
+      const ordered = sortMessagesByDateAsc(entries);
+      const latest = ordered.at(-1)!;
+      return {
+        id: threadId,
+        snippet: latest.snippet,
+        historyId: latest.history_id,
+        messages: ordered,
+      };
+    })
+    .sort((a, b) => Number(b.messages.at(-1)?.internal_date ?? 0) - Number(a.messages.at(-1)?.internal_date ?? 0));
+}
+
+export function getThreadMessages(
+  gs: GoogleStore,
+  userEmail: string,
+  threadId: string,
+  options?: { includeSpamTrash?: boolean },
+): GoogleMessage[] {
+  let messages = gs.messages
+    .findBy("user_email", userEmail)
+    .filter((message) => message.thread_id === threadId);
+
+  if (!options?.includeSpamTrash) {
+    messages = messages.filter(
+      (message) => !message.label_ids.includes("TRASH") && !message.label_ids.includes("SPAM"),
+    );
+  }
+
+  return sortMessagesByDateAsc(messages);
+}
+
+export function formatMessageResource(
+  message: GoogleMessage,
+  format: GmailMessageFormat,
+  metadataHeaders: string[] = [],
+) {
+  const headers = buildHeaders(message);
+  const filteredHeaders =
+    format === "metadata" && metadataHeaders.length > 0
+      ? headers.filter((header) => metadataHeaders.includes(header.name))
+      : headers;
+
+  const base = {
+    id: message.gmail_id,
+    threadId: message.thread_id,
+    labelIds: message.label_ids,
+    snippet: message.snippet,
+    historyId: message.history_id,
+    internalDate: message.internal_date,
+    sizeEstimate: estimateSize(message),
+  };
+
+  if (format === "minimal") return base;
+  if (format === "raw") return { ...base, raw: message.raw ?? undefined };
+
+  return {
+    ...base,
+    payload: buildPayload(message, filteredHeaders, format),
+  };
+}
+
+export function formatThreadResource(
+  messages: GoogleMessage[],
+  format: GmailMessageFormat,
+  metadataHeaders: string[] = [],
+) {
+  const ordered = sortMessagesByDateAsc(messages);
+  const latest = ordered.at(-1)!;
+
+  return {
+    id: latest.thread_id,
+    historyId: latest.history_id,
+    snippet: latest.snippet,
+    messages: ordered.map((message) => formatMessageResource(message, format, metadataHeaders)),
+  };
+}
+
+export function applyLabelMutation(
+  labelIds: string[],
+  addLabelIds: string[] = [],
+  removeLabelIds: string[] = [],
+): string[] {
+  const next = new Set(labelIds);
+  for (const labelId of addLabelIds) next.add(labelId);
+  for (const labelId of removeLabelIds) next.delete(labelId);
+  return [...next];
+}
+
+export function markMessageModified(
+  gs: GoogleStore,
+  message: GoogleMessage,
+  nextLabelIds: string[],
+): GoogleMessage {
+  return (
+    gs.messages.update(message.id, {
+      label_ids: dedupeLabelIds(nextLabelIds),
+      history_id: generateHistoryId(),
+    }) ?? message
+  );
+}
+
+export function trashLabelIds(labelIds: string[]): string[] {
+  const next = new Set(labelIds);
+  next.add("TRASH");
+  next.delete("INBOX");
+  return [...next];
+}
+
+export function untrashLabelIds(labelIds: string[]): string[] {
+  const next = new Set(labelIds);
+  next.delete("TRASH");
+  if (!next.has("SENT") && !next.has("DRAFT")) {
+    next.add("INBOX");
+  }
+  return [...next];
+}
+
+export function buildMessageQueryMatcher(
+  gs: GoogleStore,
+  userEmail: string,
+  query: string,
+): (message: GoogleMessage) => boolean {
+  const terms = query.match(/"[^"]+"|\S+/g) ?? [];
+  const predicates = terms.flatMap((term) => buildQueryPredicates(gs, userEmail, term));
+
+  if (!predicates.length) return () => true;
+  return (message) => predicates.every((predicate) => predicate(message));
+}
+
+function buildQueryPredicates(
+  gs: GoogleStore,
+  userEmail: string,
+  term: string,
+): Array<(message: GoogleMessage) => boolean> {
+  const cleaned = cleanToken(term);
+  if (!cleaned) return [];
+
+  const lower = cleaned.toLowerCase();
+  if (lower === "or" || lower === "and") return [];
+
+  if (lower.startsWith("-label:")) {
+    const labelQuery = cleaned.slice(7);
+    return [(message) => !messageMatchesLabelQuery(gs, userEmail, message, labelQuery)];
+  }
+
+  if (lower.startsWith("label:")) {
+    const labelQuery = cleaned.slice(6);
+    return [(message) => messageMatchesLabelQuery(gs, userEmail, message, labelQuery)];
+  }
+
+  if (lower.startsWith("in:")) {
+    const labelQuery = cleaned.slice(3);
+    return [(message) => messageMatchesLabelQuery(gs, userEmail, message, labelQuery)];
+  }
+
+  if (lower.startsWith("is:")) {
+    const state = cleaned.slice(3).toLowerCase();
+    if (state === "read") return [(message) => !message.label_ids.includes("UNREAD")];
+    return [(message) => messageMatchesLabelQuery(gs, userEmail, message, state)];
+  }
+
+  if (lower.startsWith("from:")) {
+    const value = cleaned.slice(5).toLowerCase();
+    return value ? [(message) => message.from.toLowerCase().includes(value)] : [];
+  }
+
+  if (lower.startsWith("to:")) {
+    const value = cleaned.slice(3).toLowerCase();
+    return value ? [(message) => message.to.toLowerCase().includes(value)] : [];
+  }
+
+  if (lower.startsWith("subject:")) {
+    const value = cleaned.slice(8).toLowerCase();
+    return value ? [(message) => message.subject.toLowerCase().includes(value)] : [];
+  }
+
+  if (lower.startsWith("rfc822msgid:")) {
+    const value = cleaned.slice(11).replace(/[<>]/g, "").toLowerCase();
+    return value ? [(message) => message.message_id.replace(/[<>]/g, "").toLowerCase() === value] : [];
+  }
+
+  if (lower.startsWith("before:")) {
+    const timestamp = parseDateFilter(cleaned.slice(7));
+    return timestamp != null ? [(message) => Number(message.internal_date) < timestamp] : [];
+  }
+
+  if (lower.startsWith("after:")) {
+    const timestamp = parseDateFilter(cleaned.slice(6));
+    return timestamp != null ? [(message) => Number(message.internal_date) > timestamp] : [];
+  }
+
+  if (lower === "has:attachment") {
+    return [() => false];
+  }
+
+  const value = cleaned.toLowerCase();
+  return value ? [(message) => searchableText(message).includes(value)] : [];
+}
+
+function messageMatchesLabelQuery(
+  gs: GoogleStore,
+  userEmail: string,
+  message: GoogleMessage,
+  query: string,
+): boolean {
+  const normalized = normalizeLabelQuery(query);
+  if (message.label_ids.includes(normalized)) return true;
+
+  return message.label_ids.some((labelId) => {
+    const label = findLabelById(gs, userEmail, labelId);
+    return label?.name.toLowerCase() === cleanToken(query).toLowerCase();
+  });
+}
+
+function parseDateFilter(value: string): number | null {
+  const trimmed = cleanToken(value);
+  if (!trimmed) return null;
+
+  if (/^\d+$/.test(trimmed)) {
+    const parsed = Number.parseInt(trimmed, 10);
+    return String(parsed).length >= 13 ? parsed : parsed * 1000;
+  }
+
+  const parsed = Date.parse(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function searchableText(message: GoogleMessage): string {
+  return [
+    message.subject,
+    message.from,
+    message.to,
+    message.cc ?? "",
+    message.bcc ?? "",
+    message.snippet,
+    message.body_text ?? "",
+    stripHtml(message.body_html ?? ""),
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+function cleanToken(token: string): string {
+  return token
+    .trim()
+    .replace(/^[()]+/, "")
+    .replace(/[()]+$/, "")
+    .replace(/^"(.*)"$/, "$1");
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function buildHeaders(message: GoogleMessage): Array<{ name: string; value: string }> {
+  const headers: Array<{ name: string; value: string | null }> = [
+    { name: "From", value: message.from },
+    { name: "To", value: message.to },
+    { name: "Cc", value: message.cc },
+    { name: "Bcc", value: message.bcc },
+    { name: "Reply-To", value: message.reply_to },
+    { name: "Subject", value: message.subject },
+    { name: "Date", value: message.date_header },
+    { name: "Message-ID", value: message.message_id },
+    { name: "References", value: message.references },
+    { name: "In-Reply-To", value: message.in_reply_to },
+  ];
+
+  return headers.filter((header): header is { name: string; value: string } => Boolean(header.value));
+}
+
+function buildPayload(
+  message: GoogleMessage,
+  headers: Array<{ name: string; value: string }>,
+  format: GmailMessageFormat,
+) {
+  const textBody = message.body_text ?? null;
+  const htmlBody = message.body_html ?? null;
+
+  if (format === "metadata") {
+    return {
+      partId: "",
+      mimeType: htmlBody ? "text/html" : "text/plain",
+      filename: "",
+      headers,
+      body: { size: 0 },
+    };
+  }
+
+  if (textBody && htmlBody) {
+    return {
+      partId: "",
+      mimeType: "multipart/alternative",
+      filename: "",
+      headers,
+      body: { size: 0 },
+      parts: [
+        createBodyPart("0", "text/plain", textBody),
+        createBodyPart("1", "text/html", htmlBody),
+      ],
+    };
+  }
+
+  if (htmlBody) return createBodyPart("", "text/html", htmlBody, headers);
+  if (textBody) return createBodyPart("", "text/plain", textBody, headers);
+
+  return {
+    partId: "",
+    mimeType: "text/plain",
+    filename: "",
+    headers,
+    body: { size: 0 },
+  };
+}
+
+function createBodyPart(
+  partId: string,
+  mimeType: string,
+  content: string,
+  headers: Array<{ name: string; value: string }> = [],
+) {
+  return {
+    partId,
+    mimeType,
+    filename: "",
+    headers,
+    body: {
+      size: Buffer.byteLength(content, "utf8"),
+      data: Buffer.from(content, "utf8").toString("base64url"),
+    },
+  };
+}
+
+function estimateSize(message: GoogleMessage): number {
+  if (message.raw) {
+    return Buffer.byteLength(message.raw, "utf8");
+  }
+  const headers = buildHeaders(message)
+    .map((header) => `${header.name}: ${header.value}`)
+    .join("\n");
+  const body = `${message.body_text ?? ""}\n${message.body_html ?? ""}`;
+  return Buffer.byteLength(`${headers}\n\n${body}`, "utf8");
+}
+
+function deriveSnippet(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 140);
+}
+
+function sortMessagesByDateDesc(messages: GoogleMessage[]): GoogleMessage[] {
+  return [...messages].sort((a, b) => Number(b.internal_date) - Number(a.internal_date));
+}
+
+function sortMessagesByDateAsc(messages: GoogleMessage[]): GoogleMessage[] {
+  return [...messages].sort((a, b) => Number(a.internal_date) - Number(b.internal_date));
+}
+
+export function buildRawMessage(message: {
+  from: string;
+  to: string;
+  cc?: string | null;
+  bcc?: string | null;
+  reply_to?: string | null;
+  subject: string;
+  body_text?: string | null;
+  body_html?: string | null;
+  message_id?: string | null;
+  references?: string | null;
+  in_reply_to?: string | null;
+  date_header?: string | null;
+}): string {
+  const headers = [
+    `From: ${message.from}`,
+    `To: ${message.to}`,
+    ...(message.cc ? [`Cc: ${message.cc}`] : []),
+    ...(message.bcc ? [`Bcc: ${message.bcc}`] : []),
+    ...(message.reply_to ? [`Reply-To: ${message.reply_to}`] : []),
+    `Subject: ${message.subject}`,
+    ...(message.message_id ? [`Message-ID: ${message.message_id}`] : []),
+    ...(message.references ? [`References: ${message.references}`] : []),
+    ...(message.in_reply_to ? [`In-Reply-To: ${message.in_reply_to}`] : []),
+    `Date: ${message.date_header ?? new Date().toUTCString()}`,
+  ];
+
+  if (message.body_text && message.body_html) {
+    const boundary = `emulate-${randomBytes(8).toString("hex")}`;
+    headers.push(`Content-Type: multipart/alternative; boundary="${boundary}"`);
+    const body = [
+      `--${boundary}`,
+      "Content-Type: text/plain; charset=utf-8",
+      "",
+      message.body_text,
+      `--${boundary}`,
+      "Content-Type: text/html; charset=utf-8",
+      "",
+      message.body_html,
+      `--${boundary}--`,
+      "",
+    ].join("\r\n");
+    return Buffer.from(`${headers.join("\r\n")}\r\n\r\n${body}`, "utf8").toString("base64url");
+  }
+
+  headers.push(`Content-Type: ${message.body_html ? "text/html" : "text/plain"}; charset=utf-8`);
+  const body = message.body_html ?? message.body_text ?? "";
+  return Buffer.from(`${headers.join("\r\n")}\r\n\r\n${body}`, "utf8").toString("base64url");
+}
+
+function parseRawMessage(raw: string): ParsedRawMessage {
+  const decoded = Buffer.from(raw, "base64url").toString("utf8").replace(/\r\n/g, "\n");
+  const separatorIndex = decoded.indexOf("\n\n");
+  const headerText = separatorIndex >= 0 ? decoded.slice(0, separatorIndex) : decoded;
+  const bodyText = separatorIndex >= 0 ? decoded.slice(separatorIndex + 2) : "";
+  const headers = parseHeaders(headerText);
+  const contentType = (headers.get("content-type") ?? "text/plain").toLowerCase();
+
+  let parsed = {
+    text: null as string | null,
+    html: null as string | null,
+  };
+
+  if (contentType.startsWith("multipart/")) {
+    parsed = parseMultipartBody(bodyText, contentType);
+  } else if (contentType.includes("text/html")) {
+    parsed.html = bodyText.trim();
+  } else {
+    parsed.text = bodyText.trim();
+  }
+
+  return {
+    raw,
+    from: headers.get("from") ?? "",
+    to: headers.get("to") ?? "",
+    cc: headers.get("cc") ?? null,
+    bcc: headers.get("bcc") ?? null,
+    reply_to: headers.get("reply-to") ?? null,
+    subject: headers.get("subject") ?? "",
+    message_id: headers.get("message-id") ?? null,
+    references: headers.get("references") ?? null,
+    in_reply_to: headers.get("in-reply-to") ?? null,
+    date_header: headers.get("date") ?? null,
+    body_text: parsed.text,
+    body_html: parsed.html,
+  };
+}
+
+function parseHeaders(headerText: string): Map<string, string> {
+  const headers = new Map<string, string>();
+  let currentKey: string | null = null;
+
+  for (const line of headerText.split("\n")) {
+    if (!line.trim()) continue;
+
+    if ((line.startsWith(" ") || line.startsWith("\t")) && currentKey) {
+      headers.set(currentKey, `${headers.get(currentKey) ?? ""} ${line.trim()}`.trim());
+      continue;
+    }
+
+    const separator = line.indexOf(":");
+    if (separator < 0) continue;
+    currentKey = line.slice(0, separator).trim().toLowerCase();
+    headers.set(currentKey, line.slice(separator + 1).trim());
+  }
+
+  return headers;
+}
+
+function parseMultipartBody(body: string, contentType: string): { text: string | null; html: string | null } {
+  const boundaryMatch = contentType.match(/boundary="?([^";]+)"?/i);
+  const boundary = boundaryMatch?.[1];
+  if (!boundary) return { text: body.trim() || null, html: null };
+
+  let text: string | null = null;
+  let html: string | null = null;
+
+  for (const chunk of body.split(`--${boundary}`)) {
+    const trimmed = chunk.trim();
+    if (!trimmed || trimmed === "--") continue;
+
+    const separatorIndex = trimmed.indexOf("\n\n");
+    const partHeaderText = separatorIndex >= 0 ? trimmed.slice(0, separatorIndex) : trimmed;
+    const partBody = separatorIndex >= 0 ? trimmed.slice(separatorIndex + 2).trim() : "";
+    const partHeaders = parseHeaders(partHeaderText);
+    const partType = (partHeaders.get("content-type") ?? "text/plain").toLowerCase();
+
+    if (partType.startsWith("multipart/")) {
+      const nested = parseMultipartBody(partBody, partType);
+      text = text ?? nested.text;
+      html = html ?? nested.html;
+      continue;
+    }
+
+    if (partType.includes("text/plain")) {
+      text = text ?? partBody;
+    } else if (partType.includes("text/html")) {
+      html = html ?? partBody;
+    }
+  }
+
+  return { text, html };
 }

--- a/packages/@internal/google/src/index.ts
+++ b/packages/@internal/google/src/index.ts
@@ -1,64 +1,180 @@
+import type {
+  AppEnv,
+  RouteContext,
+  ServicePlugin,
+  Store,
+  TokenMap,
+  WebhookDispatcher,
+} from "@internal/core";
 import type { Hono } from "hono";
-import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@internal/core";
-import { getGoogleStore } from "./store.js";
-import { generateUid } from "./helpers.js";
+import {
+  createLabelRecord,
+  createStoredMessage,
+  ensureSystemLabels,
+  findLabelById,
+  findLabelByName,
+  generateUid,
+} from "./helpers.js";
+import { labelRoutes } from "./routes/labels.js";
+import { messageRoutes } from "./routes/messages.js";
 import { oauthRoutes } from "./routes/oauth.js";
+import { threadRoutes } from "./routes/threads.js";
+import { getGoogleStore } from "./store.js";
 
 export { getGoogleStore, type GoogleStore } from "./store.js";
 export * from "./entities.js";
 
+export interface GoogleSeedUser {
+  email: string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  picture?: string;
+  locale?: string;
+  email_verified?: boolean;
+}
+
+export interface GoogleSeedLabel {
+  id?: string;
+  user_email?: string;
+  name: string;
+  type?: "system" | "user";
+  message_list_visibility?: string;
+  label_list_visibility?: string;
+  color_background?: string;
+  color_text?: string;
+}
+
+export interface GoogleSeedMessage {
+  id?: string;
+  thread_id?: string;
+  user_email?: string;
+  raw?: string;
+  from?: string;
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  reply_to?: string;
+  subject?: string;
+  snippet?: string;
+  body_text?: string;
+  body_html?: string;
+  label_ids?: string[];
+  date?: string;
+  internal_date?: string;
+  message_id?: string;
+  references?: string;
+  in_reply_to?: string;
+}
+
 export interface GoogleSeedConfig {
   port?: number;
-  users?: Array<{
-    email: string;
-    name?: string;
-    given_name?: string;
-    family_name?: string;
-    picture?: string;
-    locale?: string;
-  }>;
+  users?: GoogleSeedUser[];
   oauth_clients?: Array<{
     client_id: string;
     client_secret: string;
-    name: string;
+    name?: string;
     redirect_uris: string[];
   }>;
+  labels?: GoogleSeedLabel[];
+  messages?: GoogleSeedMessage[];
 }
 
 function seedDefaults(store: Store, _baseUrl: string): void {
   const gs = getGoogleStore(store);
+  const defaultEmail = "testuser@gmail.com";
 
-  gs.users.insert({
-    uid: generateUid("goog"),
-    email: "testuser@gmail.com",
-    name: "Test User",
-    given_name: "Test",
-    family_name: "User",
-    picture: null,
-    email_verified: true,
-    locale: "en",
-  });
+  if (!gs.users.findOneBy("email", defaultEmail)) {
+    gs.users.insert({
+      uid: generateUid("goog"),
+      email: defaultEmail,
+      name: "Test User",
+      given_name: "Test",
+      family_name: "User",
+      picture: null,
+      email_verified: true,
+      locale: "en",
+    });
+  }
+
+  ensureSystemLabels(gs, defaultEmail);
+  seedMessages(store, [
+    {
+      id: "msg_welcome",
+      thread_id: "thr_welcome",
+      user_email: defaultEmail,
+      from: "Welcome Team <welcome@example.com>",
+      to: defaultEmail,
+      subject: "Welcome to your local Gmail emulator",
+      snippet: "Your OAuth flow is set up and Gmail message, thread, and label APIs are ready.",
+      body_text:
+        "Your OAuth flow is set up and Gmail message, thread, and label APIs are ready.\n\nUse this inbox to test Gmail automations locally.",
+      label_ids: ["INBOX", "UNREAD", "CATEGORY_UPDATES"],
+      date: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: "msg_build",
+      thread_id: "thr_build",
+      user_email: defaultEmail,
+      from: "Build Bot <builds@example.com>",
+      to: defaultEmail,
+      subject: "Nightly build finished successfully",
+      snippet: "The latest build completed successfully in 6 minutes.",
+      body_text:
+        "The latest build completed successfully in 6 minutes.\n\nArtifact upload finished and smoke checks passed.",
+      label_ids: ["INBOX", "CATEGORY_UPDATES"],
+      date: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: "msg_build_reply",
+      thread_id: "thr_build",
+      user_email: defaultEmail,
+      from: defaultEmail,
+      to: "Build Bot <builds@example.com>",
+      subject: "Re: Nightly build finished successfully",
+      snippet: "Thanks, I will review the artifact after lunch.",
+      body_text: "Thanks, I will review the artifact after lunch.",
+      label_ids: ["SENT"],
+      date: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+      in_reply_to: "<msg_build@emulate.google.local>",
+      references: "<msg_build@emulate.google.local>",
+    },
+    {
+      id: "msg_draft",
+      thread_id: "thr_draft",
+      user_email: defaultEmail,
+      from: defaultEmail,
+      to: "someone@example.com",
+      subject: "Draft follow-up",
+      snippet: "Checking in on the open question from yesterday.",
+      body_text: "Checking in on the open question from yesterday.",
+      label_ids: ["DRAFT"],
+      date: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    },
+  ], defaultEmail);
 }
 
 export function seedFromConfig(store: Store, _baseUrl: string, config: GoogleSeedConfig): void {
   const gs = getGoogleStore(store);
 
   if (config.users) {
-    for (const u of config.users) {
-      const existing = gs.users.findOneBy("email", u.email);
-      if (existing) continue;
+    for (const user of config.users) {
+      const existing = gs.users.findOneBy("email", user.email);
+      if (!existing) {
+        const nameParts = (user.name ?? "").split(/\s+/).filter(Boolean);
+        gs.users.insert({
+          uid: generateUid("goog"),
+          email: user.email,
+          name: user.name ?? user.email.split("@")[0],
+          given_name: user.given_name ?? nameParts[0] ?? "",
+          family_name: user.family_name ?? nameParts.slice(1).join(" "),
+          picture: user.picture ?? null,
+          email_verified: user.email_verified ?? true,
+          locale: user.locale ?? "en",
+        });
+      }
 
-      const nameParts = (u.name ?? "").split(/\s+/);
-      gs.users.insert({
-        uid: generateUid("goog"),
-        email: u.email,
-        name: u.name ?? u.email.split("@")[0],
-        given_name: u.given_name ?? nameParts[0] ?? "",
-        family_name: u.family_name ?? nameParts.slice(1).join(" ") ?? "",
-        picture: u.picture ?? null,
-        email_verified: true,
-        locale: u.locale ?? "en",
-      });
+      ensureSystemLabels(gs, user.email);
     }
   }
 
@@ -66,21 +182,103 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: GoogleSee
     for (const client of config.oauth_clients) {
       const existing = gs.oauthClients.findOneBy("client_id", client.client_id);
       if (existing) continue;
+
       gs.oauthClients.insert({
         client_id: client.client_id,
         client_secret: client.client_secret,
-        name: client.name,
+        name: client.name ?? "Code App (Google)",
         redirect_uris: client.redirect_uris,
       });
     }
+  }
+
+  const fallbackEmail = config.users?.[0]?.email ?? gs.users.all()[0]?.email ?? "testuser@gmail.com";
+  ensureSystemLabels(gs, fallbackEmail);
+
+  if (config.labels) {
+    seedLabels(store, config.labels, fallbackEmail);
+  }
+
+  if (config.messages) {
+    seedMessages(store, config.messages, fallbackEmail);
+  }
+}
+
+function seedLabels(store: Store, labels: GoogleSeedLabel[], fallbackEmail: string): void {
+  const gs = getGoogleStore(store);
+
+  for (const label of labels) {
+    const userEmail = label.user_email ?? fallbackEmail;
+    ensureSystemLabels(gs, userEmail);
+
+    const existing =
+      (label.id ? findLabelById(gs, userEmail, label.id) : undefined) ??
+      findLabelByName(gs, userEmail, label.name);
+
+    if (existing) continue;
+
+    createLabelRecord(gs, {
+      gmail_id: label.id,
+      user_email: userEmail,
+      name: label.name,
+      type: label.type ?? "user",
+      message_list_visibility: label.message_list_visibility ?? "show",
+      label_list_visibility: label.label_list_visibility ?? "labelShow",
+      color_background: label.color_background ?? null,
+      color_text: label.color_text ?? null,
+    });
+  }
+}
+
+function seedMessages(store: Store, messages: GoogleSeedMessage[], fallbackEmail: string): void {
+  const gs = getGoogleStore(store);
+
+  for (const message of messages) {
+    const userEmail = message.user_email ?? fallbackEmail;
+    ensureSystemLabels(gs, userEmail);
+
+    if (message.id && gs.messages.findOneBy("gmail_id", message.id)) continue;
+
+    createStoredMessage(gs, {
+      gmail_id: message.id,
+      thread_id: message.thread_id,
+      user_email: userEmail,
+      raw: message.raw ?? null,
+      from: message.from,
+      to: message.to,
+      cc: message.cc ?? null,
+      bcc: message.bcc ?? null,
+      reply_to: message.reply_to ?? null,
+      subject: message.subject,
+      snippet: message.snippet,
+      body_text: message.body_text ?? null,
+      body_html: message.body_html ?? null,
+      label_ids: message.label_ids ?? ["INBOX", "UNREAD"],
+      date: message.date,
+      internal_date: message.internal_date,
+      message_id: message.message_id,
+      references: message.references ?? null,
+      in_reply_to: message.in_reply_to ?? null,
+    }, {
+      createMissingCustomLabels: true,
+    });
   }
 }
 
 export const googlePlugin: ServicePlugin = {
   name: "google",
-  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+  register(
+    app: Hono<AppEnv>,
+    store: Store,
+    webhooks: WebhookDispatcher,
+    baseUrl: string,
+    tokenMap?: TokenMap,
+  ): void {
     const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
     oauthRoutes(ctx);
+    messageRoutes(ctx);
+    threadRoutes(ctx);
+    labelRoutes(ctx);
   },
   seed(store: Store, baseUrl: string): void {
     seedDefaults(store, baseUrl);

--- a/packages/@internal/google/src/route-helpers.ts
+++ b/packages/@internal/google/src/route-helpers.ts
@@ -1,0 +1,70 @@
+import type { Context } from "hono";
+import { getAuthenticatedEmail, gmailError, matchesRequestedUser } from "./helpers.js";
+
+export function requireGmailUser(c: Context): string | Response {
+  const authEmail = getAuthenticatedEmail(c);
+  if (!authEmail) {
+    return gmailError(c, 401, "Request had invalid authentication credentials.", "authError", "UNAUTHENTICATED");
+  }
+
+  if (!matchesRequestedUser(c.req.param("userId"), authEmail)) {
+    return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+  }
+
+  return authEmail;
+}
+
+export async function parseGoogleBody(
+  c: Context,
+): Promise<Record<string, unknown>> {
+  const contentType = c.req.header("Content-Type") ?? "";
+  const rawText = await c.req.text();
+
+  if (!rawText) return {};
+
+  let parsed: Record<string, unknown>;
+
+  if (contentType.includes("application/json")) {
+    try {
+      const json = JSON.parse(rawText);
+      parsed = json && typeof json === "object" && !Array.isArray(json) ? (json as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  } else if (contentType.includes("application/x-www-form-urlencoded")) {
+    parsed = Object.fromEntries(new URLSearchParams(rawText));
+  } else {
+    parsed = {
+      raw: Buffer.from(rawText, "utf8").toString("base64url"),
+    };
+  }
+
+  const nestedBody = parsed.requestBody;
+  if (nestedBody && typeof nestedBody === "object" && !Array.isArray(nestedBody)) {
+    return nestedBody as Record<string, unknown>;
+  }
+
+  return parsed;
+}
+
+export function getStringArray(body: Record<string, unknown>, field: string): string[] {
+  const value = body[field];
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string" && item.length > 0);
+  }
+
+  if (typeof value === "string" && value.length > 0) {
+    return [value];
+  }
+
+  return [];
+}
+
+export function getString(body: Record<string, unknown>, ...fields: string[]): string | undefined {
+  for (const field of fields) {
+    const value = body[field];
+    if (typeof value === "string") return value;
+  }
+
+  return undefined;
+}

--- a/packages/@internal/google/src/routes/labels.ts
+++ b/packages/@internal/google/src/routes/labels.ts
@@ -1,0 +1,174 @@
+import type { RouteContext } from "@internal/core";
+import type { Context } from "hono";
+import {
+  createLabelRecord,
+  findLabelById,
+  findLabelByName,
+  formatLabelResource,
+  gmailError,
+  isSystemLabelId,
+  listLabelsForUser,
+  markMessageModified,
+  updateLabelRecord,
+} from "../helpers.js";
+import { requireGmailUser, parseGoogleBody, getString } from "../route-helpers.js";
+import { getGoogleStore } from "../store.js";
+
+export function labelRoutes({ app, store }: RouteContext): void {
+  const gs = getGoogleStore(store);
+
+  app.get("/gmail/v1/users/:userId/labels", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    return c.json({
+      labels: listLabelsForUser(gs, authEmail).map((label) => formatLabelResource(gs, label)),
+    });
+  });
+
+  app.get("/gmail/v1/users/:userId/labels/:id", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const label = findLabelById(gs, authEmail, c.req.param("id"));
+    if (!label) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    return c.json(formatLabelResource(gs, label));
+  });
+
+  app.post("/gmail/v1/users/:userId/labels", async (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const body = await parseGoogleBody(c);
+    const name = getString(body, "name")?.trim();
+    if (!name) {
+      return gmailError(c, 400, "Invalid label name", "invalidArgument", "INVALID_ARGUMENT");
+    }
+
+    if (findLabelByName(gs, authEmail, name)) {
+      return gmailError(
+        c,
+        400,
+        "Label name exists or conflicts",
+        "failedPrecondition",
+        "FAILED_PRECONDITION",
+      );
+    }
+
+    const color = body.color && typeof body.color === "object" && !Array.isArray(body.color)
+      ? (body.color as Record<string, unknown>)
+      : undefined;
+
+    const label = createLabelRecord(gs, {
+      user_email: authEmail,
+      name,
+      type: "user",
+      message_list_visibility: getString(body, "messageListVisibility", "message_list_visibility") ?? "show",
+      label_list_visibility: getString(body, "labelListVisibility", "label_list_visibility") ?? "labelShow",
+      color_background:
+        typeof color?.backgroundColor === "string"
+          ? color.backgroundColor
+          : getString(body, "color_background"),
+      color_text:
+        typeof color?.textColor === "string"
+          ? color.textColor
+          : getString(body, "color_text"),
+    });
+
+    return c.json(formatLabelResource(gs, label));
+  });
+
+  app.put("/gmail/v1/users/:userId/labels/:id", async (c) => {
+    return saveLabel(c, gs, true);
+  });
+
+  app.patch("/gmail/v1/users/:userId/labels/:id", async (c) => {
+    return saveLabel(c, gs, false);
+  });
+
+  app.delete("/gmail/v1/users/:userId/labels/:id", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const label = findLabelById(gs, authEmail, c.req.param("id"));
+    if (!label) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    if (isSystemLabelId(label.gmail_id)) {
+      return gmailError(c, 400, "System labels cannot be deleted.", "invalidArgument", "INVALID_ARGUMENT");
+    }
+
+    for (const message of gs.messages.findBy("user_email", authEmail)) {
+      if (!message.label_ids.includes(label.gmail_id)) continue;
+      markMessageModified(
+        gs,
+        message,
+        message.label_ids.filter((labelId) => labelId !== label.gmail_id),
+      );
+    }
+
+    gs.labels.delete(label.id);
+    return c.body(null, 204);
+  });
+}
+
+async function saveLabel(
+  c: Context,
+  gs: ReturnType<typeof getGoogleStore>,
+  replaceMissingFields: boolean,
+) {
+  const authEmail = requireGmailUser(c);
+  if (authEmail instanceof Response) return authEmail;
+
+  const label = findLabelById(gs, authEmail, c.req.param("id"));
+  if (!label) {
+    return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+  }
+
+  if (isSystemLabelId(label.gmail_id)) {
+    return gmailError(c, 400, "System labels cannot be modified.", "invalidArgument", "INVALID_ARGUMENT");
+  }
+
+  const body = await parseGoogleBody(c);
+  const name = getString(body, "name")?.trim();
+  const color = body.color && typeof body.color === "object" && !Array.isArray(body.color)
+    ? (body.color as Record<string, unknown>)
+    : undefined;
+
+  if (name) {
+    const conflicting = findLabelByName(gs, authEmail, name);
+    if (conflicting && conflicting.gmail_id !== label.gmail_id) {
+      return gmailError(
+        c,
+        400,
+        "Label name exists or conflicts",
+        "failedPrecondition",
+        "FAILED_PRECONDITION",
+      );
+    }
+  }
+
+  const updated = updateLabelRecord(gs, label, {
+    name: name ?? (replaceMissingFields ? label.name : undefined),
+    message_list_visibility:
+      getString(body, "messageListVisibility", "message_list_visibility") ??
+      (replaceMissingFields ? "show" : undefined),
+    label_list_visibility:
+      getString(body, "labelListVisibility", "label_list_visibility") ??
+      (replaceMissingFields ? "labelShow" : undefined),
+    color_background:
+      typeof color?.backgroundColor === "string"
+        ? color.backgroundColor
+        : getString(body, "color_background") ?? (replaceMissingFields ? null : undefined),
+    color_text:
+      typeof color?.textColor === "string"
+        ? color.textColor
+        : getString(body, "color_text") ?? (replaceMissingFields ? null : undefined),
+  });
+
+  return c.json(formatLabelResource(gs, updated));
+}

--- a/packages/@internal/google/src/routes/messages.ts
+++ b/packages/@internal/google/src/routes/messages.ts
@@ -1,0 +1,250 @@
+import type { RouteContext } from "@internal/core";
+import type { Context } from "hono";
+import {
+  createStoredMessage,
+  dedupeLabelIds,
+  findMissingLabelIds,
+  formatMessageResource,
+  getMessageById,
+  gmailError,
+  listMessagesForUser,
+  markMessageModified,
+  normalizeLimit,
+  parseBooleanParam,
+  parseFormat,
+  parseOffset,
+  trashLabelIds,
+  untrashLabelIds,
+} from "../helpers.js";
+import { requireGmailUser, parseGoogleBody, getStringArray, getString } from "../route-helpers.js";
+import { getGoogleStore } from "../store.js";
+
+export function messageRoutes({ app, store }: RouteContext): void {
+  const gs = getGoogleStore(store);
+
+  const createHandler =
+    (mode: "insert" | "import" | "send") =>
+    async (c: Context) => {
+      const authEmail = requireGmailUser(c);
+      if (authEmail instanceof Response) return authEmail;
+
+      const body = await parseGoogleBody(c);
+      const labelIds = getStringArray(body, "labelIds");
+      const defaultLabelIds =
+        mode === "send"
+          ? dedupeLabelIds([...labelIds, "SENT"])
+          : labelIds.length > 0
+            ? labelIds
+            : mode === "import"
+              ? ["INBOX", "UNREAD"]
+              : [];
+
+      const missingLabelIds = findMissingLabelIds(gs, authEmail, defaultLabelIds);
+      if (missingLabelIds.length > 0) {
+        return gmailError(c, 400, `Invalid label IDs: ${missingLabelIds.join(", ")}`, "invalidArgument", "INVALID_ARGUMENT");
+      }
+
+      const raw = getString(body, "raw");
+      const from = getString(body, "from") ?? (mode === "send" ? authEmail : undefined);
+      const to = getString(body, "to");
+      if (!raw && (!from || !to)) {
+        return gmailError(
+          c,
+          400,
+          "A raw MIME message or explicit from/to fields are required.",
+          "invalidArgument",
+          "INVALID_ARGUMENT",
+        );
+      }
+
+      try {
+        const message = createStoredMessage(gs, {
+          user_email: authEmail,
+          raw,
+          thread_id: getString(body, "threadId", "thread_id"),
+          from,
+          to,
+          cc: getString(body, "cc") ?? null,
+          bcc: getString(body, "bcc") ?? null,
+          reply_to: getString(body, "replyTo", "reply_to") ?? null,
+          subject: getString(body, "subject"),
+          snippet: getString(body, "snippet"),
+          body_text: getString(body, "body_text", "text") ?? null,
+          body_html: getString(body, "body_html", "html") ?? null,
+          label_ids: defaultLabelIds,
+          date: getString(body, "date"),
+          internal_date: getString(body, "internalDate", "internal_date"),
+          message_id: getString(body, "messageId", "message_id"),
+          references: getString(body, "references") ?? null,
+          in_reply_to: getString(body, "inReplyTo", "in_reply_to") ?? null,
+        });
+
+        return c.json(formatMessageResource(message, "full"));
+      } catch {
+        return gmailError(
+          c,
+          400,
+          "Invalid raw MIME message payload.",
+          "invalidArgument",
+          "INVALID_ARGUMENT",
+        );
+      }
+    };
+
+  app.get("/gmail/v1/users/:userId/messages", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const url = new URL(c.req.url);
+    const messages = listMessagesForUser(gs, authEmail, {
+      labelIds: url.searchParams.getAll("labelIds"),
+      query: url.searchParams.get("q")?.trim() ?? undefined,
+      includeSpamTrash: parseBooleanParam(url.searchParams.get("includeSpamTrash")),
+    });
+
+    const offset = parseOffset(url.searchParams.get("pageToken"));
+    const limit = normalizeLimit(url.searchParams.get("maxResults"), 100, 500);
+    const page = messages.slice(offset, offset + limit);
+    const nextPageToken = offset + limit < messages.length ? String(offset + limit) : undefined;
+
+    return c.json({
+      messages: page.map((message) => ({
+        id: message.gmail_id,
+        threadId: message.thread_id,
+      })),
+      nextPageToken,
+      resultSizeEstimate: messages.length,
+    });
+  });
+
+  app.post("/gmail/v1/users/:userId/messages/batchModify", async (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const body = await parseGoogleBody(c);
+    const ids = getStringArray(body, "ids");
+    const addLabelIds = getStringArray(body, "addLabelIds");
+    const removeLabelIds = getStringArray(body, "removeLabelIds");
+
+    const missingLabelIds = findMissingLabelIds(gs, authEmail, [...addLabelIds, ...removeLabelIds]);
+    if (missingLabelIds.length > 0) {
+      return gmailError(c, 400, `Invalid label IDs: ${missingLabelIds.join(", ")}`, "invalidArgument", "INVALID_ARGUMENT");
+    }
+
+    for (const messageId of ids) {
+      const message = getMessageById(gs, authEmail, messageId);
+      if (!message) continue;
+
+      markMessageModified(
+        gs,
+        message,
+        message.label_ids.filter((labelId) => !removeLabelIds.includes(labelId)).concat(addLabelIds),
+      );
+    }
+
+    return c.body(null, 204);
+  });
+
+  app.post("/gmail/v1/users/:userId/messages/batchDelete", async (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const body = await parseGoogleBody(c);
+    const ids = getStringArray(body, "ids");
+
+    for (const messageId of ids) {
+      const message = getMessageById(gs, authEmail, messageId);
+      if (message) gs.messages.delete(message.id);
+    }
+
+    return c.body(null, 204);
+  });
+
+  app.post("/gmail/v1/users/:userId/messages/import", createHandler("import"));
+  app.post("/upload/gmail/v1/users/:userId/messages/import", createHandler("import"));
+  app.post("/gmail/v1/users/:userId/messages/send", createHandler("send"));
+  app.post("/upload/gmail/v1/users/:userId/messages/send", createHandler("send"));
+  app.post("/gmail/v1/users/:userId/messages", createHandler("insert"));
+  app.post("/upload/gmail/v1/users/:userId/messages", createHandler("insert"));
+
+  app.get("/gmail/v1/users/:userId/messages/:id", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const message = getMessageById(gs, authEmail, c.req.param("id"));
+    if (!message) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    const url = new URL(c.req.url);
+    return c.json(
+      formatMessageResource(
+        message,
+        parseFormat(url.searchParams.get("format")),
+        url.searchParams.getAll("metadataHeaders"),
+      ),
+    );
+  });
+
+  app.post("/gmail/v1/users/:userId/messages/:id/modify", async (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const message = getMessageById(gs, authEmail, c.req.param("id"));
+    if (!message) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    const body = await parseGoogleBody(c);
+    const addLabelIds = getStringArray(body, "addLabelIds");
+    const removeLabelIds = getStringArray(body, "removeLabelIds");
+    const missingLabelIds = findMissingLabelIds(gs, authEmail, [...addLabelIds, ...removeLabelIds]);
+    if (missingLabelIds.length > 0) {
+      return gmailError(c, 400, `Invalid label IDs: ${missingLabelIds.join(", ")}`, "invalidArgument", "INVALID_ARGUMENT");
+    }
+
+    const updated = markMessageModified(
+      gs,
+      message,
+      message.label_ids.filter((labelId) => !removeLabelIds.includes(labelId)).concat(addLabelIds),
+    );
+    return c.json(formatMessageResource(updated, "full"));
+  });
+
+  app.post("/gmail/v1/users/:userId/messages/:id/trash", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const message = getMessageById(gs, authEmail, c.req.param("id"));
+    if (!message) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    return c.json(formatMessageResource(markMessageModified(gs, message, trashLabelIds(message.label_ids)), "full"));
+  });
+
+  app.post("/gmail/v1/users/:userId/messages/:id/untrash", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const message = getMessageById(gs, authEmail, c.req.param("id"));
+    if (!message) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    return c.json(formatMessageResource(markMessageModified(gs, message, untrashLabelIds(message.label_ids)), "full"));
+  });
+
+  app.delete("/gmail/v1/users/:userId/messages/:id", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const message = getMessageById(gs, authEmail, c.req.param("id"));
+    if (!message) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    gs.messages.delete(message.id);
+    return c.body(null, 204);
+  });
+}

--- a/packages/@internal/google/src/routes/oauth.ts
+++ b/packages/@internal/google/src/routes/oauth.ts
@@ -11,6 +11,7 @@ import {
   constantTimeSecretEqual,
   bodyStr,
   debug,
+  type Store,
 } from "@internal/core";
 import { getGoogleStore } from "../store.js";
 import type { GoogleUser } from "../entities.js";

--- a/packages/@internal/google/src/routes/threads.ts
+++ b/packages/@internal/google/src/routes/threads.ts
@@ -1,0 +1,143 @@
+import type { RouteContext } from "@internal/core";
+import {
+  findMissingLabelIds,
+  formatThreadResource,
+  getThreadMessages,
+  gmailError,
+  groupThreads,
+  listMessagesForUser,
+  markMessageModified,
+  normalizeLimit,
+  parseBooleanParam,
+  parseFormat,
+  parseOffset,
+  trashLabelIds,
+  untrashLabelIds,
+} from "../helpers.js";
+import { requireGmailUser, parseGoogleBody, getStringArray } from "../route-helpers.js";
+import { getGoogleStore } from "../store.js";
+
+export function threadRoutes({ app, store }: RouteContext): void {
+  const gs = getGoogleStore(store);
+
+  app.get("/gmail/v1/users/:userId/threads", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const url = new URL(c.req.url);
+    const threads = groupThreads(
+      listMessagesForUser(gs, authEmail, {
+        labelIds: url.searchParams.getAll("labelIds"),
+        query: url.searchParams.get("q")?.trim() ?? undefined,
+        includeSpamTrash: parseBooleanParam(url.searchParams.get("includeSpamTrash")),
+      }),
+    );
+
+    const offset = parseOffset(url.searchParams.get("pageToken"));
+    const limit = normalizeLimit(url.searchParams.get("maxResults"), 100, 500);
+    const page = threads.slice(offset, offset + limit);
+    const nextPageToken = offset + limit < threads.length ? String(offset + limit) : undefined;
+
+    return c.json({
+      threads: page.map((thread) => ({
+        id: thread.id,
+        snippet: thread.snippet,
+        historyId: thread.historyId,
+      })),
+      nextPageToken,
+      resultSizeEstimate: threads.length,
+    });
+  });
+
+  app.get("/gmail/v1/users/:userId/threads/:id", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const url = new URL(c.req.url);
+    const messages = getThreadMessages(gs, authEmail, c.req.param("id"), {
+      includeSpamTrash: parseBooleanParam(url.searchParams.get("includeSpamTrash")),
+    });
+
+    if (messages.length === 0) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    return c.json(
+      formatThreadResource(
+        messages,
+        parseFormat(url.searchParams.get("format")),
+        url.searchParams.getAll("metadataHeaders"),
+      ),
+    );
+  });
+
+  app.post("/gmail/v1/users/:userId/threads/:id/modify", async (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const messages = getThreadMessages(gs, authEmail, c.req.param("id"), { includeSpamTrash: true });
+    if (messages.length === 0) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    const body = await parseGoogleBody(c);
+    const addLabelIds = getStringArray(body, "addLabelIds");
+    const removeLabelIds = getStringArray(body, "removeLabelIds");
+    const missingLabelIds = findMissingLabelIds(gs, authEmail, [...addLabelIds, ...removeLabelIds]);
+    if (missingLabelIds.length > 0) {
+      return gmailError(c, 400, `Invalid label IDs: ${missingLabelIds.join(", ")}`, "invalidArgument", "INVALID_ARGUMENT");
+    }
+
+    const updated = messages.map((message) =>
+      markMessageModified(
+        gs,
+        message,
+        message.label_ids.filter((labelId) => !removeLabelIds.includes(labelId)).concat(addLabelIds),
+      ),
+    );
+
+    return c.json(formatThreadResource(updated, "full"));
+  });
+
+  app.post("/gmail/v1/users/:userId/threads/:id/trash", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const messages = getThreadMessages(gs, authEmail, c.req.param("id"), { includeSpamTrash: true });
+    if (messages.length === 0) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    const updated = messages.map((message) => markMessageModified(gs, message, trashLabelIds(message.label_ids)));
+    return c.json(formatThreadResource(updated, "full"));
+  });
+
+  app.post("/gmail/v1/users/:userId/threads/:id/untrash", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const messages = getThreadMessages(gs, authEmail, c.req.param("id"), { includeSpamTrash: true });
+    if (messages.length === 0) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    const updated = messages.map((message) => markMessageModified(gs, message, untrashLabelIds(message.label_ids)));
+    return c.json(formatThreadResource(updated, "full"));
+  });
+
+  app.delete("/gmail/v1/users/:userId/threads/:id", (c) => {
+    const authEmail = requireGmailUser(c);
+    if (authEmail instanceof Response) return authEmail;
+
+    const messages = getThreadMessages(gs, authEmail, c.req.param("id"), { includeSpamTrash: true });
+    if (messages.length === 0) {
+      return gmailError(c, 404, "Requested entity was not found.", "notFound", "NOT_FOUND");
+    }
+
+    for (const message of messages) {
+      gs.messages.delete(message.id);
+    }
+
+    return c.body(null, 204);
+  });
+}

--- a/packages/@internal/google/src/store.ts
+++ b/packages/@internal/google/src/store.ts
@@ -1,14 +1,18 @@
 import { Store, type Collection } from "@internal/core";
-import type { GoogleUser, GoogleOAuthClient } from "./entities.js";
+import type { GoogleUser, GoogleOAuthClient, GoogleMessage, GoogleLabel } from "./entities.js";
 
 export interface GoogleStore {
   users: Collection<GoogleUser>;
   oauthClients: Collection<GoogleOAuthClient>;
+  messages: Collection<GoogleMessage>;
+  labels: Collection<GoogleLabel>;
 }
 
 export function getGoogleStore(store: Store): GoogleStore {
   return {
     users: store.collection<GoogleUser>("google.users", ["uid", "email"]),
     oauthClients: store.collection<GoogleOAuthClient>("google.oauth_clients", ["client_id"]),
+    messages: store.collection<GoogleMessage>("google.messages", ["gmail_id", "thread_id", "user_email"]),
+    labels: store.collection<GoogleLabel>("google.labels", ["gmail_id", "user_email", "name"]),
   };
 }

--- a/packages/emulate/src/commands/init.ts
+++ b/packages/emulate/src/commands/init.ts
@@ -100,7 +100,29 @@ const defaultGoogleConfig = {
       {
         client_id: "example-client-id.apps.googleusercontent.com",
         client_secret: "GOCSPX-example_secret",
+        name: "Code App (Google)",
         redirect_uris: ["http://localhost:3000/api/auth/callback/google"],
+      },
+    ],
+    labels: [
+      {
+        id: "Label_ops",
+        user_email: "testuser@example.com",
+        name: "Ops/Review",
+        color_background: "#DDEEFF",
+        color_text: "#111111",
+      },
+    ],
+    messages: [
+      {
+        id: "msg_welcome",
+        user_email: "testuser@example.com",
+        from: "welcome@example.com",
+        to: "testuser@example.com",
+        subject: "Welcome to the Gmail emulator",
+        body_text: "You can now test Gmail messages, threads, and labels locally.",
+        label_ids: ["INBOX", "UNREAD", "CATEGORY_UPDATES"],
+        date: "2025-01-04T10:00:00.000Z",
       },
     ],
   },

--- a/packages/emulate/src/commands/list.ts
+++ b/packages/emulate/src/commands/list.ts
@@ -8,8 +8,8 @@ const SERVICE_DESCRIPTIONS: Record<string, { label: string; endpoints: string }>
     endpoints: "users, repos, issues, PRs, comments, reviews, labels, milestones, branches, git data, orgs, teams, releases, webhooks, search, actions, checks, rate limit",
   },
   google: {
-    label: "Google OAuth 2.0 / OpenID Connect emulator",
-    endpoints: "OAuth authorize, token exchange, userinfo, OIDC discovery, token revocation",
+    label: "Google OAuth 2.0 / OpenID Connect + Gmail emulator",
+    endpoints: "OAuth authorize, token exchange, userinfo, OIDC discovery, token revocation, Gmail messages, threads, labels",
   },
 };
 


### PR DESCRIPTION
Adds a broader Gmail surface to the Google plugin, including mutable message, thread, and label endpoints.

Also introduces the Gmail data model, shared helpers/route utilities, seed support, and integration coverage needed to exercise the API from Inbox Zero.

Docs and starter config are updated to reflect the expanded Google + Gmail support.

Opening this as a draft first because it is a fairly broad addition to the existing Google emulator surface.