### PR TITLE
feat(microsoft): add v1 OAuth token endpoint and Graph /users/{id} route

### DIFF
--- a/packages/@emulators/microsoft/src/__tests__/microsoft.test.ts
+++ b/packages/@emulators/microsoft/src/__tests__/microsoft.test.ts
@@ -569,4 +569,93 @@ describe("Microsoft plugin integration", () => {
     expect(client).toBeDefined();
     expect(client!.name).toBe("My App");
   });
+
+  // --- v1 OAuth token endpoint (legacy /{tenant}/oauth2/token) ---
+
+  it("POST /:tenant/oauth2/token issues token with client_credentials and resource param", async () => {
+    const formData = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: "test-client",
+      client_secret: "test-secret",
+      resource: "https://graph.microsoft.com",
+    });
+
+    const res = await app.request(`${base}/my-tenant/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData.toString(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.access_token).toBeDefined();
+    expect((body.access_token as string).startsWith("microsoft_")).toBe(true);
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBe(3600);
+    // resource=https://graph.microsoft.com should become scope=https://graph.microsoft.com/.default
+    expect(body.scope).toBe("https://graph.microsoft.com/.default");
+  });
+
+  it("POST /:tenant/oauth2/token preserves explicit scope over resource param", async () => {
+    const formData = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: "test-client",
+      client_secret: "test-secret",
+      scope: "https://graph.microsoft.com/.default",
+      resource: "https://something-else.example.com",
+    });
+
+    const res = await app.request(`${base}/my-tenant/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData.toString(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.scope).toBe("https://graph.microsoft.com/.default");
+  });
+
+  it("POST /:tenant/oauth2/token rejects wrong client_secret", async () => {
+    const formData = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: "test-client",
+      client_secret: "wrong-secret",
+      resource: "https://graph.microsoft.com",
+    });
+
+    const res = await app.request(`${base}/my-tenant/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData.toString(),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("invalid_client");
+  });
+
+  // --- Graph /v1.0/users/:id endpoint ---
+
+  it("GET /v1.0/users/:id returns user profile by oid", async () => {
+    const ms = getMicrosoftStore(store);
+    const user = ms.users.findOneBy("email", "testuser@example.com");
+    expect(user).toBeDefined();
+
+    const res = await app.request(`${base}/v1.0/users/${user!.oid}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.id).toBe(user!.oid);
+    expect(body.displayName).toBe("Test User");
+    expect(body.mail).toBe("testuser@example.com");
+    expect(body.userPrincipalName).toBe("testuser@example.com");
+    expect(body["@odata.context"]).toContain("$metadata#users");
+  });
+
+  it("GET /v1.0/users/:id returns 404 for unknown user id", async () => {
+    const res = await app.request(`${base}/v1.0/users/00000000-0000-0000-0000-000000000000`);
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: Record<string, unknown> };
+    expect(body.error.code).toBe("Request_ResourceNotFound");
+  });
 });

--- a/packages/@emulators/microsoft/src/routes/oauth.ts
+++ b/packages/@emulators/microsoft/src/routes/oauth.ts
@@ -526,6 +526,80 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
     });
   });
 
+  // ---------- v1 OAuth token endpoint (legacy) ----------
+  // Azure AD v1 applications use /{tenant}/oauth2/token instead of /oauth2/v2.0/token.
+  // The v1 endpoint accepts a `resource` body parameter instead of `scope`.
+  // We translate `resource` to `scope` format and delegate to the same token logic.
+
+  app.post("/:tenant/oauth2/token", async (c) => {
+    const contentType = c.req.header("Content-Type") ?? "";
+    const rawText = await c.req.text();
+
+    let body: Record<string, unknown>;
+    if (contentType.includes("application/json")) {
+      try { body = JSON.parse(rawText); } catch { body = {}; }
+    } else {
+      body = Object.fromEntries(new URLSearchParams(rawText));
+    }
+
+    // Translate v1 `resource` parameter to v2 `scope` format.
+    // e.g. resource=https://graph.microsoft.com → scope=https://graph.microsoft.com/.default
+    const resource = typeof body.resource === "string" ? body.resource : "";
+    if (resource && !body.scope) {
+      const normalized = resource.endsWith("/") ? resource : resource + "/";
+      body.scope = normalized + ".default";
+    }
+
+    // Rebuild as URL-encoded form data for the v2 handler
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(body)) {
+      if (key !== "resource" && typeof value === "string") {
+        params.set(key, value);
+      }
+    }
+
+    // Forward to the v2 token endpoint by making an internal request
+    const v2Req = new Request(`${baseUrl}/oauth2/v2.0/token`, {
+      method: "POST",
+      headers: new Headers({
+        "Content-Type": "application/x-www-form-urlencoded",
+        ...(c.req.header("Authorization") ? { Authorization: c.req.header("Authorization")! } : {}),
+      }),
+      body: params.toString(),
+    });
+
+    return app.fetch(v2Req);
+  });
+
+  // ---------- Microsoft Graph /v1.0/users/:id endpoint ----------
+  // Service-to-service calls (e.g. with client_credentials tokens) use
+  // /v1.0/users/{id} to look up any user by their object ID (oid).
+
+  app.get("/v1.0/users/:id", (c) => {
+    const userId = c.req.param("id");
+
+    // Look up by oid (the Microsoft object ID)
+    const user = ms.users.findOneBy("oid", userId);
+    if (!user) {
+      return c.json({
+        error: {
+          code: "Request_ResourceNotFound",
+          message: `Resource '${userId}' does not exist or one of its queried reference-property objects are not present.`,
+        },
+      }, 404);
+    }
+
+    return c.json({
+      "@odata.context": `${baseUrl}/v1.0/$metadata#users/$entity`,
+      id: user.oid,
+      displayName: user.name,
+      givenName: user.given_name,
+      surname: user.family_name,
+      mail: user.email,
+      userPrincipalName: user.preferred_username,
+    });
+  });
+
   // ---------- Logout ----------
 
   app.get("/oauth2/v2.0/logout", (c) => {


### PR DESCRIPTION
## Summary

Adds two missing Microsoft endpoints that legacy Azure AD applications depend on:

- **`/{tenant}/oauth2/token`** (v1 OAuth token endpoint): Many legacy and enterprise Azure AD applications still use the v1 endpoint format (`/{tenant}/oauth2/token`) with a `resource` body parameter instead of `scope`. This route translates the `resource` parameter to v2 `scope` format (by appending `/.default`) and delegates to the existing `/oauth2/v2.0/token` handler, so all grant types (client_credentials, authorization_code, refresh_token) work seamlessly through the v1 path.

- **`/v1.0/users/{id}`** (Graph API user lookup by OID): Service-to-service flows using `client_credentials` tokens need to look up users by their object ID. Currently only `/v1.0/me` exists, which requires the caller to be the authenticated user. The new `/v1.0/users/{id}` route looks up any user by their `oid` in the store and returns the same Graph-style profile shape as `/v1.0/me`.

### Why these are needed

Azure AD v1 endpoints (`login.microsoftonline.com/{tenant}/oauth2/token`) are still widely used by legacy enterprise applications, ADAL-based SDKs, and some Microsoft services. The Graph `/v1.0/users/{id}` endpoint is the standard way for daemon/service apps to resolve user profiles when they only have a user's object ID (e.g., from a JWT `oid` claim or directory sync).

Without these endpoints, the emulator cannot be used as a drop-in replacement for Azure AD in projects that use either pattern.

## Test plan

- [x] v1 token endpoint issues tokens via `client_credentials` with `resource` param translated to `scope`
- [x] v1 token endpoint preserves explicit `scope` when both `scope` and `resource` are provided
- [x] v1 token endpoint rejects incorrect `client_secret`
- [x] Graph `/v1.0/users/:id` returns user profile by OID
- [x] Graph `/v1.0/users/:id` returns 404 for unknown user IDs
- [x] All 29 tests pass (24 existing + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)