### PR TITLE
feat: add Vercel Blob storage emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,42 @@ JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's privat
 
 Every endpoint below is fully stateful with Vercel-style JSON responses and cursor-based pagination.
 
+### Blob Storage
+
+Full Vercel Blob emulation. Point the `@vercel/blob` SDK at the emulator:
+
+```bash
+VERCEL_BLOB_API_URL=http://localhost:4000/api/blob
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_mystore_secret
+```
+
+- `PUT /api/blob?pathname=` - upload blob (binary body, random suffix by default)
+- `GET /api/blob?url=` - get blob metadata
+- `GET /api/blob` - list blobs (`limit`, `prefix`, `cursor`, `mode=folded`)
+- `POST /api/blob/delete` - delete blobs by URL
+- `PUT /api/blob?pathname=&fromUrl=` - copy blob
+- `PUT /api/blob?pathname=folder/` - create folder
+- `POST /api/blob/mpu` - multipart upload (create/upload/complete via `x-mpu-action`)
+- `POST /api/blob/handle-blob-upload` - client token generation
+- `GET /:storeId/:access/*` - download blob content
+
+Supports overwrite protection (`x-allow-overwrite`), conditional writes (`x-if-match`), ETag-based caching (`If-None-Match` → 304), private blob auth, content type inference, and client upload tokens with HMAC verification.
+
+```yaml
+# Seed config
+vercel:
+  blob_stores:
+    - store_id: mystore
+      token: vercel_blob_rw_mystore_secret
+      access: public
+      blobs:
+        - pathname: welcome.txt
+          content: "Hello from the emulator!"
+        - pathname: logo.png
+          content_base64: "iVBORw0KGgo..."
+          content_type: image/png
+```
+
 ### User & Teams
 - `GET /v2/user` - authenticated user
 - `PATCH /v2/user` - update user
@@ -459,9 +495,13 @@ packages/
   emulate/          # CLI entry point (commander)
     @emulators/
     core/           # HTTP server, in-memory store, plugin interface, middleware
-    vercel/         # Vercel API service
-    github/         # GitHub API service
-    google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, and Drive APIs
+    vercel/         # Vercel API + Blob storage
+    github/         # GitHub REST API + Apps
+    google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, and Drive
+    slack/          # Slack API
+    apple/          # Apple Sign In / OAuth
+    microsoft/      # Microsoft Entra ID / OAuth 2.0
+    aws/            # AWS services (S3, SQS, IAM, STS)
 apps/
   web/              # Documentation site (Next.js)
 ```

--- a/examples/blob/test-blob.ts
+++ b/examples/blob/test-blob.ts
@@ -1,0 +1,335 @@
+/**
+ * Integration test for the Vercel Blob emulator.
+ *
+ * Usage:
+ *   cd /path/to/emulate
+ *   pnpm build
+ *   npx tsx examples/blob/test-blob.ts
+ */
+
+const BASE = "http://localhost:4000";
+const TOKEN = "vercel_blob_rw_mystore_secret123";
+
+const headers = {
+  Authorization: `Bearer ${TOKEN}`,
+};
+
+let passed = 0;
+let failed = 0;
+
+async function assert(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+  } catch (err: any) {
+    failed++;
+    console.log(`  \x1b[31m✗\x1b[0m ${name}`);
+    console.log(`    ${err.message}`);
+  }
+}
+
+function eq(actual: unknown, expected: unknown, label = "") {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label ? label + ": " : ""}expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Start emulator
+  const { createEmulator } = await import("../../packages/emulate/dist/api.js");
+  const emu = await createEmulator({ service: "vercel", port: 4000 });
+  console.log(`\nEmulator running at ${emu.url}\n`);
+
+  try {
+    // -----------------------------------------------------------------------
+    console.log("PUT (upload)");
+    // -----------------------------------------------------------------------
+
+    await assert("uploads a blob", async () => {
+      const res = await fetch(`${BASE}/api/blob?pathname=hello.txt`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "Hello from the emulator!",
+      });
+      eq(res.status, 200, "status");
+      const json = await res.json();
+      eq(json.pathname, "hello.txt", "pathname");
+      eq(json.contentType, "text/plain", "contentType");
+      eq(json.url.includes("mystore/public/hello.txt"), true, "url");
+    });
+
+    await assert("applies random suffix by default", async () => {
+      const res = await fetch(`${BASE}/api/blob?pathname=random.txt`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "public" },
+        body: "data",
+      });
+      const json = await res.json();
+      eq(/^random-[A-Za-z0-9]{6}\.txt$/.test(json.pathname), true, "pathname has suffix");
+    });
+
+    await assert("creates a folder", async () => {
+      const res = await fetch(`${BASE}/api/blob?pathname=my-folder/`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+      });
+      const json = await res.json();
+      eq(json.pathname, "my-folder/", "pathname");
+      eq(json.contentType, "application/x-directory", "contentType");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nHEAD (metadata)");
+    // -----------------------------------------------------------------------
+
+    await assert("returns blob metadata", async () => {
+      const res = await fetch(`${BASE}/api/blob?url=${encodeURIComponent(`${BASE}/mystore/public/hello.txt`)}`, {
+        headers,
+      });
+      eq(res.status, 200, "status");
+      const json = await res.json();
+      eq(json.pathname, "hello.txt", "pathname");
+      eq(json.size, 24, "size");
+      eq(json.contentType, "text/plain", "contentType");
+    });
+
+    await assert("returns 404 for unknown blob", async () => {
+      const res = await fetch(`${BASE}/api/blob?url=${encodeURIComponent(`${BASE}/mystore/public/nope.txt`)}`, {
+        headers,
+      });
+      eq(res.status, 404, "status");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nLIST");
+    // -----------------------------------------------------------------------
+
+    await assert("lists blobs", async () => {
+      const res = await fetch(`${BASE}/api/blob`, { headers });
+      const json = await res.json();
+      eq(json.blobs.length >= 2, true, "has blobs");
+      eq(json.hasMore, false, "hasMore");
+    });
+
+    await assert("filters by prefix", async () => {
+      const res = await fetch(`${BASE}/api/blob?prefix=my-folder`, { headers });
+      const json = await res.json();
+      eq(json.blobs.length, 1, "count");
+    });
+
+    await assert("folded mode returns folders", async () => {
+      // Add a nested blob first
+      await fetch(`${BASE}/api/blob?pathname=nested/deep/file.txt`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "nested",
+      });
+      const res = await fetch(`${BASE}/api/blob?mode=folded`, { headers });
+      const json = await res.json();
+      eq(Array.isArray(json.folders), true, "has folders array");
+      eq(json.folders.includes("nested/"), true, "includes nested/");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nCOPY");
+    // -----------------------------------------------------------------------
+
+    await assert("copies a blob", async () => {
+      const fromUrl = `${BASE}/mystore/public/hello.txt`;
+      const res = await fetch(`${BASE}/api/blob?pathname=hello-copy.txt&fromUrl=${encodeURIComponent(fromUrl)}`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+      });
+      eq(res.status, 200, "status");
+      const json = await res.json();
+      eq(json.pathname, "hello-copy.txt", "pathname");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nDOWNLOAD (content serving)");
+    // -----------------------------------------------------------------------
+
+    await assert("serves blob content", async () => {
+      const res = await fetch(`${BASE}/mystore/public/hello.txt`);
+      eq(res.status, 200, "status");
+      eq(await res.text(), "Hello from the emulator!", "body");
+      eq(res.headers.get("content-type"), "text/plain", "content-type");
+    });
+
+    await assert("304 on matching ETag", async () => {
+      const head = await fetch(`${BASE}/api/blob?url=${encodeURIComponent(`${BASE}/mystore/public/hello.txt`)}`, {
+        headers,
+      });
+      const { etag } = await head.json();
+
+      const res = await fetch(`${BASE}/mystore/public/hello.txt`, {
+        headers: { "if-none-match": etag },
+      });
+      eq(res.status, 304, "status");
+    });
+
+    await assert("private blobs require auth", async () => {
+      await fetch(`${BASE}/api/blob?pathname=secret.txt`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "private", "x-add-random-suffix": "0" },
+        body: "secret data",
+      });
+
+      const noAuth = await fetch(`${BASE}/mystore/private/secret.txt`);
+      eq(noAuth.status, 403, "no auth → 403");
+
+      const withAuth = await fetch(`${BASE}/mystore/private/secret.txt`, { headers });
+      eq(withAuth.status, 200, "with auth → 200");
+      eq(await withAuth.text(), "secret data", "body");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nOVERWRITE + CONDITIONAL");
+    // -----------------------------------------------------------------------
+
+    await assert("blocks overwrite by default", async () => {
+      const res = await fetch(`${BASE}/api/blob?pathname=hello.txt`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "overwrite attempt",
+      });
+      eq(res.status, 409, "status");
+    });
+
+    await assert("allows overwrite with header", async () => {
+      const res = await fetch(`${BASE}/api/blob?pathname=hello.txt`, {
+        method: "PUT",
+        headers: { ...headers, "x-vercel-blob-access": "public", "x-add-random-suffix": "0", "x-allow-overwrite": "1" },
+        body: "overwritten!",
+      });
+      eq(res.status, 200, "status");
+    });
+
+    await assert("412 on ETag mismatch", async () => {
+      const res = await fetch(`${BASE}/api/blob?pathname=hello.txt`, {
+        method: "PUT",
+        headers: {
+          ...headers,
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+          "x-allow-overwrite": "1",
+          "x-if-match": '"bad-etag"',
+        },
+        body: "should fail",
+      });
+      eq(res.status, 412, "status");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nDELETE");
+    // -----------------------------------------------------------------------
+
+    await assert("deletes a blob", async () => {
+      const url = `${BASE}/mystore/public/hello-copy.txt`;
+      const res = await fetch(`${BASE}/api/blob/delete`, {
+        method: "POST",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ urls: [url] }),
+      });
+      eq(res.status, 200, "status");
+
+      const head = await fetch(`${BASE}/api/blob?url=${encodeURIComponent(url)}`, { headers });
+      eq(head.status, 404, "gone after delete");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nMULTIPART UPLOAD");
+    // -----------------------------------------------------------------------
+
+    await assert("full multipart flow", async () => {
+      // Create
+      const createRes = await fetch(`${BASE}/api/blob/mpu?pathname=big.bin`, {
+        method: "POST",
+        headers: { ...headers, "x-mpu-action": "create", "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+      });
+      eq(createRes.status, 200, "create status");
+      const { uploadId, key } = await createRes.json();
+
+      // Upload parts
+      const p1Res = await fetch(`${BASE}/api/blob/mpu?pathname=big.bin`, {
+        method: "POST",
+        headers: { ...headers, "x-mpu-action": "upload", "x-mpu-upload-id": uploadId, "x-mpu-key": key, "x-mpu-part-number": "1" },
+        body: "AAAA",
+      });
+      const p1 = await p1Res.json();
+
+      const p2Res = await fetch(`${BASE}/api/blob/mpu?pathname=big.bin`, {
+        method: "POST",
+        headers: { ...headers, "x-mpu-action": "upload", "x-mpu-upload-id": uploadId, "x-mpu-key": key, "x-mpu-part-number": "2" },
+        body: "BBBB",
+      });
+      const p2 = await p2Res.json();
+
+      // Complete
+      const completeRes = await fetch(`${BASE}/api/blob/mpu?pathname=big.bin`, {
+        method: "POST",
+        headers: { ...headers, "x-mpu-action": "complete", "x-mpu-upload-id": uploadId, "x-mpu-key": key, "content-type": "application/json" },
+        body: JSON.stringify([{ etag: p1.etag, partNumber: 1 }, { etag: p2.etag, partNumber: 2 }]),
+      });
+      eq(completeRes.status, 200, "complete status");
+      const blob = await completeRes.json();
+
+      // Verify content
+      const dl = await fetch(blob.url);
+      eq(await dl.text(), "AAAABBBB", "concatenated content");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nCLIENT TOKENS");
+    // -----------------------------------------------------------------------
+
+    await assert("generate token + upload with it", async () => {
+      const genRes = await fetch(`${BASE}/api/blob/handle-blob-upload`, {
+        method: "POST",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "blob.generate-client-token",
+          payload: { pathname: "client.txt", callbackUrl: `${BASE}/api/blob/handle-blob-upload` },
+        }),
+      });
+      eq(genRes.status, 200, "gen status");
+      const { clientToken } = await genRes.json();
+      eq(clientToken.startsWith("vercel_blob_client_"), true, "token format");
+
+      const uploadRes = await fetch(`${BASE}/api/blob?pathname=client.txt`, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${clientToken}`, "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "client content",
+      });
+      eq(uploadRes.status, 200, "upload status");
+      const blob = await uploadRes.json();
+      eq(blob.pathname, "client.txt", "pathname");
+    });
+
+    // -----------------------------------------------------------------------
+    console.log("\nRESET");
+    // -----------------------------------------------------------------------
+
+    await assert("reset clears all blobs", async () => {
+      emu.reset();
+      const res = await fetch(`${BASE}/api/blob`, { headers });
+      const json = await res.json();
+      eq(json.blobs.length, 0, "empty after reset");
+    });
+
+  } finally {
+    await emu.close();
+  }
+
+  // -----------------------------------------------------------------------
+  console.log(`\n\x1b[${failed ? 31 : 32}m${passed} passed, ${failed} failed\x1b[0m\n`);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Hono } from "hono";
-import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
+import { Store, WebhookDispatcher, authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
 import { vercelPlugin, seedFromConfig } from "../index.js";
 
 const base = "http://localhost:4000";
+const TEST_RW_TOKEN = "vercel_blob_rw_teststore_testsecret";
 
 function createTestApp() {
   const store = new Store();
@@ -12,6 +13,8 @@ function createTestApp() {
   tokenMap.set("test-token", { login: "testuser", id: 1, scopes: ["user"] });
 
   const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
   app.use("*", authMiddleware(tokenMap));
   vercelPlugin.register(app as any, store, webhooks, base, tokenMap);
   vercelPlugin.seed?.(store, base);
@@ -24,6 +27,10 @@ function createTestApp() {
 
 function authHeaders(): HeadersInit {
   return { Authorization: "Bearer test-token" };
+}
+
+function blobHeaders(token = TEST_RW_TOKEN) {
+  return { Authorization: `Bearer ${token}` };
 }
 
 describe("Vercel plugin integration", () => {
@@ -69,5 +76,656 @@ describe("Vercel plugin integration", () => {
     const body = (await res.json()) as { deployments: unknown[]; pagination: unknown };
     expect(Array.isArray(body.deployments)).toBe(true);
     expect(body.pagination).toBeDefined();
+  });
+});
+
+describe("Vercel Blob", () => {
+  let app: Hono;
+  let store: Store;
+
+  beforeEach(() => {
+    ({ app, store } = createTestApp());
+  });
+
+  describe("authentication", () => {
+    it("rejects requests without auth", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=test.txt`, {
+        method: "PUT",
+        headers: { "x-vercel-blob-access": "public" },
+        body: "hello",
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("blob_access_error");
+    });
+
+    it("accepts vercel_blob_rw_ tokens", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=test.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public" },
+        body: "hello",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("accepts generic tokens from token map", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=test.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders("test-token"), "x-vercel-blob-access": "public" },
+        body: "hello",
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("PUT /api/blob", () => {
+    it("uploads a blob and returns metadata", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=docs/hello.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public" },
+        body: "hello world",
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.pathname).toContain("docs/hello");
+      expect(json.pathname).toContain(".txt");
+      expect(json.contentType).toBe("text/plain");
+      expect(json.url).toContain("teststore/public/");
+      expect(json.downloadUrl).toContain("?download=1");
+      expect(json.etag).toMatch(/^"[a-f0-9]+"$/);
+    });
+
+    it("applies random suffix by default", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=file.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public" },
+        body: "data",
+      });
+      const json = await res.json();
+      expect(json.pathname).toMatch(/^file-[A-Za-z0-9]{6}\.txt$/);
+    });
+
+    it("skips random suffix when x-add-random-suffix is 0", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=exact.txt`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders(),
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+        },
+        body: "data",
+      });
+      const json = await res.json();
+      expect(json.pathname).toBe("exact.txt");
+    });
+
+    it("uses x-content-type header when provided", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=data.bin`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders(),
+          "x-vercel-blob-access": "public",
+          "x-content-type": "application/json",
+          "x-add-random-suffix": "0",
+        },
+        body: '{"key":"value"}',
+      });
+      const json = await res.json();
+      expect(json.contentType).toBe("application/json");
+    });
+
+    it("infers content type from extension", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=image.png`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders(),
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+        },
+        body: "fake png data",
+      });
+      const json = await res.json();
+      expect(json.contentType).toBe("image/png");
+    });
+
+    it("uses generic store ID for non-rw tokens", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=test.txt`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders("test-token"),
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+        },
+        body: "data",
+      });
+      const json = await res.json();
+      expect(json.url).toContain("default/public/");
+    });
+
+    it("creates a folder with trailing slash pathname", async () => {
+      const res = await app.request(`${base}/api/blob?pathname=my-folder/`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders(),
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+        },
+        body: "",
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.pathname).toBe("my-folder/");
+      expect(json.contentType).toBe("application/x-directory");
+    });
+  });
+
+  describe("GET /api/blob (head)", () => {
+    it("returns blob metadata by URL", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=meta.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "metadata test",
+      });
+      const { url } = await putRes.json();
+
+      const res = await app.request(`${base}/api/blob?url=${encodeURIComponent(url)}`, {
+        headers: blobHeaders(),
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.pathname).toBe("meta.txt");
+      expect(json.size).toBe(13);
+      expect(json.contentType).toBe("text/plain");
+      expect(json.url).toBe(url);
+      expect(json.uploadedAt).toBeDefined();
+    });
+
+    it("returns 404 for unknown blob", async () => {
+      const res = await app.request(`${base}/api/blob?url=${encodeURIComponent(`${base}/no/such/blob`)}`, {
+        headers: blobHeaders(),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("blob_not_found");
+    });
+  });
+
+  describe("POST /api/blob/delete", () => {
+    it("deletes blobs by URL", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=to-delete.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "delete me",
+      });
+      const { url } = await putRes.json();
+
+      const delRes = await app.request(`${base}/api/blob/delete`, {
+        method: "POST",
+        headers: { ...blobHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ urls: [url] }),
+      });
+      expect(delRes.status).toBe(200);
+
+      const headRes = await app.request(`${base}/api/blob?url=${encodeURIComponent(url)}`, {
+        headers: blobHeaders(),
+      });
+      expect(headRes.status).toBe(404);
+    });
+
+    it("silently skips unknown URLs", async () => {
+      const res = await app.request(`${base}/api/blob/delete`, {
+        method: "POST",
+        headers: { ...blobHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ urls: [`${base}/no/such/blob`] }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("GET /api/blob (list)", () => {
+    async function seedBlobs() {
+      const paths = ["a.txt", "b.txt", "dir/c.txt", "dir/d.txt", "dir/sub/e.txt"];
+      for (const p of paths) {
+        await app.request(`${base}/api/blob?pathname=${p}`, {
+          method: "PUT",
+          headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+          body: `content of ${p}`,
+        });
+      }
+    }
+
+    it("lists all blobs", async () => {
+      await seedBlobs();
+      const res = await app.request(`${base}/api/blob`, { headers: blobHeaders() });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.blobs).toHaveLength(5);
+      expect(json.hasMore).toBe(false);
+    });
+
+    it("filters by prefix", async () => {
+      await seedBlobs();
+      const res = await app.request(`${base}/api/blob?prefix=dir/`, { headers: blobHeaders() });
+      const json = await res.json();
+      expect(json.blobs).toHaveLength(3);
+      expect(json.blobs.every((b: any) => b.pathname.startsWith("dir/"))).toBe(true);
+    });
+
+    it("paginates with limit and cursor", async () => {
+      await seedBlobs();
+      const res1 = await app.request(`${base}/api/blob?limit=2`, { headers: blobHeaders() });
+      const json1 = await res1.json();
+      expect(json1.blobs).toHaveLength(2);
+      expect(json1.hasMore).toBe(true);
+      expect(json1.cursor).toBeDefined();
+
+      const res2 = await app.request(`${base}/api/blob?limit=2&cursor=${json1.cursor}`, { headers: blobHeaders() });
+      const json2 = await res2.json();
+      expect(json2.blobs).toHaveLength(2);
+
+      const res3 = await app.request(`${base}/api/blob?limit=2&cursor=${json2.cursor}`, { headers: blobHeaders() });
+      const json3 = await res3.json();
+      expect(json3.blobs).toHaveLength(1);
+      expect(json3.hasMore).toBe(false);
+    });
+
+    it("returns folders in folded mode", async () => {
+      await seedBlobs();
+      const res = await app.request(`${base}/api/blob?mode=folded`, { headers: blobHeaders() });
+      const json = await res.json();
+      expect(json.blobs.map((b: any) => b.pathname)).toEqual(["a.txt", "b.txt"]);
+      expect(json.folders).toEqual(["dir/"]);
+    });
+
+    it("returns folders in folded mode with prefix", async () => {
+      await seedBlobs();
+      const res = await app.request(`${base}/api/blob?mode=folded&prefix=dir/`, { headers: blobHeaders() });
+      const json = await res.json();
+      expect(json.blobs.map((b: any) => b.pathname)).toEqual(["dir/c.txt", "dir/d.txt"]);
+      expect(json.folders).toEqual(["dir/sub/"]);
+    });
+  });
+
+  describe("PUT /api/blob (copy)", () => {
+    it("copies a blob to a new pathname", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=original.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "copy me",
+      });
+      const { url: fromUrl } = await putRes.json();
+
+      const copyRes = await app.request(
+        `${base}/api/blob?pathname=copied.txt&fromUrl=${encodeURIComponent(fromUrl)}`,
+        {
+          method: "PUT",
+          headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        }
+      );
+      expect(copyRes.status).toBe(200);
+      const json = await copyRes.json();
+      expect(json.pathname).toBe("copied.txt");
+      expect(json.contentType).toBe("text/plain");
+    });
+
+    it("returns 404 when source blob does not exist", async () => {
+      const res = await app.request(
+        `${base}/api/blob?pathname=dest.txt&fromUrl=${encodeURIComponent(`${base}/no/such/blob`)}`,
+        {
+          method: "PUT",
+          headers: { ...blobHeaders(), "x-vercel-blob-access": "public" },
+        }
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /:storeId/:access/* (download)", () => {
+    it("serves blob content", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=download.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "file content here",
+      });
+      const { url } = await putRes.json();
+
+      const res = await app.request(url);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("file content here");
+      expect(res.headers.get("content-type")).toBe("text/plain");
+      expect(res.headers.get("etag")).toMatch(/^"[a-f0-9]+"$/);
+    });
+
+    it("returns 304 for matching If-None-Match", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=cached.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "cached content",
+      });
+      const { etag, url } = await putRes.json();
+
+      const res = await app.request(url, {
+        headers: { "if-none-match": etag },
+      });
+      expect(res.status).toBe(304);
+    });
+
+    it("sets attachment disposition with ?download=1", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=attach.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "download me",
+      });
+      const { downloadUrl } = await putRes.json();
+
+      const res = await app.request(downloadUrl);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-disposition")).toContain("attachment");
+    });
+
+    it("requires auth for private blobs", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=secret.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "private", "x-add-random-suffix": "0" },
+        body: "secret",
+      });
+      const { url } = await putRes.json();
+
+      const res = await app.request(url);
+      expect(res.status).toBe(403);
+
+      const authedRes = await app.request(url, { headers: blobHeaders() });
+      expect(authedRes.status).toBe(200);
+    });
+
+    it("returns 404 for non-blob paths", async () => {
+      const res = await app.request(`${base}/teststore/public/nonexistent.txt`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /api/blob/mpu (multipart)", () => {
+    it("completes a full multipart upload flow", async () => {
+      const createRes = await app.request(`${base}/api/blob/mpu?pathname=big-file.bin`, {
+        method: "POST",
+        headers: {
+          ...blobHeaders(),
+          "x-mpu-action": "create",
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+        },
+      });
+      expect(createRes.status).toBe(200);
+      const { uploadId, key } = await createRes.json();
+      expect(uploadId).toBeDefined();
+      expect(key).toBeDefined();
+
+      const part1 = await app.request(`${base}/api/blob/mpu?pathname=big-file.bin`, {
+        method: "POST",
+        headers: {
+          ...blobHeaders(),
+          "x-mpu-action": "upload",
+          "x-mpu-upload-id": uploadId,
+          "x-mpu-key": key,
+          "x-mpu-part-number": "1",
+        },
+        body: "part one data ",
+      });
+      expect(part1.status).toBe(200);
+      const p1 = await part1.json();
+      expect(p1.etag).toBeDefined();
+
+      const part2 = await app.request(`${base}/api/blob/mpu?pathname=big-file.bin`, {
+        method: "POST",
+        headers: {
+          ...blobHeaders(),
+          "x-mpu-action": "upload",
+          "x-mpu-upload-id": uploadId,
+          "x-mpu-key": key,
+          "x-mpu-part-number": "2",
+        },
+        body: "part two data",
+      });
+      expect(part2.status).toBe(200);
+      const p2 = await part2.json();
+
+      const completeRes = await app.request(`${base}/api/blob/mpu?pathname=big-file.bin`, {
+        method: "POST",
+        headers: {
+          ...blobHeaders(),
+          "x-mpu-action": "complete",
+          "x-mpu-upload-id": uploadId,
+          "x-mpu-key": key,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify([
+          { etag: p1.etag, partNumber: 1 },
+          { etag: p2.etag, partNumber: 2 },
+        ]),
+      });
+      expect(completeRes.status).toBe(200);
+      const result = await completeRes.json();
+      expect(result.pathname).toBe("big-file.bin");
+      expect(result.url).toContain("teststore/public/big-file.bin");
+
+      const dlRes = await app.request(result.url);
+      expect(dlRes.status).toBe(200);
+      expect(await dlRes.text()).toBe("part one data part two data");
+    });
+  });
+
+  describe("overwrite + conditional operations", () => {
+    it("blocks overwrite by default when no random suffix", async () => {
+      await app.request(`${base}/api/blob?pathname=ow.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "first",
+      });
+      const res = await app.request(`${base}/api/blob?pathname=ow.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "second",
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("allows overwrite with x-allow-overwrite", async () => {
+      await app.request(`${base}/api/blob?pathname=ow2.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "first",
+      });
+      const res = await app.request(`${base}/api/blob?pathname=ow2.txt`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders(),
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+          "x-allow-overwrite": "1",
+        },
+        body: "second",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 412 on ETag mismatch for put", async () => {
+      await app.request(`${base}/api/blob?pathname=cond.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "original",
+      });
+      const res = await app.request(`${base}/api/blob?pathname=cond.txt`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders(),
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+          "x-allow-overwrite": "1",
+          "x-if-match": '"wrong-etag"',
+        },
+        body: "updated",
+      });
+      expect(res.status).toBe(412);
+    });
+
+    it("succeeds on ETag match for put", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=cond2.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "original",
+      });
+      const { etag } = await putRes.json();
+      const res = await app.request(`${base}/api/blob?pathname=cond2.txt`, {
+        method: "PUT",
+        headers: {
+          ...blobHeaders(),
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+          "x-allow-overwrite": "1",
+          "x-if-match": etag,
+        },
+        body: "updated",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 412 on ETag mismatch for delete", async () => {
+      const putRes = await app.request(`${base}/api/blob?pathname=cond-del.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "delete me",
+      });
+      const { url } = await putRes.json();
+      const res = await app.request(`${base}/api/blob/delete`, {
+        method: "POST",
+        headers: { ...blobHeaders(), "content-type": "application/json", "x-if-match": '"wrong"' },
+        body: JSON.stringify({ urls: [url] }),
+      });
+      expect(res.status).toBe(412);
+    });
+  });
+
+  describe("seed configuration", () => {
+    it("seeds blobs from config", async () => {
+      const seededApp = (() => {
+        const s = new Store();
+        const w = new WebhookDispatcher();
+        const tm: TokenMap = new Map();
+        const a = new Hono();
+        a.onError(createApiErrorHandler());
+        a.use("*", createErrorHandler());
+        a.use("*", authMiddleware(tm));
+        vercelPlugin.register(a, s, w, base, tm);
+        vercelPlugin.seed?.(s, base);
+        seedFromConfig(s, base, {
+          blob_stores: [
+            {
+              store_id: "seedstore",
+              token: "vercel_blob_rw_seedstore_secret",
+              access: "public" as const,
+              blobs: [
+                { pathname: "seeded.txt", content: "seeded content", content_type: "text/plain" },
+                { pathname: "seeded.bin", content_base64: Buffer.from("binary data").toString("base64"), content_type: "application/octet-stream" },
+              ],
+            },
+          ],
+        }, tm);
+        return a;
+      })();
+
+      const res = await seededApp.request(`${base}/api/blob`, {
+        headers: { Authorization: "Bearer vercel_blob_rw_seedstore_secret" },
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.blobs).toHaveLength(2);
+      expect(json.blobs.map((b: any) => b.pathname).sort()).toEqual(["seeded.bin", "seeded.txt"]);
+    });
+  });
+
+  describe("POST /api/blob/handle-blob-upload (client tokens)", () => {
+    it("generates a client token and uses it to upload", async () => {
+      await app.request(`${base}/api/blob?pathname=warmup.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "warmup",
+      });
+
+      const genRes = await app.request(`${base}/api/blob/handle-blob-upload`, {
+        method: "POST",
+        headers: { ...blobHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "blob.generate-client-token",
+          payload: {
+            pathname: "client-upload.txt",
+            callbackUrl: `${base}/api/blob/handle-blob-upload`,
+            multipart: false,
+            clientPayload: null,
+          },
+        }),
+      });
+      expect(genRes.status).toBe(200);
+      const genJson = await genRes.json();
+      expect(genJson.type).toBe("blob.generate-client-token");
+      expect(genJson.clientToken).toMatch(/^vercel_blob_client_/);
+
+      const uploadRes = await app.request(`${base}/api/blob?pathname=client-upload.txt`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${genJson.clientToken}`,
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+        },
+        body: "client uploaded content",
+      });
+      expect(uploadRes.status).toBe(200);
+      const uploadJson = await uploadRes.json();
+      expect(uploadJson.pathname).toBe("client-upload.txt");
+    });
+
+    it("acknowledges upload-completed callback", async () => {
+      const res = await app.request(`${base}/api/blob/handle-blob-upload`, {
+        method: "POST",
+        headers: { ...blobHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "blob.upload-completed",
+          payload: { blob: { url: "http://example.com/blob" }, tokenPayload: null },
+        }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects expired client token", async () => {
+      await app.request(`${base}/api/blob?pathname=warmup2.txt`, {
+        method: "PUT",
+        headers: { ...blobHeaders(), "x-vercel-blob-access": "public", "x-add-random-suffix": "0" },
+        body: "warmup",
+      });
+
+      const genRes = await app.request(`${base}/api/blob/handle-blob-upload`, {
+        method: "POST",
+        headers: { ...blobHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "blob.generate-client-token",
+          payload: {
+            pathname: "expired.txt",
+            callbackUrl: `${base}/api/blob/handle-blob-upload`,
+            validUntil: 0,
+          },
+        }),
+      });
+      const { clientToken } = await genRes.json();
+
+      const res = await app.request(`${base}/api/blob?pathname=expired.txt`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${clientToken}`,
+          "x-vercel-blob-access": "public",
+          "x-add-random-suffix": "0",
+        },
+        body: "should fail",
+      });
+      expect(res.status).toBe(403);
+    });
   });
 });

--- a/packages/@emulators/vercel/src/entities.ts
+++ b/packages/@emulators/vercel/src/entities.ts
@@ -242,3 +242,34 @@ export interface VercelIntegration extends Entity {
   name: string;
   redirect_uris: string[];
 }
+
+export interface VercelBlob extends Entity {
+  storeId: string;
+  pathname: string;
+  url: string;
+  downloadUrl: string;
+  access: "public" | "private";
+  contentType: string;
+  contentDisposition: string;
+  cacheControl: string;
+  size: number;
+  etag: string;
+  content: Buffer;
+}
+
+export interface VercelBlobMultipartUpload extends Entity {
+  storeId: string;
+  pathname: string;
+  uploadId: string;
+  key: string;
+  access: "public" | "private";
+  contentType: string;
+}
+
+export interface VercelBlobMultipartPart extends Entity {
+  uploadId: string;
+  partNumber: number;
+  etag: string;
+  content: Buffer;
+  size: number;
+}

--- a/packages/@emulators/vercel/src/index.ts
+++ b/packages/@emulators/vercel/src/index.ts
@@ -10,6 +10,7 @@ import { domainsRoutes } from "./routes/domains.js";
 import { envRoutes } from "./routes/env.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { apiKeysRoutes } from "./routes/api-keys.js";
+import { blobRoutes, computeEtag, inferContentType } from "./routes/blob.js";
 
 export { getVercelStore, type VercelStore } from "./store.js";
 export * from "./entities.js";
@@ -47,6 +48,17 @@ export interface VercelSeedConfig {
     name: string;
     redirect_uris: string[];
   }>;
+  blob_stores?: Array<{
+    store_id: string;
+    token: string;
+    access: "public" | "private";
+    blobs?: Array<{
+      pathname: string;
+      content?: string;
+      content_base64?: string;
+      content_type?: string;
+    }>;
+  }>;
 }
 
 function seedDefaults(store: Store, _baseUrl: string): void {
@@ -67,7 +79,7 @@ function seedDefaults(store: Store, _baseUrl: string): void {
   });
 }
 
-export function seedFromConfig(store: Store, baseUrl: string, config: VercelSeedConfig): void {
+export function seedFromConfig(store: Store, baseUrl: string, config: VercelSeedConfig, tokenMap?: TokenMap): void {
   const vs = getVercelStore(store);
 
   if (config.users) {
@@ -205,6 +217,49 @@ export function seedFromConfig(store: Store, baseUrl: string, config: VercelSeed
       });
     }
   }
+
+  if (config.blob_stores) {
+    const vs = getVercelStore(store);
+    for (const bs of config.blob_stores) {
+      // Register token
+      if (tokenMap && bs.token) {
+        tokenMap.set(bs.token, { login: bs.store_id, id: 0, scopes: [] });
+        const rwTokens = store.getData<Map<string, string>>("vercel.blob_rw_tokens") ?? new Map();
+        rwTokens.set(bs.store_id, bs.token);
+        store.setData("vercel.blob_rw_tokens", rwTokens);
+      }
+
+      if (bs.blobs) {
+        for (const b of bs.blobs) {
+          const existing = vs.blobs
+            .findBy("storeId", bs.store_id as any)
+            .find((e) => e.pathname === b.pathname);
+          if (existing) continue;
+
+          const content = b.content_base64
+            ? Buffer.from(b.content_base64, "base64")
+            : Buffer.from(b.content ?? "");
+          const contentType = b.content_type ?? inferContentType(b.pathname);
+          const url = `${baseUrl}/${bs.store_id}/${bs.access}/${b.pathname}`;
+          const filename = b.pathname.split("/").pop() ?? b.pathname;
+
+          vs.blobs.insert({
+            storeId: bs.store_id,
+            pathname: b.pathname,
+            url,
+            downloadUrl: `${url}?download=1`,
+            access: bs.access,
+            contentType,
+            contentDisposition: `attachment; filename="${filename}"`,
+            cacheControl: "public, max-age=2592000",
+            size: content.length,
+            etag: computeEtag(content),
+            content,
+          });
+        }
+      }
+    }
+  }
 }
 
 export const vercelPlugin: ServicePlugin = {
@@ -218,6 +273,7 @@ export const vercelPlugin: ServicePlugin = {
     domainsRoutes(ctx);
     envRoutes(ctx);
     apiKeysRoutes(ctx);
+    blobRoutes(ctx);
   },
   seed(store: Store, baseUrl: string): void {
     seedDefaults(store, baseUrl);

--- a/packages/@emulators/vercel/src/routes/blob.ts
+++ b/packages/@emulators/vercel/src/routes/blob.ts
@@ -1,0 +1,630 @@
+import { createHash, createHmac, randomBytes } from "crypto";
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { RouteContext, Store } from "@emulators/core";
+import { getVercelStore } from "../store.js";
+import type { VercelBlob } from "../entities.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function blobErr(c: Context, status: ContentfulStatusCode, code: string, message: string) {
+  return c.json({ error: { code, message } }, status);
+}
+
+interface ParsedBlobToken {
+  token: string;
+  storeId: string;
+  type: "rw" | "client" | "generic";
+}
+
+export function parseBlobToken(authHeader: string | undefined): ParsedBlobToken | null {
+  if (!authHeader) return null;
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!token) return null;
+
+  const rwMatch = token.match(/^vercel_blob_rw_([^_]+)_(.+)$/);
+  if (rwMatch) return { token, storeId: rwMatch[1], type: "rw" };
+
+  const clientMatch = token.match(/^vercel_blob_client_([^_]+)_(.+)$/);
+  if (clientMatch) return { token, storeId: clientMatch[1], type: "client" };
+
+  return { token, storeId: "default", type: "generic" };
+}
+
+export function computeEtag(content: Buffer): string {
+  return `"${createHash("md5").update(content).digest("hex")}"`;
+}
+
+export function applyRandomSuffix(pathname: string): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const bytes = randomBytes(6);
+  let suffix = "";
+  for (let i = 0; i < 6; i++) suffix += chars[bytes[i] % chars.length];
+
+  const lastDot = pathname.lastIndexOf(".");
+  const lastSlash = pathname.lastIndexOf("/");
+  if (lastDot === -1 || lastDot < lastSlash) return `${pathname}-${suffix}`;
+  return `${pathname.slice(0, lastDot)}-${suffix}${pathname.slice(lastDot)}`;
+}
+
+const CONTENT_TYPE_MAP: Record<string, string> = {
+  ".html": "text/html", ".css": "text/css", ".js": "application/javascript",
+  ".json": "application/json", ".txt": "text/plain", ".xml": "application/xml",
+  ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+  ".gif": "image/gif", ".svg": "image/svg+xml", ".webp": "image/webp",
+  ".ico": "image/x-icon", ".pdf": "application/pdf", ".zip": "application/zip",
+  ".woff": "font/woff", ".woff2": "font/woff2", ".ttf": "font/ttf",
+  ".mp3": "audio/mpeg", ".mp4": "video/mp4", ".webm": "video/webm",
+  ".csv": "text/csv", ".md": "text/markdown",
+};
+
+export function inferContentType(pathname: string): string {
+  const dot = pathname.lastIndexOf(".");
+  if (dot === -1) return "application/octet-stream";
+  const ext = pathname.slice(dot).toLowerCase();
+  return CONTENT_TYPE_MAP[ext] ?? "application/octet-stream";
+}
+
+function buildBlobUrl(baseUrl: string, storeId: string, access: string, pathname: string): string {
+  return `${baseUrl}/${storeId}/${access}/${pathname}`;
+}
+
+function contentDispositionFor(pathname: string): string {
+  const filename = pathname.split("/").pop() ?? pathname;
+  return `attachment; filename="${filename}"`;
+}
+
+function requireBlobAuth(c: Context): ParsedBlobToken | null {
+  return parseBlobToken(c.req.header("authorization"));
+}
+
+function formatBlobResult(blob: VercelBlob) {
+  return {
+    pathname: blob.pathname,
+    contentType: blob.contentType,
+    contentDisposition: blob.contentDisposition,
+    url: blob.url,
+    downloadUrl: blob.downloadUrl,
+    etag: blob.etag,
+  };
+}
+
+function formatBlobHead(blob: VercelBlob) {
+  return {
+    url: blob.url,
+    downloadUrl: blob.downloadUrl,
+    pathname: blob.pathname,
+    size: blob.size,
+    uploadedAt: blob.created_at,
+    contentType: blob.contentType,
+    contentDisposition: blob.contentDisposition,
+    cacheControl: blob.cacheControl,
+    etag: blob.etag,
+  };
+}
+
+interface ClientTokenPayload {
+  pathname: string;
+  maximumSizeInBytes: number | null;
+  allowedContentTypes: string[] | null;
+  validUntil: number;
+  addRandomSuffix: boolean;
+  allowOverwrite: boolean;
+  cacheControlMaxAge: number;
+}
+
+function verifyClientToken(auth: ParsedBlobToken, store: Store): {
+  valid: boolean;
+  code?: string;
+  message?: string;
+  payload?: ClientTokenPayload;
+} {
+  const tokenMap = store.getData<Map<string, string>>("vercel.blob_rw_tokens");
+  if (!tokenMap) return { valid: false, code: "blob_access_error", message: "No RW token found for store" };
+
+  const rwToken = tokenMap.get(auth.storeId);
+  if (!rwToken) return { valid: false, code: "blob_access_error", message: "No RW token found for store" };
+
+  try {
+    const encoded = auth.token.replace(`vercel_blob_client_${auth.storeId}_`, "");
+    const decoded = Buffer.from(encoded, "base64url").toString();
+    const dotIdx = decoded.indexOf(".");
+    if (dotIdx === -1) return { valid: false, code: "blob_access_error", message: "Invalid client token" };
+
+    const signature = decoded.slice(0, dotIdx);
+    const payloadStr = decoded.slice(dotIdx + 1);
+
+    const expectedSig = createHmac("sha256", rwToken).update(payloadStr).digest("base64url");
+    if (signature !== expectedSig) {
+      return { valid: false, code: "blob_access_error", message: "Invalid client token signature" };
+    }
+
+    const payload: ClientTokenPayload = JSON.parse(payloadStr);
+
+    if (payload.validUntil < Date.now()) {
+      return { valid: false, code: "blob_access_error", message: "Client token expired" };
+    }
+
+    return { valid: true, payload };
+  } catch {
+    return { valid: false, code: "blob_access_error", message: "Invalid client token" };
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Routes                                                            */
+/* ------------------------------------------------------------------ */
+
+export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
+  const vs = getVercelStore(store);
+
+  // PUT /api/blob — put or copy
+  app.put("/api/blob", async (c) => {
+    const auth = requireBlobAuth(c);
+    if (!auth) return blobErr(c, 403, "blob_access_error", "Authentication required");
+
+    const pathname = c.req.query("pathname");
+    if (!pathname) return blobErr(c, 400, "blob_unknown_error", "Missing pathname");
+
+    const fromUrl = c.req.query("fromUrl");
+    if (fromUrl) {
+      return handleCopy(c, vs, auth, pathname, fromUrl, baseUrl);
+    }
+    return handlePut(c, vs, auth, pathname, baseUrl, store);
+  });
+
+  // GET /api/blob — head (with url param) or list (without)
+  app.get("/api/blob", (c) => {
+    const auth = requireBlobAuth(c);
+    if (!auth) return blobErr(c, 403, "blob_access_error", "Authentication required");
+
+    const url = c.req.query("url");
+    if (url) {
+      return handleHead(c, vs, url);
+    }
+    return handleList(c, vs, auth);
+  });
+
+  // POST /api/blob/delete
+  app.post("/api/blob/delete", async (c) => {
+    const auth = requireBlobAuth(c);
+    if (!auth) return blobErr(c, 403, "blob_access_error", "Authentication required");
+    return handleDelete(c, vs);
+  });
+
+  // POST /api/blob/mpu — multipart upload
+  app.post("/api/blob/mpu", async (c) => {
+    const auth = requireBlobAuth(c);
+    if (!auth) return blobErr(c, 403, "blob_access_error", "Authentication required");
+    return handleMpu(c, vs, auth, baseUrl, store);
+  });
+
+  // POST /api/blob/handle-blob-upload — client token flow
+  app.post("/api/blob/handle-blob-upload", async (c) => {
+    const auth = requireBlobAuth(c);
+    if (!auth) return blobErr(c, 403, "blob_access_error", "Authentication required");
+    return handleBlobUpload(c, auth, store);
+  });
+
+  // GET /:storeId/:access/* — content serving (registered last)
+  app.get("/:storeId/:access/*", (c) => {
+    const access = c.req.param("access");
+    if (access !== "public" && access !== "private") return c.notFound();
+
+    const storeId = c.req.param("storeId");
+    const pathname = c.req.path.slice(`/${storeId}/${access}/`.length);
+    if (!pathname) return c.notFound();
+
+    if (access === "private") {
+      const auth = requireBlobAuth(c);
+      if (!auth) return blobErr(c, 403, "blob_access_error", "Authentication required for private blobs");
+    }
+
+    const blob = vs.blobs
+      .findBy("storeId", storeId as VercelBlob["storeId"])
+      .find((b) => b.pathname === pathname);
+    if (!blob) return c.notFound();
+
+    const ifNoneMatch = c.req.header("if-none-match");
+    if (ifNoneMatch && ifNoneMatch === blob.etag) {
+      return new Response(null, { status: 304, headers: { etag: blob.etag } });
+    }
+
+    const isDownload = c.req.query("download") === "1";
+    const disposition = isDownload ? contentDispositionFor(blob.pathname) : "inline";
+
+    return new Response(blob.content, {
+      status: 200,
+      headers: {
+        "content-type": blob.contentType,
+        "content-disposition": disposition,
+        "content-length": String(blob.size),
+        "cache-control": blob.cacheControl,
+        etag: blob.etag,
+      },
+    });
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Handler implementations                                           */
+/* ------------------------------------------------------------------ */
+
+async function handlePut(
+  c: Context,
+  vs: ReturnType<typeof getVercelStore>,
+  auth: ParsedBlobToken,
+  pathname: string,
+  baseUrl: string,
+  store: Store,
+) {
+  // Client token verification
+  let clientPayload: ClientTokenPayload | undefined;
+  if (auth.type === "client") {
+    const verification = verifyClientToken(auth, store);
+    if (!verification.valid) {
+      return blobErr(c, 403, verification.code!, verification.message!);
+    }
+    clientPayload = verification.payload;
+  }
+
+  const access = (c.req.header("x-vercel-blob-access") ?? "public") as "public" | "private";
+  const addSuffix = c.req.header("x-add-random-suffix") !== "0";
+  const allowOverwrite = c.req.header("x-allow-overwrite") === "1";
+  const cacheMaxAge = parseInt(c.req.header("x-cache-control-max-age") ?? "2592000", 10);
+  const ifMatch = c.req.header("x-if-match");
+  const contentType = c.req.header("x-content-type") ?? inferContentType(pathname);
+
+  // Folder creation: trailing slash pathname
+  if (pathname.endsWith("/")) {
+    const url = buildBlobUrl(baseUrl, auth.storeId, access, pathname);
+    const blob = vs.blobs.insert({
+      storeId: auth.storeId,
+      pathname,
+      url,
+      downloadUrl: `${url}?download=1`,
+      access,
+      contentType: "application/x-directory",
+      contentDisposition: contentDispositionFor(pathname),
+      cacheControl: `public, max-age=${cacheMaxAge}`,
+      size: 0,
+      etag: computeEtag(Buffer.alloc(0)),
+      content: Buffer.alloc(0),
+    });
+    return c.json(formatBlobResult(blob));
+  }
+
+  const resolvedPathname = addSuffix ? applyRandomSuffix(pathname) : pathname;
+
+  // Overwrite / conditional check
+  const existing = vs.blobs
+    .findBy("storeId", auth.storeId as VercelBlob["storeId"])
+    .find((b) => b.pathname === resolvedPathname);
+
+  if (ifMatch && existing && existing.etag !== ifMatch) {
+    return blobErr(c, 412, "blob_precondition_failed", "ETag mismatch");
+  }
+  if (existing && !allowOverwrite && !addSuffix) {
+    return blobErr(c, 409, "blob_unknown_error", "Blob already exists. Use allowOverwrite or addRandomSuffix.");
+  }
+
+  const buf = Buffer.from(await c.req.arrayBuffer());
+
+  if (clientPayload) {
+    if (clientPayload.maximumSizeInBytes !== null && buf.length > clientPayload.maximumSizeInBytes) {
+      return blobErr(c, 400, "blob_file_too_large", `File exceeds maximum size of ${clientPayload.maximumSizeInBytes} bytes`);
+    }
+    if (clientPayload.allowedContentTypes !== null && !clientPayload.allowedContentTypes.includes(contentType)) {
+      return blobErr(c, 400, "blob_content_type_not_allowed", `Content type ${contentType} is not allowed`);
+    }
+  }
+
+  const etag = computeEtag(buf);
+  const url = buildBlobUrl(baseUrl, auth.storeId, access, resolvedPathname);
+  const downloadUrl = `${url}?download=1`;
+
+  // If overwriting, delete old blob first
+  if (existing && allowOverwrite) {
+    vs.blobs.delete(existing.id);
+  }
+
+  // Record the rw token for client token verification later
+  if (auth.type === "rw") {
+    const tokenMap = store.getData<Map<string, string>>("vercel.blob_rw_tokens") ?? new Map();
+    tokenMap.set(auth.storeId, auth.token);
+    store.setData("vercel.blob_rw_tokens", tokenMap);
+  }
+
+  const blob = vs.blobs.insert({
+    storeId: auth.storeId,
+    pathname: resolvedPathname,
+    url,
+    downloadUrl,
+    access,
+    contentType,
+    contentDisposition: contentDispositionFor(resolvedPathname),
+    cacheControl: `public, max-age=${cacheMaxAge}`,
+    size: buf.length,
+    etag,
+    content: buf,
+  });
+
+  return c.json(formatBlobResult(blob));
+}
+
+function handleHead(c: Context, vs: ReturnType<typeof getVercelStore>, url: string) {
+  const blob = vs.blobs.findOneBy("url", url as VercelBlob["url"]);
+  if (!blob) return blobErr(c, 404, "blob_not_found", "The requested blob does not exist");
+  return c.json(formatBlobHead(blob));
+}
+
+async function handleDelete(c: Context, vs: ReturnType<typeof getVercelStore>) {
+  const body = await c.req.json();
+  const urls: string[] = body.urls ?? [];
+  const ifMatch = c.req.header("x-if-match");
+
+  for (const url of urls) {
+    const blob = vs.blobs.findOneBy("url", url as VercelBlob["url"]);
+    if (!blob) continue;
+    if (ifMatch && blob.etag !== ifMatch) {
+      return blobErr(c, 412, "blob_precondition_failed", "ETag mismatch");
+    }
+    vs.blobs.delete(blob.id);
+  }
+
+  return c.body(null, 200);
+}
+
+function handleList(c: Context, vs: ReturnType<typeof getVercelStore>, auth: ParsedBlobToken) {
+  const limit = Math.min(1000, Math.max(1, parseInt(c.req.query("limit") ?? "1000", 10)));
+  const prefix = c.req.query("prefix") ?? "";
+  const cursor = c.req.query("cursor");
+  const mode = c.req.query("mode") ?? "expanded";
+
+  let blobs = vs.blobs
+    .findBy("storeId", auth.storeId as VercelBlob["storeId"])
+    .filter((b) => b.pathname.startsWith(prefix))
+    .sort((a, b) => a.pathname.localeCompare(b.pathname));
+
+  const offset = cursor ? parseInt(Buffer.from(cursor, "base64url").toString(), 10) : 0;
+  blobs = blobs.slice(offset);
+
+  const hasMore = blobs.length > limit;
+  const page = blobs.slice(0, limit);
+  const nextCursor = hasMore ? Buffer.from(String(offset + limit)).toString("base64url") : undefined;
+
+  if (mode === "folded") {
+    const folderSet = new Set<string>();
+    const directBlobs: typeof page = [];
+
+    for (const blob of page) {
+      const rest = blob.pathname.slice(prefix.length);
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx !== -1) {
+        folderSet.add(prefix + rest.slice(0, slashIdx + 1));
+      } else {
+        directBlobs.push(blob);
+      }
+    }
+
+    return c.json({
+      blobs: directBlobs.map((b) => ({
+        url: b.url,
+        downloadUrl: b.downloadUrl,
+        pathname: b.pathname,
+        size: b.size,
+        uploadedAt: b.created_at,
+        etag: b.etag,
+      })),
+      folders: [...folderSet].sort(),
+      cursor: nextCursor,
+      hasMore,
+    });
+  }
+
+  return c.json({
+    blobs: page.map((b) => ({
+      url: b.url,
+      downloadUrl: b.downloadUrl,
+      pathname: b.pathname,
+      size: b.size,
+      uploadedAt: b.created_at,
+      etag: b.etag,
+    })),
+    cursor: nextCursor,
+    hasMore,
+  });
+}
+
+async function handleCopy(
+  c: Context,
+  vs: ReturnType<typeof getVercelStore>,
+  auth: ParsedBlobToken,
+  toPathname: string,
+  fromUrl: string,
+  baseUrl: string,
+) {
+  const source = vs.blobs.findOneBy("url", fromUrl as VercelBlob["url"]);
+  if (!source) return blobErr(c, 404, "blob_not_found", "Source blob not found");
+
+  const access = (c.req.header("x-vercel-blob-access") ?? source.access) as "public" | "private";
+  const addSuffix = c.req.header("x-add-random-suffix") !== "0";
+  const allowOverwrite = c.req.header("x-allow-overwrite") === "1";
+  const cacheMaxAge = parseInt(c.req.header("x-cache-control-max-age") ?? "2592000", 10);
+  const ifMatch = c.req.header("x-if-match");
+  const contentType = c.req.header("x-content-type") ?? source.contentType;
+
+  const resolvedPathname = addSuffix ? applyRandomSuffix(toPathname) : toPathname;
+
+  const existing = vs.blobs
+    .findBy("storeId", auth.storeId as VercelBlob["storeId"])
+    .find((b) => b.pathname === resolvedPathname);
+
+  if (ifMatch && existing && existing.etag !== ifMatch) {
+    return blobErr(c, 412, "blob_precondition_failed", "ETag mismatch");
+  }
+  if (existing && !allowOverwrite && !addSuffix) {
+    return blobErr(c, 409, "blob_unknown_error", "Blob already exists. Use allowOverwrite or addRandomSuffix.");
+  }
+  if (existing && allowOverwrite) {
+    vs.blobs.delete(existing.id);
+  }
+
+  const url = buildBlobUrl(baseUrl, auth.storeId, access, resolvedPathname);
+  const blob = vs.blobs.insert({
+    storeId: auth.storeId,
+    pathname: resolvedPathname,
+    url,
+    downloadUrl: `${url}?download=1`,
+    access,
+    contentType,
+    contentDisposition: contentDispositionFor(resolvedPathname),
+    cacheControl: `public, max-age=${cacheMaxAge}`,
+    size: source.size,
+    etag: source.etag,
+    content: Buffer.from(source.content),
+  });
+
+  return c.json(formatBlobResult(blob));
+}
+
+async function handleMpu(
+  c: Context,
+  vs: ReturnType<typeof getVercelStore>,
+  auth: ParsedBlobToken,
+  baseUrl: string,
+  store: Store,
+) {
+  const action = c.req.header("x-mpu-action");
+
+  if (action === "create") {
+    const pathname = c.req.query("pathname");
+    if (!pathname) return blobErr(c, 400, "blob_unknown_error", "Missing pathname");
+
+    const access = (c.req.header("x-vercel-blob-access") ?? "public") as "public" | "private";
+    const addSuffix = c.req.header("x-add-random-suffix") !== "0";
+    const contentType = c.req.header("x-content-type") ?? inferContentType(pathname);
+    const resolvedPathname = addSuffix ? applyRandomSuffix(pathname) : pathname;
+
+    const uploadId = randomBytes(16).toString("hex");
+    const key = resolvedPathname;
+
+    vs.blobMultipartUploads.insert({
+      storeId: auth.storeId,
+      pathname: resolvedPathname,
+      uploadId,
+      key,
+      access,
+      contentType,
+    });
+
+    if (auth.type === "rw") {
+      const tokenMap = store.getData<Map<string, string>>("vercel.blob_rw_tokens") ?? new Map();
+      tokenMap.set(auth.storeId, auth.token);
+      store.setData("vercel.blob_rw_tokens", tokenMap);
+    }
+
+    return c.json({ uploadId, key });
+  }
+
+  if (action === "upload") {
+    const uploadId = c.req.header("x-mpu-upload-id");
+    const partNumber = parseInt(c.req.header("x-mpu-part-number") ?? "0", 10);
+    if (!uploadId || !partNumber) {
+      return blobErr(c, 400, "blob_unknown_error", "Missing uploadId or partNumber");
+    }
+
+    const upload = vs.blobMultipartUploads.findOneBy("uploadId", uploadId as any);
+    if (!upload) return blobErr(c, 404, "blob_not_found", "Upload not found");
+
+    const buf = Buffer.from(await c.req.arrayBuffer());
+    const etag = computeEtag(buf);
+
+    vs.blobMultipartParts.insert({
+      uploadId,
+      partNumber,
+      etag,
+      content: buf,
+      size: buf.length,
+    });
+
+    return c.json({ etag, partNumber });
+  }
+
+  if (action === "complete") {
+    const uploadId = c.req.header("x-mpu-upload-id");
+    if (!uploadId) return blobErr(c, 400, "blob_unknown_error", "Missing uploadId");
+
+    const upload = vs.blobMultipartUploads.findOneBy("uploadId", uploadId as any);
+    if (!upload) return blobErr(c, 404, "blob_not_found", "Upload not found");
+
+    const parts = vs.blobMultipartParts
+      .findBy("uploadId", uploadId as any)
+      .sort((a, b) => a.partNumber - b.partNumber);
+
+    const content = Buffer.concat(parts.map((p) => p.content));
+    const etag = computeEtag(content);
+    const cacheMaxAge = parseInt(c.req.header("x-cache-control-max-age") ?? "2592000", 10);
+    const url = buildBlobUrl(baseUrl, upload.storeId, upload.access, upload.pathname);
+
+    const blob = vs.blobs.insert({
+      storeId: upload.storeId,
+      pathname: upload.pathname,
+      url,
+      downloadUrl: `${url}?download=1`,
+      access: upload.access,
+      contentType: upload.contentType,
+      contentDisposition: contentDispositionFor(upload.pathname),
+      cacheControl: `public, max-age=${cacheMaxAge}`,
+      size: content.length,
+      etag,
+      content,
+    });
+
+    // Cleanup multipart state
+    for (const part of parts) vs.blobMultipartParts.delete(part.id);
+    vs.blobMultipartUploads.delete(upload.id);
+
+    return c.json(formatBlobResult(blob));
+  }
+
+  return blobErr(c, 400, "blob_unknown_error", `Unknown mpu action: ${action}`);
+}
+
+async function handleBlobUpload(c: Context, auth: ParsedBlobToken, store: Store) {
+  const body = await c.req.json();
+
+  if (body.type === "blob.generate-client-token") {
+    const payload = body.payload ?? {};
+    const validUntil = payload.validUntil ?? (Date.now() + 3600_000);
+
+    const tokenPayload = JSON.stringify({
+      pathname: payload.pathname,
+      maximumSizeInBytes: payload.maximumSizeInBytes ?? null,
+      allowedContentTypes: payload.allowedContentTypes ?? null,
+      validUntil,
+      addRandomSuffix: payload.addRandomSuffix ?? true,
+      allowOverwrite: payload.allowOverwrite ?? false,
+      cacheControlMaxAge: payload.cacheControlMaxAge ?? 2592000,
+    });
+
+    const signature = createHmac("sha256", auth.token).update(tokenPayload).digest("base64url");
+    const encoded = Buffer.from(`${signature}.${tokenPayload}`).toString("base64url");
+    const clientToken = `vercel_blob_client_${auth.storeId}_${encoded}`;
+
+    // Store the rw token so we can verify client tokens later
+    const tokenMap = store.getData<Map<string, string>>("vercel.blob_rw_tokens") ?? new Map();
+    tokenMap.set(auth.storeId, auth.token);
+    store.setData("vercel.blob_rw_tokens", tokenMap);
+
+    return c.json({ type: "blob.generate-client-token", clientToken });
+  }
+
+  if (body.type === "blob.upload-completed") {
+    return c.json({ received: true });
+  }
+
+  return blobErr(c, 400, "blob_unknown_error", `Unknown type: ${body.type}`);
+}

--- a/packages/@emulators/vercel/src/store.ts
+++ b/packages/@emulators/vercel/src/store.ts
@@ -3,6 +3,7 @@ import type {
   VercelUser, VercelTeam, VercelTeamMember, VercelProject, VercelDeployment,
   VercelDeploymentAlias, VercelBuild, VercelDeploymentEvent, VercelFile,
   VercelDeploymentFile, VercelDomain, VercelEnvVar, VercelProtectionBypass, VercelIntegration, VercelApiKey,
+  VercelBlob, VercelBlobMultipartUpload, VercelBlobMultipartPart,
 } from "./entities.js";
 
 export interface VercelStore {
@@ -21,6 +22,9 @@ export interface VercelStore {
   protectionBypasses: Collection<VercelProtectionBypass>;
   apiKeys: Collection<VercelApiKey>;
   integrations: Collection<VercelIntegration>;
+  blobs: Collection<VercelBlob>;
+  blobMultipartUploads: Collection<VercelBlobMultipartUpload>;
+  blobMultipartParts: Collection<VercelBlobMultipartPart>;
 }
 
 export function getVercelStore(store: Store): VercelStore {
@@ -40,5 +44,8 @@ export function getVercelStore(store: Store): VercelStore {
     protectionBypasses: store.collection<VercelProtectionBypass>("vercel.protection_bypasses", ["projectId"]),
     apiKeys: store.collection<VercelApiKey>("vercel.api_keys", ["uid", "teamId", "userId"]),
     integrations: store.collection<VercelIntegration>("vercel.integrations", ["client_id"]),
+    blobs: store.collection<VercelBlob>("vercel.blobs", ["storeId", "pathname", "url"]),
+    blobMultipartUploads: store.collection<VercelBlobMultipartUpload>("vercel.blob_mpu", ["uploadId", "storeId"]),
+    blobMultipartParts: store.collection<VercelBlobMultipartPart>("vercel.blob_mpu_parts", ["uploadId", "partNumber"]),
   };
 }


### PR DESCRIPTION
## Summary

- Adds full Vercel Blob API emulation to `@emulators/vercel`
- All `@vercel/blob` SDK operations work transparently: `put`, `get`, `del`, `head`, `list`, `copy`, `createFolder`, multipart uploads, and client upload tokens
- In-memory storage with per-store isolation, token-aware auth, ETag-based caching, and seed configuration

## Details

**New file:** `packages/@emulators/vercel/src/routes/blob.ts` — single route file with all blob handlers and helpers

**Modified files:**
- `entities.ts` — 3 new interfaces (`VercelBlob`, `VercelBlobMultipartUpload`, `VercelBlobMultipartPart`)
- `store.ts` — 3 new collections
- `index.ts` — route registration + seed config support for `blob_stores`
- `vercel.test.ts` — 40 tests (4 existing + 36 new blob tests)
- `README.md` — Blob Storage section with endpoints, SDK setup, and seed config

**Features:**
- Token format parsing (`vercel_blob_rw_*` → store ID extraction, fallback to `"default"`)
- Random suffix, overwrite protection, conditional writes (`x-if-match` → 412)
- Cursor-based list pagination with `folded` mode (returns `folders[]`)
- Multipart upload: create → upload parts → complete
- Client token generation (HMAC-SHA256) + verification on upload
- Content serving with `If-None-Match` → 304, private blob auth
- Seed configuration for pre-populating blob stores

**SDK usage:**
```bash
VERCEL_BLOB_API_URL=http://localhost:4000/api/blob
BLOB_READ_WRITE_TOKEN=vercel_blob_rw_mystore_secret
```

## Test plan

- [x] 40 unit tests in `vercel.test.ts` covering auth, PUT, HEAD, DELETE, LIST, COPY, download, overwrite/conditional, multipart, client tokens, seed config
- [x] Integration test script at `examples/blob/test-blob.ts` (19 tests against a live emulator instance)
- [x] Full monorepo build passes
- [x] All existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #33 