### PR TITLE
fix(s3): fix binary data corruption on upload/download

### DIFF
--- a/packages/@emulators/aws/src/__tests__/aws.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws.test.ts
@@ -213,6 +213,26 @@ describe("AWS plugin - S3 Objects", () => {
     expect(res.headers.get("Content-Type")).toBe("text/plain");
   });
 
+  it("puts and gets binary data intact", async () => {
+    const binaryData = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd, 0x80, 0x7f]);
+    const putRes = await app.request(`${base}/s3/emulate-default/binary.bin`, {
+      method: "PUT",
+      headers: { ...authHeaders(), "Content-Type": "application/octet-stream" },
+      body: binaryData,
+    });
+    expect(putRes.status).toBe(200);
+
+    const getRes = await app.request(`${base}/s3/emulate-default/binary.bin`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    expect(getRes.status).toBe(200);
+    const responseBuffer = Buffer.from(await getRes.arrayBuffer());
+    expect(responseBuffer).toEqual(binaryData);
+    expect(getRes.headers.get("Content-Length")).toBe(String(binaryData.length));
+    expect(getRes.headers.get("Content-Type")).toBe("application/octet-stream");
+  });
+
   it("copies an object with x-amz-copy-source", async () => {
     await app.request(`${base}/s3/emulate-default/source.txt`, {
       method: "PUT",

--- a/packages/@emulators/aws/src/helpers.ts
+++ b/packages/@emulators/aws/src/helpers.ts
@@ -23,7 +23,7 @@ export function generateReceiptHandle(): string {
   return randomBytes(48).toString("base64url");
 }
 
-export function md5(content: string): string {
+export function md5(content: string | Buffer): string {
   return createHash("md5").update(content).digest("hex");
 }
 

--- a/packages/@emulators/aws/src/routes/s3.ts
+++ b/packages/@emulators/aws/src/routes/s3.ts
@@ -215,9 +215,10 @@ ${prefixesXml}
       return awsXmlResponse(c, xml);
     }
 
-    const body = await c.req.text();
+    const bodyBuffer = Buffer.from(await c.req.arrayBuffer());
+    const body = bodyBuffer.toString("base64");
     const contentType = c.req.header("Content-Type") ?? "application/octet-stream";
-    const etag = md5(body);
+    const etag = md5(bodyBuffer);
 
     // Extract user metadata (x-amz-meta-*)
     const metadata: Record<string, string> = {};
@@ -235,7 +236,7 @@ ${prefixesXml}
       aws().s3Objects.update(existing.id, {
         body,
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: bodyBuffer.byteLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -246,7 +247,7 @@ ${prefixesXml}
         key,
         body,
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: bodyBuffer.byteLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -284,7 +285,7 @@ ${prefixesXml}
       headers[`x-amz-meta-${k}`] = v;
     }
 
-    return c.text(obj.body, 200, headers);
+    return c.body(Buffer.from(obj.body, "base64"), 200, headers);
   });
 
   // HeadObject - HEAD /s3/:bucket/:key{.+}


### PR DESCRIPTION
## Summary

- PutObject used `c.req.text()` which corrupted binary files (docx, xlsx, etc.) via lossy UTF-8 conversion
- Switch to `arrayBuffer()` and store body as base64, decode back to Buffer on GET using `c.body()`
- Fix ETag and content_length to reflect actual binary byte counts

## Reproduce

```bash
# Upload Word file
curl -X PUT http://localhost:4000/s3/emulate-default/sample.docx \
  -H "Authorization: Bearer token" \
  -H "Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document" \
  -H "x-amz-meta-author: test" \
  --data-binary @"./sample.docx"

# Download Word file
curl http://localhost:4000/s3/emulate-default/sample.docx \
  -H "Authorization: Bearer token" -O

# Open Word file, but it's broken
open sample.docx
```

## Changes

- `c.req.text()` → `c.req.arrayBuffer()` + base64 encoding for storage
- `c.text()` → `c.body()` + base64 decoding for retrieval
- Widen `md5()` type signature to accept `string | Buffer`
- Add binary data round-trip test

I've confirmed that base64 encoding resolves the binary corruption issue, but I'm not sure if this is the best approach for the project. If there's a more suitable way to handle binary data storage, I'd appreciate any feedback or suggestions. Happy to revise the implementation accordingly.