### PR TITLE
feat: add Twilio SMS, voice, and verification emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ All services start with sensible defaults. No config file needed:
 - **Apple** on `http://localhost:4004`
 - **Microsoft** on `http://localhost:4005`
 - **AWS** on `http://localhost:4006`
+- **Twilio** on `http://localhost:4007`
 
 ## CLI
 

--- a/examples/resend-magic-link/src/app/actions.ts
+++ b/examples/resend-magic-link/src/app/actions.ts
@@ -55,11 +55,11 @@ export async function verifyCodeAction(_prev: { error: string } | null, formData
 
   const cookieStore = await cookies();
   cookieStore.delete("pending_signin");
-  cookieStore.set(
-    "session",
-    encodeSession({ email: pending.email, signedInAt: new Date().toISOString() }),
-    { httpOnly: true, path: "/", maxAge: 86400 },
-  );
+  cookieStore.set("session", encodeSession({ email: pending.email, signedInAt: new Date().toISOString() }), {
+    httpOnly: true,
+    path: "/",
+    maxAge: 86400,
+  });
 
   redirect("/dashboard");
 }

--- a/examples/resend-magic-link/src/app/verify/page.tsx
+++ b/examples/resend-magic-link/src/app/verify/page.tsx
@@ -22,9 +22,7 @@ export default async function VerifyPage() {
         <CardContent className="flex flex-col gap-4">
           <VerifyForm />
           <div className="rounded-lg border border-dashed border-border bg-muted/50 p-3 text-center">
-            <p className="text-xs text-muted-foreground mb-2">
-              Using the emulator? View the email in the inbox:
-            </p>
+            <p className="text-xs text-muted-foreground mb-2">Using the emulator? View the email in the inbox:</p>
             <a
               href="/emulate/resend/inbox"
               target="_blank"

--- a/packages/@emulators/clerk/src/__tests__/clerk.test.ts
+++ b/packages/@emulators/clerk/src/__tests__/clerk.test.ts
@@ -156,21 +156,21 @@ describe("Clerk plugin integration", () => {
     it("returns discovery document", async () => {
       const res = await app.request(`${base}/.well-known/openid-configuration`);
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.issuer).toBe(base);
       expect(body.authorization_endpoint).toBe(`${base}/oauth/authorize`);
       expect(body.token_endpoint).toBe(`${base}/oauth/token`);
       expect(body.jwks_uri).toBe(`${base}/v1/jwks`);
       expect(body.userinfo_endpoint).toBe(`${base}/oauth/userinfo`);
       expect(body.code_challenge_methods_supported).toEqual(["plain", "S256"]);
-      expect((body.claims_supported as string[])).toContain("org_id");
-      expect((body.claims_supported as string[])).toContain("sid");
+      expect(body.claims_supported as string[]).toContain("org_id");
+      expect(body.claims_supported as string[]).toContain("sid");
     });
 
     it("returns JWKS with RS256 key", async () => {
       const res = await app.request(`${base}/v1/jwks`);
       expect(res.status).toBe(200);
-      const body = await res.json() as { keys: Array<Record<string, unknown>> };
+      const body = (await res.json()) as { keys: Array<Record<string, unknown>> };
       expect(body.keys).toHaveLength(1);
       expect(body.keys[0].kty).toBe("RSA");
       expect(body.keys[0].kid).toBe("emulate-clerk-1");
@@ -207,7 +207,7 @@ describe("Clerk plugin integration", () => {
 
       const tokenRes = await exchangeCode(app, code);
       expect(tokenRes.status).toBe(200);
-      const body = await tokenRes.json() as Record<string, unknown>;
+      const body = (await tokenRes.json()) as Record<string, unknown>;
       expect((body.access_token as string).startsWith("clerk_")).toBe(true);
       expect(body.token_type).toBe("Bearer");
       expect(body.expires_in).toBe(3600);
@@ -225,7 +225,7 @@ describe("Clerk plugin integration", () => {
       expect(first.status).toBe(200);
       const second = await exchangeCode(app, code);
       expect(second.status).toBe(400);
-      const body = await second.json() as Record<string, unknown>;
+      const body = (await second.json()) as Record<string, unknown>;
       expect(body.error).toBe("invalid_grant");
     });
 
@@ -266,7 +266,7 @@ describe("Clerk plugin integration", () => {
     it("rejects requests without auth", async () => {
       const res = await app.request(`${base}/v1/users`);
       expect(res.status).toBe(401);
-      const body = await res.json() as { errors: Array<{ code: string }> };
+      const body = (await res.json()) as { errors: Array<{ code: string }> };
       expect(body.errors[0].code).toBe("UNAUTHORIZED");
     });
 
@@ -282,7 +282,7 @@ describe("Clerk plugin integration", () => {
     it("lists users with pagination", async () => {
       const res = await app.request(`${base}/v1/users`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: unknown[]; total_count: number; has_more: boolean };
+      const body = (await res.json()) as { data: unknown[]; total_count: number; has_more: boolean };
       expect(body.total_count).toBeGreaterThanOrEqual(3);
       expect(body.has_more).toBe(false);
       expect(body.data.length).toBeGreaterThanOrEqual(3);
@@ -291,7 +291,7 @@ describe("Clerk plugin integration", () => {
     it("lists users with limit and offset", async () => {
       const res = await app.request(`${base}/v1/users?limit=1&offset=0`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: unknown[]; total_count: number; has_more: boolean };
+      const body = (await res.json()) as { data: unknown[]; total_count: number; has_more: boolean };
       expect(body.data).toHaveLength(1);
       expect(body.has_more).toBe(true);
     });
@@ -299,7 +299,7 @@ describe("Clerk plugin integration", () => {
     it("filters users by query", async () => {
       const res = await app.request(`${base}/v1/users?query=alice`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: Array<{ first_name: string }>; total_count: number };
+      const body = (await res.json()) as { data: Array<{ first_name: string }>; total_count: number };
       expect(body.total_count).toBe(1);
       expect(body.data[0].first_name).toBe("Alice");
     });
@@ -307,7 +307,7 @@ describe("Clerk plugin integration", () => {
     it("filters users by email_address", async () => {
       const res = await app.request(`${base}/v1/users?email_address=bob@example.com`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: Array<{ first_name: string }>; total_count: number };
+      const body = (await res.json()) as { data: Array<{ first_name: string }>; total_count: number };
       expect(body.total_count).toBe(1);
       expect(body.data[0].first_name).toBe("Bob");
     });
@@ -324,9 +324,9 @@ describe("Clerk plugin integration", () => {
         }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.object).toBe("user");
-      expect((body.id as string)).toMatch(/^user_/);
+      expect(body.id as string).toMatch(/^user_/);
       expect(body.first_name).toBe("New");
       expect(body.password_enabled).toBe(true);
       expect((body.email_addresses as Array<{ email_address: string }>)[0].email_address).toBe("new@example.com");
@@ -337,7 +337,7 @@ describe("Clerk plugin integration", () => {
       const user = cs.users.all().find((u) => u.first_name === "Alice")!;
       const res = await app.request(`${base}/v1/users/${user.clerk_id}`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.first_name).toBe("Alice");
     });
 
@@ -355,7 +355,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ first_name: "Alicia" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.first_name).toBe("Alicia");
     });
 
@@ -367,7 +367,7 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.object).toBe("deleted_object");
       expect(body.deleted).toBe(true);
     });
@@ -381,14 +381,14 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
       });
       expect(banRes.status).toBe(200);
-      expect((await banRes.json() as Record<string, unknown>).banned).toBe(true);
+      expect(((await banRes.json()) as Record<string, unknown>).banned).toBe(true);
 
       const unbanRes = await app.request(`${base}/v1/users/${user.clerk_id}/unban`, {
         method: "POST",
         headers: authHeaders(),
       });
       expect(unbanRes.status).toBe(200);
-      expect((await unbanRes.json() as Record<string, unknown>).banned).toBe(false);
+      expect(((await unbanRes.json()) as Record<string, unknown>).banned).toBe(false);
     });
 
     it("locks and unlocks a user", async () => {
@@ -400,14 +400,14 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
       });
       expect(lockRes.status).toBe(200);
-      expect((await lockRes.json() as Record<string, unknown>).locked).toBe(true);
+      expect(((await lockRes.json()) as Record<string, unknown>).locked).toBe(true);
 
       const unlockRes = await app.request(`${base}/v1/users/${user.clerk_id}/unlock`, {
         method: "POST",
         headers: authHeaders(),
       });
       expect(unlockRes.status).toBe(200);
-      expect((await unlockRes.json() as Record<string, unknown>).locked).toBe(false);
+      expect(((await unlockRes.json()) as Record<string, unknown>).locked).toBe(false);
     });
 
     it("updates metadata (merge)", async () => {
@@ -426,7 +426,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ public_metadata: { role: "admin" } }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       const meta = body.public_metadata as Record<string, unknown>;
       expect(meta.plan).toBe("pro");
       expect(meta.role).toBe("admin");
@@ -435,7 +435,7 @@ describe("Clerk plugin integration", () => {
     it("returns user count", async () => {
       const res = await app.request(`${base}/v1/users/count`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { total_count: number };
+      const body = (await res.json()) as { total_count: number };
       expect(body.total_count).toBeGreaterThanOrEqual(3);
     });
 
@@ -448,7 +448,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ password: "alice123" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as { verified: boolean };
+      const body = (await res.json()) as { verified: boolean };
       expect(body.verified).toBe(true);
     });
 
@@ -461,7 +461,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ password: "wrong" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as { verified: boolean };
+      const body = (await res.json()) as { verified: boolean };
       expect(body.verified).toBe(false);
     });
   });
@@ -480,7 +480,7 @@ describe("Clerk plugin integration", () => {
         }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.object).toBe("email_address");
       expect(body.email_address).toBe("alice2@example.com");
       expect((body.verification as Record<string, unknown>).status).toBe("verified");
@@ -491,7 +491,7 @@ describe("Clerk plugin integration", () => {
       const email = cs.emailAddresses.all().find((e) => e.email_address === "alice@example.com")!;
       const res = await app.request(`${base}/v1/email_addresses/${email.email_id}`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.email_address).toBe("alice@example.com");
     });
 
@@ -504,14 +504,14 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ user_id: user.clerk_id, email_address: "delete-me@example.com" }),
       });
-      const created = await createRes.json() as Record<string, unknown>;
+      const created = (await createRes.json()) as Record<string, unknown>;
 
       const res = await app.request(`${base}/v1/email_addresses/${created.id}`, {
         method: "DELETE",
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.object).toBe("deleted_object");
       expect(body.deleted).toBe(true);
     });
@@ -521,7 +521,7 @@ describe("Clerk plugin integration", () => {
     it("lists organizations", async () => {
       const res = await app.request(`${base}/v1/organizations`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: Array<Record<string, unknown>>; total_count: number };
+      const body = (await res.json()) as { data: Array<Record<string, unknown>>; total_count: number };
       expect(body.total_count).toBeGreaterThanOrEqual(1);
       const acme = body.data.find((o) => o.slug === "acme");
       expect(acme).toBeDefined();
@@ -533,7 +533,7 @@ describe("Clerk plugin integration", () => {
       const org = cs.organizations.findOneBy("slug", "acme")!;
       const res = await app.request(`${base}/v1/organizations/${org.clerk_id}`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.name).toBe("Acme Corp");
     });
 
@@ -542,7 +542,7 @@ describe("Clerk plugin integration", () => {
       const org = cs.organizations.findOneBy("slug", "acme")!;
       const res = await app.request(`${base}/v1/organizations/acme`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.id).toBe(org.clerk_id);
     });
 
@@ -553,11 +553,11 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ name: "New Org", slug: "new-org" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.object).toBe("organization");
       expect(body.name).toBe("New Org");
       expect(body.slug).toBe("new-org");
-      expect((body.id as string)).toMatch(/^org_/);
+      expect(body.id as string).toMatch(/^org_/);
     });
 
     it("updates an organization", async () => {
@@ -569,7 +569,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ name: "Acme Inc" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.name).toBe("Acme Inc");
     });
 
@@ -579,14 +579,14 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ name: "Delete Me" }),
       });
-      const created = await createRes.json() as Record<string, unknown>;
+      const created = (await createRes.json()) as Record<string, unknown>;
 
       const res = await app.request(`${base}/v1/organizations/${created.id}`, {
         method: "DELETE",
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.deleted).toBe(true);
     });
   });
@@ -597,7 +597,7 @@ describe("Clerk plugin integration", () => {
       const org = cs.organizations.findOneBy("slug", "acme")!;
       const res = await app.request(`${base}/v1/organizations/${org.clerk_id}/memberships`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: Array<Record<string, unknown>>; total_count: number };
+      const body = (await res.json()) as { data: Array<Record<string, unknown>>; total_count: number };
       expect(body.total_count).toBe(2);
     });
 
@@ -609,7 +609,7 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ name: "Membership Test", slug: "membership-test" }),
       });
-      const org = await createRes.json() as Record<string, unknown>;
+      const org = (await createRes.json()) as Record<string, unknown>;
 
       const user = cs.users.all().find((u) => u.first_name === "Alice")!;
       const res = await app.request(`${base}/v1/organizations/${org.id}/memberships`, {
@@ -618,7 +618,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ user_id: user.clerk_id, role: "org:admin" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.role).toBe("org:admin");
     });
 
@@ -633,7 +633,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ role: "org:admin" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.role).toBe("org:admin");
     });
 
@@ -647,7 +647,7 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.deleted).toBe(true);
     });
 
@@ -662,7 +662,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ user_id: aliceUser.clerk_id, role: "org:member" }),
       });
       expect(res.status).toBe(422);
-      const body = await res.json() as { errors: Array<{ code: string }> };
+      const body = (await res.json()) as { errors: Array<{ code: string }> };
       expect(body.errors[0].code).toBe("DUPLICATE_RECORD");
     });
   });
@@ -678,7 +678,7 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ email_address: "invite@example.com", role: "org:member" }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.object).toBe("organization_invitation");
       expect(body.email_address).toBe("invite@example.com");
       expect(body.status).toBe("pending");
@@ -694,9 +694,11 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ email_address: "inv1@example.com" }),
       });
 
-      const res = await app.request(`${base}/v1/organizations/${org.clerk_id}/invitations?status=pending`, { headers: authHeaders() });
+      const res = await app.request(`${base}/v1/organizations/${org.clerk_id}/invitations?status=pending`, {
+        headers: authHeaders(),
+      });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: unknown[]; total_count: number };
+      const body = (await res.json()) as { data: unknown[]; total_count: number };
       expect(body.total_count).toBeGreaterThanOrEqual(1);
     });
 
@@ -709,14 +711,14 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ email_address: "revoke@example.com" }),
       });
-      const invitation = await createRes.json() as Record<string, unknown>;
+      const invitation = (await createRes.json()) as Record<string, unknown>;
 
       const res = await app.request(`${base}/v1/organizations/${org.clerk_id}/invitations/${invitation.id}/revoke`, {
         method: "POST",
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.status).toBe("revoked");
     });
 
@@ -733,7 +735,7 @@ describe("Clerk plugin integration", () => {
         }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Array<Record<string, unknown>>;
+      const body = (await res.json()) as Array<Record<string, unknown>>;
       expect(body).toHaveLength(2);
     });
   });
@@ -749,9 +751,9 @@ describe("Clerk plugin integration", () => {
         body: JSON.stringify({ user_id: user.clerk_id }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.object).toBe("session");
-      expect((body.id as string)).toMatch(/^sess_/);
+      expect(body.id as string).toMatch(/^sess_/);
       expect(body.status).toBe("active");
       expect(body.user_id).toBe(user.clerk_id);
     });
@@ -768,7 +770,7 @@ describe("Clerk plugin integration", () => {
 
       const res = await app.request(`${base}/v1/sessions`, { headers: authHeaders() });
       expect(res.status).toBe(200);
-      const body = await res.json() as { data: unknown[]; total_count: number };
+      const body = (await res.json()) as { data: unknown[]; total_count: number };
       expect(body.total_count).toBeGreaterThanOrEqual(1);
     });
 
@@ -781,14 +783,14 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ user_id: user.clerk_id }),
       });
-      const session = await createRes.json() as Record<string, unknown>;
+      const session = (await createRes.json()) as Record<string, unknown>;
 
       const res = await app.request(`${base}/v1/sessions/${session.id}/revoke`, {
         method: "POST",
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as Record<string, unknown>;
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.status).toBe("revoked");
     });
 
@@ -801,14 +803,14 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ user_id: user.clerk_id }),
       });
-      const session = await createRes.json() as Record<string, unknown>;
+      const session = (await createRes.json()) as Record<string, unknown>;
 
       const res = await app.request(`${base}/v1/sessions/${session.id}/tokens`, {
         method: "POST",
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
-      const body = await res.json() as { object: string; jwt: string };
+      const body = (await res.json()) as { object: string; jwt: string };
       expect(body.object).toBe("token");
       expect(body.jwt).toBeTruthy();
 
@@ -829,13 +831,13 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ user_id: aliceUser.clerk_id }),
       });
-      const session = await createRes.json() as Record<string, unknown>;
+      const session = (await createRes.json()) as Record<string, unknown>;
 
       const res = await app.request(`${base}/v1/sessions/${session.id}/tokens`, {
         method: "POST",
         headers: authHeaders(),
       });
-      const body = await res.json() as { jwt: string };
+      const body = (await res.json()) as { jwt: string };
       const claims = decodeJwt(body.jwt);
       expect(claims.org_id).toMatch(/^org_/);
       expect(claims.org_role).toBe("org:admin");
@@ -851,7 +853,7 @@ describe("Clerk plugin integration", () => {
         headers: authHeaders(),
         body: JSON.stringify({ user_id: user.clerk_id }),
       });
-      const session = await createRes.json() as Record<string, unknown>;
+      const session = (await createRes.json()) as Record<string, unknown>;
 
       await app.request(`${base}/v1/sessions/${session.id}/revoke`, {
         method: "POST",
@@ -911,7 +913,9 @@ describe("Clerk plugin integration", () => {
     it("returns Clerk error format", async () => {
       const res = await app.request(`${base}/v1/users/user_nonexistent`, { headers: authHeaders() });
       expect(res.status).toBe(404);
-      const body = await res.json() as { errors: Array<{ code: string; message: string; long_message: string; meta: unknown }> };
+      const body = (await res.json()) as {
+        errors: Array<{ code: string; message: string; long_message: string; meta: unknown }>;
+      };
       expect(body.errors).toHaveLength(1);
       expect(body.errors[0].code).toBe("RESOURCE_NOT_FOUND");
       expect(body.errors[0].message).toBeDefined();

--- a/packages/@emulators/clerk/src/index.ts
+++ b/packages/@emulators/clerk/src/index.ts
@@ -1,18 +1,6 @@
 import type { Hono } from "hono";
-import type {
-  AppEnv,
-  RouteContext,
-  ServicePlugin,
-  Store,
-  TokenMap,
-  WebhookDispatcher,
-} from "@emulators/core";
-import {
-  generateClerkId,
-  nowUnix,
-  createDefaultUser,
-  createDefaultEmailAddress,
-} from "./helpers.js";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { generateClerkId, nowUnix, createDefaultUser, createDefaultEmailAddress } from "./helpers.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { userRoutes } from "./routes/users.js";
 import { emailAddressRoutes } from "./routes/email-addresses.js";
@@ -68,9 +56,7 @@ function seedDefaults(store: Store, _baseUrl: string): void {
   const userInput = createDefaultUser();
   const user = cs.users.insert(userInput);
 
-  const email = cs.emailAddresses.insert(
-    createDefaultEmailAddress(user.clerk_id, "test@example.com", true),
-  );
+  const email = cs.emailAddresses.insert(createDefaultEmailAddress(user.clerk_id, "test@example.com", true));
 
   cs.users.update(user.id, { primary_email_address_id: email.email_id });
 
@@ -145,7 +131,12 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: ClerkSeed
 
   if (config.organizations) {
     for (const orgCfg of config.organizations) {
-      const existingSlug = orgCfg.slug ?? orgCfg.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const existingSlug =
+        orgCfg.slug ??
+        orgCfg.name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-|-$/g, "");
       const existing = cs.organizations.findOneBy("slug", existingSlug);
       if (existing) continue;
 
@@ -175,9 +166,7 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: ClerkSeed
           const user = cs.users.findOneBy("clerk_id", emailEntry.user_id);
           if (!user) continue;
 
-          const existingMembership = cs.memberships
-            .findBy("org_id", orgId)
-            .find((m) => m.user_id === user.clerk_id);
+          const existingMembership = cs.memberships.findBy("org_id", orgId).find((m) => m.user_id === user.clerk_id);
           if (existingMembership) continue;
 
           const role = memberCfg.role.startsWith("org:") ? memberCfg.role : `org:${memberCfg.role}`;
@@ -186,9 +175,15 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: ClerkSeed
             org_id: orgId,
             user_id: user.clerk_id,
             role,
-            permissions: role === "org:admin"
-              ? ["org:sys_profile:manage", "org:sys_profile:delete", "org:sys_memberships:read", "org:sys_memberships:manage"]
-              : ["org:sys_memberships:read"],
+            permissions:
+              role === "org:admin"
+                ? [
+                    "org:sys_profile:manage",
+                    "org:sys_profile:delete",
+                    "org:sys_memberships:read",
+                    "org:sys_memberships:manage",
+                  ]
+                : ["org:sys_memberships:read"],
             public_metadata: {},
             private_metadata: {},
             created_at_unix: now,
@@ -223,13 +218,7 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: ClerkSeed
 
 export const clerkPlugin: ServicePlugin = {
   name: "clerk",
-  register(
-    app: Hono<AppEnv>,
-    store: Store,
-    webhooks: WebhookDispatcher,
-    baseUrl: string,
-    tokenMap?: TokenMap,
-  ): void {
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
     const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
     oauthRoutes(ctx);
     userRoutes(ctx);

--- a/packages/@emulators/clerk/src/route-helpers.ts
+++ b/packages/@emulators/clerk/src/route-helpers.ts
@@ -1,7 +1,14 @@
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AuthUser, TokenMap, AppEnv } from "@emulators/core";
-import type { ClerkUser, ClerkEmailAddress, ClerkOrganization, ClerkOrganizationMembership, ClerkOrganizationInvitation, ClerkSession } from "./entities.js";
+import type {
+  ClerkUser,
+  ClerkEmailAddress,
+  ClerkOrganization,
+  ClerkOrganizationMembership,
+  ClerkOrganizationInvitation,
+  ClerkSession,
+} from "./entities.js";
 import type { ClerkStore } from "./store.js";
 
 export function clerkError(
@@ -61,7 +68,12 @@ export function deletedResponse(objectType: string, objectId: string): Record<st
   };
 }
 
-export function paginatedResponse<T>(data: T[], totalCount: number, limit: number, offset: number): Record<string, unknown> {
+export function paginatedResponse<T>(
+  data: T[],
+  totalCount: number,
+  limit: number,
+  offset: number,
+): Record<string, unknown> {
   return {
     data,
     total_count: totalCount,

--- a/packages/@emulators/clerk/src/routes/email-addresses.ts
+++ b/packages/@emulators/clerk/src/routes/email-addresses.ts
@@ -31,8 +31,8 @@ export function emailAddressRoutes({ app, store, tokenMap }: RouteContext): void
     const body = await readJsonBody(c);
     const userId = body.user_id as string;
     const emailAddr = body.email_address as string;
-    const verified = body.verified as boolean ?? false;
-    const primary = body.primary as boolean ?? false;
+    const verified = (body.verified as boolean) ?? false;
+    const primary = (body.primary as boolean) ?? false;
 
     if (!userId || !emailAddr) {
       return clerkError(c, 422, "INVALID_REQUEST_BODY", "user_id and email_address are required");

--- a/packages/@emulators/clerk/src/routes/memberships.ts
+++ b/packages/@emulators/clerk/src/routes/memberships.ts
@@ -164,7 +164,10 @@ export function membershipRoutes({ app, store, tokenMap }: RouteContext): void {
       patch.public_metadata = { ...membership.public_metadata, ...(body.public_metadata as Record<string, unknown>) };
     }
     if (body.private_metadata !== undefined) {
-      patch.private_metadata = { ...membership.private_metadata, ...(body.private_metadata as Record<string, unknown>) };
+      patch.private_metadata = {
+        ...membership.private_metadata,
+        ...(body.private_metadata as Record<string, unknown>),
+      };
     }
 
     cs.memberships.update(membership.id, patch);

--- a/packages/@emulators/clerk/src/routes/oauth.ts
+++ b/packages/@emulators/clerk/src/routes/oauth.ts
@@ -162,7 +162,11 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       }
       if (!matchesRedirectUri(redirectUri, oauthApp.redirect_uris)) {
         return c.html(
-          renderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", SERVICE_LABEL),
+          renderErrorPage(
+            "Redirect URI mismatch",
+            "The redirect_uri is not registered for this application.",
+            SERVICE_LABEL,
+          ),
           400,
         );
       }
@@ -228,10 +232,7 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
 
     const user = clerkStore.users.findOneBy("clerk_id", userRef);
     if (!user) {
-      return c.html(
-        renderErrorPage("Unknown user", "The selected user is not available.", SERVICE_LABEL),
-        400,
-      );
+      return c.html(renderErrorPage("Unknown user", "The selected user is not available.", SERVICE_LABEL), 400);
     }
 
     const oauthApps = clerkStore.oauthApps.all();
@@ -245,7 +246,11 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       }
       if (!matchesRedirectUri(redirectUri, oauthApp.redirect_uris)) {
         return c.html(
-          renderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", SERVICE_LABEL),
+          renderErrorPage(
+            "Redirect URI mismatch",
+            "The redirect_uri is not registered for this application.",
+            SERVICE_LABEL,
+          ),
           400,
         );
       }
@@ -275,7 +280,7 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
 
     if (contentType.includes("application/json")) {
       try {
-        const parsed = await c.req.json() as Record<string, unknown>;
+        const parsed = (await c.req.json()) as Record<string, unknown>;
         for (const [key, value] of Object.entries(parsed)) {
           if (typeof value === "string") body[key] = value;
         }
@@ -306,7 +311,10 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
     }
 
     if (grantType !== "authorization_code") {
-      return c.json({ error: "unsupported_grant_type", error_description: "Only authorization_code is supported." }, 400);
+      return c.json(
+        { error: "unsupported_grant_type", error_description: "Only authorization_code is supported." },
+        400,
+      );
     }
 
     const pending = getPendingCodes(store).get(code);

--- a/packages/@emulators/clerk/src/routes/organizations.ts
+++ b/packages/@emulators/clerk/src/routes/organizations.ts
@@ -55,7 +55,12 @@ export function organizationRoutes({ app, store, tokenMap }: RouteContext): void
     const name = body.name as string;
     if (!name) return clerkError(c, 422, "INVALID_REQUEST_BODY", "name is required");
 
-    const slug = (body.slug as string) ?? name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    const slug =
+      (body.slug as string) ??
+      name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
     const now = nowUnix();
 
     const org = cs.organizations.insert({
@@ -83,7 +88,14 @@ export function organizationRoutes({ app, store, tokenMap }: RouteContext): void
           org_id: org.clerk_id,
           user_id: userId,
           role: "org:admin",
-          permissions: ["org:sys_profile:manage", "org:sys_profile:delete", "org:sys_memberships:read", "org:sys_memberships:manage", "org:sys_domains:read", "org:sys_domains:manage"],
+          permissions: [
+            "org:sys_profile:manage",
+            "org:sys_profile:delete",
+            "org:sys_memberships:read",
+            "org:sys_memberships:manage",
+            "org:sys_domains:read",
+            "org:sys_domains:manage",
+          ],
           public_metadata: {},
           private_metadata: {},
           created_at_unix: now,

--- a/packages/@emulators/clerk/src/routes/sessions.ts
+++ b/packages/@emulators/clerk/src/routes/sessions.ts
@@ -120,16 +120,7 @@ export function sessionRoutes({ app, store, baseUrl, tokenMap }: RouteContext): 
       }
     }
 
-    const jwt = await createSessionToken(
-      store,
-      user,
-      sessionId,
-      baseUrl,
-      orgId,
-      orgRole,
-      orgSlug,
-      orgPermissions,
-    );
+    const jwt = await createSessionToken(store, user, sessionId, baseUrl, orgId, orgRole, orgSlug, orgPermissions);
 
     cs.sessions.update(session.id, { last_active_at: nowUnix() });
 

--- a/packages/@emulators/clerk/src/routes/users.ts
+++ b/packages/@emulators/clerk/src/routes/users.ts
@@ -163,8 +163,10 @@ export function userRoutes({ app, store, tokenMap }: RouteContext): void {
     if (body.last_name !== undefined) patch.last_name = body.last_name as string | null;
     if (body.username !== undefined) patch.username = body.username as string | null;
     if (body.external_id !== undefined) patch.external_id = body.external_id as string | null;
-    if (body.primary_email_address_id !== undefined) patch.primary_email_address_id = body.primary_email_address_id as string;
-    if (body.primary_phone_number_id !== undefined) patch.primary_phone_number_id = body.primary_phone_number_id as string;
+    if (body.primary_email_address_id !== undefined)
+      patch.primary_email_address_id = body.primary_email_address_id as string;
+    if (body.primary_phone_number_id !== undefined)
+      patch.primary_phone_number_id = body.primary_phone_number_id as string;
     if (body.public_metadata !== undefined) patch.public_metadata = body.public_metadata as Record<string, unknown>;
     if (body.private_metadata !== undefined) patch.private_metadata = body.private_metadata as Record<string, unknown>;
     if (body.unsafe_metadata !== undefined) patch.unsafe_metadata = body.unsafe_metadata as Record<string, unknown>;

--- a/packages/@emulators/clerk/src/store.ts
+++ b/packages/@emulators/clerk/src/store.ts
@@ -24,7 +24,11 @@ export function getClerkStore(store: Store): ClerkStore {
     users: store.collection<ClerkUser>("clerk.users", ["clerk_id", "username"]),
     emailAddresses: store.collection<ClerkEmailAddress>("clerk.emails", ["email_id", "user_id", "email_address"]),
     organizations: store.collection<ClerkOrganization>("clerk.orgs", ["clerk_id", "slug"]),
-    memberships: store.collection<ClerkOrganizationMembership>("clerk.memberships", ["membership_id", "org_id", "user_id"]),
+    memberships: store.collection<ClerkOrganizationMembership>("clerk.memberships", [
+      "membership_id",
+      "org_id",
+      "user_id",
+    ]),
     invitations: store.collection<ClerkOrganizationInvitation>("clerk.invitations", ["invitation_id", "org_id"]),
     sessions: store.collection<ClerkSession>("clerk.sessions", ["clerk_id", "user_id"]),
     oauthApps: store.collection<ClerkOAuthApplication>("clerk.oauth_apps", ["app_id", "client_id"]),

--- a/packages/@emulators/stripe/src/__tests__/stripe.test.ts
+++ b/packages/@emulators/stripe/src/__tests__/stripe.test.ts
@@ -379,7 +379,14 @@ describe("Stripe plugin", () => {
         }),
       });
       expect(res.status).toBe(200);
-      const session = (await res.json()) as { object: string; client_secret: string; customer: string; components: Record<string, unknown>; created: number; expires_at: number };
+      const session = (await res.json()) as {
+        object: string;
+        client_secret: string;
+        customer: string;
+        components: Record<string, unknown>;
+        created: number;
+        expires_at: number;
+      };
       expect(session.object).toBe("customer_session");
       expect(session.client_secret).toBeTruthy();
       expect(session.customer).toBe(cust.id);

--- a/packages/@emulators/stripe/src/routes/customer-sessions.ts
+++ b/packages/@emulators/stripe/src/routes/customer-sessions.ts
@@ -12,16 +12,26 @@ export function customerSessionRoutes({ app, store }: RouteContext): void {
 
     const customer = ss.customers.findOneBy("stripe_id", body.customer as string);
     if (!customer)
-      return stripeError(c, 400, "invalid_request_error", `No such customer: '${body.customer}'`, "resource_missing", "customer");
+      return stripeError(
+        c,
+        400,
+        "invalid_request_error",
+        `No such customer: '${body.customer}'`,
+        "resource_missing",
+        "customer",
+      );
 
-    return c.json({
-      object: "customer_session" as const,
-      client_secret: stripeId("cuss_secret"),
-      components: (body.components as Record<string, unknown>) ?? {},
-      created: Math.floor(Date.now() / 1000),
-      customer: customer.stripe_id,
-      expires_at: Math.floor(Date.now() / 1000) + 1800,
-      livemode: false,
-    }, 200);
+    return c.json(
+      {
+        object: "customer_session" as const,
+        client_secret: stripeId("cuss_secret"),
+        components: (body.components as Record<string, unknown>) ?? {},
+        created: Math.floor(Date.now() / 1000),
+        customer: customer.stripe_id,
+        expires_at: Math.floor(Date.now() / 1000) + 1800,
+        livemode: false,
+      },
+      200,
+    );
   });
 }

--- a/packages/@emulators/stripe/src/routes/payment-methods.ts
+++ b/packages/@emulators/stripe/src/routes/payment-methods.ts
@@ -8,14 +8,24 @@ export function paymentMethodRoutes({ app, store }: RouteContext): void {
   app.get("/v1/payment_methods", (c) => {
     const customerId = c.req.query("customer");
     if (customerId && !ss.customers.findOneBy("stripe_id", customerId)) {
-      return stripeError(c, 400, "invalid_request_error", `No such customer: '${customerId}'`, "resource_missing", "customer");
+      return stripeError(
+        c,
+        400,
+        "invalid_request_error",
+        `No such customer: '${customerId}'`,
+        "resource_missing",
+        "customer",
+      );
     }
 
-    return c.json({
-      object: "list" as const,
-      url: "/v1/payment_methods",
-      has_more: false,
-      data: [],
-    }, 200);
+    return c.json(
+      {
+        object: "list" as const,
+        url: "/v1/payment_methods",
+        has_more: false,
+        data: [],
+      },
+      200,
+    );
   });
 }

--- a/packages/@emulators/twilio/package.json
+++ b/packages/@emulators/twilio/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@emulators/twilio",
+  "version": "0.4.1",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/twilio"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*",
+    "hono": "^4"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/twilio/src/entities.ts
+++ b/packages/@emulators/twilio/src/entities.ts
@@ -1,0 +1,48 @@
+import type { Entity } from "@emulators/core";
+
+export interface TwilioMessage extends Entity {
+  sid: string;
+  account_sid: string;
+  to: string;
+  from: string;
+  body: string;
+  status: "queued" | "sent" | "delivered" | "failed";
+  direction: "outbound-api" | "inbound";
+  num_segments: number;
+  date_sent: string;
+}
+
+export interface TwilioCall extends Entity {
+  sid: string;
+  account_sid: string;
+  to: string;
+  from: string;
+  status: "queued" | "ringing" | "in-progress" | "completed" | "failed";
+  direction: "outbound-api" | "inbound";
+  duration: number | null;
+  start_time: string | null;
+  end_time: string | null;
+}
+
+export interface TwilioVerifyService extends Entity {
+  sid: string;
+  friendly_name: string;
+  code_length: number;
+}
+
+export interface TwilioVerification extends Entity {
+  sid: string;
+  service_sid: string;
+  to: string;
+  channel: "sms" | "email" | "call";
+  status: "pending" | "approved" | "canceled" | "expired";
+  code: string;
+  expires_at: string;
+}
+
+export interface TwilioPhoneNumber extends Entity {
+  sid: string;
+  account_sid: string;
+  phone_number: string;
+  friendly_name: string;
+}

--- a/packages/@emulators/twilio/src/helpers.ts
+++ b/packages/@emulators/twilio/src/helpers.ts
@@ -1,0 +1,48 @@
+import { randomBytes } from "crypto";
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+
+export function generateSid(prefix: string): string {
+  return prefix + randomBytes(16).toString("hex").slice(0, 32);
+}
+
+export function twilioError(c: Context, statusCode: number, code: number, message: string) {
+  return c.json(
+    { status: statusCode, code, message, more_info: `https://www.twilio.com/docs/errors/${code}` },
+    statusCode as ContentfulStatusCode,
+  );
+}
+
+export async function parseTwilioBody(c: Context): Promise<Record<string, unknown>> {
+  const contentType = c.req.header("content-type") ?? "";
+
+  if (contentType.includes("application/x-www-form-urlencoded")) {
+    const text = await c.req.text();
+    const params = new URLSearchParams(text);
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of params.entries()) {
+      result[key] = value;
+    }
+    return result;
+  }
+
+  try {
+    const body = await c.req.json();
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      return body as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+export function generateVerificationCode(length: number): string {
+  const digits = "0123456789";
+  let code = "";
+  const bytes = randomBytes(length);
+  for (let i = 0; i < length; i++) {
+    code += digits[bytes[i] % 10];
+  }
+  return code;
+}

--- a/packages/@emulators/twilio/src/index.ts
+++ b/packages/@emulators/twilio/src/index.ts
@@ -1,0 +1,78 @@
+import type { Hono } from "hono";
+import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@emulators/core";
+import { getTwilioStore } from "./store.js";
+import { generateSid } from "./helpers.js";
+import { messageRoutes } from "./routes/messages.js";
+import { callRoutes } from "./routes/calls.js";
+import { verifyRoutes } from "./routes/verify.js";
+import { inboxRoutes } from "./routes/inbox.js";
+
+export { getTwilioStore, type TwilioStore } from "./store.js";
+export * from "./entities.js";
+
+export interface TwilioSeedConfig {
+  port?: number;
+  account_sid?: string;
+  auth_token?: string;
+  phone_numbers?: string[];
+  verify_services?: Array<{
+    sid?: string;
+    friendly_name: string;
+    code_length?: number;
+  }>;
+}
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSeedConfig): void {
+  const ts = getTwilioStore(store);
+  const accountSid = config.account_sid ?? "AC_test_account";
+
+  if (config.phone_numbers) {
+    for (const num of config.phone_numbers) {
+      ts.phoneNumbers.insert({
+        sid: generateSid("PN"),
+        account_sid: accountSid,
+        phone_number: num,
+        friendly_name: num,
+      });
+    }
+  }
+
+  if (config.verify_services) {
+    for (const svc of config.verify_services) {
+      ts.verifyServices.insert({
+        sid: svc.sid ?? generateSid("VA"),
+        friendly_name: svc.friendly_name,
+        code_length: svc.code_length ?? 6,
+      });
+    }
+  }
+}
+
+export const twilioPlugin: ServicePlugin = {
+  name: "twilio",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    messageRoutes(ctx);
+    callRoutes(ctx);
+    verifyRoutes(ctx);
+    inboxRoutes(ctx);
+  },
+  seed(store: Store, _baseUrl: string): void {
+    const ts = getTwilioStore(store);
+    // Seed a default phone number
+    ts.phoneNumbers.insert({
+      sid: generateSid("PN"),
+      account_sid: "AC_test_account",
+      phone_number: "+15551234567",
+      friendly_name: "+15551234567",
+    });
+    // Seed a default verify service
+    ts.verifyServices.insert({
+      sid: "VA_default_service",
+      friendly_name: "Default Verify Service",
+      code_length: 6,
+    });
+  },
+};
+
+export default twilioPlugin;

--- a/packages/@emulators/twilio/src/routes/calls.ts
+++ b/packages/@emulators/twilio/src/routes/calls.ts
@@ -1,0 +1,72 @@
+import type { RouteContext } from "@emulators/core";
+import { getTwilioStore } from "../store.js";
+import { generateSid, parseTwilioBody, twilioError } from "../helpers.js";
+
+const DEFAULT_ACCOUNT_SID = "AC_test_account";
+
+export function callRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+  const ts = getTwilioStore(store);
+
+  // Create call
+  app.post("/2010-04-01/Accounts/:accountSid/Calls.json", async (c) => {
+    const accountSid = c.req.param("accountSid") || DEFAULT_ACCOUNT_SID;
+    const body = await parseTwilioBody(c);
+
+    const to = String(body.To ?? body.to ?? "");
+    const from = String(body.From ?? body.from ?? "");
+
+    if (!to || !from) {
+      return twilioError(c, 400, 21211, "The 'To' and 'From' parameters are required");
+    }
+
+    const sid = generateSid("CA");
+    const now = new Date().toISOString();
+
+    const call = ts.calls.insert({
+      sid,
+      account_sid: accountSid,
+      to,
+      from,
+      status: "completed",
+      direction: "outbound-api",
+      duration: 0,
+      start_time: now,
+      end_time: now,
+    });
+
+    return c.json({
+      sid: call.sid,
+      account_sid: call.account_sid,
+      to: call.to,
+      from: call.from,
+      status: call.status,
+      direction: call.direction,
+      duration: call.duration,
+      start_time: call.start_time,
+      end_time: call.end_time,
+      date_created: call.created_at,
+      uri: `/2010-04-01/Accounts/${accountSid}/Calls/${call.sid}.json`,
+    }, 201);
+  });
+
+  // List calls
+  app.get("/2010-04-01/Accounts/:accountSid/Calls.json", (c) => {
+    const accountSid = c.req.param("accountSid") || DEFAULT_ACCOUNT_SID;
+    const calls = ts.calls.findBy("account_sid", accountSid);
+
+    return c.json({
+      calls: calls.map((call) => ({
+        sid: call.sid,
+        account_sid: call.account_sid,
+        to: call.to,
+        from: call.from,
+        status: call.status,
+        direction: call.direction,
+        duration: call.duration,
+      })),
+      page: 0,
+      page_size: 50,
+    });
+  });
+}

--- a/packages/@emulators/twilio/src/routes/calls.ts
+++ b/packages/@emulators/twilio/src/routes/calls.ts
@@ -35,19 +35,22 @@ export function callRoutes(ctx: RouteContext): void {
       end_time: now,
     });
 
-    return c.json({
-      sid: call.sid,
-      account_sid: call.account_sid,
-      to: call.to,
-      from: call.from,
-      status: call.status,
-      direction: call.direction,
-      duration: call.duration,
-      start_time: call.start_time,
-      end_time: call.end_time,
-      date_created: call.created_at,
-      uri: `/2010-04-01/Accounts/${accountSid}/Calls/${call.sid}.json`,
-    }, 201);
+    return c.json(
+      {
+        sid: call.sid,
+        account_sid: call.account_sid,
+        to: call.to,
+        from: call.from,
+        status: call.status,
+        direction: call.direction,
+        duration: call.duration,
+        start_time: call.start_time,
+        end_time: call.end_time,
+        date_created: call.created_at,
+        uri: `/2010-04-01/Accounts/${accountSid}/Calls/${call.sid}.json`,
+      },
+      201,
+    );
   });
 
   // List calls

--- a/packages/@emulators/twilio/src/routes/inbox.ts
+++ b/packages/@emulators/twilio/src/routes/inbox.ts
@@ -19,7 +19,9 @@ export function inboxRoutes(ctx: RouteContext): void {
     let contentHtml = "";
 
     if (tab === "messages") {
-      const messages = ts().messages.all().sort((a, b) => b.id - a.id);
+      const messages = ts()
+        .messages.all()
+        .sort((a, b) => b.id - a.id);
       const rows = messages
         .map(
           (m) =>
@@ -43,7 +45,9 @@ export function inboxRoutes(ctx: RouteContext): void {
           </table>
         </div>`;
     } else if (tab === "verifications") {
-      const verifications = ts().verifications.all().sort((a, b) => b.id - a.id);
+      const verifications = ts()
+        .verifications.all()
+        .sort((a, b) => b.id - a.id);
       const rows = verifications
         .map(
           (v) =>
@@ -67,7 +71,9 @@ export function inboxRoutes(ctx: RouteContext): void {
           </table>
         </div>`;
     } else if (tab === "calls") {
-      const calls = ts().calls.all().sort((a, b) => b.id - a.id);
+      const calls = ts()
+        .calls.all()
+        .sort((a, b) => b.id - a.id);
       const rows = calls
         .map(
           (call) =>

--- a/packages/@emulators/twilio/src/routes/inbox.ts
+++ b/packages/@emulators/twilio/src/routes/inbox.ts
@@ -1,0 +1,96 @@
+import { renderInspectorPage, type InspectorTab, escapeHtml } from "@emulators/core";
+import type { RouteContext } from "@emulators/core";
+import { getTwilioStore } from "../store.js";
+
+const SERVICE_LABEL = "Twilio";
+
+const TABS: InspectorTab[] = [
+  { id: "messages", label: "Messages", href: "/?tab=messages" },
+  { id: "verifications", label: "Verify", href: "/?tab=verifications" },
+  { id: "calls", label: "Calls", href: "/?tab=calls" },
+];
+
+export function inboxRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+  const ts = () => getTwilioStore(store);
+
+  app.get("/", (c) => {
+    const tab = c.req.query("tab") ?? "messages";
+    let contentHtml = "";
+
+    if (tab === "messages") {
+      const messages = ts().messages.all().sort((a, b) => b.id - a.id);
+      const rows = messages
+        .map(
+          (m) =>
+            `<tr>
+              <td>${escapeHtml(m.sid)}</td>
+              <td>${escapeHtml(m.to)}</td>
+              <td>${escapeHtml(m.from)}</td>
+              <td>${escapeHtml(m.body)}</td>
+              <td><span class="badge">${m.status}</span></td>
+              <td>${escapeHtml(m.date_sent)}</td>
+            </tr>`,
+        )
+        .join("");
+
+      contentHtml = `
+        <div class="inspector-section">
+          <h2>Messages (${messages.length})</h2>
+          <table class="inspector-table">
+            <thead><tr><th>SID</th><th>To</th><th>From</th><th>Body</th><th>Status</th><th>Sent</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="6"><div class="inspector-empty">No messages sent yet</div></td></tr>'}</tbody>
+          </table>
+        </div>`;
+    } else if (tab === "verifications") {
+      const verifications = ts().verifications.all().sort((a, b) => b.id - a.id);
+      const rows = verifications
+        .map(
+          (v) =>
+            `<tr>
+              <td>${escapeHtml(v.sid)}</td>
+              <td>${escapeHtml(v.to)}</td>
+              <td>${v.channel}</td>
+              <td><code>${escapeHtml(v.code)}</code></td>
+              <td><span class="badge">${v.status}</span></td>
+              <td>${escapeHtml(v.expires_at)}</td>
+            </tr>`,
+        )
+        .join("");
+
+      contentHtml = `
+        <div class="inspector-section">
+          <h2>Verifications (${verifications.length})</h2>
+          <table class="inspector-table">
+            <thead><tr><th>SID</th><th>To</th><th>Channel</th><th>Code</th><th>Status</th><th>Expires</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="6"><div class="inspector-empty">No verifications sent yet</div></td></tr>'}</tbody>
+          </table>
+        </div>`;
+    } else if (tab === "calls") {
+      const calls = ts().calls.all().sort((a, b) => b.id - a.id);
+      const rows = calls
+        .map(
+          (call) =>
+            `<tr>
+              <td>${escapeHtml(call.sid)}</td>
+              <td>${escapeHtml(call.to)}</td>
+              <td>${escapeHtml(call.from)}</td>
+              <td><span class="badge">${call.status}</span></td>
+              <td>${call.duration ?? 0}s</td>
+            </tr>`,
+        )
+        .join("");
+
+      contentHtml = `
+        <div class="inspector-section">
+          <h2>Calls (${calls.length})</h2>
+          <table class="inspector-table">
+            <thead><tr><th>SID</th><th>To</th><th>From</th><th>Status</th><th>Duration</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="5"><div class="inspector-empty">No calls made yet</div></td></tr>'}</tbody>
+          </table>
+        </div>`;
+    }
+
+    return c.html(renderInspectorPage("Inspector", TABS, tab, contentHtml, SERVICE_LABEL));
+  });
+}

--- a/packages/@emulators/twilio/src/routes/messages.ts
+++ b/packages/@emulators/twilio/src/routes/messages.ts
@@ -1,0 +1,96 @@
+import type { RouteContext } from "@emulators/core";
+import { getTwilioStore } from "../store.js";
+import { generateSid, parseTwilioBody, twilioError } from "../helpers.js";
+
+const DEFAULT_ACCOUNT_SID = "AC_test_account";
+
+export function messageRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+  const ts = getTwilioStore(store);
+
+  // Send SMS
+  app.post("/2010-04-01/Accounts/:accountSid/Messages.json", async (c) => {
+    const accountSid = c.req.param("accountSid") || DEFAULT_ACCOUNT_SID;
+    const body = await parseTwilioBody(c);
+
+    const to = String(body.To ?? body.to ?? "");
+    const from = String(body.From ?? body.from ?? "");
+    const messageBody = String(body.Body ?? body.body ?? "");
+
+    if (!to || !messageBody) {
+      return twilioError(c, 400, 21211, "The 'To' number and 'Body' are required");
+    }
+
+    const sid = generateSid("SM");
+    const now = new Date().toISOString();
+
+    const message = ts.messages.insert({
+      sid,
+      account_sid: accountSid,
+      to,
+      from: from || ts.phoneNumbers.all()[0]?.phone_number || "+15551234567",
+      body: messageBody,
+      status: "delivered",
+      direction: "outbound-api",
+      num_segments: Math.ceil(messageBody.length / 160),
+      date_sent: now,
+    });
+
+    return c.json({
+      sid: message.sid,
+      account_sid: message.account_sid,
+      to: message.to,
+      from: message.from,
+      body: message.body,
+      status: message.status,
+      direction: message.direction,
+      num_segments: message.num_segments,
+      date_created: message.created_at,
+      date_sent: message.date_sent,
+      date_updated: message.updated_at,
+      uri: `/2010-04-01/Accounts/${accountSid}/Messages/${message.sid}.json`,
+    }, 201);
+  });
+
+  // List messages
+  app.get("/2010-04-01/Accounts/:accountSid/Messages.json", (c) => {
+    const accountSid = c.req.param("accountSid") || DEFAULT_ACCOUNT_SID;
+    const messages = ts.messages.findBy("account_sid", accountSid);
+
+    return c.json({
+      messages: messages.map((m) => ({
+        sid: m.sid,
+        account_sid: m.account_sid,
+        to: m.to,
+        from: m.from,
+        body: m.body,
+        status: m.status,
+        direction: m.direction,
+        num_segments: m.num_segments,
+        date_sent: m.date_sent,
+      })),
+      page: 0,
+      page_size: 50,
+    });
+  });
+
+  // Get single message
+  app.get("/2010-04-01/Accounts/:accountSid/Messages/:messageSid.json", (c) => {
+    const messageSid = c.req.param("messageSid");
+    const message = ts.messages.findOneBy("sid", messageSid);
+    if (!message) {
+      return twilioError(c, 404, 20404, "The requested resource was not found");
+    }
+    return c.json({
+      sid: message.sid,
+      account_sid: message.account_sid,
+      to: message.to,
+      from: message.from,
+      body: message.body,
+      status: message.status,
+      direction: message.direction,
+      num_segments: message.num_segments,
+      date_sent: message.date_sent,
+    });
+  });
+}

--- a/packages/@emulators/twilio/src/routes/messages.ts
+++ b/packages/@emulators/twilio/src/routes/messages.ts
@@ -36,20 +36,23 @@ export function messageRoutes(ctx: RouteContext): void {
       date_sent: now,
     });
 
-    return c.json({
-      sid: message.sid,
-      account_sid: message.account_sid,
-      to: message.to,
-      from: message.from,
-      body: message.body,
-      status: message.status,
-      direction: message.direction,
-      num_segments: message.num_segments,
-      date_created: message.created_at,
-      date_sent: message.date_sent,
-      date_updated: message.updated_at,
-      uri: `/2010-04-01/Accounts/${accountSid}/Messages/${message.sid}.json`,
-    }, 201);
+    return c.json(
+      {
+        sid: message.sid,
+        account_sid: message.account_sid,
+        to: message.to,
+        from: message.from,
+        body: message.body,
+        status: message.status,
+        direction: message.direction,
+        num_segments: message.num_segments,
+        date_created: message.created_at,
+        date_sent: message.date_sent,
+        date_updated: message.updated_at,
+        uri: `/2010-04-01/Accounts/${accountSid}/Messages/${message.sid}.json`,
+      },
+      201,
+    );
   });
 
   // List messages

--- a/packages/@emulators/twilio/src/routes/verify.ts
+++ b/packages/@emulators/twilio/src/routes/verify.ts
@@ -35,15 +35,18 @@ export function verifyRoutes(ctx: RouteContext): void {
       expires_at: expiresAt,
     });
 
-    return c.json({
-      sid: verification.sid,
-      service_sid: verification.service_sid,
-      to: verification.to,
-      channel: verification.channel,
-      status: verification.status,
-      date_created: verification.created_at,
-      date_updated: verification.updated_at,
-    }, 201);
+    return c.json(
+      {
+        sid: verification.sid,
+        service_sid: verification.service_sid,
+        to: verification.to,
+        channel: verification.channel,
+        status: verification.status,
+        date_created: verification.created_at,
+        date_updated: verification.updated_at,
+      },
+      201,
+    );
   });
 
   // Check verification

--- a/packages/@emulators/twilio/src/routes/verify.ts
+++ b/packages/@emulators/twilio/src/routes/verify.ts
@@ -1,0 +1,100 @@
+import type { RouteContext } from "@emulators/core";
+import { getTwilioStore } from "../store.js";
+import { generateSid, generateVerificationCode, parseTwilioBody, twilioError } from "../helpers.js";
+
+export function verifyRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+  const ts = getTwilioStore(store);
+
+  // Send verification
+  app.post("/v2/Services/:serviceSid/Verifications", async (c) => {
+    const serviceSid = c.req.param("serviceSid");
+    const service = ts.verifyServices.findOneBy("sid", serviceSid);
+    if (!service) {
+      return twilioError(c, 404, 60200, "Verify service not found");
+    }
+
+    const body = await parseTwilioBody(c);
+    const to = String(body.To ?? body.to ?? "");
+    const channel = String(body.Channel ?? body.channel ?? "sms");
+
+    if (!to) {
+      return twilioError(c, 400, 60200, "The 'To' parameter is required");
+    }
+
+    const code = generateVerificationCode(service.code_length);
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+
+    const verification = ts.verifications.insert({
+      sid: generateSid("VE"),
+      service_sid: serviceSid,
+      to,
+      channel: channel as "sms" | "email" | "call",
+      status: "pending",
+      code,
+      expires_at: expiresAt,
+    });
+
+    return c.json({
+      sid: verification.sid,
+      service_sid: verification.service_sid,
+      to: verification.to,
+      channel: verification.channel,
+      status: verification.status,
+      date_created: verification.created_at,
+      date_updated: verification.updated_at,
+    }, 201);
+  });
+
+  // Check verification
+  app.post("/v2/Services/:serviceSid/VerificationCheck", async (c) => {
+    const serviceSid = c.req.param("serviceSid");
+    const body = await parseTwilioBody(c);
+    const to = String(body.To ?? body.to ?? "");
+    const code = String(body.Code ?? body.code ?? "");
+
+    if (!to || !code) {
+      return twilioError(c, 400, 60200, "The 'To' and 'Code' parameters are required");
+    }
+
+    const verifications = ts.verifications
+      .findBy("service_sid", serviceSid)
+      .filter((v) => v.to === to && v.status === "pending");
+
+    const latest = verifications[verifications.length - 1];
+    if (!latest) {
+      return twilioError(c, 404, 60200, "No pending verification found for this number");
+    }
+
+    const expired = new Date(latest.expires_at) < new Date();
+    if (expired) {
+      ts.verifications.update(latest.id, { status: "expired" });
+      return c.json({
+        sid: latest.sid,
+        service_sid: latest.service_sid,
+        to: latest.to,
+        channel: latest.channel,
+        status: "expired",
+      });
+    }
+
+    if (latest.code === code) {
+      ts.verifications.update(latest.id, { status: "approved" });
+      return c.json({
+        sid: latest.sid,
+        service_sid: latest.service_sid,
+        to: latest.to,
+        channel: latest.channel,
+        status: "approved",
+      });
+    }
+
+    return c.json({
+      sid: latest.sid,
+      service_sid: latest.service_sid,
+      to: latest.to,
+      channel: latest.channel,
+      status: "pending",
+    });
+  });
+}

--- a/packages/@emulators/twilio/src/store.ts
+++ b/packages/@emulators/twilio/src/store.ts
@@ -1,0 +1,26 @@
+import { Store, type Collection } from "@emulators/core";
+import type {
+  TwilioMessage,
+  TwilioCall,
+  TwilioVerifyService,
+  TwilioVerification,
+  TwilioPhoneNumber,
+} from "./entities.js";
+
+export interface TwilioStore {
+  messages: Collection<TwilioMessage>;
+  calls: Collection<TwilioCall>;
+  verifyServices: Collection<TwilioVerifyService>;
+  verifications: Collection<TwilioVerification>;
+  phoneNumbers: Collection<TwilioPhoneNumber>;
+}
+
+export function getTwilioStore(store: Store): TwilioStore {
+  return {
+    messages: store.collection<TwilioMessage>("twilio.messages", ["sid", "account_sid"]),
+    calls: store.collection<TwilioCall>("twilio.calls", ["sid", "account_sid"]),
+    verifyServices: store.collection<TwilioVerifyService>("twilio.verify_services", ["sid"]),
+    verifications: store.collection<TwilioVerification>("twilio.verifications", ["sid", "service_sid"]),
+    phoneNumbers: store.collection<TwilioPhoneNumber>("twilio.phone_numbers", ["sid", "phone_number"]),
+  };
+}

--- a/packages/@emulators/twilio/tsconfig.json
+++ b/packages/@emulators/twilio/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/twilio/tsup.config.ts
+++ b/packages/@emulators/twilio/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/@emulators/twilio/vitest.config.ts
+++ b/packages/@emulators/twilio/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -71,6 +71,7 @@
     "@emulators/resend": "workspace:*",
     "@emulators/stripe": "workspace:*",
     "@emulators/clerk": "workspace:*",
+    "@emulators/twilio": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/emulate/src/__tests__/api.test.ts
+++ b/packages/emulate/src/__tests__/api.test.ts
@@ -58,6 +58,57 @@ describe("createEmulator", () => {
     await github.close();
   });
 
+  it("twilio sends SMS and lists messages", async () => {
+    const twilio = await createEmulator({ service: "twilio", port: 14300 });
+
+    const sendRes = await fetch(`${twilio.url}/2010-04-01/Accounts/AC_test/Messages.json`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "To=+15559876543&From=+15551234567&Body=Hello from emulate",
+    });
+    expect(sendRes.status).toBe(201);
+    const msg = (await sendRes.json()) as { sid: string; body: string; status: string };
+    expect(msg.sid).toMatch(/^SM/);
+    expect(msg.body).toBe("Hello from emulate");
+    expect(msg.status).toBe("delivered");
+
+    const listRes = await fetch(`${twilio.url}/2010-04-01/Accounts/AC_test/Messages.json`);
+    const list = (await listRes.json()) as { messages: Array<{ sid: string }> };
+    expect(list.messages.length).toBeGreaterThanOrEqual(1);
+
+    await twilio.close();
+  });
+
+  it("twilio verify sends code and checks it", async () => {
+    const twilio = await createEmulator({ service: "twilio", port: 14310 });
+
+    const sendRes = await fetch(`${twilio.url}/v2/Services/VA_default_service/Verifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "To=+15559876543&Channel=sms",
+    });
+    expect(sendRes.status).toBe(201);
+    const verification = (await sendRes.json()) as { sid: string; status: string };
+    expect(verification.sid).toMatch(/^VE/);
+    expect(verification.status).toBe("pending");
+
+    // Get the code from the verifications tab
+    const inboxRes = await fetch(`${twilio.url}/?tab=verifications`);
+    const html = await inboxRes.text();
+    const codeMatch = html.match(/<code>(\d{6})<\/code>/);
+    expect(codeMatch).toBeTruthy();
+
+    const checkRes = await fetch(`${twilio.url}/v2/Services/VA_default_service/VerificationCheck`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: `To=+15559876543&Code=${codeMatch![1]}`,
+    });
+    const result = (await checkRes.json()) as { status: string };
+    expect(result.status).toBe("approved");
+
+    await twilio.close();
+  });
+
   it("throws on unknown service", async () => {
     // @ts-expect-error testing invalid service name
     await expect(createEmulator({ service: "unknown-svc" })).rejects.toThrow("Unknown service");

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -27,6 +27,7 @@ const SERVICE_NAME_LIST = [
   "stripe",
   "mongoatlas",
   "clerk",
+  "twilio",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -437,6 +438,30 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
           name: "Emulate App",
           redirect_uris: ["http://localhost:3000/api/auth/callback/clerk"],
         }],
+      },
+    },
+  },
+  twilio: {
+    label: "Twilio SMS, voice, and verification emulator",
+    endpoints: "Messages (send, list, get), Calls (create, list), Verify (send code, check code), inbox UI",
+    async load() {
+      const mod = await import("@emulators/twilio");
+      return { plugin: mod.twilioPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback() {
+      return { login: "AC_test_account", id: 1, scopes: [] };
+    },
+    initConfig: {
+      twilio: {
+        account_sid: "AC_test_account",
+        auth_token: "test_auth_token",
+        phone_numbers: ["+15551234567"],
+        verify_services: [
+          {
+            sid: "VA_test_service",
+            friendly_name: "My App Verify",
+          },
+        ],
       },
     },
   },

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -372,7 +372,8 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   },
   stripe: {
     label: "Stripe payments emulator",
-    endpoints: "customers, payment methods, customer sessions, payment intents, charges, products, prices, checkout sessions, webhooks",
+    endpoints:
+      "customers, payment methods, customer sessions, payment intents, charges, products, prices, checkout sessions, webhooks",
     async load() {
       const mod = await import("@emulators/stripe");
       return { plugin: mod.stripePlugin, seedFromConfig: mod.seedFromConfig };
@@ -410,34 +411,43 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   },
   clerk: {
     label: "Clerk authentication and user management emulator",
-    endpoints: "OIDC discovery, JWKS, OAuth authorize/token/userinfo, users, email addresses, organizations, memberships, invitations, sessions",
+    endpoints:
+      "OIDC discovery, JWKS, OAuth authorize/token/userinfo, users, email addresses, organizations, memberships, invitations, sessions",
     async load() {
       const mod = await import("@emulators/clerk");
       return { plugin: mod.clerkPlugin, seedFromConfig: mod.seedFromConfig };
     },
     defaultFallback(cfg) {
-      const firstEmail = (cfg?.users as Array<{ email_addresses?: string[] }> | undefined)?.[0]?.email_addresses?.[0] ?? "test@example.com";
+      const firstEmail =
+        (cfg?.users as Array<{ email_addresses?: string[] }> | undefined)?.[0]?.email_addresses?.[0] ??
+        "test@example.com";
       return { login: firstEmail, id: 1, scopes: [] };
     },
     initConfig: {
       clerk: {
-        users: [{
-          first_name: "Test",
-          last_name: "User",
-          email_addresses: ["test@example.com"],
-          password: "clerk_test_password",
-        }],
-        organizations: [{
-          name: "My Company",
-          slug: "my-company",
-          members: [{ email: "test@example.com", role: "admin" }],
-        }],
-        oauth_applications: [{
-          client_id: "clerk_emulate_client",
-          client_secret: "clerk_emulate_secret",
-          name: "Emulate App",
-          redirect_uris: ["http://localhost:3000/api/auth/callback/clerk"],
-        }],
+        users: [
+          {
+            first_name: "Test",
+            last_name: "User",
+            email_addresses: ["test@example.com"],
+            password: "clerk_test_password",
+          },
+        ],
+        organizations: [
+          {
+            name: "My Company",
+            slug: "my-company",
+            members: [{ email: "test@example.com", role: "admin" }],
+          },
+        ],
+        oauth_applications: [
+          {
+            client_id: "clerk_emulate_client",
+            client_secret: "clerk_emulate_secret",
+            name: "Emulate App",
+            redirect_uris: ["http://localhost:3000/api/auth/callback/clerk"],
+          },
+        ],
       },
     },
   },

--- a/skills/twilio/SKILL.md
+++ b/skills/twilio/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: twilio
+description: Emulated Twilio SMS, voice, and verification API for local development and testing. Use when the user needs to send SMS locally, test 2FA/verification flows, create calls, inspect sent messages, or work with the Twilio API without sending real messages. Triggers include "Twilio API", "emulate Twilio", "send SMS locally", "test 2FA", "verification code", "mock Twilio", "local SMS", or any task requiring a local Twilio API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Twilio SMS, Voice, and Verify Emulator
+
+Fully stateful Twilio API emulation. Messages, calls, and verification codes persist in memory. Sent messages and verification codes are visible through the inbox UI.
+
+No real SMS or calls are sent. Every API call stores the data locally so you can inspect it programmatically or in the browser.
+
+## Start
+
+```bash
+# Twilio only
+npx emulate --service twilio
+
+# Default port (when run alone)
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const twilio = await createEmulator({ service: 'twilio', port: 4000 })
+// twilio.url === 'http://localhost:4000'
+```
+
+## Auth
+
+Pass any token in the Authorization header. Twilio uses Basic auth with Account SID and Auth Token, but the emulator accepts any credentials.
+
+## Endpoints
+
+### Messages
+
+```bash
+# Send an SMS
+curl -X POST http://localhost:4000/2010-04-01/Accounts/AC_test/Messages.json \
+  -d "To=+15559876543&From=+15551234567&Body=Hello"
+
+# List messages
+curl http://localhost:4000/2010-04-01/Accounts/AC_test/Messages.json
+
+# Get a message
+curl http://localhost:4000/2010-04-01/Accounts/AC_test/Messages/SMXXXXXXXX.json
+```
+
+### Calls
+
+```bash
+# Create a call
+curl -X POST http://localhost:4000/2010-04-01/Accounts/AC_test/Calls.json \
+  -d "To=+15559876543&From=+15551234567"
+
+# List calls
+curl http://localhost:4000/2010-04-01/Accounts/AC_test/Calls.json
+```
+
+### Verify (2FA)
+
+```bash
+# Send a verification code
+curl -X POST http://localhost:4000/v2/Services/VA_default_service/Verifications \
+  -d "To=+15559876543&Channel=sms"
+
+# Check a code (get the code from the inbox UI at http://localhost:4000/)
+curl -X POST http://localhost:4000/v2/Services/VA_default_service/VerificationCheck \
+  -d "To=+15559876543&Code=123456"
+```
+
+### Inbox UI
+
+Open `http://localhost:4000/` in a browser to see all sent messages, verification codes, and calls. Verification codes are shown in plain text for testing.
+
+## Seed Config
+
+```yaml
+twilio:
+  account_sid: AC_test_account
+  auth_token: test_auth_token
+  phone_numbers:
+    - "+15551234567"
+    - "+15559876543"
+  verify_services:
+    - sid: VA_test_service
+      friendly_name: "My App Verify"
+      code_length: 6
+```
+
+## Pointing Your App at the Emulator
+
+Set `TWILIO_API_URL=http://localhost:PORT` or configure the Twilio client's base URL. Most Twilio SDKs support a custom API endpoint for testing.


### PR DESCRIPTION
## Summary

Add `@emulators/twilio` package with full Twilio REST API emulation for SMS, voice calls, and the Verify API (2FA verification codes). Includes an inspector UI with tabs for messages, verifications, and calls.

## Why this matters

Nearly every app with user authentication needs SMS verification or 2FA. Testing these flows currently requires hitting production Twilio (costs money per SMS, slow, unreliable in CI) or mocking at the HTTP level. No existing API emulator covers Twilio.

With this emulator, the full auth flow can run locally: OAuth sign-in (GitHub/Google emulator) -> phone verification (Twilio emulator) -> welcome email (Resend emulator). All without network access.

## Changes

### New package: `@emulators/twilio`

**Messages API** (`/2010-04-01/Accounts/:sid/Messages.json`):
- POST to send SMS (generates realistic SIDs, tracks segments)
- GET to list messages
- GET /:sid to fetch a single message

**Calls API** (`/2010-04-01/Accounts/:sid/Calls.json`):
- POST to create a call record
- GET to list calls

**Verify API** (`/v2/Services/:sid/Verifications` and `VerificationCheck`):
- POST Verifications to generate a 6-digit code (configurable length)
- POST VerificationCheck to validate the code
- Codes expire after 10 minutes
- Wrong codes leave status as "pending" rather than consuming the attempt

**Inspector UI** (`/`):
- Tabbed interface (Messages, Verify, Calls) using shared `renderInspectorPage`
- Verification codes displayed in plain text for easy testing

**Seed config:**
```yaml
twilio:
  account_sid: AC_test_account
  phone_numbers: ["+15551234567"]
  verify_services:
    - sid: VA_test_service
      friendly_name: "My App Verify"
```

### Integration
- Registered `twilio` in `SERVICE_REGISTRY` (`packages/emulate/src/registry.ts`)
- Added `@emulators/twilio` as dev dependency of `emulate`
- Updated README.md with Twilio in the service list
- Created `skills/twilio/SKILL.md` with endpoint docs and examples

## Demo

![twilio-demo](https://files.catbox.moe/b38ve1.gif)

Shows sending an SMS, creating a verification code, and checking the code (approved). All local, no real SMS sent.

## Testing

6 tests pass (4 existing + 2 new for Twilio):
- `twilio sends SMS and lists messages` - Messages API
- `twilio verify sends code and checks it` - Verify API with code extraction from inspector UI

This follows the same pattern as our previous service emulator PRs (#4 Stripe, #7 Resend, #10 Slack).

This contribution was developed with AI assistance (Claude Code).