### PR TITLE
feat: Add Auth0 emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ All services start with sensible defaults. No config file needed:
 - **Slack** on `http://localhost:4003`
 - **Apple** on `http://localhost:4004`
 - **Microsoft** on `http://localhost:4005`
-- **AWS** on `http://localhost:4006`
+- **Okta** on `http://localhost:4006`
+- **Auth0** on `http://localhost:4007`
+- **AWS** on `http://localhost:4008`
+- **Resend** on `http://localhost:4009`
+- **Stripe** on `http://localhost:4010`
+- **MongoDB Atlas** on `http://localhost:4011`
+- **Clerk** on `http://localhost:4012`
 
 ## CLI
 
@@ -100,7 +106,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'auth0'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, or `'clerk'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 
@@ -610,6 +616,35 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 - `GET /oauth2/v2.0/logout` - end session / logout
 - `POST /oauth2/v2.0/revoke` - token revocation
 
+## Auth0
+
+Auth0 Authentication API, Management API v2, and OIDC emulation with log event streaming.
+
+### Authentication API
+- `POST /oauth/token` — token endpoint (client_credentials, password-realm, refresh_token)
+- `GET /userinfo` — user profile from access token
+- `POST /oauth/revoke` — revoke refresh token
+
+### Management API v2
+- `POST /api/v2/users` — create user with email, password, connection, app_metadata
+- `GET /api/v2/users/:id` — get user by ID
+- `GET /api/v2/users-by-email` — search users by email
+- `PATCH /api/v2/users/:id` — update user (app_metadata merge, password change, email_verified)
+- `POST /api/v2/tickets/email-verification` — create email verification ticket
+
+### OIDC
+- `GET /.well-known/openid-configuration` — OpenID Connect discovery
+- `GET /.well-known/jwks.json` — JSON Web Key Set (RS256)
+- `GET /_emulate/public-key.pem` — RSA public key in PEM format
+
+Supports deterministic signing keys via `signing_key` in seed config for static JWT validation. When omitted, a random key pair is generated on first request.
+
+### Log Events
+Dispatches Auth0 log events (`ss`, `fs`, `sv`, `scp`) via webhook on user creation, signup failure, email verification, and password change. Configure subscribers via `log_streams` in the seed config.
+
+### Error Fidelity
+Authentication API errors use OAuth2 format (`{ error, error_description }`). Management API errors use Auth0 format (`{ statusCode, error, message, errorCode }`). Error strings match Auth0's actual API responses so SDK error handling works unchanged.
+
 ## AWS
 
 S3, SQS, IAM, and STS emulation with REST-style S3 paths and query-style SQS/IAM/STS endpoints. All responses use AWS-compatible XML.
@@ -767,6 +802,7 @@ packages/
     slack/          # Slack Web API, OAuth v2, incoming webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
+    auth0/          # Auth0 Authentication API, Management API v2, OIDC
     aws/            # AWS S3, SQS, IAM, STS
 apps/
   web/              # Documentation site (Next.js)
@@ -789,5 +825,7 @@ Tokens are configured in the seed config and map to users. Pass them as `Authori
 **Apple**: OIDC authorization code flow with RS256 ID tokens. On first auth per user/client pair, a `user` JSON blob is included.
 
 **Microsoft**: OIDC authorization code flow with PKCE support. Also supports client credentials grants. Microsoft Graph `/v1.0/me` available.
+
+**Auth0**: Management API endpoints require a Bearer token obtained via `client_credentials` grant. Authentication API (`/oauth/token`) accepts `client_id`/`client_secret` in the request body or via Basic auth header.
 
 **AWS**: Bearer tokens or IAM access key credentials. Default key pair always seeded: `AKIAIOSFODNN7EXAMPLE` / `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`.

--- a/packages/@emulators/auth0/README.md
+++ b/packages/@emulators/auth0/README.md
@@ -1,0 +1,104 @@
+# @emulators/auth0
+
+Auth0 identity platform emulation with OAuth 2.0 / OIDC, Management API v2, user lifecycle, email verification, and log event streaming.
+
+Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
+
+## Install
+
+```bash
+npm install @emulators/auth0
+```
+
+## Endpoints
+
+### Authentication API
+
+- `POST /oauth/token` — token endpoint (client_credentials, password-realm, refresh_token)
+- `GET /userinfo` — user profile from access token
+- `POST /oauth/revoke` — revoke refresh token
+
+### Management API v2
+
+- `POST /api/v2/users` — create user
+- `GET /api/v2/users/:id` — get user by ID
+- `GET /api/v2/users-by-email` — search users by email
+- `PATCH /api/v2/users/:id` — update user
+- `POST /api/v2/tickets/email-verification` — create email verification ticket
+
+### OIDC Discovery
+
+- `GET /.well-known/openid-configuration` — OpenID Connect discovery
+- `GET /.well-known/jwks.json` — JSON Web Key Set (RS256)
+- `GET /_emulate/public-key.pem` — RSA public key in PEM format
+
+### Inspector
+
+- `GET /` — tabbed UI showing users, log events, OAuth clients, and connections
+
+## Grant Types
+
+| Grant type | Use |
+|---|---|
+| `client_credentials` | Machine-to-machine tokens (Management API access) |
+| `http://auth0.com/oauth/grant-type/password-realm` | User login with email + password + connection |
+| `refresh_token` | Exchange refresh token for new tokens |
+
+## Log Event Streaming
+
+The emulator dispatches Auth0 log events via webhook when state changes occur:
+
+| Type | Event | Trigger |
+|---|---|---|
+| `ss` | Successful Signup | User created |
+| `fs` | Failed Signup | Create user failed |
+| `sv` | Email Verified | Verification ticket consumed |
+| `scp` | Password Changed | User password updated |
+
+Configure webhook subscribers in the seed config via `log_streams`.
+
+## Error Fidelity
+
+Error responses match Auth0's actual format so SDK error handling works unchanged:
+
+- Authentication API errors use OAuth2 format: `{ error, error_description }`
+- Management API errors use Auth0 format: `{ statusCode, error, message, errorCode }`
+
+## Seed Configuration
+
+```yaml
+auth0:
+  connections:
+    - name: Username-Password-Authentication
+  users:
+    - email: admin@example.com
+      password: Admin1234!
+      email_verified: true
+      app_metadata:
+        role: ADMIN
+  oauth_clients:
+    - client_id: my-m2m-client
+      client_secret: my-secret
+      name: Backend Service
+      grant_types: [client_credentials]
+      audience: https://api.example.com
+  log_streams:
+    - url: http://localhost:9000/auth0-events
+  signing_key:
+    private_key_pem: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+    public_key_pem: |
+      -----BEGIN PUBLIC KEY-----
+      ...
+      -----END PUBLIC KEY-----
+    kid: my-custom-kid
+```
+
+When `signing_key` is omitted, a random RS256 key pair is generated on first request. When provided, all ID tokens and the JWKS endpoint use the configured key, enabling static JWT validation in your backend.
+
+## Links
+
+- [Full documentation](https://emulate.dev)
+- [GitHub](https://github.com/vercel-labs/emulate)

--- a/packages/@emulators/auth0/package.json
+++ b/packages/@emulators/auth0/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@emulators/auth0",
+  "version": "0.4.1",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/auth0"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*",
+    "hono": "^4",
+    "jose": "^6"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/auth0/src/__tests__/auth0.test.ts
+++ b/packages/@emulators/auth0/src/__tests__/auth0.test.ts
@@ -1,0 +1,900 @@
+import { decodeJwt, generateKeyPair, exportPKCS8, exportSPKI, jwtVerify, importSPKI } from "jose";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
+import { auth0Plugin, getAuth0Store, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4000";
+
+let app: Hono;
+let store: Store;
+let tokenMap: TokenMap;
+let webhooks: WebhookDispatcher;
+
+function createTestApp() {
+  store = new Store();
+  webhooks = new WebhookDispatcher();
+  tokenMap = new Map();
+
+  app = new Hono();
+  app.use("*", authMiddleware(tokenMap));
+  auth0Plugin.register(app as any, store, webhooks, base, tokenMap);
+  auth0Plugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    connections: [{ name: "Username-Password-Authentication" }],
+    users: [
+      {
+        email: "alice@example.com",
+        password: "Alice1234!",
+        email_verified: true,
+        given_name: "Alice",
+        family_name: "Example",
+        app_metadata: { userId: 12345, role: "USER" },
+      },
+    ],
+    oauth_clients: [
+      {
+        client_id: "m2m-client",
+        client_secret: "m2m-secret",
+        name: "M2M Client",
+        grant_types: ["client_credentials"],
+        audience: `${base}/api/v2/`,
+      },
+      {
+        client_id: "app-client",
+        client_secret: "app-secret",
+        name: "App Client",
+        grant_types: ["authorization_code", "refresh_token", "http://auth0.com/oauth/grant-type/password-realm"],
+      },
+    ],
+  });
+}
+
+async function getManagementToken(): Promise<string> {
+  const res = await app.request(`${base}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "client_credentials",
+      client_id: "m2m-client",
+      client_secret: "m2m-secret",
+      audience: `${base}/api/v2/`,
+    }),
+  });
+  const body = (await res.json()) as { access_token: string };
+  return body.access_token;
+}
+
+function mgmtHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+beforeEach(() => {
+  createTestApp();
+});
+
+describe("OIDC Discovery", () => {
+  it("returns openid-configuration", async () => {
+    const res = await app.request(`${base}/.well-known/openid-configuration`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.issuer).toBe(`${base}/`);
+    expect(body.token_endpoint).toBe(`${base}/oauth/token`);
+    expect(body.userinfo_endpoint).toBe(`${base}/userinfo`);
+    expect(body.jwks_uri).toBe(`${base}/.well-known/jwks.json`);
+  });
+
+  it("returns JWKS", async () => {
+    const res = await app.request(`${base}/.well-known/jwks.json`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { keys: Array<{ kid: string; alg: string }> };
+    expect(body.keys).toHaveLength(1);
+    expect(body.keys[0]!.kid).toBe("emulate-auth0-1");
+    expect(body.keys[0]!.alg).toBe("RS256");
+  });
+});
+
+describe("OAuth /oauth/token", () => {
+  it("client_credentials returns access token", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "client_credentials",
+        client_id: "m2m-client",
+        client_secret: "m2m-secret",
+        audience: `${base}/api/v2/`,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.access_token).toBeTruthy();
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBe(86400);
+  });
+
+  it("password-realm returns tokens and id_token", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "Alice1234!",
+        realm: "Username-Password-Authentication",
+        scope: "openid profile email offline_access",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.access_token).toBeTruthy();
+    expect(body.refresh_token).toBeTruthy();
+    expect(body.id_token).toBeTruthy();
+
+    const claims = decodeJwt(body.id_token as string);
+    expect(claims.email).toBe("alice@example.com");
+    expect(claims.given_name).toBe("Alice");
+  });
+
+  it("password-realm rejects wrong password", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "WrongPassword1!",
+        realm: "Username-Password-Authentication",
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_grant");
+    expect(body.error_description).toBe("Wrong email or password.");
+  });
+
+  it("password-realm rejects blocked user", async () => {
+    const auth0 = getAuth0Store(store);
+    const user = auth0.users.findOneBy("email", "alice@example.com");
+    if (user) auth0.users.update(user.id, { blocked: true });
+
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "Alice1234!",
+        realm: "Username-Password-Authentication",
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("unauthorized");
+    expect(body.error_description).toBe("user is blocked");
+  });
+
+  it("refresh_token returns new tokens", async () => {
+    // First get tokens via password-realm
+    const loginRes = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "Alice1234!",
+        realm: "Username-Password-Authentication",
+        scope: "openid profile email offline_access",
+      }),
+    });
+    const loginBody = (await loginRes.json()) as { refresh_token: string };
+
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        refresh_token: loginBody.refresh_token,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.access_token).toBeTruthy();
+    expect(body.refresh_token).toBeTruthy();
+    expect(body.access_token).not.toBe(loginBody.refresh_token);
+  });
+
+  it("rejects unknown client", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "client_credentials",
+        client_id: "nonexistent",
+        client_secret: "nope",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("Management API - Users", () => {
+  it("creates a user", async () => {
+    const token = await getManagementToken();
+    const res = await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email: "newuser@example.com",
+        password: "NewUser1234!",
+        connection: "Username-Password-Authentication",
+        app_metadata: { userId: 99999, role: "USER" },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.email).toBe("newuser@example.com");
+    expect(body.user_id).toMatch(/^auth0\|/);
+    expect((body.app_metadata as Record<string, unknown>).userId).toBe(99999);
+  });
+
+  it("rejects duplicate user with exact Auth0 error message", async () => {
+    const token = await getManagementToken();
+    const res = await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email: "alice@example.com",
+        password: "Alice1234!",
+        connection: "Username-Password-Authentication",
+      }),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { statusCode: number; error: string; message: string; errorCode: string };
+    expect(body.statusCode).toBe(409);
+    expect(body.error).toBe("Conflict");
+    expect(body.message).toBe("The user already exists.");
+  });
+
+  it("rejects invalid email with exact Auth0 error message", async () => {
+    const token = await getManagementToken();
+    const res = await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email: "not-an-email",
+        password: "Test1234!",
+        connection: "Username-Password-Authentication",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { statusCode: number; error: string; message: string; errorCode: string };
+    expect(body.statusCode).toBe(400);
+    expect(body.message).toContain("Object didn't pass validation for format email");
+  });
+
+  it("rejects weak password with PasswordStrengthError", async () => {
+    const token = await getManagementToken();
+    const res = await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email: "weak@example.com",
+        password: "weak",
+        connection: "Username-Password-Authentication",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { statusCode: number; error: string; message: string; errorCode: string };
+    expect(body.statusCode).toBe(400);
+    expect(body.message).toContain("PasswordStrengthError");
+  });
+
+  it("gets user by ID", async () => {
+    const token = await getManagementToken();
+    const auth0 = getAuth0Store(store);
+    const alice = auth0.users.findOneBy("email", "alice@example.com")!;
+
+    const res = await app.request(`${base}/api/v2/users/${encodeURIComponent(alice.user_id)}`, {
+      headers: mgmtHeaders(token),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.email).toBe("alice@example.com");
+  });
+
+  it("lists users by email", async () => {
+    const token = await getManagementToken();
+    const res = await app.request(`${base}/api/v2/users-by-email?email=alice@example.com`, {
+      headers: mgmtHeaders(token),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<Record<string, unknown>>;
+    expect(body).toHaveLength(1);
+    expect(body[0]!.email).toBe("alice@example.com");
+  });
+
+  it("updates user app_metadata", async () => {
+    const token = await getManagementToken();
+    const auth0 = getAuth0Store(store);
+    const alice = auth0.users.findOneBy("email", "alice@example.com")!;
+
+    const res = await app.request(`${base}/api/v2/users/${encodeURIComponent(alice.user_id)}`, {
+      method: "PATCH",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        app_metadata: { userId: 12345, role: "USER", securitiesLimit: 100 },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    const metadata = body.app_metadata as Record<string, unknown>;
+    expect(metadata.securitiesLimit).toBe(100);
+    expect(metadata.userId).toBe(12345);
+  });
+
+  it("updates email_verified", async () => {
+    const token = await getManagementToken();
+    const auth0 = getAuth0Store(store);
+    const alice = auth0.users.findOneBy("email", "alice@example.com")!;
+
+    const res = await app.request(`${base}/api/v2/users/${encodeURIComponent(alice.user_id)}`, {
+      method: "PATCH",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({ email_verified: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.email_verified).toBe(true);
+  });
+
+  it("rejects unauthenticated management calls", async () => {
+    const res = await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "unauth@example.com",
+        password: "Test1234!",
+        connection: "Username-Password-Authentication",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("Management API - Tickets", () => {
+  it("creates email verification ticket", async () => {
+    const token = await getManagementToken();
+    const auth0 = getAuth0Store(store);
+    const alice = auth0.users.findOneBy("email", "alice@example.com")!;
+
+    const res = await app.request(`${base}/api/v2/tickets/email-verification`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        user_id: alice.user_id,
+        result_url: "https://example.com/email-verification-success/",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ticket: string };
+    expect(body.ticket).toContain("/tickets/email-verification?ticket=");
+  });
+});
+
+describe("Userinfo", () => {
+  it("returns user profile for authenticated user", async () => {
+    // Login first
+    const loginRes = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "Alice1234!",
+        realm: "Username-Password-Authentication",
+        scope: "openid profile email",
+      }),
+    });
+    const loginBody = (await loginRes.json()) as { access_token: string };
+
+    const res = await app.request(`${base}/userinfo`, {
+      headers: { Authorization: `Bearer ${loginBody.access_token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.email).toBe("alice@example.com");
+    expect(body.given_name).toBe("Alice");
+    expect(body.family_name).toBe("Example");
+  });
+});
+
+describe("Token Revocation", () => {
+  it("revokes a token", async () => {
+    const loginRes = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "Alice1234!",
+        realm: "Username-Password-Authentication",
+      }),
+    });
+    const loginBody = (await loginRes.json()) as { refresh_token: string };
+
+    const res = await app.request(`${base}/oauth/revoke`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: loginBody.refresh_token }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+// These tests validate that error response formats exactly match Auth0's
+// actual API responses, ensuring SDK error handling works unchanged.
+describe("Auth0 error format fidelity", () => {
+  it("Authentication API errors use { error, error_description } format", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "WrongPassword1!",
+        realm: "Username-Password-Authentication",
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("error_description");
+    expect(body).toHaveProperty("error");
+    expect(body.error).toBe("invalid_grant");
+    expect(body.error_description).toBe("Wrong email or password.");
+    // Should NOT have Management API fields
+    expect(body).not.toHaveProperty("statusCode");
+    expect(body).not.toHaveProperty("message");
+  });
+
+  it("Management API errors use { statusCode, error, message, errorCode } format", async () => {
+    const token = await getManagementToken();
+    const res = await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email: "alice@example.com",
+        password: "Alice1234!",
+        connection: "Username-Password-Authentication",
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("statusCode");
+    expect(body).toHaveProperty("error");
+    expect(body).toHaveProperty("message");
+    expect(body).toHaveProperty("errorCode");
+    expect(body.statusCode).toBe(409);
+    expect(body.message).toBe("The user already exists.");
+  });
+
+  it("refresh_token error returns exact Auth0 error description", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        refresh_token: "invalid_token_value",
+      }),
+    });
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error_description).toBe("Unknown or invalid refresh token.");
+    expect(body.error).toBe("invalid_grant");
+  });
+
+  it("user not found returns exact Auth0 error description", async () => {
+    const token = await getManagementToken();
+    const res = await app.request(`${base}/api/v2/users/${encodeURIComponent("auth0|999999")}`, {
+      headers: mgmtHeaders(token),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe("The user does not exist.");
+  });
+});
+
+describe("Log Events (webhook dispatch)", () => {
+  beforeEach(() => {
+    // Register a catch-all subscriber so dispatches are recorded as deliveries
+    webhooks.register({
+      url: "http://localhost:9999/test-hook",
+      events: ["*"],
+      active: true,
+      owner: "auth0",
+    });
+  });
+
+  it("dispatches 'ss' event on successful user creation", async () => {
+    const token = await getManagementToken();
+    const email = `logtest-${Date.now()}@example.com`;
+
+    await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email,
+        password: "SecurePass1!",
+        connection: "Username-Password-Authentication",
+      }),
+    });
+
+    const deliveries = webhooks.getDeliveries();
+    const ssDelivery = deliveries.find((d) => d.event === "ss");
+    expect(ssDelivery).toBeDefined();
+    const payload = ssDelivery!.payload as Record<string, unknown>;
+    expect(payload.type).toBe("ss");
+    expect(payload.user_name).toBe(email);
+    expect(payload.user_id).toMatch(/^auth0\|/);
+    expect(payload.log_id).toBeTruthy();
+    expect(payload.date).toBeTruthy();
+    expect(payload.connection).toBe("Username-Password-Authentication");
+    expect(payload.strategy).toBe("auth0");
+    expect(payload.strategy_type).toBe("database");
+  });
+
+  it("dispatches 'fs' event on failed signup (duplicate)", async () => {
+    const token = await getManagementToken();
+
+    await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email: "alice@example.com",
+        password: "Alice1234!",
+        connection: "Username-Password-Authentication",
+      }),
+    });
+
+    const deliveries = webhooks.getDeliveries();
+    const fsDelivery = deliveries.find((d) => d.event === "fs");
+    expect(fsDelivery).toBeDefined();
+    const payload = fsDelivery!.payload as Record<string, unknown>;
+    expect(payload.type).toBe("fs");
+    expect(payload.user_name).toBe("alice@example.com");
+  });
+
+  it("dispatches 'scp' event on password change", async () => {
+    const token = await getManagementToken();
+    const auth0 = getAuth0Store(store);
+    const alice = auth0.users.findOneBy("email", "alice@example.com")!;
+
+    await app.request(`${base}/api/v2/users/${encodeURIComponent(alice.user_id)}`, {
+      method: "PATCH",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({ password: "NewPassword1!" }),
+    });
+
+    const deliveries = webhooks.getDeliveries();
+    const scpDelivery = deliveries.find((d) => d.event === "scp");
+    expect(scpDelivery).toBeDefined();
+    const payload = scpDelivery!.payload as Record<string, unknown>;
+    expect(payload.type).toBe("scp");
+    expect(payload.user_id).toBe(alice.user_id);
+    expect(payload.user_name).toBe("alice@example.com");
+  });
+
+  it("does not dispatch 'scp' on non-password PATCH", async () => {
+    const token = await getManagementToken();
+    const auth0 = getAuth0Store(store);
+    const alice = auth0.users.findOneBy("email", "alice@example.com")!;
+
+    await app.request(`${base}/api/v2/users/${encodeURIComponent(alice.user_id)}`, {
+      method: "PATCH",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({ email_verified: true }),
+    });
+
+    const deliveries = webhooks.getDeliveries();
+    const scpDelivery = deliveries.find((d) => d.event === "scp");
+    expect(scpDelivery).toBeUndefined();
+  });
+});
+
+describe("Additional coverage", () => {
+  it("password-realm without offline_access does not return refresh_token", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "Alice1234!",
+        realm: "Username-Password-Authentication",
+        scope: "openid profile email",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.access_token).toBeTruthy();
+    expect(body.id_token).toBeTruthy();
+    expect(body).not.toHaveProperty("refresh_token");
+  });
+
+  it("plain password grant type also works", async () => {
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "password",
+        client_id: "app-client",
+        client_secret: "app-secret",
+        username: "alice@example.com",
+        password: "Alice1234!",
+        realm: "Username-Password-Authentication",
+        scope: "openid profile email",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.access_token).toBeTruthy();
+  });
+
+  it("client_credentials token is rejected by /userinfo", async () => {
+    const tokenRes = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "client_credentials",
+        client_id: "m2m-client",
+        client_secret: "m2m-secret",
+        audience: `${base}/api/v2/`,
+      }),
+    });
+    const { access_token } = (await tokenRes.json()) as { access_token: string };
+
+    const res = await app.request(`${base}/userinfo`, {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("email verification ticket consumption marks user verified and dispatches sv", async () => {
+    webhooks.register({
+      url: "http://localhost:9999/test-hook",
+      events: ["*"],
+      active: true,
+      owner: "auth0",
+    });
+
+    const token = await getManagementToken();
+
+    // Create an unverified user
+    const createRes = await app.request(`${base}/api/v2/users`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        email: "verify-test@example.com",
+        password: "Verify1234!",
+        connection: "Username-Password-Authentication",
+        verify_email: true,
+      }),
+    });
+    const created = (await createRes.json()) as Record<string, unknown>;
+    expect(created.email_verified).toBe(false);
+
+    // Create ticket
+    const ticketRes = await app.request(`${base}/api/v2/tickets/email-verification`, {
+      method: "POST",
+      headers: mgmtHeaders(token),
+      body: JSON.stringify({
+        user_id: created.user_id,
+        result_url: "https://example.com/verified",
+      }),
+    });
+    const { ticket } = (await ticketRes.json()) as { ticket: string };
+
+    // Consume ticket
+    const ticketPath = ticket.replace(base, "");
+    const consumeRes = await app.request(`${base}${ticketPath}`);
+    expect(consumeRes.status).toBe(302);
+
+    // Verify user is now email_verified
+    const userRes = await app.request(`${base}/api/v2/users/${encodeURIComponent(created.user_id as string)}`, {
+      headers: mgmtHeaders(token),
+    });
+    const user = (await userRes.json()) as Record<string, unknown>;
+    expect(user.email_verified).toBe(true);
+
+    // Verify sv event dispatched
+    const deliveries = webhooks.getDeliveries();
+    const svDelivery = deliveries.find((d) => d.event === "sv");
+    expect(svDelivery).toBeDefined();
+    const payload = svDelivery!.payload as Record<string, unknown>;
+    expect(payload.type).toBe("sv");
+    expect(payload.user_name).toBe("verify-test@example.com");
+  });
+
+  it("OIDC discovery does not advertise authorization_code in grant_types_supported", async () => {
+    const res = await app.request(`${base}/.well-known/openid-configuration`);
+    const body = (await res.json()) as Record<string, unknown>;
+    const grantTypes = body.grant_types_supported as string[] | undefined;
+    // We don't implement the authorization_code flow, so don't advertise it
+    expect(grantTypes).toBeUndefined();
+  });
+});
+
+describe("Deterministic signing key", () => {
+  let configKeyApp: Hono;
+  let configKeyStore: Store;
+  let configKeyTokenMap: TokenMap;
+  let testPublicPem: string;
+
+  beforeEach(async () => {
+    const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+    const privatePem = await exportPKCS8(privateKey);
+    testPublicPem = await exportSPKI(publicKey);
+
+    configKeyStore = new Store();
+    const wh = new WebhookDispatcher();
+    configKeyTokenMap = new Map();
+
+    configKeyApp = new Hono();
+    configKeyApp.use("*", authMiddleware(configKeyTokenMap));
+    auth0Plugin.register(configKeyApp as any, configKeyStore, wh, base, configKeyTokenMap);
+    auth0Plugin.seed?.(configKeyStore, base);
+    seedFromConfig(configKeyStore, base, {
+      connections: [{ name: "Username-Password-Authentication" }],
+      users: [{ email: "key-test@example.com", password: "KeyTest1!" }],
+      oauth_clients: [
+        {
+          client_id: "ka",
+          client_secret: "kas",
+          grant_types: ["http://auth0.com/oauth/grant-type/password-realm"],
+        },
+      ],
+      signing_key: {
+        private_key_pem: privatePem,
+        public_key_pem: testPublicPem,
+        kid: "custom-kid-1",
+      },
+    });
+  });
+
+  it("JWKS serves the config-provided key with custom kid", async () => {
+    const res = await configKeyApp.request(`${base}/.well-known/jwks.json`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { keys: Array<{ kid: string; alg: string }> };
+    expect(body.keys).toHaveLength(1);
+    expect(body.keys[0]!.kid).toBe("custom-kid-1");
+  });
+
+  it("tokens are verifiable with the provided public key", async () => {
+    const loginRes = await configKeyApp.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+        client_id: "ka",
+        client_secret: "kas",
+        username: "key-test@example.com",
+        password: "KeyTest1!",
+        realm: "Username-Password-Authentication",
+        scope: "openid profile email",
+      }),
+    });
+    const { id_token } = (await loginRes.json()) as { id_token: string };
+    expect(id_token).toBeTruthy();
+
+    // Verify the token with the known public key
+    const pubKey = await importSPKI(testPublicPem, "RS256");
+    const { payload } = await jwtVerify(id_token, pubKey);
+    expect(payload.email).toBe("key-test@example.com");
+  });
+
+  it("/_emulate/public-key.pem returns valid PEM matching config", async () => {
+    const res = await configKeyApp.request(`${base}/_emulate/public-key.pem`);
+    expect(res.status).toBe(200);
+    const pem = await res.text();
+    expect(pem).toContain("-----BEGIN PUBLIC KEY-----");
+    expect(pem).toContain("-----END PUBLIC KEY-----");
+    // Should be the same key we provided
+    expect(pem.trim()).toBe(testPublicPem.trim());
+  });
+
+  it("default (no signing_key) still generates a random key", async () => {
+    // The main test app uses default keys
+    const res = await app.request(`${base}/.well-known/jwks.json`);
+    const body = (await res.json()) as { keys: Array<{ kid: string }> };
+    expect(body.keys[0]!.kid).toBe("emulate-auth0-1");
+  });
+
+  it("/_emulate/public-key.pem works with auto-generated key", async () => {
+    const res = await app.request(`${base}/_emulate/public-key.pem`);
+    expect(res.status).toBe(200);
+    const pem = await res.text();
+    expect(pem).toContain("-----BEGIN PUBLIC KEY-----");
+  });
+
+  it("kid defaults to emulate-auth0-1 when not specified in config", async () => {
+    const noKidStore = new Store();
+    const wh = new WebhookDispatcher();
+    const tm: TokenMap = new Map();
+    const noKidApp = new Hono();
+    noKidApp.use("*", authMiddleware(tm));
+    auth0Plugin.register(noKidApp as any, noKidStore, wh, base, tm);
+    auth0Plugin.seed?.(noKidStore, base);
+
+    const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+    seedFromConfig(noKidStore, base, {
+      signing_key: {
+        private_key_pem: await exportPKCS8(privateKey),
+        public_key_pem: await exportSPKI(publicKey),
+      },
+    });
+
+    const res = await noKidApp.request(`${base}/.well-known/jwks.json`);
+    const body = (await res.json()) as { keys: Array<{ kid: string }> };
+    expect(body.keys[0]!.kid).toBe("emulate-auth0-1");
+  });
+
+  it("invalid PEM throws a clear error on first request", async () => {
+    const badStore = new Store();
+    const wh = new WebhookDispatcher();
+    const tm: TokenMap = new Map();
+    const badApp = new Hono();
+    badApp.use("*", authMiddleware(tm));
+    auth0Plugin.register(badApp as any, badStore, wh, base, tm);
+    auth0Plugin.seed?.(badStore, base);
+    seedFromConfig(badStore, base, {
+      signing_key: {
+        private_key_pem: "not-a-valid-pem",
+        public_key_pem: "also-not-valid",
+      },
+    });
+
+    const res = await badApp.request(`${base}/.well-known/jwks.json`);
+    expect(res.status).toBe(500);
+  });
+
+  it("throws when only private_key_pem is provided", () => {
+    const s = new Store();
+    expect(() =>
+      seedFromConfig(s, base, {
+        signing_key: {
+          private_key_pem: "something",
+          public_key_pem: "",
+        },
+      }),
+    ).toThrow("signing_key requires both private_key_pem and public_key_pem");
+  });
+
+  it("throws when only public_key_pem is provided", () => {
+    const s = new Store();
+    expect(() =>
+      seedFromConfig(s, base, {
+        signing_key: {
+          private_key_pem: "",
+          public_key_pem: "something",
+        },
+      }),
+    ).toThrow("signing_key requires both private_key_pem and public_key_pem");
+  });
+});

--- a/packages/@emulators/auth0/src/entities.ts
+++ b/packages/@emulators/auth0/src/entities.ts
@@ -1,0 +1,38 @@
+import type { Entity } from "@emulators/core";
+
+export interface Auth0User extends Entity {
+  user_id: string;
+  email: string;
+  email_verified: boolean;
+  password_hash: string;
+  connection: string;
+  blocked: boolean;
+  app_metadata: Record<string, unknown>;
+  user_metadata: Record<string, unknown>;
+  given_name: string;
+  family_name: string;
+  name: string;
+  nickname: string;
+  picture: string;
+}
+
+export interface Auth0Connection extends Entity {
+  name: string;
+  strategy: string;
+}
+
+export interface Auth0OAuthClient extends Entity {
+  client_id: string;
+  client_secret: string;
+  name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  audience: string;
+}
+
+export interface Auth0EmailVerificationTicket extends Entity {
+  user_id: string;
+  ticket_id: string;
+  result_url: string;
+  ttl_seconds: number;
+}

--- a/packages/@emulators/auth0/src/helpers.ts
+++ b/packages/@emulators/auth0/src/helpers.ts
@@ -1,0 +1,64 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { Auth0User } from "./entities.js";
+
+export const DEFAULT_CONNECTION = "Username-Password-Authentication";
+
+export function generateAuth0UserId(): string {
+  const id = randomBytes(8).toString("hex");
+  return `auth0|${id}`;
+}
+
+export function hashPassword(password: string): string {
+  return createHash("sha256").update(password).digest("hex");
+}
+
+export function verifyPassword(password: string, hash: string): boolean {
+  return hashPassword(password) === hash;
+}
+
+export function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export function isStrongPassword(password: string): boolean {
+  return password.length >= 8 && /[a-z]/.test(password) && /[A-Z]/.test(password) && /[0-9]/.test(password);
+}
+
+export function generateToken(prefix: string): string {
+  return `${prefix}_${randomBytes(20).toString("base64url")}`;
+}
+
+export function buildLogEvent(type: string, fields: Record<string, unknown>): Record<string, unknown> {
+  return {
+    log_id: randomBytes(12).toString("hex"),
+    date: new Date().toISOString(),
+    type,
+    ...fields,
+  };
+}
+
+export function userResponse(user: Auth0User): Record<string, unknown> {
+  return {
+    user_id: user.user_id,
+    email: user.email,
+    email_verified: user.email_verified,
+    name: user.name,
+    given_name: user.given_name,
+    family_name: user.family_name,
+    nickname: user.nickname,
+    picture: user.picture,
+    blocked: user.blocked,
+    app_metadata: user.app_metadata,
+    user_metadata: user.user_metadata,
+    created_at: user.created_at,
+    updated_at: user.updated_at,
+    identities: [
+      {
+        connection: user.connection,
+        user_id: user.user_id.replace("auth0|", ""),
+        provider: "auth0",
+        isSocial: false,
+      },
+    ],
+  };
+}

--- a/packages/@emulators/auth0/src/index.ts
+++ b/packages/@emulators/auth0/src/index.ts
@@ -1,0 +1,192 @@
+import type { Hono } from "hono";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { DEFAULT_CONNECTION, generateAuth0UserId, hashPassword } from "./helpers.js";
+import { inspectorRoutes } from "./routes/inspector.js";
+import { oauthRoutes } from "./routes/oauth.js";
+import { ticketRoutes } from "./routes/tickets.js";
+import { userRoutes } from "./routes/users.js";
+import { getAuth0Store } from "./store.js";
+
+export { getAuth0Store, type Auth0Store } from "./store.js";
+export * from "./entities.js";
+
+export interface Auth0SeedConfig {
+  connections?: Array<{
+    name: string;
+    strategy?: string;
+  }>;
+  users?: Array<{
+    email: string;
+    password?: string;
+    connection?: string;
+    email_verified?: boolean;
+    blocked?: boolean;
+    given_name?: string;
+    family_name?: string;
+    name?: string;
+    nickname?: string;
+    picture?: string;
+    app_metadata?: Record<string, unknown>;
+    user_metadata?: Record<string, unknown>;
+    user_id?: string;
+  }>;
+  oauth_clients?: Array<{
+    client_id: string;
+    client_secret?: string;
+    name?: string;
+    redirect_uris?: string[];
+    grant_types?: string[];
+    audience?: string;
+  }>;
+  log_streams?: Array<{
+    url: string;
+    events?: string[];
+    secret?: string;
+  }>;
+  signing_key?: {
+    private_key_pem: string;
+    public_key_pem: string;
+    kid?: string;
+  };
+}
+
+function seedDefaults(store: Store, _baseUrl: string): void {
+  const auth0 = getAuth0Store(store);
+
+  if (!auth0.connections.findOneBy("name", DEFAULT_CONNECTION)) {
+    auth0.connections.insert({
+      name: DEFAULT_CONNECTION,
+      strategy: "auth0",
+    });
+  }
+
+  if (auth0.users.all().length === 0) {
+    const userId = generateAuth0UserId();
+    const nickname = "testuser";
+    auth0.users.insert({
+      user_id: userId,
+      email: "testuser@auth0.local",
+      email_verified: true,
+      password_hash: hashPassword("Test1234!"),
+      connection: DEFAULT_CONNECTION,
+      blocked: false,
+      app_metadata: {},
+      user_metadata: {},
+      given_name: "Test",
+      family_name: "User",
+      name: "Test User",
+      nickname,
+      picture: `https://s.gravatar.com/avatar/${userId}?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png`,
+    });
+  }
+
+  if (auth0.oauthClients.all().length === 0) {
+    auth0.oauthClients.insert({
+      client_id: "auth0-test-client",
+      client_secret: "auth0-test-secret",
+      name: "Sample Auth0 Client",
+      redirect_uris: ["http://localhost:3000/callback"],
+      grant_types: ["authorization_code", "refresh_token", "client_credentials"],
+      audience: "",
+    });
+  }
+}
+
+export function seedFromConfig(
+  store: Store,
+  _baseUrl: string,
+  config: Auth0SeedConfig,
+  webhooks?: WebhookDispatcher,
+): void {
+  const auth0 = getAuth0Store(store);
+
+  if (config.connections) {
+    for (const conn of config.connections) {
+      if (auth0.connections.findOneBy("name", conn.name)) continue;
+      auth0.connections.insert({
+        name: conn.name,
+        strategy: conn.strategy ?? "auth0",
+      });
+    }
+  }
+
+  if (config.users) {
+    for (const user of config.users) {
+      if (auth0.users.findOneBy("email", user.email)) continue;
+      const connection = user.connection ?? DEFAULT_CONNECTION;
+      const userId = user.user_id ? `auth0|${user.user_id}` : generateAuth0UserId();
+      const nickname = user.nickname ?? user.email.split("@")[0] ?? "";
+      auth0.users.insert({
+        user_id: userId,
+        email: user.email,
+        email_verified: user.email_verified ?? false,
+        password_hash: hashPassword(user.password ?? "Test1234!"),
+        connection,
+        blocked: user.blocked ?? false,
+        app_metadata: user.app_metadata ?? {},
+        user_metadata: user.user_metadata ?? {},
+        given_name: user.given_name ?? "",
+        family_name: user.family_name ?? "",
+        name: user.name ?? user.email,
+        nickname,
+        picture:
+          user.picture ??
+          `https://s.gravatar.com/avatar/${userId}?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2F${nickname.slice(0, 2)}.png`,
+      });
+    }
+  }
+
+  if (config.oauth_clients) {
+    for (const client of config.oauth_clients) {
+      if (auth0.oauthClients.findOneBy("client_id", client.client_id)) continue;
+      auth0.oauthClients.insert({
+        client_id: client.client_id,
+        client_secret: client.client_secret ?? "",
+        name: client.name ?? client.client_id,
+        redirect_uris: client.redirect_uris ?? ["http://localhost:3000/callback"],
+        grant_types: client.grant_types ?? ["authorization_code", "refresh_token", "client_credentials"],
+        audience: client.audience ?? "",
+      });
+    }
+  }
+
+  if (config.signing_key) {
+    const { private_key_pem, public_key_pem } = config.signing_key;
+    if (!private_key_pem || !public_key_pem) {
+      throw new Error("signing_key requires both private_key_pem and public_key_pem");
+    }
+    store.setData("auth0.signing.config", {
+      private_key_pem,
+      public_key_pem,
+      kid: config.signing_key.kid ?? "emulate-auth0-1",
+    });
+  }
+
+  if (config.log_streams && webhooks) {
+    for (const stream of config.log_streams) {
+      webhooks.register({
+        url: stream.url,
+        events: stream.events ?? ["*"],
+        active: true,
+        secret: stream.secret,
+        owner: "auth0",
+      });
+    }
+  }
+}
+
+export const auth0Plugin: ServicePlugin = {
+  name: "auth0",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    inspectorRoutes(ctx);
+    oauthRoutes(ctx);
+    userRoutes(ctx);
+    ticketRoutes(ctx);
+  },
+  seed(store: Store, baseUrl: string): void {
+    seedDefaults(store, baseUrl);
+  },
+};
+
+export default auth0Plugin;

--- a/packages/@emulators/auth0/src/index.ts
+++ b/packages/@emulators/auth0/src/index.ts
@@ -48,6 +48,7 @@ export interface Auth0SeedConfig {
     public_key_pem: string;
     kid?: string;
   };
+  token_claim_mappings?: Record<string, string>;
 }
 
 function seedDefaults(store: Store, _baseUrl: string): void {
@@ -160,6 +161,10 @@ export function seedFromConfig(
       public_key_pem,
       kid: config.signing_key.kid ?? "emulate-auth0-1",
     });
+  }
+
+  if (config.token_claim_mappings) {
+    store.setData("auth0.token_claim_mappings", config.token_claim_mappings);
   }
 
   if (config.log_streams && webhooks) {

--- a/packages/@emulators/auth0/src/route-helpers.ts
+++ b/packages/@emulators/auth0/src/route-helpers.ts
@@ -1,0 +1,102 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AuthUser, TokenMap, AppEnv } from "@emulators/core";
+import type { Auth0Store } from "./store.js";
+import type { Auth0User } from "./entities.js";
+
+// Centralized error messages matching Auth0's actual API responses.
+// These exact strings are critical for SDK error handling compatibility.
+export const AUTH0_ERRORS = {
+  USER_EXISTS: "The user already exists.",
+  USER_NOT_FOUND: "The user does not exist.",
+  INVALID_EMAIL: "Object didn't pass validation for format email: ",
+  WEAK_PASSWORD: "PasswordStrengthError: Password is too weak",
+  WRONG_CREDENTIALS: "Wrong email or password.",
+  USER_BLOCKED: "user is blocked",
+  INVALID_REFRESH_TOKEN: "Unknown or invalid refresh token.",
+} as const;
+
+// Management API error format: { statusCode, error, message, errorCode }
+export function managementApiError(c: Context<AppEnv>, status: number, message: string, errorCode?: string): Response {
+  return c.json(
+    {
+      statusCode: status,
+      error: httpStatusText(status),
+      message,
+      errorCode: errorCode ?? httpStatusText(status),
+    },
+    status as ContentfulStatusCode,
+  );
+}
+
+// Authentication API error format: { error, error_description }
+// Standard OAuth2 error format used by /oauth/token, /oauth/revoke, /userinfo
+export function authenticationApiError(
+  c: Context<AppEnv>,
+  status: number,
+  error: string,
+  errorDescription: string,
+): Response {
+  return c.json(
+    {
+      error,
+      error_description: errorDescription,
+    },
+    status as ContentfulStatusCode,
+  );
+}
+
+function httpStatusText(status: number): string {
+  switch (status) {
+    case 400:
+      return "Bad Request";
+    case 401:
+      return "Unauthorized";
+    case 403:
+      return "Forbidden";
+    case 404:
+      return "Not Found";
+    case 409:
+      return "Conflict";
+    case 429:
+      return "Too Many Requests";
+    default:
+      return "Error";
+  }
+}
+
+export async function readJsonObject(c: Context<AppEnv>): Promise<Record<string, unknown>> {
+  try {
+    const body = await c.req.json();
+    if (body && typeof body === "object") {
+      return body as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+export function requireManagementToken(c: Context<AppEnv>, tokenMap?: TokenMap): AuthUser | Response {
+  const existing = c.get("authUser");
+  if (existing) return existing;
+
+  const authHeader = c.req.header("Authorization") ?? "";
+  if (authHeader.startsWith("Bearer ")) {
+    const token = authHeader.slice(7).trim();
+    const mapped = tokenMap?.get(token);
+    if (mapped) {
+      c.set("authUser", mapped);
+      c.set("authToken", token);
+      c.set("authScopes", mapped.scopes);
+      return mapped;
+    }
+  }
+
+  return managementApiError(c, 401, "Invalid token", "invalid_token");
+}
+
+export function findUserById(store: Auth0Store, userId: string): Auth0User | undefined {
+  const decoded = decodeURIComponent(userId);
+  return store.users.findOneBy("user_id", decoded);
+}

--- a/packages/@emulators/auth0/src/routes/inspector.ts
+++ b/packages/@emulators/auth0/src/routes/inspector.ts
@@ -1,0 +1,189 @@
+import type { RouteContext, InspectorTab, Store } from "@emulators/core";
+import { renderInspectorPage, escapeHtml } from "@emulators/core";
+import { getAuth0Store } from "../store.js";
+
+const SERVICE_LABEL = "Auth0";
+
+const TABS: InspectorTab[] = [
+  { id: "users", label: "Users", href: "/?tab=users" },
+  { id: "events", label: "Log Events", href: "/?tab=events" },
+  { id: "clients", label: "OAuth Clients", href: "/?tab=clients" },
+  { id: "connections", label: "Connections", href: "/?tab=connections" },
+];
+
+interface StoredLogEvent {
+  received_at: string;
+  payload: Record<string, unknown>;
+}
+
+function getLogEventSink(store: Store): StoredLogEvent[] {
+  let events = store.getData<StoredLogEvent[]>("auth0.inspector.events");
+  if (!events) {
+    events = [];
+    store.setData("auth0.inspector.events", events);
+  }
+  return events;
+}
+
+const MAX_EVENTS = 200;
+
+function metadataSummary(metadata: Record<string, unknown>): string {
+  const keys = Object.keys(metadata);
+  if (keys.length === 0) return '<span class="inspector-empty">none</span>';
+  return keys.map((k) => `${escapeHtml(k)}=${escapeHtml(String(metadata[k]))}`).join(", ");
+}
+
+function statusBadge(verified: boolean, blocked: boolean): string {
+  if (blocked) return '<span class="badge badge-denied">blocked</span>';
+  if (verified) return '<span class="badge badge-granted">verified</span>';
+  return '<span class="badge badge-requested">unverified</span>';
+}
+
+function eventTypeBadge(type: string): string {
+  const success = ["ss", "sv", "scp", "s"].includes(type);
+  const cls = success ? "badge-granted" : "badge-denied";
+  return `<span class="badge ${cls}">${escapeHtml(type)}</span>`;
+}
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
+
+export function inspectorRoutes({ app, store, baseUrl, webhooks }: RouteContext): void {
+  const auth0 = () => getAuth0Store(store);
+
+  // Internal hook sink for log event capture
+  app.post("/_emulate/hook-sink", async (c) => {
+    const events = getLogEventSink(store);
+    try {
+      const payload = await c.req.json();
+      events.push({ received_at: new Date().toISOString(), payload });
+      if (events.length > MAX_EVENTS) {
+        events.splice(0, events.length - MAX_EVENTS);
+      }
+    } catch {
+      // ignore malformed payloads
+    }
+    return c.text("ok", 200);
+  });
+
+  // JSON API for log events (used by external tools)
+  app.get("/_emulate/events", (c) => {
+    const events = getLogEventSink(store);
+    const since = c.req.query("since") ?? "";
+    if (since) {
+      return c.json(events.filter((e) => e.received_at > since));
+    }
+    return c.json(events);
+  });
+
+  // Auto-register the hook sink as a log stream subscriber
+  webhooks.register({
+    url: `${baseUrl}/_emulate/hook-sink`,
+    events: ["*"],
+    active: true,
+    owner: "auth0",
+  });
+
+  // Inspector UI
+  app.get("/", (c) => {
+    const tab = c.req.query("tab") ?? "users";
+    const s = auth0();
+    let contentHtml = "";
+
+    if (tab === "users") {
+      const users = s.users.all();
+      const rows = users
+        .map(
+          (u) => `<tr>
+            <td>${escapeHtml(u.email)}</td>
+            <td style="font-size:11px;opacity:0.7">${escapeHtml(u.user_id)}</td>
+            <td>${escapeHtml(u.connection)}</td>
+            <td>${statusBadge(u.email_verified, u.blocked)}</td>
+            <td style="font-size:11px">${metadataSummary(u.app_metadata)}</td>
+          </tr>`,
+        )
+        .join("\n");
+
+      contentHtml = `
+        <div class="inspector-section">
+          <h2>Users (${users.length})</h2>
+          <table class="inspector-table">
+            <thead><tr><th>Email</th><th>User ID</th><th>Connection</th><th>Status</th><th>App Metadata</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="5"><div class="inspector-empty">No users</div></td></tr>'}</tbody>
+          </table>
+        </div>`;
+    } else if (tab === "events") {
+      const events = getLogEventSink(store).slice().reverse();
+      const rows = events
+        .map((e) => {
+          const p = e.payload;
+          return `<tr>
+            <td>${eventTypeBadge(String(p.type ?? ""))}</td>
+            <td>${formatTime(e.received_at)}</td>
+            <td>${escapeHtml(String(p.user_name ?? p.user_id ?? ""))}</td>
+            <td>${escapeHtml(String(p.description ?? ""))}</td>
+            <td style="font-size:11px;opacity:0.7">${escapeHtml(String(p.connection ?? ""))}</td>
+          </tr>`;
+        })
+        .join("\n");
+
+      contentHtml = `
+        <div class="inspector-section">
+          <h2>Log Events (${events.length})</h2>
+          <p style="font-size:12px;opacity:0.5;margin-bottom:12px">Auth0 log stream events dispatched via webhook. Refresh to update.</p>
+          <table class="inspector-table">
+            <thead><tr><th>Type</th><th>Time</th><th>User</th><th>Description</th><th>Connection</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="5"><div class="inspector-empty">No events yet. Create or update users to generate log events.</div></td></tr>'}</tbody>
+          </table>
+        </div>`;
+    } else if (tab === "clients") {
+      const clients = s.oauthClients.all();
+      const rows = clients
+        .map(
+          (cl) => `<tr>
+            <td>${escapeHtml(cl.client_id)}</td>
+            <td>${escapeHtml(cl.name)}</td>
+            <td style="font-size:11px">${escapeHtml(cl.grant_types.join(", "))}</td>
+            <td>${escapeHtml(cl.audience || "default")}</td>
+          </tr>`,
+        )
+        .join("\n");
+
+      contentHtml = `
+        <div class="inspector-section">
+          <h2>OAuth Clients (${clients.length})</h2>
+          <table class="inspector-table">
+            <thead><tr><th>Client ID</th><th>Name</th><th>Grant Types</th><th>Audience</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="4"><div class="inspector-empty">No clients</div></td></tr>'}</tbody>
+          </table>
+        </div>`;
+    } else if (tab === "connections") {
+      const connections = s.connections.all();
+      const rows = connections
+        .map(
+          (conn) => `<tr>
+            <td>${escapeHtml(conn.name)}</td>
+            <td>${escapeHtml(conn.strategy)}</td>
+          </tr>`,
+        )
+        .join("\n");
+
+      contentHtml = `
+        <div class="inspector-section">
+          <h2>Connections (${connections.length})</h2>
+          <table class="inspector-table">
+            <thead><tr><th>Name</th><th>Strategy</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="2"><div class="inspector-empty">No connections</div></td></tr>'}</tbody>
+          </table>
+        </div>`;
+    }
+
+    return c.html(renderInspectorPage("Inspector", TABS, tab, contentHtml, SERVICE_LABEL));
+  });
+}

--- a/packages/@emulators/auth0/src/routes/oauth.ts
+++ b/packages/@emulators/auth0/src/routes/oauth.ts
@@ -1,0 +1,417 @@
+import { randomBytes } from "node:crypto";
+import {
+  SignJWT,
+  exportJWK,
+  exportSPKI,
+  generateKeyPair,
+  importPKCS8,
+  importSPKI,
+  type CryptoKey as JoseCryptoKey,
+} from "jose";
+import type { Context } from "hono";
+import type { AppEnv, RouteContext, Store } from "@emulators/core";
+import { debug } from "@emulators/core";
+import type { Auth0User } from "../entities.js";
+import { generateToken, verifyPassword } from "../helpers.js";
+import { AUTH0_ERRORS, authenticationApiError } from "../route-helpers.js";
+import { getAuth0Store } from "../store.js";
+
+const DEFAULT_KID = "emulate-auth0-1";
+
+type ResolvedKeyPair = {
+  privateKey: JoseCryptoKey;
+  publicKey: JoseCryptoKey;
+  kid: string;
+};
+
+export type SigningKeyConfig = {
+  private_key_pem: string;
+  public_key_pem: string;
+  kid: string;
+};
+
+// Cache the Promise (not the resolved value) to prevent race conditions when
+// concurrent requests both trigger key resolution before the first completes.
+function getSigningKeyPair(store: Store): Promise<ResolvedKeyPair> {
+  const cached = store.getData<Promise<ResolvedKeyPair>>("auth0.signing.pending");
+  if (cached) return cached;
+
+  const pending = resolveSigningKeyPair(store);
+  store.setData("auth0.signing.pending", pending);
+  return pending;
+}
+
+async function resolveSigningKeyPair(store: Store): Promise<ResolvedKeyPair> {
+  const config = store.getData<SigningKeyConfig>("auth0.signing.config");
+
+  if (config) {
+    try {
+      const privateKey = await importPKCS8(config.private_key_pem, "RS256");
+      const publicKey = await importSPKI(config.public_key_pem, "RS256");
+      return { privateKey, publicKey, kid: config.kid };
+    } catch (e) {
+      throw new Error(`Invalid signing_key PEM: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  const { privateKey, publicKey } = await generateKeyPair("RS256");
+  return { privateKey, publicKey, kid: DEFAULT_KID };
+}
+
+type StoredAccessToken = {
+  clientId: string;
+  scope: string;
+  issuedAt: number;
+  expiresAt: number;
+  userAuth0Id: string | null;
+  audience: string;
+};
+
+type StoredRefreshToken = {
+  clientId: string;
+  scope: string;
+  userAuth0Id: string;
+  audience: string;
+};
+
+function getAccessTokens(store: Store): Map<string, StoredAccessToken> {
+  let map = store.getData<Map<string, StoredAccessToken>>("auth0.oauth.accessTokens");
+  if (!map) {
+    map = new Map();
+    store.setData("auth0.oauth.accessTokens", map);
+  }
+  return map;
+}
+
+function getRefreshTokens(store: Store): Map<string, StoredRefreshToken> {
+  let map = store.getData<Map<string, StoredRefreshToken>>("auth0.oauth.refreshTokens");
+  if (!map) {
+    map = new Map();
+    store.setData("auth0.oauth.refreshTokens", map);
+  }
+  return map;
+}
+
+async function parseTokenBody(c: Context<AppEnv>): Promise<Record<string, string>> {
+  const contentType = c.req.header("Content-Type") ?? "";
+  const raw = await c.req.text();
+
+  if (contentType.includes("application/json")) {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const out: Record<string, string> = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "string") out[key] = value;
+      }
+      return out;
+    } catch {
+      return {};
+    }
+  }
+
+  return Object.fromEntries(new URLSearchParams(raw));
+}
+
+function parseClientCredentials(
+  c: Context<AppEnv>,
+  body: Record<string, string>,
+): { clientId: string; clientSecret: string } {
+  let clientId = body.client_id ?? "";
+  let clientSecret = body.client_secret ?? "";
+
+  const authHeader = c.req.header("Authorization") ?? "";
+  if (authHeader.startsWith("Basic ")) {
+    const decoded = Buffer.from(authHeader.slice(6), "base64").toString("utf8");
+    const sep = decoded.indexOf(":");
+    if (sep !== -1) {
+      const headerId = decodeURIComponent(decoded.slice(0, sep));
+      const headerSecret = decodeURIComponent(decoded.slice(sep + 1));
+      if (!clientId) clientId = headerId;
+      if (!clientSecret) clientSecret = headerSecret;
+    }
+  }
+
+  return { clientId, clientSecret };
+}
+
+async function createIdToken(store: Store, user: Auth0User, clientId: string, issuer: string): Promise<string> {
+  const { privateKey, kid } = await getSigningKeyPair(store);
+  const now = Math.floor(Date.now() / 1000);
+
+  const claims: Record<string, unknown> = {
+    sub: user.user_id,
+    name: user.name,
+    given_name: user.given_name,
+    family_name: user.family_name,
+    nickname: user.nickname,
+    email: user.email,
+    email_verified: user.email_verified,
+    picture: user.picture,
+  };
+
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid, typ: "JWT" })
+    .setIssuer(issuer)
+    .setAudience(clientId)
+    .setIssuedAt(now)
+    .setExpirationTime("1h")
+    .sign(privateKey);
+}
+
+export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): void {
+  const auth0Store = getAuth0Store(store);
+
+  // OIDC Discovery
+  app.get("/.well-known/openid-configuration", (c) => {
+    return c.json({
+      issuer: `${baseUrl}/`,
+      authorization_endpoint: `${baseUrl}/authorize`,
+      token_endpoint: `${baseUrl}/oauth/token`,
+      userinfo_endpoint: `${baseUrl}/userinfo`,
+      jwks_uri: `${baseUrl}/.well-known/jwks.json`,
+      revocation_endpoint: `${baseUrl}/oauth/revoke`,
+      response_types_supported: ["code", "token"],
+      subject_types_supported: ["public"],
+      id_token_signing_alg_values_supported: ["RS256"],
+      scopes_supported: ["openid", "profile", "email", "offline_access"],
+      token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+      claims_supported: [
+        "sub",
+        "iss",
+        "aud",
+        "exp",
+        "iat",
+        "name",
+        "given_name",
+        "family_name",
+        "nickname",
+        "email",
+        "email_verified",
+        "picture",
+      ],
+    });
+  });
+
+  // JWKS
+  app.get("/.well-known/jwks.json", async (c) => {
+    const { publicKey, kid } = await getSigningKeyPair(store);
+    const jwk = await exportJWK(publicKey);
+    return c.json({
+      keys: [{ ...jwk, kid, use: "sig", alg: "RS256" }],
+    });
+  });
+
+  // Public key PEM export
+  app.get("/_emulate/public-key.pem", async (c) => {
+    const { publicKey } = await getSigningKeyPair(store);
+    const pem = await exportSPKI(publicKey);
+    return c.text(pem, 200, { "Content-Type": "text/plain" });
+  });
+
+  // Token endpoint — uses OAuth2 error format: { error, error_description }
+  app.post("/oauth/token", async (c) => {
+    const body = await parseTokenBody(c);
+    const grantType = body.grant_type ?? "";
+    const creds = parseClientCredentials(c, body);
+
+    // Validate client
+    const clients = auth0Store.oauthClients.all();
+    if (clients.length > 0) {
+      const client = clients.find((entry) => entry.client_id === creds.clientId);
+      if (!client) {
+        return authenticationApiError(c, 401, "access_denied", "Unauthorized");
+      }
+      if (client.client_secret && client.client_secret !== creds.clientSecret) {
+        return authenticationApiError(c, 401, "access_denied", "Unauthorized");
+      }
+    }
+
+    // client_credentials grant — used to get Management API tokens
+    if (grantType === "client_credentials") {
+      const audience = body.audience ?? "";
+      const now = Math.floor(Date.now() / 1000);
+      const accessToken = generateToken("auth0_m2m");
+
+      getAccessTokens(store).set(accessToken, {
+        clientId: creds.clientId,
+        scope: body.scope ?? "",
+        issuedAt: now,
+        expiresAt: now + 86400,
+        userAuth0Id: null,
+        audience,
+      });
+
+      tokenMap?.set(accessToken, {
+        login: creds.clientId,
+        id: 0,
+        scopes: (body.scope ?? "").split(/\s+/).filter(Boolean),
+      });
+
+      debug("auth0.oauth", `[client_credentials] client=${creds.clientId} audience=${audience}`);
+
+      return c.json({
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: 86400,
+        scope: body.scope ?? "",
+      });
+    }
+
+    // password-realm grant (Auth0's ROPG extension)
+    // password-realm grant (Auth0's ROPG extension)
+    if (grantType === "http://auth0.com/oauth/grant-type/password-realm" || grantType === "password") {
+      const username = body.username ?? "";
+      const password = body.password ?? "";
+      const realm = body.realm ?? "Username-Password-Authentication";
+      const audience = body.audience ?? "";
+      const scope = body.scope ?? "openid profile email";
+
+      const user = auth0Store.users.findOneBy("email", username);
+      if (!user || user.connection !== realm || !verifyPassword(password, user.password_hash)) {
+        return authenticationApiError(c, 403, "invalid_grant", AUTH0_ERRORS.WRONG_CREDENTIALS);
+      }
+      if (user.blocked) {
+        return authenticationApiError(c, 403, "unauthorized", AUTH0_ERRORS.USER_BLOCKED);
+      }
+
+      const now = Math.floor(Date.now() / 1000);
+      const accessToken = generateToken("auth0_at");
+      const includeRefresh = scope.includes("offline_access");
+      const refreshToken = includeRefresh ? generateToken("auth0_rt") : null;
+      const issuer = `${baseUrl}/`;
+
+      getAccessTokens(store).set(accessToken, {
+        clientId: creds.clientId,
+        scope,
+        issuedAt: now,
+        expiresAt: now + 86400,
+        userAuth0Id: user.user_id,
+        audience,
+      });
+
+      if (refreshToken) {
+        getRefreshTokens(store).set(refreshToken, {
+          clientId: creds.clientId,
+          scope,
+          userAuth0Id: user.user_id,
+          audience,
+        });
+      }
+
+      tokenMap?.set(accessToken, {
+        login: user.email,
+        id: user.id,
+        scopes: scope.split(/\s+/).filter(Boolean),
+      });
+
+      const idToken = await createIdToken(store, user, creds.clientId, issuer);
+
+      debug("auth0.oauth", `[password-realm] user=${user.email}`);
+
+      const response: Record<string, unknown> = {
+        access_token: accessToken,
+        id_token: idToken,
+        token_type: "Bearer",
+        expires_in: 86400,
+        scope,
+      };
+      if (refreshToken) response.refresh_token = refreshToken;
+
+      return c.json(response);
+    }
+
+    // refresh_token grant
+    if (grantType === "refresh_token") {
+      const refreshToken = body.refresh_token ?? "";
+      const existing = getRefreshTokens(store).get(refreshToken);
+      if (!existing) {
+        return authenticationApiError(c, 403, "invalid_grant", AUTH0_ERRORS.INVALID_REFRESH_TOKEN);
+      }
+
+      const user = auth0Store.users.findOneBy("user_id", existing.userAuth0Id);
+      if (!user) {
+        return authenticationApiError(c, 403, "invalid_grant", AUTH0_ERRORS.INVALID_REFRESH_TOKEN);
+      }
+
+      getRefreshTokens(store).delete(refreshToken);
+
+      const now = Math.floor(Date.now() / 1000);
+      const nextAccessToken = generateToken("auth0_at");
+      const nextRefreshToken = generateToken("auth0_rt");
+      const scope = existing.scope;
+      const issuer = `${baseUrl}/`;
+
+      getAccessTokens(store).set(nextAccessToken, {
+        clientId: existing.clientId,
+        scope,
+        issuedAt: now,
+        expiresAt: now + 86400,
+        userAuth0Id: user.user_id,
+        audience: existing.audience,
+      });
+
+      getRefreshTokens(store).set(nextRefreshToken, {
+        ...existing,
+      });
+
+      tokenMap?.set(nextAccessToken, {
+        login: user.email,
+        id: user.id,
+        scopes: scope.split(/\s+/).filter(Boolean),
+      });
+
+      const response: Record<string, unknown> = {
+        access_token: nextAccessToken,
+        refresh_token: nextRefreshToken,
+        token_type: "Bearer",
+        expires_in: 86400,
+        scope,
+      };
+
+      if (scope.includes("openid")) {
+        response.id_token = await createIdToken(store, user, existing.clientId, issuer);
+      }
+
+      debug("auth0.oauth", `[refresh_token] user=${user.email}`);
+
+      return c.json(response);
+    }
+
+    return authenticationApiError(c, 400, "unsupported_grant_type", `Grant type '${grantType}' not allowed.`);
+  });
+
+  // Userinfo — uses OAuth2 error format
+  app.get("/userinfo", (c) => {
+    const token = c.get("authToken") ?? "";
+    const access = getAccessTokens(store).get(token);
+    if (!access || !access.userAuth0Id) {
+      return authenticationApiError(c, 401, "invalid_token", "The access token is invalid.");
+    }
+
+    const user = auth0Store.users.findOneBy("user_id", access.userAuth0Id);
+    if (!user) {
+      return authenticationApiError(c, 401, "invalid_token", "The access token is invalid.");
+    }
+
+    return c.json({
+      sub: user.user_id,
+      name: user.name,
+      given_name: user.given_name,
+      family_name: user.family_name,
+      nickname: user.nickname,
+      email: user.email,
+      email_verified: user.email_verified,
+      picture: user.picture,
+    });
+  });
+
+  // Revoke token
+  app.post("/oauth/revoke", async (c) => {
+    const body = await parseTokenBody(c);
+    const token = body.token ?? "";
+    getAccessTokens(store).delete(token);
+    getRefreshTokens(store).delete(token);
+    tokenMap?.delete(token);
+    return c.body("", 200);
+  });
+}

--- a/packages/@emulators/auth0/src/routes/oauth.ts
+++ b/packages/@emulators/auth0/src/routes/oauth.ts
@@ -134,6 +134,56 @@ function parseClientCredentials(
   return { clientId, clientSecret };
 }
 
+async function createAccessToken(
+  store: Store,
+  user: Auth0User,
+  clientId: string,
+  audience: string,
+  scope: string,
+  issuer: string,
+): Promise<string> {
+  const { privateKey, kid } = await getSigningKeyPair(store);
+  const now = Math.floor(Date.now() / 1000);
+
+  const claims: Record<string, unknown> = {
+    scope,
+    azp: clientId,
+  };
+
+  // Inject app_metadata fields as custom claims on the access token.
+  // In real Auth0, Rules/Actions map metadata fields to namespaced JWT claims.
+  // The emulator supports this via token_claim_mappings in seed config, which maps
+  // app_metadata keys to JWT claim names (e.g., role -> https://example.com/role).
+  // Any app_metadata key that is already a URL is also injected directly.
+  if (user.app_metadata && typeof user.app_metadata === "object") {
+    const mappings = store.getData<Record<string, string>>("auth0.token_claim_mappings") ?? {};
+    for (const [metaKey, value] of Object.entries(user.app_metadata)) {
+      if (value === null || value === undefined) continue;
+      // Apply configured mappings (e.g., role -> https://example.com/role)
+      if (mappings[metaKey]) {
+        claims[mappings[metaKey]] = value;
+      }
+      // URL-namespaced keys pass through directly
+      if (metaKey.startsWith("https://")) {
+        claims[metaKey] = value;
+      }
+    }
+  }
+
+  const builder = new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid, typ: "JWT" })
+    .setSubject(user.user_id)
+    .setIssuer(issuer)
+    .setIssuedAt(now)
+    .setExpirationTime("1h");
+
+  if (audience) {
+    builder.setAudience(audience);
+  }
+
+  return builder.sign(privateKey);
+}
+
 async function createIdToken(store: Store, user: Auth0User, clientId: string, issuer: string): Promise<string> {
   const { privateKey, kid } = await getSigningKeyPair(store);
   const now = Math.floor(Date.now() / 1000);
@@ -275,10 +325,15 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       }
 
       const now = Math.floor(Date.now() / 1000);
-      const accessToken = generateToken("auth0_at");
       const includeRefresh = scope.includes("offline_access");
       const refreshToken = includeRefresh ? generateToken("auth0_rt") : null;
       const issuer = `${baseUrl}/`;
+
+      // When audience is specified, return a JWT access token (matches real Auth0 behavior).
+      // Otherwise return an opaque token.
+      const accessToken = audience
+        ? await createAccessToken(store, user, creds.clientId, audience, scope, issuer)
+        : generateToken("auth0_at");
 
       getAccessTokens(store).set(accessToken, {
         clientId: creds.clientId,
@@ -336,10 +391,13 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       getRefreshTokens(store).delete(refreshToken);
 
       const now = Math.floor(Date.now() / 1000);
-      const nextAccessToken = generateToken("auth0_at");
       const nextRefreshToken = generateToken("auth0_rt");
       const scope = existing.scope;
       const issuer = `${baseUrl}/`;
+
+      const nextAccessToken = existing.audience
+        ? await createAccessToken(store, user, existing.clientId, existing.audience, scope, issuer)
+        : generateToken("auth0_at");
 
       getAccessTokens(store).set(nextAccessToken, {
         clientId: existing.clientId,

--- a/packages/@emulators/auth0/src/routes/tickets.ts
+++ b/packages/@emulators/auth0/src/routes/tickets.ts
@@ -1,0 +1,83 @@
+import { randomBytes } from "node:crypto";
+import type { RouteContext } from "@emulators/core";
+import { debug } from "@emulators/core";
+import { buildLogEvent } from "../helpers.js";
+import {
+  AUTH0_ERRORS,
+  managementApiError,
+  findUserById,
+  readJsonObject,
+  requireManagementToken,
+} from "../route-helpers.js";
+import { getAuth0Store } from "../store.js";
+
+export function ticketRoutes({ app, store, baseUrl, tokenMap, webhooks }: RouteContext): void {
+  const auth0Store = getAuth0Store(store);
+
+  // Create email verification ticket
+  app.post("/api/v2/tickets/email-verification", async (c) => {
+    const auth = requireManagementToken(c, tokenMap);
+    if (auth instanceof Response) return auth;
+
+    const body = await readJsonObject(c);
+    const userId = typeof body.user_id === "string" ? body.user_id : "";
+    const resultUrl = typeof body.result_url === "string" ? body.result_url : "";
+    const ttlSeconds = typeof body.ttl_sec === "number" ? body.ttl_sec : 432000; // 5 days default
+
+    if (!userId) {
+      return managementApiError(c, 400, "Payload validation error: 'user_id' is required.");
+    }
+
+    const user = findUserById(auth0Store, userId);
+    if (!user) return managementApiError(c, 404, AUTH0_ERRORS.USER_NOT_FOUND);
+
+    const ticketId = randomBytes(16).toString("hex");
+    auth0Store.emailVerificationTickets.insert({
+      user_id: userId,
+      ticket_id: ticketId,
+      result_url: resultUrl,
+      ttl_seconds: ttlSeconds,
+    });
+
+    const ticket = `${baseUrl}/tickets/email-verification?ticket=${ticketId}`;
+
+    debug("auth0.tickets", `[email-verification] user=${userId} ticket=${ticketId.slice(0, 8)}...`);
+
+    return c.json({ ticket });
+  });
+
+  // Handle email verification ticket (simulate clicking the link)
+  app.get("/tickets/email-verification", async (c) => {
+    const ticketId = c.req.query("ticket") ?? "";
+    const ticket = auth0Store.emailVerificationTickets.findOneBy("ticket_id", ticketId);
+    if (!ticket) {
+      return c.text("Invalid or expired ticket", 400);
+    }
+
+    const user = findUserById(auth0Store, ticket.user_id);
+    if (user) {
+      auth0Store.users.update(user.id, { email_verified: true });
+
+      await webhooks.dispatch(
+        "sv",
+        undefined,
+        buildLogEvent("sv", {
+          user_id: user.user_id,
+          user_name: user.email,
+          description: "Successfully consumed email verification link",
+          connection: user.connection,
+          strategy: "auth0",
+          strategy_type: "database",
+        }),
+        "auth0",
+      );
+    }
+
+    auth0Store.emailVerificationTickets.delete(ticket.id);
+
+    if (ticket.result_url) {
+      return c.redirect(ticket.result_url, 302);
+    }
+    return c.text("Email verified successfully");
+  });
+}

--- a/packages/@emulators/auth0/src/routes/users.ts
+++ b/packages/@emulators/auth0/src/routes/users.ts
@@ -1,0 +1,237 @@
+import type { RouteContext } from "@emulators/core";
+import type { Auth0User } from "../entities.js";
+import {
+  buildLogEvent,
+  DEFAULT_CONNECTION,
+  generateAuth0UserId,
+  hashPassword,
+  isStrongPassword,
+  isValidEmail,
+  userResponse,
+} from "../helpers.js";
+import {
+  AUTH0_ERRORS,
+  managementApiError,
+  findUserById,
+  readJsonObject,
+  requireManagementToken,
+} from "../route-helpers.js";
+import { getAuth0Store } from "../store.js";
+
+export function userRoutes({ app, store, baseUrl, tokenMap, webhooks }: RouteContext): void {
+  const auth0Store = getAuth0Store(store);
+
+  // Create user
+  app.post("/api/v2/users", async (c) => {
+    const auth = requireManagementToken(c, tokenMap);
+    if (auth instanceof Response) return auth;
+
+    const body = await readJsonObject(c);
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    const password = typeof body.password === "string" ? body.password : "";
+    const connection = typeof body.connection === "string" ? body.connection : DEFAULT_CONNECTION;
+    const verifyEmail = body.verify_email !== false;
+    const userId = typeof body.user_id === "string" ? body.user_id : undefined;
+
+    if (!email) {
+      return managementApiError(c, 400, "Payload validation error: 'email' is required.");
+    }
+
+    if (!isValidEmail(email)) {
+      await webhooks.dispatch(
+        "fs",
+        undefined,
+        buildLogEvent("fs", {
+          user_name: email,
+          description: AUTH0_ERRORS.INVALID_EMAIL + email,
+          connection,
+        }),
+        "auth0",
+      );
+      return managementApiError(c, 400, AUTH0_ERRORS.INVALID_EMAIL + email);
+    }
+
+    if (!password) {
+      return managementApiError(c, 400, "Payload validation error: 'password' is required.");
+    }
+
+    if (!isStrongPassword(password)) {
+      await webhooks.dispatch(
+        "fs",
+        undefined,
+        buildLogEvent("fs", {
+          user_name: email,
+          description: AUTH0_ERRORS.WEAK_PASSWORD,
+          connection,
+        }),
+        "auth0",
+      );
+      return managementApiError(c, 400, AUTH0_ERRORS.WEAK_PASSWORD);
+    }
+
+    const existingConn = auth0Store.connections.findOneBy("name", connection);
+    if (!existingConn) {
+      return managementApiError(c, 400, `Connection '${connection}' does not exist.`);
+    }
+
+    const existingUser = auth0Store.users.findBy("email", email).find((u) => u.connection === connection);
+    if (existingUser) {
+      await webhooks.dispatch(
+        "fs",
+        undefined,
+        buildLogEvent("fs", {
+          user_name: email,
+          description: AUTH0_ERRORS.USER_EXISTS,
+          connection,
+        }),
+        "auth0",
+      );
+      return managementApiError(c, 409, AUTH0_ERRORS.USER_EXISTS);
+    }
+
+    const auth0UserId = userId ? `auth0|${userId}` : generateAuth0UserId();
+    const appMetadata = (body.app_metadata && typeof body.app_metadata === "object" ? body.app_metadata : {}) as Record<
+      string,
+      unknown
+    >;
+    const userMetadata = (
+      body.user_metadata && typeof body.user_metadata === "object" ? body.user_metadata : {}
+    ) as Record<string, unknown>;
+
+    const nickname = email.split("@")[0] ?? "";
+
+    // Find the client name from the management token's login (client_id)
+    const clientId = auth.login;
+    const client = auth0Store.oauthClients.findOneBy("client_id", clientId);
+    const clientName = client?.name ?? clientId;
+
+    const created = auth0Store.users.insert({
+      user_id: auth0UserId,
+      email,
+      email_verified: !verifyEmail,
+      password_hash: hashPassword(password),
+      connection,
+      blocked: false,
+      app_metadata: appMetadata,
+      user_metadata: userMetadata,
+      given_name: "",
+      family_name: "",
+      name: email,
+      nickname,
+      picture: `https://s.gravatar.com/avatar/${auth0UserId}?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2F${nickname.slice(0, 2)}.png`,
+    });
+
+    await webhooks.dispatch(
+      "ss",
+      undefined,
+      buildLogEvent("ss", {
+        user_id: auth0UserId,
+        user_name: email,
+        client_id: clientId,
+        client_name: clientName,
+        connection,
+        description: "Successful signup",
+        strategy: "auth0",
+        strategy_type: "database",
+      }),
+      "auth0",
+    );
+
+    return c.json(userResponse(created), 201);
+  });
+
+  // Get user by ID
+  app.get("/api/v2/users/:userId{.+}", (c) => {
+    const auth = requireManagementToken(c, tokenMap);
+    if (auth instanceof Response) return auth;
+
+    const user = findUserById(auth0Store, c.req.param("userId"));
+    if (!user) return managementApiError(c, 404, AUTH0_ERRORS.USER_NOT_FOUND);
+    return c.json(userResponse(user));
+  });
+
+  // List users by email
+  app.get("/api/v2/users-by-email", (c) => {
+    const auth = requireManagementToken(c, tokenMap);
+    if (auth instanceof Response) return auth;
+
+    const email = c.req.query("email") ?? "";
+    if (!email) {
+      return c.json([]);
+    }
+
+    const users = auth0Store.users.findBy("email", email);
+    return c.json(users.map(userResponse));
+  });
+
+  // Update user (PATCH)
+  app.patch("/api/v2/users/:userId{.+}", async (c) => {
+    const auth = requireManagementToken(c, tokenMap);
+    if (auth instanceof Response) return auth;
+
+    const user = findUserById(auth0Store, c.req.param("userId"));
+    if (!user) return managementApiError(c, 404, AUTH0_ERRORS.USER_NOT_FOUND);
+
+    const body = await readJsonObject(c);
+    const updates: Partial<Auth0User> = {};
+    let passwordChanged = false;
+
+    if (typeof body.email_verified === "boolean") {
+      updates.email_verified = body.email_verified;
+    }
+    if (typeof body.blocked === "boolean") {
+      updates.blocked = body.blocked;
+    }
+    if (typeof body.email === "string") {
+      updates.email = body.email.trim();
+    }
+    if (typeof body.given_name === "string") {
+      updates.given_name = body.given_name;
+    }
+    if (typeof body.family_name === "string") {
+      updates.family_name = body.family_name;
+    }
+    if (typeof body.name === "string") {
+      updates.name = body.name;
+    }
+    if (typeof body.nickname === "string") {
+      updates.nickname = body.nickname;
+    }
+    if (typeof body.picture === "string") {
+      updates.picture = body.picture;
+    }
+    if (body.app_metadata && typeof body.app_metadata === "object") {
+      updates.app_metadata = { ...user.app_metadata, ...(body.app_metadata as Record<string, unknown>) };
+    }
+    if (body.user_metadata && typeof body.user_metadata === "object") {
+      updates.user_metadata = { ...user.user_metadata, ...(body.user_metadata as Record<string, unknown>) };
+    }
+    if (typeof body.password === "string") {
+      if (!isStrongPassword(body.password)) {
+        return managementApiError(c, 400, AUTH0_ERRORS.WEAK_PASSWORD);
+      }
+      updates.password_hash = hashPassword(body.password);
+      passwordChanged = true;
+    }
+
+    const updated = auth0Store.users.update(user.id, updates);
+
+    if (passwordChanged) {
+      await webhooks.dispatch(
+        "scp",
+        undefined,
+        buildLogEvent("scp", {
+          user_id: user.user_id,
+          user_name: user.email,
+          description: "Successful change password request",
+          connection: user.connection,
+          strategy: "auth0",
+          strategy_type: "database",
+        }),
+        "auth0",
+      );
+    }
+
+    return c.json(userResponse(updated ?? user));
+  });
+}

--- a/packages/@emulators/auth0/src/store.ts
+++ b/packages/@emulators/auth0/src/store.ts
@@ -1,0 +1,21 @@
+import { Store, type Collection } from "@emulators/core";
+import type { Auth0User, Auth0Connection, Auth0OAuthClient, Auth0EmailVerificationTicket } from "./entities.js";
+
+export interface Auth0Store {
+  users: Collection<Auth0User>;
+  connections: Collection<Auth0Connection>;
+  oauthClients: Collection<Auth0OAuthClient>;
+  emailVerificationTickets: Collection<Auth0EmailVerificationTicket>;
+}
+
+export function getAuth0Store(store: Store): Auth0Store {
+  return {
+    users: store.collection<Auth0User>("auth0.users", ["user_id", "email"]),
+    connections: store.collection<Auth0Connection>("auth0.connections", ["name"]),
+    oauthClients: store.collection<Auth0OAuthClient>("auth0.oauth_clients", ["client_id"]),
+    emailVerificationTickets: store.collection<Auth0EmailVerificationTicket>("auth0.email_verification_tickets", [
+      "user_id",
+      "ticket_id",
+    ]),
+  };
+}

--- a/packages/@emulators/auth0/tsconfig.json
+++ b/packages/@emulators/auth0/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/auth0/tsup.config.ts
+++ b/packages/@emulators/auth0/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/@emulators/auth0/vitest.config.ts
+++ b/packages/@emulators/auth0/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -63,6 +63,7 @@
     "@emulators/apple": "workspace:*",
     "@emulators/microsoft": "workspace:*",
     "@emulators/okta": "workspace:*",
+    "@emulators/auth0": "workspace:*",
     "@emulators/aws": "workspace:*",
     "@emulators/google": "workspace:*",
     "@emulators/mongoatlas": "workspace:*",

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -52,13 +52,13 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
   const svcSeedConfig = seedConfig?.[service] as Record<string, unknown> | undefined;
   const fallbackUser = entry.defaultFallback(svcSeedConfig);
 
-  const { app, store } = createServer(loaded.plugin, { port, baseUrl, tokens, appKeyResolver, fallbackUser });
+  const { app, store, webhooks } = createServer(loaded.plugin, { port, baseUrl, tokens, appKeyResolver, fallbackUser });
   cachedResolver = loaded.createAppKeyResolver?.(store);
 
   const seed = () => {
     loaded.plugin.seed?.(store, baseUrl);
     if (svcSeedConfig && loaded.seedFromConfig) {
-      loaded.seedFromConfig(store, baseUrl, svcSeedConfig);
+      loaded.seedFromConfig(store, baseUrl, svcSeedConfig, webhooks);
     }
   };
   seed();

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -128,14 +128,20 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
     const fallbackUser = entry.defaultFallback(svcSeedConfig);
 
-    const { app, store } = createServer(loadedSvc.plugin, { port, baseUrl, tokens, appKeyResolver, fallbackUser });
+    const { app, store, webhooks } = createServer(loadedSvc.plugin, {
+      port,
+      baseUrl,
+      tokens,
+      appKeyResolver,
+      fallbackUser,
+    });
     cachedResolver = loadedSvc.createAppKeyResolver?.(store);
     stores.push(store);
 
     loadedSvc.plugin.seed?.(store, baseUrl);
 
     if (svcSeedConfig && loadedSvc.seedFromConfig) {
-      loadedSvc.seedFromConfig(store, baseUrl, svcSeedConfig);
+      loadedSvc.seedFromConfig(store, baseUrl, svcSeedConfig, webhooks);
     }
 
     const httpServer = serve({ fetch: app.fetch, port });

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -1,8 +1,8 @@
-import type { ServicePlugin, Store, AppKeyResolver, AuthFallback } from "@emulators/core";
+import type { ServicePlugin, Store, AppKeyResolver, AuthFallback, WebhookDispatcher } from "@emulators/core";
 
 export interface LoadedService {
   plugin: ServicePlugin;
-  seedFromConfig?(store: Store, baseUrl: string, config: unknown): void;
+  seedFromConfig?(store: Store, baseUrl: string, config: unknown, webhooks?: WebhookDispatcher): void;
   createAppKeyResolver?(store: Store): AppKeyResolver;
 }
 
@@ -22,6 +22,7 @@ const SERVICE_NAME_LIST = [
   "apple",
   "microsoft",
   "okta",
+  "auth0",
   "aws",
   "resend",
   "stripe",
@@ -323,6 +324,43 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
             name: "Sample OIDC Client",
             redirect_uris: ["http://localhost:3000/callback"],
             auth_server_id: "default",
+          },
+        ],
+      },
+    },
+  },
+
+  auth0: {
+    label: "Auth0 OAuth 2.0 / OpenID Connect + Management API emulator",
+    endpoints:
+      "OIDC discovery, JWKS, OAuth token (client_credentials, password-realm, refresh_token), userinfo, revoke, Management API users, users-by-email, tickets",
+    async load() {
+      const mod = await import("@emulators/auth0");
+      return { plugin: mod.auth0Plugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback(cfg) {
+      const firstEmail = (cfg?.users as Array<{ email?: string }> | undefined)?.[0]?.email ?? "testuser@auth0.local";
+      return { login: firstEmail, id: 1, scopes: ["openid", "profile", "email"] };
+    },
+    initConfig: {
+      auth0: {
+        connections: [{ name: "Username-Password-Authentication" }],
+        users: [
+          {
+            email: "testuser@auth0.local",
+            password: "Test1234!",
+            email_verified: true,
+            given_name: "Test",
+            family_name: "User",
+          },
+        ],
+        oauth_clients: [
+          {
+            client_id: "auth0-test-client",
+            client_secret: "auth0-test-secret",
+            name: "Sample Auth0 Client",
+            redirect_uris: ["http://localhost:3000/callback"],
+            grant_types: ["authorization_code", "refresh_token", "client_credentials"],
           },
         ],
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^3.0.118
-        version: 3.0.153(react@19.2.4)(zod@4.3.6)
+        version: 3.0.153(react@19.2.4)(zod@3.25.76)
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1
@@ -55,10 +55,10 @@ importers:
         version: 1.37.0
       ai:
         specifier: ^6.0.116
-        version: 6.0.151(zod@4.3.6)
+        version: 6.0.151(zod@3.25.76)
       bash-tool:
         specifier: ^1.3.15
-        version: 1.3.16(ai@6.0.151(zod@4.3.6))(just-bash@2.14.0)
+        version: 1.3.16(ai@6.0.151(zod@3.25.76))(just-bash@2.14.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -67,7 +67,7 @@ importers:
         version: 2.1.1
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.2.0(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.7.0(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       just-bash:
         specifier: ^2.14.0
         version: 2.14.0
@@ -363,6 +363,28 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/@emulators/auth0:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+      hono:
+        specifier: ^4
+        version: 4.12.12
+      jose:
+        specifier: ^6
+        version: 6.2.2
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+
   packages/@emulators/aws:
     dependencies:
       '@emulators/core':
@@ -621,6 +643,9 @@ importers:
       '@emulators/apple':
         specifier: workspace:*
         version: link:../@emulators/apple
+      '@emulators/auth0':
+        specifier: workspace:*
+        version: link:../@emulators/auth0
       '@emulators/aws':
         specifier: workspace:*
         version: link:../@emulators/aws
@@ -6348,28 +6373,28 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.93(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.93(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       '@vercel/oidc': 3.1.0
-      zod: 4.3.6
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 3.25.76
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.153(react@19.2.4)(zod@4.3.6)':
+  '@ai-sdk/react@3.0.153(react@19.2.4)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
-      ai: 6.0.151(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      ai: 6.0.151(zod@3.25.76)
       react: 19.2.4
       swr: 2.4.1(react@19.2.4)
       throttleit: 2.1.0
@@ -8614,13 +8639,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.151(zod@4.3.6):
+  ai@6.0.151(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.93(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.93(zod@3.25.76)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
+      zod: 3.25.76
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -8758,9 +8783,9 @@ snapshots:
 
   baseline-browser-mapping@2.10.9: {}
 
-  bash-tool@1.3.16(ai@6.0.151(zod@4.3.6))(just-bash@2.14.0):
+  bash-tool@1.3.16(ai@6.0.151(zod@3.25.76))(just-bash@2.14.0):
     dependencies:
-      ai: 6.0.151(zod@4.3.6)
+      ai: 6.0.151(zod@3.25.76)
       fast-glob: 3.3.3
       yaml: 2.8.3
       zod: 3.25.76
@@ -9935,7 +9960,7 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  geist@1.7.0(next@16.2.0(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  geist@1.7.0(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       next: 16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 

--- a/skills/auth0/SKILL.md
+++ b/skills/auth0/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: auth0
+description: Emulated Auth0 Authentication API, Management API v2, and OIDC for local development and testing. Use when the user needs to test Auth0 login locally, emulate Auth0 token exchange, create or manage Auth0 users, test email verification flows, configure Auth0 OAuth clients, work with Auth0 Management API, handle Auth0 log events, or work with Auth0 OIDC discovery without hitting real Auth0 tenants. Triggers include "Auth0 OAuth", "emulate Auth0", "mock Auth0", "test Auth0 login", "Auth0 Management API", "Auth0 OIDC", "local Auth0", "Auth0 user registration", "Auth0 password-realm", "Auth0 log stream", or any task requiring a local Auth0 identity provider.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Auth0 Emulator
+
+Auth0 Authentication API, Management API v2, and OIDC emulation with user lifecycle, email verification, and log event streaming.
+
+## Start
+
+```bash
+# Auth0 only
+npx emulate --service auth0
+
+# Default port
+# http://localhost:4007
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const auth0 = await createEmulator({ service: 'auth0', port: 4007 })
+// auth0.url === 'http://localhost:4007'
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+AUTH0_EMULATOR_URL=http://localhost:4007
+```
+
+### URL Mapping
+
+| Real Auth0 URL | Emulator URL |
+|----------------|-------------|
+| `https://{tenant}.auth0.com/oauth/token` | `$AUTH0_EMULATOR_URL/oauth/token` |
+| `https://{tenant}.auth0.com/userinfo` | `$AUTH0_EMULATOR_URL/userinfo` |
+| `https://{tenant}.auth0.com/oauth/revoke` | `$AUTH0_EMULATOR_URL/oauth/revoke` |
+| `https://{tenant}.auth0.com/api/v2/users` | `$AUTH0_EMULATOR_URL/api/v2/users` |
+| `https://{tenant}.auth0.com/api/v2/users-by-email` | `$AUTH0_EMULATOR_URL/api/v2/users-by-email` |
+| `https://{tenant}.auth0.com/api/v2/tickets/email-verification` | `$AUTH0_EMULATOR_URL/api/v2/tickets/email-verification` |
+| `https://{tenant}.auth0.com/.well-known/openid-configuration` | `$AUTH0_EMULATOR_URL/.well-known/openid-configuration` |
+| `https://{tenant}.auth0.com/.well-known/jwks.json` | `$AUTH0_EMULATOR_URL/.well-known/jwks.json` |
+
+### auth0-java SDK
+
+Override the domain to point at the emulator:
+
+```java
+// application.conf or local.conf
+auth0 {
+  domain = "http://localhost:4007"
+  clientId = "my-m2m-client"
+  clientSecret = "my-secret"
+  connection = "Username-Password-Authentication"
+}
+```
+
+### auth0 Node.js SDK (npm: `auth0`)
+
+```typescript
+import { ManagementClient, AuthenticationClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: 'localhost:4007',
+  clientId: 'my-m2m-client',
+  clientSecret: 'my-secret',
+})
+```
+
+### @auth0/nextjs-auth0
+
+```bash
+AUTH0_DOMAIN=localhost:4007
+AUTH0_CLIENT_ID=my-app-client
+AUTH0_CLIENT_SECRET=my-app-secret
+AUTH0_SECRET=a-long-random-secret
+APP_BASE_URL=http://localhost:3000
+```
+
+### Auth.js / NextAuth.js
+
+```typescript
+import Auth0Provider from '@auth/core/providers/auth0'
+
+Auth0Provider({
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  issuer: process.env.AUTH0_EMULATOR_URL,
+})
+```
+
+### openid-client
+
+```typescript
+import { Issuer } from 'openid-client'
+
+const auth0Issuer = await Issuer.discover(
+  process.env.AUTH0_EMULATOR_URL ?? 'https://my-tenant.auth0.com'
+)
+
+const client = new auth0Issuer.Client({
+  client_id: process.env.AUTH0_CLIENT_ID,
+  client_secret: process.env.AUTH0_CLIENT_SECRET,
+  redirect_uris: ['http://localhost:3000/api/auth/callback/auth0'],
+})
+```
+
+## Seed Config
+
+```yaml
+auth0:
+  connections:
+    - name: Username-Password-Authentication
+  users:
+    - email: admin@example.com
+      password: Admin1234!
+      email_verified: true
+      given_name: Admin
+      family_name: User
+      app_metadata:
+        role: ADMIN
+        securitiesLimit: 100
+    - email: test@example.com
+      password: Test1234!
+      email_verified: false
+      app_metadata:
+        role: USER
+  oauth_clients:
+    - client_id: my-m2m-client
+      client_secret: my-secret
+      name: Backend Service
+      grant_types: [client_credentials]
+      audience: https://api.example.com
+    - client_id: my-app-client
+      client_secret: my-app-secret
+      name: Web App
+      grant_types: [authorization_code, refresh_token, "http://auth0.com/oauth/grant-type/password-realm"]
+  log_streams:
+    - url: http://localhost:9000/auth0-events
+```
+
+## Authentication API
+
+### Get Management API Token
+
+```bash
+curl -X POST http://localhost:4007/oauth/token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "grant_type": "client_credentials",
+    "client_id": "my-m2m-client",
+    "client_secret": "my-secret",
+    "audience": "http://localhost:4007/api/v2/"
+  }'
+```
+
+Returns:
+
+```json
+{
+  "access_token": "auth0_m2m_...",
+  "token_type": "Bearer",
+  "expires_in": 86400,
+  "scope": ""
+}
+```
+
+### Login User (password-realm)
+
+Auth0's Resource Owner Password extension. The `grant_type` is `http://auth0.com/oauth/grant-type/password-realm`.
+
+```bash
+curl -X POST http://localhost:4007/oauth/token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "grant_type": "http://auth0.com/oauth/grant-type/password-realm",
+    "client_id": "my-app-client",
+    "client_secret": "my-app-secret",
+    "username": "admin@example.com",
+    "password": "Admin1234!",
+    "realm": "Username-Password-Authentication",
+    "scope": "openid profile email offline_access"
+  }'
+```
+
+Returns:
+
+```json
+{
+  "access_token": "auth0_at_...",
+  "refresh_token": "auth0_rt_...",
+  "id_token": "<jwt>",
+  "token_type": "Bearer",
+  "expires_in": 86400,
+  "scope": "openid profile email offline_access"
+}
+```
+
+The `id_token` is an RS256 JWT with claims: `sub`, `name`, `given_name`, `family_name`, `nickname`, `email`, `email_verified`, `picture`.
+
+Error responses use OAuth2 format:
+
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Wrong email or password."
+}
+```
+
+### Refresh Token
+
+```bash
+curl -X POST http://localhost:4007/oauth/token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "grant_type": "refresh_token",
+    "client_id": "my-app-client",
+    "client_secret": "my-app-secret",
+    "refresh_token": "auth0_rt_..."
+  }'
+```
+
+### Userinfo
+
+```bash
+curl http://localhost:4007/userinfo \
+  -H "Authorization: Bearer auth0_at_..."
+```
+
+### Revoke Token
+
+```bash
+curl -X POST http://localhost:4007/oauth/revoke \
+  -H "Content-Type: application/json" \
+  -d '{"token": "auth0_rt_..."}'
+```
+
+## Management API v2
+
+All Management API endpoints require a Bearer token obtained via client_credentials grant.
+
+### Create User
+
+```bash
+TOKEN="auth0_m2m_..."
+
+curl -X POST http://localhost:4007/api/v2/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "newuser@example.com",
+    "password": "SecurePass1!",
+    "connection": "Username-Password-Authentication",
+    "verify_email": false,
+    "app_metadata": {
+      "userId": 12345,
+      "role": "USER",
+      "securitiesLimit": 100
+    }
+  }'
+```
+
+Returns `201` with the user object including `user_id` in `auth0|{id}` format.
+
+Error responses use Management API format:
+
+```json
+{
+  "statusCode": 409,
+  "error": "Conflict",
+  "message": "The user already exists.",
+  "errorCode": "Conflict"
+}
+```
+
+### Get User
+
+```bash
+curl http://localhost:4007/api/v2/users/auth0%7C100001 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Search Users by Email
+
+```bash
+curl "http://localhost:4007/api/v2/users-by-email?email=admin@example.com" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Returns an array of matching users.
+
+### Update User
+
+```bash
+curl -X PATCH http://localhost:4007/api/v2/users/auth0%7C100001 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_metadata": { "securitiesLimit": 200 },
+    "email_verified": true
+  }'
+```
+
+`app_metadata` is merged with existing metadata, not replaced.
+
+### Email Verification Ticket
+
+```bash
+curl -X POST http://localhost:4007/api/v2/tickets/email-verification \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "auth0|100001",
+    "result_url": "https://example.com/email-verified"
+  }'
+```
+
+Returns `{ "ticket": "http://localhost:4007/tickets/email-verification?ticket=..." }`.
+
+Visit the ticket URL to mark the user's email as verified.
+
+## OIDC Discovery
+
+```bash
+# OpenID Configuration
+curl http://localhost:4007/.well-known/openid-configuration
+
+# JWKS (RS256 public key)
+curl http://localhost:4007/.well-known/jwks.json
+
+# Public key in PEM format (for static JWT validation)
+curl http://localhost:4007/_emulate/public-key.pem
+```
+
+## Deterministic Signing Key
+
+By default, a random RS256 key pair is generated on first request. To use a known key pair for static JWT validation:
+
+```yaml
+auth0:
+  signing_key:
+    private_key_pem: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+    public_key_pem: |
+      -----BEGIN PUBLIC KEY-----
+      ...
+      -----END PUBLIC KEY-----
+    kid: my-custom-kid
+```
+
+When configured, all ID tokens and the JWKS endpoint use the provided key. The `kid` defaults to `emulate-auth0-1` if omitted.
+
+## Log Event Streaming
+
+The emulator dispatches Auth0 log events via webhook when state changes:
+
+| Type | Event | Trigger |
+|------|-------|---------|
+| `ss` | Successful Signup | User created via Management API |
+| `fs` | Failed Signup | Create user failed (duplicate, invalid email, weak password) |
+| `sv` | Email Verified | Verification ticket consumed |
+| `scp` | Password Changed | User password updated via PATCH |
+
+Events follow the Auth0 log schema:
+
+```json
+{
+  "log_id": "a1b2c3d4e5f6",
+  "date": "2025-01-15T10:30:00.000Z",
+  "type": "ss",
+  "user_id": "auth0|100001",
+  "user_name": "newuser@example.com",
+  "client_id": "my-m2m-client",
+  "client_name": "Backend Service",
+  "connection": "Username-Password-Authentication",
+  "strategy": "auth0",
+  "strategy_type": "database",
+  "description": "Successful signup"
+}
+```
+
+Configure subscribers in the seed config via `log_streams`. Events are also visible in the inspector UI at `GET /` under the Log Events tab.
+
+## Inspector UI
+
+Browse to `http://localhost:4007/` to see a tabbed dashboard:
+
+- **Users** tab shows all users with email, user_id, connection, verified/blocked status, and app_metadata
+- **Log Events** tab shows dispatched events with type badges and timestamps
+- **OAuth Clients** tab shows configured clients with grant types and audiences
+- **Connections** tab shows database connections and strategies
+
+## Common Patterns
+
+### Full Registration Flow
+
+```bash
+AUTH0="http://localhost:4007"
+
+# 1. Get management token
+TOKEN=$(curl -s -X POST $AUTH0/oauth/token \
+  -H "Content-Type: application/json" \
+  -d '{"grant_type":"client_credentials","client_id":"my-m2m-client","client_secret":"my-secret","audience":"'$AUTH0'/api/v2/"}' \
+  | jq -r '.access_token')
+
+# 2. Create user
+USER=$(curl -s -X POST $AUTH0/api/v2/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"new@example.com","password":"Secure1!","connection":"Username-Password-Authentication","app_metadata":{"userId":42}}')
+echo $USER | jq .
+
+# 3. Send verification email
+USER_ID=$(echo $USER | jq -r '.user_id')
+curl -s -X POST $AUTH0/api/v2/tickets/email-verification \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id":"'$USER_ID'","result_url":"https://example.com/verified"}' | jq .
+
+# 4. Login
+curl -s -X POST $AUTH0/oauth/token \
+  -H "Content-Type: application/json" \
+  -d '{"grant_type":"http://auth0.com/oauth/grant-type/password-realm","client_id":"my-app-client","client_secret":"my-app-secret","username":"new@example.com","password":"Secure1!","realm":"Username-Password-Authentication","scope":"openid profile email offline_access"}' \
+  | jq .
+```
+
+### Error Handling Fidelity
+
+Error strings match Auth0's actual API responses so SDK error handling works unchanged:
+
+| Scenario | Emulator response |
+|----------|------------------|
+| Duplicate user | `{ "message": "The user already exists." }` |
+| Weak password | `{ "message": "PasswordStrengthError: Password is too weak" }` |
+| Invalid email | `{ "message": "Object didn't pass validation for format email: ..." }` |
+| Wrong credentials | `{ "error": "invalid_grant", "error_description": "Wrong email or password." }` |
+| Blocked user | `{ "error": "unauthorized", "error_description": "user is blocked" }` |
+| Invalid refresh token | `{ "error": "invalid_grant", "error_description": "Unknown or invalid refresh token." }` |
+| User not found | `{ "message": "The user does not exist." }` |


### PR DESCRIPTION
I had attempted this a few years ago but with this project and modern tooling its much more effective now. This PR adds an emulator for the Auth0 APIs required to register, validate, and login as real user. This is now a working replacement for a live integration we have and it was as much of a drop-in replacement as you can get.

---
## Summary

Add `@emulators/auth0` package with Auth0 Authentication API, Management API v2, and OIDC emulation. Covers the OAuth token endpoint (client_credentials, password-realm, refresh_token), user CRUD, email verification tickets, and log event streaming via webhooks. Includes a tabbed inspector UI.

## Why this matters

Testing Auth0 registration, login, and token flows currently requires hitting real Auth0 tenants (rate-limited, costs money, unreliable in CI) or mocking at the HTTP level. No existing emulator covers Auth0's Management API or its `password-realm` grant type (an Auth0 extension to OAuth2 that routes login to a named database connection).

With this emulator, the full identity flow can run locally: user registration (Management API) -> login (password-realm grant) -> token refresh -> email verification -> log event webhooks. All without network access.

## Changes

### New package: `@emulators/auth0`

**Authentication API** (`/oauth/token`):
- POST with `grant_type=client_credentials` for Management API tokens
- POST with `grant_type=http://auth0.com/oauth/grant-type/password-realm` for user login (returns access_token, refresh_token, id_token JWT)
- POST with `grant_type=refresh_token` for token renewal
- POST `/oauth/revoke` to revoke refresh tokens
- GET `/userinfo` for authenticated user profile

**Management API v2**:
- POST `/api/v2/users` to create users with email, password, connection, app_metadata
- GET `/api/v2/users/:id` to fetch a user
- GET `/api/v2/users-by-email` to search by email
- PATCH `/api/v2/users/:id` to update user fields (including password, app_metadata merge)
- POST `/api/v2/tickets/email-verification` to create verification tickets
- GET `/tickets/email-verification` to consume a ticket (marks email as verified)

**OIDC Discovery**:
- GET `/.well-known/openid-configuration`
- GET `/.well-known/jwks.json` (RS256 key pair)
- GET `/_emulate/public-key.pem` (RSA public key in PEM format)

**Deterministic Signing Key**:
- Optional `signing_key` in seed config to provide a known RSA key pair for static JWT validation
- When omitted, a random key pair is generated on first request (default behavior)
- When provided, all ID tokens and the JWKS endpoint use the configured key
- Custom `kid` supported, defaults to `emulate-auth0-1`

**Log Event Streaming**:
- Dispatches Auth0 log events (`ss`, `fs`, `sv`, `scp`) via webhook on user creation, signup failure, email verification, and password change
- Log events follow the canonical Auth0 log schema (`log_id`, `date`, `type`, `user_id`, `user_name`, `client_id`, `client_name`, `connection`, `strategy`, `strategy_type`, `description`)
- Configurable via `log_streams` in seed config

**Inspector UI** (`/`):
- Tabbed interface (Users, Log Events, OAuth Clients, Connections) using shared `renderInspectorPage`
- User status badges (verified/unverified/blocked)
- Log events displayed with type badges and timestamps

**Error responses**:
- Authentication API uses OAuth2 format (`{ error, error_description }`)
- Management API uses Auth0 format (`{ statusCode, error, message, errorCode }`)

### Seed config

```yaml
auth0:
  connections:
    - name: Username-Password-Authentication
  users:
    - email: admin@example.com
      password: Admin1234!
      email_verified: true
      app_metadata:
        role: ADMIN
  oauth_clients:
    - client_id: my-m2m-client
      client_secret: my-secret
      name: Backend Service
      grant_types: [client_credentials]
      audience: https://api.example.com
  log_streams:
    - url: http://localhost:9000/auth0-events
```

### Changes outside `@emulators/auth0`

**Registry and CLI wiring** (standard for any new service):
- `packages/emulate/src/registry.ts`: added `auth0` to `SERVICE_NAME_LIST` and `SERVICE_REGISTRY`
- `packages/emulate/package.json`: added `@emulators/auth0` workspace dependency

**`seedFromConfig` webhooks passthrough** (needed for log stream subscriber registration):
- `packages/emulate/src/registry.ts`: widened `LoadedService.seedFromConfig` signature to accept an optional 4th `webhooks` parameter
- `packages/emulate/src/commands/start.ts` and `api.ts`: destructure `webhooks` from `createServer()` (already returned, previously unused) and pass it through to `seedFromConfig`

The `webhooks` parameter is optional, so all 12 existing emulators are unaffected — their `seedFromConfig` functions ignore the extra argument. Verified by running the full monorepo `pnpm build` and `pnpm lint` with no failures.

**Root `README.md`**: updated port listing (all 13 services), added Auth0 endpoint section, Auth section, and architecture tree entry. Also updated the service name list in the programmatic API options table. The port listing was previously stale (only 7 of 13 services listed) — this PR brings it current.

## Testing

42 unit tests covering all endpoints, error response formats, log event dispatch, signing key configuration (deterministic and auto-generated), and edge cases (invalid PEM, half-configured keys, missing `offline_access` scope, blocked users). All pass against `pnpm test`, `pnpm type-check`, `pnpm format:check`, and `pnpm lint`.

Every endpoint was also manually tested against the running emulator via curl and an interactive browser-based test harness that exercises all API flows with inline assertions and a live log event stream.

## Demo

https://github.com/user-attachments/assets/58c10d4d-14d4-4a43-ad39-dda57566570a