### PR TITLE
feat: support external emulator plugins

### DIFF
--- a/packages/emulate/src/__tests__/api.test.ts
+++ b/packages/emulate/src/__tests__/api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { resolve } from "path";
 import { createEmulator } from "../api.js";
 
 describe("createEmulator", () => {
@@ -59,7 +60,21 @@ describe("createEmulator", () => {
   });
 
   it("throws on unknown service", async () => {
-    // @ts-expect-error testing invalid service name
     await expect(createEmulator({ service: "unknown-svc" })).rejects.toThrow("Unknown service");
+  });
+
+  it("starts an external plugin", async () => {
+    const echo = await createEmulator({
+      service: "echo",
+      port: 14030,
+      plugins: [resolve("src/__tests__/fixtures/echo-plugin.ts")],
+    });
+
+    const res = await fetch(`${echo.url}/ping`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; service: string };
+    expect(body).toEqual({ ok: true, service: "echo" });
+
+    await echo.close();
   });
 });

--- a/packages/emulate/src/__tests__/fixtures/echo-plugin.ts
+++ b/packages/emulate/src/__tests__/fixtures/echo-plugin.ts
@@ -1,0 +1,20 @@
+import type { ServicePlugin, Store } from "@emulators/core";
+
+export const plugin: ServicePlugin = {
+  name: "echo",
+  register(app) {
+    app.get("/ping", (c) => c.json({ ok: true, service: "echo" }));
+  },
+};
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: unknown): void {
+  store.setData("echo:config", config);
+}
+
+export const label = "Echo test plugin";
+export const endpoints = "ping";
+export const initConfig = {
+  echo: {
+    message: "hello",
+  },
+};

--- a/packages/emulate/src/__tests__/init.test.ts
+++ b/packages/emulate/src/__tests__/init.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { initCommand } from "../commands/init.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe("initCommand", () => {
+  const originalCwd = process.cwd();
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "emulate-init-"));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates config for an external plugin when explicitly targeted", async () => {
+    await initCommand({
+      service: "echo",
+      plugin: resolve(__dirname, "fixtures/echo-plugin.ts"),
+    });
+
+    const content = readFileSync(join(tempDir, "emulate.config.yaml"), "utf-8");
+    expect(content).toContain("tokens:");
+    expect(content).toContain("echo:");
+    expect(content).toContain("message: hello");
+  });
+});

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -1,5 +1,5 @@
-import { createServer, type AppKeyResolver, type Store } from "@emulators/core";
-import { SERVICE_REGISTRY } from "./registry.js";
+import { createServer, type AppKeyResolver } from "@emulators/core";
+import { resolveServiceEntries } from "./registry.js";
 export type { ServiceName } from "./registry.js";
 import type { ServiceName } from "./registry.js";
 import { serve } from "@hono/node-server";
@@ -11,10 +11,11 @@ export interface SeedConfig {
 }
 
 export interface EmulatorOptions {
-  service: ServiceName;
+  service: ServiceName | (string & {});
   port?: number;
   seed?: SeedConfig;
   baseUrl?: string;
+  plugins?: string[];
 }
 
 export interface Emulator {
@@ -24,9 +25,10 @@ export interface Emulator {
 }
 
 export async function createEmulator(options: EmulatorOptions): Promise<Emulator> {
-  const { service, port = 4000, seed: seedConfig } = options;
+  const { service, port = 4000, seed: seedConfig, plugins = [] } = options;
 
-  const entry = SERVICE_REGISTRY[service];
+  const registry = await resolveServiceEntries(plugins);
+  const entry = registry[service];
   if (!entry) {
     throw new Error(`Unknown service: ${service}`);
   }

--- a/packages/emulate/src/commands/init.ts
+++ b/packages/emulate/src/commands/init.ts
@@ -1,13 +1,14 @@
 import { writeFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import { stringify as yamlStringify } from "yaml";
-import { SERVICE_REGISTRY, SERVICE_NAMES, DEFAULT_TOKENS, type ServiceName } from "../registry.js";
+import { DEFAULT_TOKENS, getBuiltInServiceNames, resolveServiceEntries } from "../registry.js";
 
 interface InitOptions {
   service: string;
+  plugin?: string;
 }
 
-export function initCommand(options: InitOptions): void {
+export async function initCommand(options: InitOptions): Promise<void> {
   const filename = "emulate.config.yaml";
   const fullPath = resolve(filename);
 
@@ -16,16 +17,21 @@ export function initCommand(options: InitOptions): void {
     process.exit(1);
   }
 
+  const pluginSpecifiers = options.plugin?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+  const registry = await resolveServiceEntries(pluginSpecifiers);
+  const builtInServices = getBuiltInServiceNames();
+  const availableServices = Object.keys(registry);
+
   let config: Record<string, unknown>;
   if (options.service === "all") {
     config = { ...DEFAULT_TOKENS };
-    for (const name of SERVICE_NAMES) {
-      Object.assign(config, SERVICE_REGISTRY[name].initConfig);
+    for (const name of builtInServices) {
+      Object.assign(config, registry[name].initConfig);
     }
   } else {
-    const entry = SERVICE_REGISTRY[options.service as ServiceName];
+    const entry = registry[options.service];
     if (!entry) {
-      console.error(`Unknown service: ${options.service}. Available: ${SERVICE_NAMES.join(", ")}, all`);
+      console.error(`Unknown service: ${options.service}. Available: ${availableServices.join(", ")}, all`);
       process.exit(1);
     }
     config = { ...DEFAULT_TOKENS, ...entry.initConfig };

--- a/packages/emulate/src/commands/init.ts
+++ b/packages/emulate/src/commands/init.ts
@@ -1,7 +1,7 @@
 import { writeFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import { stringify as yamlStringify } from "yaml";
-import { DEFAULT_TOKENS, getBuiltInServiceNames, resolveServiceEntries } from "../registry.js";
+import { DEFAULT_TOKENS, resolveServiceEntries } from "../registry.js";
 
 interface InitOptions {
   service: string;
@@ -17,15 +17,18 @@ export async function initCommand(options: InitOptions): Promise<void> {
     process.exit(1);
   }
 
-  const pluginSpecifiers = options.plugin?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+  const pluginSpecifiers =
+    options.plugin
+      ?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? [];
   const registry = await resolveServiceEntries(pluginSpecifiers);
-  const builtInServices = getBuiltInServiceNames();
   const availableServices = Object.keys(registry);
 
   let config: Record<string, unknown>;
   if (options.service === "all") {
     config = { ...DEFAULT_TOKENS };
-    for (const name of builtInServices) {
+    for (const name of availableServices) {
       Object.assign(config, registry[name].initConfig);
     }
   } else {

--- a/packages/emulate/src/commands/list.ts
+++ b/packages/emulate/src/commands/list.ts
@@ -1,8 +1,15 @@
-import { SERVICE_REGISTRY } from "../registry.js";
+import { resolveServiceEntries } from "../registry.js";
 
-export function listCommand(): void {
+interface ListOptions {
+  plugin?: string;
+}
+
+export async function listCommand(options: ListOptions = {}): Promise<void> {
+  const pluginSpecifiers = options.plugin?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+  const registry = await resolveServiceEntries(pluginSpecifiers);
+
   console.log("\nAvailable services:\n");
-  for (const [name, entry] of Object.entries(SERVICE_REGISTRY)) {
+  for (const [name, entry] of Object.entries(registry)) {
     console.log(`  ${name.padEnd(10)}${entry.label}`);
     console.log(`            Endpoints: ${entry.endpoints}`);
     console.log();

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -1,5 +1,5 @@
 import { createServer, type AppKeyResolver, type Store } from "@emulators/core";
-import { SERVICE_REGISTRY, SERVICE_NAMES, type ServiceName } from "../registry.js";
+import { resolveServiceEntries, getBuiltInServiceNames, type LoadedService, type ServiceEntry } from "../registry.js";
 import { serve } from "@hono/node-server";
 import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
@@ -17,6 +17,7 @@ export interface StartOptions {
   seed?: string;
   baseUrl?: string;
   portless?: boolean;
+  plugin?: string;
 }
 
 interface SeedConfig {
@@ -72,8 +73,8 @@ function loadSeedConfig(seedPath?: string): LoadResult | null {
   return null;
 }
 
-function inferServicesFromConfig(config: SeedConfig): ServiceName[] | null {
-  const found = SERVICE_NAMES.filter((k) => k in config);
+function inferServicesFromConfig(config: SeedConfig, availableServices: string[]): string[] | null {
+  const found = availableServices.filter((k) => k in config);
   return found.length > 0 ? [...found] : null;
 }
 
@@ -89,17 +90,36 @@ export async function startCommand(options: StartOptions): Promise<void> {
   const seedConfig = loaded?.config ?? null;
   const configSource = loaded?.source ?? null;
 
-  let services: ServiceName[];
+  const pluginSpecifiers =
+    options.plugin
+      ?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? [];
+  let allEntries: Record<string, ServiceEntry>;
+  try {
+    allEntries = await resolveServiceEntries(pluginSpecifiers);
+  } catch (err) {
+    console.error(`Failed to load plugins: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  }
+
+  const builtInServices = getBuiltInServiceNames();
+  const externalServices = Object.keys(allEntries).filter((name) => !builtInServices.includes(name));
+
+  let services: string[];
   if (options.service) {
-    services = options.service.split(",").map((s) => s.trim()) as ServiceName[];
+    services = options.service.split(",").map((s) => s.trim());
   } else if (seedConfig) {
-    services = inferServicesFromConfig(seedConfig) ?? [...SERVICE_NAMES];
+    services = inferServicesFromConfig(seedConfig, Object.keys(allEntries)) ?? [
+      ...builtInServices,
+      ...externalServices,
+    ];
   } else {
-    services = [...SERVICE_NAMES];
+    services = [...builtInServices, ...externalServices];
   }
 
   for (const svc of services) {
-    if (!SERVICE_REGISTRY[svc]) {
+    if (!allEntries[svc]) {
       console.error(`Unknown service: ${svc}`);
       process.exit(1);
     }
@@ -120,9 +140,9 @@ export async function startCommand(options: StartOptions): Promise<void> {
   }
 
   interface PreparedService {
-    svc: ServiceName;
-    entry: (typeof SERVICE_REGISTRY)[ServiceName];
-    loadedSvc: Awaited<ReturnType<(typeof SERVICE_REGISTRY)[ServiceName]["load"]>>;
+    svc: string;
+    entry: ServiceEntry;
+    loadedSvc: LoadedService;
     svcSeedConfig: Record<string, unknown> | undefined;
     port: number;
     baseUrl: string;
@@ -133,7 +153,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   for (let i = 0; i < services.length; i++) {
     const svc = services[i];
-    const entry = SERVICE_REGISTRY[svc];
+    const entry = allEntries[svc];
     const loadedSvc = await entry.load();
 
     const svcSeedConfig = seedConfig?.[svc] as Record<string, unknown> | undefined;

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -23,6 +23,7 @@ program
   .option("--seed <file>", "Path to seed config file")
   .option("--base-url <url>", "Override advertised base URL (supports {service} template)")
   .option("--portless", "Serve over HTTPS via portless (auto-registers aliases)")
+  .option("--plugin <plugins>", "Comma-separated external plugin paths or package names")
   .action(async (opts) => {
     const port = parseInt(opts.port, 10);
     if (Number.isNaN(port) || port < 1 || port > 65535) {
@@ -35,6 +36,7 @@ program
       seed: opts.seed,
       baseUrl: opts.baseUrl,
       portless: opts.portless,
+      plugin: opts.plugin,
     });
   });
 
@@ -42,16 +44,18 @@ program
   .command("init")
   .description("Generate a starter config file")
   .option("-s, --service <service>", "Service to generate config for", "all")
-  .action((opts) => {
-    initCommand({ service: opts.service });
+  .option("--plugin <plugins>", "Comma-separated external plugin paths or package names")
+  .action(async (opts) => {
+    await initCommand({ service: opts.service, plugin: opts.plugin });
   });
 
 program
   .command("list")
   .alias("list-services")
   .description("List available services")
-  .action(() => {
-    listCommand();
+  .option("--plugin <plugins>", "Comma-separated external plugin paths or package names")
+  .action(async (opts) => {
+    await listCommand({ plugin: opts.plugin });
   });
 
 program.parse();

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -1,4 +1,5 @@
 import type { ServicePlugin, Store, AppKeyResolver, AuthFallback, WebhookDispatcher } from "@emulators/core";
+import { isAbsolute, resolve } from "path";
 
 export interface LoadedService {
   plugin: ServicePlugin;
@@ -12,6 +13,42 @@ export interface ServiceEntry {
   load(): Promise<LoadedService>;
   defaultFallback(svcSeedConfig?: Record<string, unknown>): AuthFallback;
   initConfig: Record<string, unknown>;
+}
+
+export interface ExternalPluginModule {
+  plugin?: ServicePlugin;
+  default?: ServicePlugin;
+  seedFromConfig?(store: Store, baseUrl: string, config: unknown, webhooks?: WebhookDispatcher): void;
+  label?: string;
+  endpoints?: string;
+  defaultFallback?(svcSeedConfig?: Record<string, unknown>): AuthFallback;
+  initConfig?: Record<string, unknown>;
+}
+
+export async function loadExternalPlugin(specifier: string): Promise<{ name: string; entry: ServiceEntry }> {
+  const modulePath = specifier.startsWith(".") || isAbsolute(specifier) ? resolve(specifier) : specifier;
+
+  const mod = (await import(modulePath)) as ExternalPluginModule;
+  const plugin = mod.plugin ?? mod.default;
+  if (!plugin || typeof plugin.register !== "function" || typeof plugin.name !== "string") {
+    throw new Error(`Plugin "${specifier}" must export a ServicePlugin (as "plugin" or default export)`);
+  }
+
+  const name = plugin.name;
+  const entry: ServiceEntry = {
+    label: mod.label ?? `${name} (external plugin)`,
+    endpoints: mod.endpoints ?? "",
+    async load() {
+      return {
+        plugin,
+        seedFromConfig: mod.seedFromConfig,
+      };
+    },
+    defaultFallback: mod.defaultFallback ?? (() => ({ login: "admin", id: 1, scopes: [] })),
+    initConfig: mod.initConfig ?? {},
+  };
+
+  return { name, entry };
 }
 
 const SERVICE_NAME_LIST = [
@@ -464,3 +501,24 @@ export const DEFAULT_TOKENS = {
     },
   },
 };
+
+export async function resolveServiceEntries(pluginSpecifiers: string[] = []): Promise<Record<string, ServiceEntry>> {
+  const results = await Promise.all(pluginSpecifiers.map(loadExternalPlugin));
+
+  const externalEntries: Record<string, ServiceEntry> = {};
+  for (const { name, entry } of results) {
+    if (name in SERVICE_REGISTRY) {
+      throw new Error(`Plugin "${name}" conflicts with built-in service "${name}"`);
+    }
+    if (name in externalEntries) {
+      throw new Error(`Duplicate plugin name "${name}"`);
+    }
+    externalEntries[name] = entry;
+  }
+
+  return { ...SERVICE_REGISTRY, ...externalEntries };
+}
+
+export function getBuiltInServiceNames(): string[] {
+  return [...SERVICE_NAMES];
+}


### PR DESCRIPTION
## Summary

Adds a small external-plugin loading path on top of the existing `ServicePlugin` architecture.

This keeps built-in emulators unchanged, but lets teams run emulator packages that are not ready or appropriate for core yet:

```bash
npx emulate start --plugin ./plugins/my-service.ts --service my-service
npx emulate init --plugin ./plugins/my-service.ts --service my-service
npx emulate list --plugin ./plugins/my-service.ts
```

Programmatic usage also works:

```ts
await createEmulator({
  service: "my-service",
  plugins: ["./plugins/my-service.ts"],
});
```

## Why this matters

The volume of emulator PRs since this was opened is the signal: service coverage is valuable, but every new provider currently has to land as a core registry/package change. That makes the project carry every niche, experimental, or company-specific emulator forever.

This PR gives maintainers a lower-risk answer:

- widely useful emulators can still be built in;
- experimental or private emulators can live outside this repo;
- users still get the same `start`, `init`, `list`, seed config, auth fallback, and programmatic APIs.

## Low-risk shape

- Built-in service behavior is preserved.
- Existing `ServicePlugin` is reused; no new runtime abstraction.
- External plugins are opt-in via `--plugin` / `plugins`.
- External plugin names cannot collide with built-ins.
- Duplicate external plugin names are rejected.
- Local paths and package names are both supported.
- `init all` includes external plugins only when explicitly supplied.

## Plugin contract

A plugin module exports a `ServicePlugin` as either `plugin` or default export.

Optional exports:

- `seedFromConfig`
- `label`
- `endpoints`
- `defaultFallback`
- `initConfig`

The tests include a tiny `echo-plugin.ts` fixture to make the contract concrete and reviewable.

## Test plan

- [x] `pnpm --filter emulate type-check`
- [x] `pnpm --filter emulate test`
- [x] `pnpm --filter emulate lint`
