### PR TITLE
Add release workflow with npm trusted publisher and provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
       - run: pnpm build
 
+      - run: node scripts/sync-versions.mjs --check
+
       - run: pnpm format:check
 
       - run: pnpm type-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  check-release:
+    name: Check for new version
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Compare versions to registry
+        id: check
+        run: |
+          LOCAL_VERSION=$(node -p "require('./packages/emulate/package.json').version")
+          SHOULD_RELEASE=false
+
+          REGISTRY_VERSION=$(npm view emulate version 2>/dev/null || echo "0.0.0")
+          echo "emulate — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
+          if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
+            SHOULD_RELEASE=true
+          fi
+
+          for pkg in adapter-next apple aws clerk core github google microsoft mongoatlas okta resend slack stripe vercel; do
+            REGISTRY_VERSION=$(npm view "@emulators/$pkg" version 2>/dev/null || echo "0.0.0")
+            echo "@emulators/$pkg — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
+            if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
+              SHOULD_RELEASE=true
+            fi
+          done
+
+          echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish
+    needs: check-release
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish packages
+        run: |
+          LOCAL_VERSION="${{ needs.check-release.outputs.version }}"
+          FAILED=""
+
+          REGISTRY_VERSION=$(npm view emulate version 2>/dev/null || echo "0.0.0")
+          if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
+            echo "emulate@$LOCAL_VERSION already published, skipping"
+          else
+            echo "Publishing emulate@$LOCAL_VERSION..."
+            if ! (cd packages/emulate && npm publish --provenance); then
+              FAILED="$FAILED emulate"
+            fi
+          fi
+
+          for pkg in adapter-next apple aws clerk core github google microsoft mongoatlas okta resend slack stripe vercel; do
+            REGISTRY_VERSION=$(npm view "@emulators/$pkg" version 2>/dev/null || echo "0.0.0")
+            if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
+              echo "@emulators/$pkg@$LOCAL_VERSION already published, skipping"
+              continue
+            fi
+            echo "Publishing @emulators/$pkg@$LOCAL_VERSION..."
+            if ! (cd "packages/@emulators/$pkg" && npm publish --provenance); then
+              FAILED="$FAILED @emulators/$pkg"
+            fi
+          done
+
+          if [ -n "$FAILED" ]; then
+            echo "Failed to publish:$FAILED"
+            exit 1
+          fi
+
+  github-release:
+    name: Create GitHub Release
+    needs: [check-release, publish]
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract changelog entry
+        run: |
+          VERSION="${{ needs.check-release.outputs.version }}"
+
+          awk '/<!-- release:start -->/{found=1; next} /<!-- release:end -->/{found=0} found{print}' CHANGELOG.md > /tmp/release-notes.md
+
+          LINES=$(wc -l < /tmp/release-notes.md | tr -d ' ')
+          if [ "$LINES" -lt 2 ]; then
+            echo "Error: No release notes found between <!-- release:start --> and <!-- release:end --> markers in CHANGELOG.md"
+            exit 1
+          fi
+          echo "Extracted release notes for $VERSION ($LINES lines)"
+
+      - name: Create GitHub Release
+        run: |
+          VERSION="${{ needs.check-release.outputs.version }}"
+          TAG="v$VERSION"
+
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists, skipping"
+          else
+            echo "Creating release $TAG..."
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --target ${{ github.sha }} \
+              --notes-file /tmp/release-notes.md
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,15 @@ on:
       - main
   workflow_dispatch:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
+
+env:
+  EMULATOR_PACKAGES: adapter-next apple aws clerk core github google microsoft mongoatlas okta resend slack stripe vercel
 
 jobs:
   check-release:
@@ -34,7 +39,7 @@ jobs:
             SHOULD_RELEASE=true
           fi
 
-          for pkg in adapter-next apple aws clerk core github google microsoft mongoatlas okta resend slack stripe vercel; do
+          for pkg in $EMULATOR_PACKAGES; do
             REGISTRY_VERSION=$(npm view "@emulators/$pkg" version 2>/dev/null || echo "0.0.0")
             echo "@emulators/$pkg — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
             if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
@@ -91,7 +96,7 @@ jobs:
             fi
           fi
 
-          for pkg in adapter-next apple aws clerk core github google microsoft mongoatlas okta resend slack stripe vercel; do
+          for pkg in $EMULATOR_PACKAGES; do
             REGISTRY_VERSION=$(npm view "@emulators/$pkg" version 2>/dev/null || echo "0.0.0")
             if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
               echo "@emulators/$pkg@$LOCAL_VERSION already published, skipping"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,21 @@ When a change affects how humans or agents use emulate (new/changed/removed comm
 3. `apps/web/` (docs site pages)
 4. CLI `--help` output in `packages/emulate/src/index.ts`
 
+## Releasing
+
+Releases are manual, single-PR affairs. The maintainer controls the changelog voice and format. All packages share a single version number (`emulate` + every `@emulators/*`).
+
+To prepare a release:
+
+1. Create a branch (e.g. `prepare-v0.5.0`)
+2. Bump the version in `packages/emulate/package.json`
+3. Run `pnpm sync-versions` to update all `@emulators/*` packages
+4. Write the changelog entry in `CHANGELOG.md`, wrapped in `<!-- release:start -->` and `<!-- release:end -->` markers
+5. Remove the `<!-- release:start -->` and `<!-- release:end -->` markers from the previous release entry (only the latest release should have markers)
+6. Open a PR and merge to `main`
+
+CI compares the version in `packages/emulate/package.json` to what's on npm. If it differs, it builds, publishes all packages with provenance, and creates the GitHub release automatically. The release body is extracted from the content between the markers.
+
 <!-- opensrc:start -->
 
 ## Source Code Reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ## 0.4.0
 
-<!-- release:start -->
 ### New Features
 
 - **Next.js adapter** — embed emulators directly in your Next.js app via `@emulators/adapter-next`, solving the Vercel preview deployment problem where OAuth callback URLs change with every deployment (#43)
@@ -33,4 +32,3 @@
 - @ctate
 - @jk4235
 - @mvanhorn
-<!-- release:end -->

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "clean": "turbo clean",
     "type-check": "turbo type-check",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx}\"",
+    "sync-versions": "node scripts/sync-versions.mjs"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/packages/@emulators/clerk/package.json
+++ b/packages/@emulators/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/clerk",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Reads the version from packages/emulate/package.json (the canonical
+ * source) and writes it to every @emulators/* package.json.
+ *
+ * Usage:
+ *   node scripts/sync-versions.mjs          # sync
+ *   node scripts/sync-versions.mjs --check  # CI check (exit 1 if out of sync)
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
+const root = join(fileURLToPath(import.meta.url), "../..");
+const emulatePkgPath = join(root, "packages/emulate/package.json");
+const emulatorsDir = join(root, "packages/@emulators");
+
+const canonicalPkg = JSON.parse(readFileSync(emulatePkgPath, "utf8"));
+const version = canonicalPkg.version;
+
+const check = process.argv.includes("--check");
+let mismatches = [];
+
+for (const dir of readdirSync(emulatorsDir)) {
+  const pkgPath = join(emulatorsDir, dir, "package.json");
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch {
+    continue;
+  }
+
+  if (pkg.version === version) continue;
+
+  if (check) {
+    mismatches.push(`${pkg.name}: ${pkg.version} (expected ${version})`);
+  } else {
+    pkg.version = version;
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+    console.log(`Updated ${pkg.name} to ${version}`);
+  }
+}
+
+if (check && mismatches.length > 0) {
+  console.error("Version mismatch:");
+  for (const m of mismatches) console.error(`  ${m}`);
+  process.exit(1);
+} else if (check) {
+  console.log(`All @emulators/* packages are at ${version}`);
+}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` with three jobs: version check against npm, publish with `--provenance` (OIDC trusted publisher via `id-token: write`), and GitHub release creation from changelog markers
- Add `scripts/sync-versions.mjs` to keep all `@emulators/*` package versions in sync with the canonical version in `packages/emulate/package.json` (supports `--check` for CI)
- Add `pnpm sync-versions` script to root `package.json`
- Add concurrency group to CI workflow
- Document the releasing process in `AGENTS.md`
- Fix `@emulators/clerk` version (was 0.3.0, now 0.4.1)
- Remove stale release markers from old changelog entry