### PR TITLE
feat(emulate): add portless integration and base URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,45 @@ emulate list
 | `-p, --port` | `4000` | Base port (auto-increments per service) |
 | `-s, --service` | all | Comma-separated services to enable |
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
+| `--base-url` | none | Override advertised base URL (supports `{service}` template) |
+| `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+
+## HTTPS with portless
+
+[portless](https://github.com/vercel-labs/portless) gives emulators trusted HTTPS URLs with auto-generated certs and no browser warnings.
+
+```bash
+# Start the portless proxy (first time only)
+portless proxy start
+
+# Start emulate with portless integration
+emulate start --portless
+```
+
+Each service registers as a portless alias and gets a named HTTPS URL:
+
+```
+github  https://github.emulate.localhost
+google  https://google.emulate.localhost
+slack   https://slack.emulate.localhost
+```
+
+If portless is not installed, emulate will prompt to install it (`npm i -g portless`).
+
+For a custom base URL without portless (any reverse proxy), use `--base-url` or the `EMULATE_BASE_URL` env var:
+
+```bash
+emulate start --base-url "https://{service}.myproxy.test"
+```
+
+Per-service overrides are also supported in the seed config:
+
+```yaml
+github:
+  baseUrl: https://github.emulate.localhost
+```
 
 ## Programmatic API
 
@@ -103,6 +140,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 | `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
+| `baseUrl` | none | Override advertised base URL. Falls back to `PORTLESS_URL` env var, then `http://localhost:<port>`. |
 
 ### Instance methods
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ slack   https://slack.emulate.localhost
 
 If portless is not installed, emulate will prompt to install it (`npm i -g portless`).
 
+The `--portless` flag overwrites any existing portless aliases matching `*.emulate`. Aliases are removed automatically when emulate shuts down.
+
 For a custom base URL without portless (any reverse proxy), use `--base-url` or the `EMULATE_BASE_URL` env var:
 
 ```bash
@@ -140,7 +142,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 | `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
-| `baseUrl` | none | Override advertised base URL. Falls back to `PORTLESS_URL` env var, then `http://localhost:<port>`. |
+| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL`, then `http://localhost:<port>`. |
 
 ### Instance methods
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ For a custom base URL without portless (any reverse proxy), use `--base-url` or 
 emulate start --base-url "https://{service}.myproxy.test"
 ```
 
-The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`). When no explicit `baseUrl` is provided, it is used as a fallback.
+The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`), typically to a value like `https://{service}.emulate.localhost`. It supports `{service}` interpolation, just like `--base-url` and `EMULATE_BASE_URL`. When no explicit `baseUrl` is provided, it is used as a fallback.
 
-Per-service overrides are also supported in the seed config:
+Per-service overrides are also supported in the seed config (these take highest priority over all other base URL sources):
 
 ```yaml
 github:
@@ -144,7 +144,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 | `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
-| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
+| `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
 
 ### Instance methods
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ For a custom base URL without portless (any reverse proxy), use `--base-url` or 
 emulate start --base-url "https://{service}.myproxy.test"
 ```
 
+The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`). When no explicit `baseUrl` is provided, it is used as a fallback.
+
 Per-service overrides are also supported in the seed config:
 
 ```yaml
@@ -142,7 +144,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 | `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
-| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL`, then `http://localhost:<port>`. |
+| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
 
 ### Instance methods
 

--- a/apps/web/app/programmatic-api/page.mdx
+++ b/apps/web/app/programmatic-api/page.mdx
@@ -74,7 +74,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>baseUrl</code></td>
       <td>none</td>
-      <td>Override the advertised base URL (used in OAuth redirects, webhook URLs, etc.). Falls back to the <code>PORTLESS_URL</code> env var, then <code>{`http://localhost:<port>`}</code>.</td>
+      <td>Override the advertised base URL (used in OAuth redirects, webhook URLs, etc.). Falls back to the <code>EMULATE_BASE_URL</code> env var (supports <code>{'{service}'}</code> template), then <code>PORTLESS_URL</code>, then <code>{`http://localhost:<port>`}</code>.</td>
     </tr>
   </tbody>
 </table>

--- a/apps/web/app/programmatic-api/page.mdx
+++ b/apps/web/app/programmatic-api/page.mdx
@@ -74,7 +74,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>baseUrl</code></td>
       <td>none</td>
-      <td>Override the advertised base URL (used in OAuth redirects, webhook URLs, etc.). Falls back to the <code>EMULATE_BASE_URL</code> env var (supports <code>{'{service}'}</code> template), then <code>PORTLESS_URL</code>, then <code>{`http://localhost:<port>`}</code>.</td>
+      <td>Override the advertised base URL (used in OAuth redirects, webhook URLs, etc.). Falls back to the <code>EMULATE_BASE_URL</code> env var (supports <code>{'{service}'}</code> template), then <code>PORTLESS_URL</code> (automatically set by the <code>portless</code> CLI wrapper), then <code>{`http://localhost:<port>`}</code>.</td>
     </tr>
   </tbody>
 </table>

--- a/apps/web/app/programmatic-api/page.mdx
+++ b/apps/web/app/programmatic-api/page.mdx
@@ -71,6 +71,11 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
       <td>none</td>
       <td>Inline seed data (same shape as YAML config)</td>
     </tr>
+    <tr>
+      <td><code>baseUrl</code></td>
+      <td>none</td>
+      <td>Override the advertised base URL (used in OAuth redirects, webhook URLs, etc.). Falls back to the <code>PORTLESS_URL</code> env var, then <code>{`http://localhost:<port>`}</code>.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/apps/web/app/programmatic-api/page.mdx
+++ b/apps/web/app/programmatic-api/page.mdx
@@ -74,7 +74,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>baseUrl</code></td>
       <td>none</td>
-      <td>Override the advertised base URL (used in OAuth redirects, webhook URLs, etc.). Falls back to the <code>EMULATE_BASE_URL</code> env var (supports <code>{'{service}'}</code> template), then <code>PORTLESS_URL</code> (automatically set by the <code>portless</code> CLI wrapper), then <code>{`http://localhost:<port>`}</code>.</td>
+      <td>Override the advertised base URL (used in OAuth redirects, webhook URLs, etc.). Per-service <code>baseUrl</code> in seed config takes highest priority, then this option, then the <code>EMULATE_BASE_URL</code> env var (supports <code>{'{service}'}</code> template), then <code>PORTLESS_URL</code> (supports <code>{'{service}'}</code>, automatically set by the <code>portless</code> CLI wrapper), then <code>{`http://localhost:<port>`}</code>.</td>
     </tr>
   </tbody>
 </table>

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -44,9 +44,8 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
   }
 
   const svcSeedConfig = seedConfig?.[service] as Record<string, unknown> | undefined;
-  const seedBaseUrl = typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
-    ? svcSeedConfig.baseUrl
-    : undefined;
+  const seedBaseUrl =
+    typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0 ? svcSeedConfig.baseUrl : undefined;
   const baseUrl = resolveBaseUrl({ service, port, baseUrl: options.baseUrl, seedBaseUrl });
 
   // eslint-disable-next-line prefer-const -- reassigned after closure captures it

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -42,7 +42,10 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
     tokens["test_token_admin"] = { login: "admin", id: 2, scopes: ["repo", "user", "admin:org", "admin:repo_hook"] };
   }
 
-  const baseUrl = options.baseUrl ?? process.env.PORTLESS_URL ?? `http://localhost:${port}`;
+  const baseUrl = options.baseUrl
+    ?? process.env.EMULATE_BASE_URL?.replace(/\{service\}/g, service)
+    ?? process.env.PORTLESS_URL?.replace(/\{service\}/g, service)
+    ?? `http://localhost:${port}`;
 
   // eslint-disable-next-line prefer-const -- reassigned after closure captures it
   let cachedResolver: AppKeyResolver | undefined;

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -13,6 +13,7 @@ export interface EmulatorOptions {
   service: ServiceName;
   port?: number;
   seed?: SeedConfig;
+  baseUrl?: string;
 }
 
 export interface Emulator {
@@ -41,7 +42,7 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
     tokens["test_token_admin"] = { login: "admin", id: 2, scopes: ["repo", "user", "admin:org", "admin:repo_hook"] };
   }
 
-  const baseUrl = `http://localhost:${port}`;
+  const baseUrl = options.baseUrl ?? process.env.PORTLESS_URL ?? `http://localhost:${port}`;
 
   // eslint-disable-next-line prefer-const -- reassigned after closure captures it
   let cachedResolver: AppKeyResolver | undefined;

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -3,6 +3,7 @@ import { SERVICE_REGISTRY } from "./registry.js";
 export type { ServiceName } from "./registry.js";
 import type { ServiceName } from "./registry.js";
 import { serve } from "@hono/node-server";
+import { resolveBaseUrl } from "./base-url.js";
 
 export interface SeedConfig {
   tokens?: Record<string, { login: string; scopes?: string[] }>;
@@ -42,10 +43,11 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
     tokens["test_token_admin"] = { login: "admin", id: 2, scopes: ["repo", "user", "admin:org", "admin:repo_hook"] };
   }
 
-  const baseUrl = options.baseUrl
-    ?? process.env.EMULATE_BASE_URL?.replace(/\{service\}/g, service)
-    ?? process.env.PORTLESS_URL?.replace(/\{service\}/g, service)
-    ?? `http://localhost:${port}`;
+  const svcSeedConfig = seedConfig?.[service] as Record<string, unknown> | undefined;
+  const seedBaseUrl = typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
+    ? svcSeedConfig.baseUrl
+    : undefined;
+  const baseUrl = resolveBaseUrl({ service, port, baseUrl: options.baseUrl, seedBaseUrl });
 
   // eslint-disable-next-line prefer-const -- reassigned after closure captures it
   let cachedResolver: AppKeyResolver | undefined;
@@ -53,7 +55,6 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
     ? (appId) => cachedResolver!(appId)
     : undefined;
 
-  const svcSeedConfig = seedConfig?.[service] as Record<string, unknown> | undefined;
   const fallbackUser = entry.defaultFallback(svcSeedConfig);
 
   const { app, store } = createServer(loaded.plugin, { port, baseUrl, tokens, appKeyResolver, fallbackUser });

--- a/packages/emulate/src/base-url.ts
+++ b/packages/emulate/src/base-url.ts
@@ -15,7 +15,7 @@ export interface ResolveBaseUrlOptions {
  */
 export function resolveBaseUrl(opts: ResolveBaseUrlOptions): string {
   if (opts.seedBaseUrl) {
-    return opts.seedBaseUrl;
+    return opts.seedBaseUrl.replace(/\{service\}/g, opts.service);
   }
   if (opts.baseUrl) {
     return opts.baseUrl.replace(/\{service\}/g, opts.service);

--- a/packages/emulate/src/base-url.ts
+++ b/packages/emulate/src/base-url.ts
@@ -1,0 +1,32 @@
+export interface ResolveBaseUrlOptions {
+  service: string;
+  port: number;
+  baseUrl?: string;
+  seedBaseUrl?: string;
+}
+
+/**
+ * Fallback chain:
+ * 1. Per-service baseUrl from seed config
+ * 2. Explicit baseUrl (CLI flag or programmatic option)
+ * 3. EMULATE_BASE_URL env var (with {service} interpolation)
+ * 4. PORTLESS_URL env var (with {service} interpolation)
+ * 5. http://localhost:<port>
+ */
+export function resolveBaseUrl(opts: ResolveBaseUrlOptions): string {
+  if (opts.seedBaseUrl) {
+    return opts.seedBaseUrl;
+  }
+  if (opts.baseUrl) {
+    return opts.baseUrl.replace(/\{service\}/g, opts.service);
+  }
+  const envBaseUrl = process.env.EMULATE_BASE_URL;
+  if (envBaseUrl) {
+    return envBaseUrl.replace(/\{service\}/g, opts.service);
+  }
+  const portlessUrl = process.env.PORTLESS_URL;
+  if (portlessUrl) {
+    return portlessUrl.replace(/\{service\}/g, opts.service);
+  }
+  return `http://localhost:${opts.port}`;
+}

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -82,7 +82,7 @@ function resolveBaseUrl(
   svcSeedConfig: Record<string, unknown> | undefined,
   cliBaseUrl: string | undefined,
 ): string {
-  if (svcSeedConfig?.baseUrl && typeof svcSeedConfig.baseUrl === "string") {
+  if (typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0) {
     return svcSeedConfig.baseUrl;
   }
   if (cliBaseUrl) {
@@ -93,7 +93,7 @@ function resolveBaseUrl(
     return envBaseUrl.replace(/\{service\}/g, service);
   }
   if (process.env.PORTLESS_URL) {
-    return process.env.PORTLESS_URL;
+    return process.env.PORTLESS_URL.replace(/\{service\}/g, service);
   }
   return `http://localhost:${port}`;
 }
@@ -186,16 +186,27 @@ export async function startCommand(options: StartOptions): Promise<void> {
   }
 
   if (portlessAliases.length > 0) {
-    registerAliases(portlessAliases);
+    try {
+      registerAliases(portlessAliases);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : err);
+      for (const srv of httpServers) {
+        srv.close();
+      }
+      process.exit(1);
+    }
   }
 
   printBanner(serviceUrls, tokens, configSource);
 
+  if (portlessAliases.length > 0) {
+    process.on("exit", () => {
+      removeAliases(portlessAliases);
+    });
+  }
+
   const shutdown = () => {
     console.log(`\n${pc.dim("Shutting down...")}`);
-    if (portlessAliases.length > 0) {
-      removeAliases(portlessAliases);
-    }
     for (const store of stores) {
       store.reset();
     }

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -119,10 +119,17 @@ export async function startCommand(options: StartOptions): Promise<void> {
     await ensurePortless();
   }
 
-  const serviceUrls: Array<{ name: string; url: string }> = [];
-  const stores: Store[] = [];
-  const httpServers: ReturnType<typeof serve>[] = [];
+  interface PreparedService {
+    svc: ServiceName;
+    entry: (typeof SERVICE_REGISTRY)[ServiceName];
+    loadedSvc: Awaited<ReturnType<(typeof SERVICE_REGISTRY)[ServiceName]["load"]>>;
+    svcSeedConfig: Record<string, unknown> | undefined;
+    port: number;
+    baseUrl: string;
+  }
+
   const portlessAliases: PortlessAlias[] = [];
+  const prepared: PreparedService[] = [];
 
   for (let i = 0; i < services.length; i++) {
     const svc = services[i];
@@ -132,17 +139,28 @@ export async function startCommand(options: StartOptions): Promise<void> {
     const svcSeedConfig = seedConfig?.[svc] as Record<string, unknown> | undefined;
     const port = (svcSeedConfig?.port as number | undefined) ?? basePort + i;
 
-    let baseUrl: string;
     if (options.portless) {
-      const aliasName = `${svc}.emulate`;
-      portlessAliases.push({ name: aliasName, port });
-      baseUrl = portlessBaseUrl(svc);
-    } else {
-      const seedBaseUrl = typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
-        ? svcSeedConfig.baseUrl
-        : undefined;
-      baseUrl = resolveBaseUrl({ service: svc, port, baseUrl: options.baseUrl, seedBaseUrl });
+      portlessAliases.push({ name: `${svc}.emulate`, port });
     }
+
+    const seedBaseUrl = typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
+      ? svcSeedConfig.baseUrl
+      : undefined;
+    const effectiveBaseUrl = options.portless ? portlessBaseUrl(svc) : options.baseUrl;
+    const baseUrl = resolveBaseUrl({ service: svc, port, baseUrl: effectiveBaseUrl, seedBaseUrl });
+
+    prepared.push({ svc, entry, loadedSvc, svcSeedConfig, port, baseUrl });
+  }
+
+  if (portlessAliases.length > 0) {
+    registerAliases(portlessAliases);
+  }
+
+  const serviceUrls: Array<{ name: string; url: string }> = [];
+  const stores: Store[] = [];
+  const httpServers: ReturnType<typeof serve>[] = [];
+
+  for (const { svc, entry, loadedSvc, svcSeedConfig, port, baseUrl } of prepared) {
     serviceUrls.push({ name: svc, url: baseUrl });
 
     // eslint-disable-next-line prefer-const -- reassigned after closure captures it
@@ -165,18 +183,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
     const httpServer = serve({ fetch: app.fetch, port });
     httpServers.push(httpServer);
-  }
-
-  if (portlessAliases.length > 0) {
-    try {
-      registerAliases(portlessAliases);
-    } catch (err) {
-      console.error(err instanceof Error ? err.message : err);
-      for (const srv of httpServers) {
-        srv.close();
-      }
-      process.exit(1);
-    }
   }
 
   printBanner(serviceUrls, tokens, configSource);

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -143,9 +143,10 @@ export async function startCommand(options: StartOptions): Promise<void> {
       portlessAliases.push({ name: `${svc}.emulate`, port });
     }
 
-    const seedBaseUrl = typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
-      ? svcSeedConfig.baseUrl
-      : undefined;
+    const seedBaseUrl =
+      typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
+        ? svcSeedConfig.baseUrl
+        : undefined;
     const effectiveBaseUrl = options.portless ? portlessBaseUrl(svc) : options.baseUrl;
     const baseUrl = resolveBaseUrl({ service: svc, port, baseUrl: effectiveBaseUrl, seedBaseUrl });
 

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -5,6 +5,7 @@ import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import { parse as parseYaml } from "yaml";
 import pc from "picocolors";
+import { ensurePortless, registerAliases, removeAliases, portlessBaseUrl, type PortlessAlias } from "../portless.js";
 
 declare const PKG_VERSION: string;
 const pkg = { version: PKG_VERSION };
@@ -13,6 +14,8 @@ export interface StartOptions {
   port: number;
   service?: string;
   seed?: string;
+  baseUrl?: string;
+  portless?: boolean;
 }
 
 interface SeedConfig {
@@ -73,8 +76,35 @@ function inferServicesFromConfig(config: SeedConfig): ServiceName[] | null {
   return found.length > 0 ? [...found] : null;
 }
 
+function resolveBaseUrl(
+  service: string,
+  port: number,
+  svcSeedConfig: Record<string, unknown> | undefined,
+  cliBaseUrl: string | undefined,
+): string {
+  if (svcSeedConfig?.baseUrl && typeof svcSeedConfig.baseUrl === "string") {
+    return svcSeedConfig.baseUrl;
+  }
+  if (cliBaseUrl) {
+    return cliBaseUrl.replace(/\{service\}/g, service);
+  }
+  const envBaseUrl = process.env.EMULATE_BASE_URL;
+  if (envBaseUrl) {
+    return envBaseUrl.replace(/\{service\}/g, service);
+  }
+  if (process.env.PORTLESS_URL) {
+    return process.env.PORTLESS_URL;
+  }
+  return `http://localhost:${port}`;
+}
+
 export async function startCommand(options: StartOptions): Promise<void> {
   const { port: basePort } = options;
+
+  if (options.portless && options.baseUrl) {
+    console.error("--portless and --base-url are mutually exclusive.");
+    process.exit(1);
+  }
 
   const loaded = loadSeedConfig(options.seed);
   const seedConfig = loaded?.config ?? null;
@@ -106,9 +136,14 @@ export async function startCommand(options: StartOptions): Promise<void> {
     tokens["test_token_admin"] = { login: "admin", id: 2, scopes: ["repo", "user", "admin:org", "admin:repo_hook"] };
   }
 
+  if (options.portless) {
+    await ensurePortless();
+  }
+
   const serviceUrls: Array<{ name: string; url: string }> = [];
   const stores: Store[] = [];
   const httpServers: ReturnType<typeof serve>[] = [];
+  const portlessAliases: PortlessAlias[] = [];
 
   for (let i = 0; i < services.length; i++) {
     const svc = services[i];
@@ -117,7 +152,15 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
     const svcSeedConfig = seedConfig?.[svc] as Record<string, unknown> | undefined;
     const port = (svcSeedConfig?.port as number | undefined) ?? basePort + i;
-    const baseUrl = `http://localhost:${port}`;
+
+    let baseUrl: string;
+    if (options.portless) {
+      const aliasName = `${svc}.emulate`;
+      portlessAliases.push({ name: aliasName, port });
+      baseUrl = portlessBaseUrl(svc);
+    } else {
+      baseUrl = resolveBaseUrl(svc, port, svcSeedConfig, options.baseUrl);
+    }
     serviceUrls.push({ name: svc, url: baseUrl });
 
     // eslint-disable-next-line prefer-const -- reassigned after closure captures it
@@ -142,10 +185,17 @@ export async function startCommand(options: StartOptions): Promise<void> {
     httpServers.push(httpServer);
   }
 
+  if (portlessAliases.length > 0) {
+    registerAliases(portlessAliases);
+  }
+
   printBanner(serviceUrls, tokens, configSource);
 
   const shutdown = () => {
     console.log(`\n${pc.dim("Shutting down...")}`);
+    if (portlessAliases.length > 0) {
+      removeAliases(portlessAliases);
+    }
     for (const store of stores) {
       store.reset();
     }

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -6,6 +6,7 @@ import { resolve } from "path";
 import { parse as parseYaml } from "yaml";
 import pc from "picocolors";
 import { ensurePortless, registerAliases, removeAliases, portlessBaseUrl, type PortlessAlias } from "../portless.js";
+import { resolveBaseUrl } from "../base-url.js";
 
 declare const PKG_VERSION: string;
 const pkg = { version: PKG_VERSION };
@@ -76,28 +77,6 @@ function inferServicesFromConfig(config: SeedConfig): ServiceName[] | null {
   return found.length > 0 ? [...found] : null;
 }
 
-function resolveBaseUrl(
-  service: string,
-  port: number,
-  svcSeedConfig: Record<string, unknown> | undefined,
-  cliBaseUrl: string | undefined,
-): string {
-  if (typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0) {
-    return svcSeedConfig.baseUrl;
-  }
-  if (cliBaseUrl) {
-    return cliBaseUrl.replace(/\{service\}/g, service);
-  }
-  const envBaseUrl = process.env.EMULATE_BASE_URL;
-  if (envBaseUrl) {
-    return envBaseUrl.replace(/\{service\}/g, service);
-  }
-  if (process.env.PORTLESS_URL) {
-    return process.env.PORTLESS_URL.replace(/\{service\}/g, service);
-  }
-  return `http://localhost:${port}`;
-}
-
 export async function startCommand(options: StartOptions): Promise<void> {
   const { port: basePort } = options;
 
@@ -159,7 +138,10 @@ export async function startCommand(options: StartOptions): Promise<void> {
       portlessAliases.push({ name: aliasName, port });
       baseUrl = portlessBaseUrl(svc);
     } else {
-      baseUrl = resolveBaseUrl(svc, port, svcSeedConfig, options.baseUrl);
+      const seedBaseUrl = typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
+        ? svcSeedConfig.baseUrl
+        : undefined;
+      baseUrl = resolveBaseUrl({ service: svc, port, baseUrl: options.baseUrl, seedBaseUrl });
     }
     serviceUrls.push({ name: svc, url: baseUrl });
 
@@ -199,14 +181,11 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   printBanner(serviceUrls, tokens, configSource);
 
-  if (portlessAliases.length > 0) {
-    process.on("exit", () => {
-      removeAliases(portlessAliases);
-    });
-  }
-
   const shutdown = () => {
     console.log(`\n${pc.dim("Shutting down...")}`);
+    if (portlessAliases.length > 0) {
+      removeAliases(portlessAliases);
+    }
     for (const store of stores) {
       store.reset();
     }

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -21,6 +21,8 @@ program
   .option("-p, --port <port>", "Base port", defaultPort)
   .option("-s, --service <services>", "Comma-separated services to enable")
   .option("--seed <file>", "Path to seed config file")
+  .option("--base-url <url>", "Override advertised base URL (supports {service} template)")
+  .option("--portless", "Serve over HTTPS via portless (auto-registers aliases)")
   .action(async (opts) => {
     const port = parseInt(opts.port, 10);
     if (Number.isNaN(port) || port < 1 || port > 65535) {
@@ -31,6 +33,8 @@ program
       port,
       service: opts.service,
       seed: opts.seed,
+      baseUrl: opts.baseUrl,
+      portless: opts.portless,
     });
   });
 

--- a/packages/emulate/src/portless.ts
+++ b/packages/emulate/src/portless.ts
@@ -60,12 +60,10 @@ export function registerAliases(aliases: PortlessAlias[]): void {
       stdio: "inherit",
     });
     if (result.status !== 0) {
-      console.error(`Failed to register portless alias: ${name} -> ${port}`);
       if (registered.length > 0) {
-        console.error("Cleaning up previously registered aliases...");
         removeAliases(registered);
       }
-      process.exit(1);
+      throw new Error(`Failed to register portless alias: ${name} -> ${port}`);
     }
     registered.push({ name, port });
   }

--- a/packages/emulate/src/portless.ts
+++ b/packages/emulate/src/portless.ts
@@ -22,7 +22,7 @@ function promptYesNo(question: string): Promise<boolean> {
 }
 
 function isProxyRunning(): boolean {
-  const result = spawnSync("portless", ["proxy", "status"], { stdio: "ignore" });
+  const result = spawnSync("portless", ["list"], { stdio: "ignore" });
   return result.status === 0;
 }
 

--- a/packages/emulate/src/portless.ts
+++ b/packages/emulate/src/portless.ts
@@ -1,0 +1,76 @@
+import { execSync, spawnSync } from "child_process";
+import { createInterface } from "readline";
+
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY) && !process.env.CI;
+}
+
+function hasPortless(): boolean {
+  const result = spawnSync("portless", ["--version"], { stdio: "ignore" });
+  return result.status === 0;
+}
+
+function promptYesNo(question: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      const normalized = answer.trim().toLowerCase();
+      resolve(normalized === "" || normalized === "y" || normalized === "yes");
+    });
+  });
+}
+
+export async function ensurePortless(): Promise<void> {
+  if (hasPortless()) return;
+
+  if (!isInteractive()) {
+    console.error("portless is required but not installed. Run: npm i -g portless");
+    process.exit(1);
+  }
+
+  const yes = await promptYesNo("portless is not installed. Install it now? (npm i -g portless) [Y/n] ");
+  if (!yes) {
+    console.error("Cannot continue without portless.");
+    process.exit(1);
+  }
+
+  try {
+    execSync("npm i -g portless", { stdio: "inherit" });
+  } catch {
+    console.error("Failed to install portless.");
+    process.exit(1);
+  }
+
+  if (!hasPortless()) {
+    console.error("portless was installed but could not be found on PATH.");
+    process.exit(1);
+  }
+}
+
+export interface PortlessAlias {
+  name: string;
+  port: number;
+}
+
+export function registerAliases(aliases: PortlessAlias[]): void {
+  for (const { name, port } of aliases) {
+    const result = spawnSync("portless", ["alias", name, String(port), "--force"], {
+      stdio: "inherit",
+    });
+    if (result.status !== 0) {
+      console.error(`Failed to register portless alias: ${name} -> ${port}`);
+      process.exit(1);
+    }
+  }
+}
+
+export function removeAliases(aliases: PortlessAlias[]): void {
+  for (const { name } of aliases) {
+    spawnSync("portless", ["alias", "--remove", name], { stdio: "ignore" });
+  }
+}
+
+export function portlessBaseUrl(serviceName: string): string {
+  return `https://${serviceName}.emulate.localhost`;
+}

--- a/packages/emulate/src/portless.ts
+++ b/packages/emulate/src/portless.ts
@@ -21,29 +21,39 @@ function promptYesNo(question: string): Promise<boolean> {
   });
 }
 
+function isProxyRunning(): boolean {
+  const result = spawnSync("portless", ["proxy", "status"], { stdio: "ignore" });
+  return result.status === 0;
+}
+
 export async function ensurePortless(): Promise<void> {
-  if (hasPortless()) return;
-
-  if (!isInteractive()) {
-    console.error("portless is required but not installed. Run: npm i -g portless");
-    process.exit(1);
-  }
-
-  const yes = await promptYesNo("portless is not installed. Install it now? (npm i -g portless) [Y/n] ");
-  if (!yes) {
-    console.error("Cannot continue without portless.");
-    process.exit(1);
-  }
-
-  try {
-    execSync("npm i -g portless", { stdio: "inherit" });
-  } catch {
-    console.error("Failed to install portless.");
-    process.exit(1);
-  }
-
   if (!hasPortless()) {
-    console.error("portless was installed but could not be found on PATH.");
+    if (!isInteractive()) {
+      console.error("portless is required but not installed. Run: npm i -g portless");
+      process.exit(1);
+    }
+
+    const yes = await promptYesNo("portless is not installed. Install it now? (npm i -g portless) [Y/n] ");
+    if (!yes) {
+      console.error("Cannot continue without portless.");
+      process.exit(1);
+    }
+
+    try {
+      execSync("npm i -g portless", { stdio: "inherit" });
+    } catch {
+      console.error("Failed to install portless.");
+      process.exit(1);
+    }
+
+    if (!hasPortless()) {
+      console.error("portless was installed but could not be found on PATH.");
+      process.exit(1);
+    }
+  }
+
+  if (!isProxyRunning()) {
+    console.error("portless proxy is not running. Start it with: portless proxy start");
     process.exit(1);
   }
 }

--- a/packages/emulate/src/portless.ts
+++ b/packages/emulate/src/portless.ts
@@ -81,7 +81,10 @@ export function registerAliases(aliases: PortlessAlias[]): void {
 
 export function removeAliases(aliases: PortlessAlias[]): void {
   for (const { name } of aliases) {
-    spawnSync("portless", ["alias", "--remove", name], { stdio: "ignore" });
+    const result = spawnSync("portless", ["alias", "--remove", name], { stdio: "ignore" });
+    if (result.status !== 0) {
+      console.error(`Warning: failed to remove portless alias: ${name}`);
+    }
   }
 }
 

--- a/packages/emulate/src/portless.ts
+++ b/packages/emulate/src/portless.ts
@@ -54,14 +54,20 @@ export interface PortlessAlias {
 }
 
 export function registerAliases(aliases: PortlessAlias[]): void {
+  const registered: PortlessAlias[] = [];
   for (const { name, port } of aliases) {
     const result = spawnSync("portless", ["alias", name, String(port), "--force"], {
       stdio: "inherit",
     });
     if (result.status !== 0) {
       console.error(`Failed to register portless alias: ${name} -> ${port}`);
+      if (registered.length > 0) {
+        console.error("Cleaning up previously registered aliases...");
+        removeAliases(registered);
+      }
       process.exit(1);
     }
+    registered.push({ name, port });
   }
 }
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -93,7 +93,7 @@ await vercel.close()
 | `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
-| `baseUrl` | none | Override advertised base URL. Falls back to `PORTLESS_URL` env var, then `http://localhost:<port>`. |
+| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL`, then `http://localhost:<port>`. |
 
 ### Instance Methods
 
@@ -268,6 +268,8 @@ emulate start --portless
 ```
 
 This requires the portless proxy to be running (`portless proxy start`). If portless is not installed, emulate will prompt to install it.
+
+The `--portless` flag overwrites any existing portless aliases matching `*.emulate`. Aliases are removed automatically when emulate shuts down.
 
 For a single service behind portless:
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -93,7 +93,7 @@ await vercel.close()
 | `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
-| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL`, then `http://localhost:<port>`. |
+| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
 
 ### Instance Methods
 
@@ -284,6 +284,8 @@ emulate start --base-url "https://{service}.myproxy.test"
 # or
 EMULATE_BASE_URL="https://{service}.myproxy.test" emulate start
 ```
+
+The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`). When no explicit `baseUrl` is provided, it is used as a fallback.
 
 Per-service overrides in the seed config:
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -93,7 +93,7 @@ await vercel.close()
 | `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
-| `baseUrl` | none | Override advertised base URL. Falls back to `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
+| `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
 
 ### Instance Methods
 
@@ -285,9 +285,9 @@ emulate start --base-url "https://{service}.myproxy.test"
 EMULATE_BASE_URL="https://{service}.myproxy.test" emulate start
 ```
 
-The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`). When no explicit `baseUrl` is provided, it is used as a fallback.
+The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`), typically to a value like `https://{service}.emulate.localhost`. It supports `{service}` interpolation, just like `--base-url` and `EMULATE_BASE_URL`. When no explicit `baseUrl` is provided, it is used as a fallback.
 
-Per-service overrides in the seed config:
+Per-service overrides in the seed config (these take highest priority over all other base URL sources):
 
 ```yaml
 github:

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -58,8 +58,12 @@ emulate list
 | `-p, --port` | `4000` | Base port (auto-increments per service) |
 | `-s, --service` | all | Comma-separated services to enable |
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
+| `--base-url` | none | Override advertised base URL (supports `{service}` template) |
+| `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+
+The advertised base URL (used in OAuth redirects, webhook URLs, etc.) can be overridden via `--base-url`, the `EMULATE_BASE_URL` env var (supports `{service}` template), or per-service `baseUrl` in the seed config. When running under portless, the `PORTLESS_URL` env var is also detected automatically.
 
 ## Programmatic API
 
@@ -89,6 +93,7 @@ await vercel.close()
 | `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
+| `baseUrl` | none | Override advertised base URL. Falls back to `PORTLESS_URL` env var, then `http://localhost:<port>`. |
 
 ### Instance Methods
 
@@ -250,6 +255,42 @@ aws:
 Tokens map to users. Pass them as `Authorization: Bearer <token>` or `Authorization: token <token>`. When no tokens are configured, a default `test_token_admin` is created for the `admin` user.
 
 Each service also has a fallback user. If no token is provided, requests authenticate as the first seeded user.
+
+## HTTPS with portless
+
+[portless](https://github.com/vercel-labs/portless) gives emulators trusted HTTPS URLs with auto-generated certs. Use the `--portless` flag to auto-register each service as a portless alias:
+
+```bash
+emulate start --portless
+# github  https://github.emulate.localhost
+# google  https://google.emulate.localhost
+# ...
+```
+
+This requires the portless proxy to be running (`portless proxy start`). If portless is not installed, emulate will prompt to install it.
+
+For a single service behind portless:
+
+```bash
+portless github.emulate emulate start --service github
+```
+
+For a custom base URL without portless (any reverse proxy):
+
+```bash
+emulate start --base-url "https://{service}.myproxy.test"
+# or
+EMULATE_BASE_URL="https://{service}.myproxy.test" emulate start
+```
+
+Per-service overrides in the seed config:
+
+```yaml
+github:
+  baseUrl: https://github.emulate.localhost
+google:
+  baseUrl: https://google.emulate.localhost
+```
 
 ## Pointing Your App at the Emulator
 


### PR DESCRIPTION
## Summary

- Add `--portless` flag that auto-registers each emulator service as a portless alias, giving every service a trusted HTTPS URL (e.g. `https://github.emulate.localhost`). If portless is not installed, prompts the user to install it; in CI/non-interactive environments, exits with a clear error.
- Add generic `--base-url` flag and `EMULATE_BASE_URL` env var with `{service}` template support for use with any reverse proxy. Per-service `baseUrl` in seed config is also supported.
- Add `baseUrl` option to the programmatic `createEmulator()` API, with `PORTLESS_URL` env var as automatic fallback.
- Fixes the core issue where emulate hardcodes `http://localhost:<port>` as the advertised URL, causing OAuth redirects, webhook URLs, OIDC discovery, and other generated URLs to use the wrong origin when behind a proxy.

### Base URL resolution order

1. Per-service `baseUrl` in seed config
2. `--base-url` CLI flag
3. `EMULATE_BASE_URL` env var (with `{service}` interpolation)
4. `PORTLESS_URL` env var (auto-detected from portless)
5. `http://localhost:<port>` (default, unchanged)