### PR TITLE
docs(google): document hd claim in seed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ google:
   users:
     - email: testuser@example.com
       name: Test User
+    - email: admin@acme.com
+      name: Admin
+      hd: acme.com
   oauth_clients:
     - client_id: my-client-id.apps.googleusercontent.com
       client_secret: GOCSPX-secret

--- a/apps/web/app/configuration/page.mdx
+++ b/apps/web/app/configuration/page.mdx
@@ -144,6 +144,9 @@ google:
   users:
     - email: testuser@example.com
       name: Test User
+    - email: admin@acme.com
+      name: Admin
+      hd: acme.com
   oauth_clients:
     - client_id: my-client-id.apps.googleusercontent.com
       client_secret: GOCSPX-secret
@@ -180,6 +183,12 @@ google:
       mime_type: application/vnd.google-apps.folder
       parent_ids: [root]
 ```
+
+### Hosted domain (hd) claim
+
+Google Workspace accounts include an `hd` claim in ID tokens and userinfo responses identifying the user's hosted domain. The emulator derives this automatically from the user's email domain. Consumer domains (`gmail.com`, `googlemail.com`) omit the claim, matching real Google behavior.
+
+To override the derived value, set `hd` on a seeded user. To suppress the claim entirely, set `hd` to an empty string.
 
 ## Slack Seed Config
 

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -116,6 +116,9 @@ google:
       locale: en
     - email: dev@example.com
       name: Developer
+    - email: admin@acme.com
+      name: Admin
+      hd: acme.com
   oauth_clients:
     - client_id: my-client-id.apps.googleusercontent.com
       client_secret: GOCSPX-secret
@@ -175,6 +178,12 @@ google:
 ```
 
 When no OAuth clients are configured, the emulator accepts any `client_id`. With clients configured, strict validation is enforced for `client_id`, `client_secret`, and `redirect_uri`.
+
+### Hosted domain (hd) claim
+
+Google Workspace accounts include an `hd` claim in ID tokens and userinfo responses identifying the user's hosted domain. The emulator derives this automatically from the user's email domain. Consumer domains (`gmail.com`, `googlemail.com`) omit the claim, matching real Google behavior.
+
+To override the derived value, set `hd` on a seeded user. To suppress the claim entirely, set `hd` to an empty string.
 
 ## OAuth / OIDC Endpoints
 


### PR DESCRIPTION
## Summary

Follow-up to #73. Documents the new `hd` (hosted domain) field on Google seed users across all doc surfaces:

- **README.md**: Added a Workspace user with `hd` to the Google seed config example
- **apps/web/app/configuration/page.mdx**: Same seed example update, plus a new "Hosted domain (hd) claim" section explaining auto-derivation, consumer domain omission, and override/suppression
- **skills/google/SKILL.md**: Same seed example update and explanation section

No code changes.