### PR TITLE
fix(resend): make links clickable in email inbox preview

### DIFF
--- a/packages/@emulators/resend/src/routes/inbox.ts
+++ b/packages/@emulators/resend/src/routes/inbox.ts
@@ -81,10 +81,12 @@ export function inboxRoutes(ctx: RouteContext): void {
       recipientLines.push(`<strong>Bcc:</strong> ${escapeHtml(email.bcc.join(", "))}`);
     }
 
-    const previewContent = email.html
+    const srcdocHtml = email.html ? escapeAttr(`<base target="_blank">${email.html}`) : null;
+
+    const previewContent = srcdocHtml
       ? `<iframe
-  sandbox=""
-  srcdoc="${escapeAttr(email.html)}"
+  sandbox="allow-popups allow-popups-to-escape-sandbox"
+  srcdoc="${srcdocHtml}"
   class="s-card"
   style="width:100%;min-height:300px;border:1px solid #0a3300;border-radius:8px;background:#fff;"
 ></iframe>`


### PR DESCRIPTION
Fixes #68.

## Summary

- The email preview iframe used `sandbox=""` (most restrictive), which blocked all popups and top-level navigation, making buttons and links in HTML emails unclickable.
- Changed the sandbox to `allow-popups allow-popups-to-escape-sandbox` so links open in new browser tabs while still blocking scripts, forms, and same-origin access.
- Injected `<base target="_blank">` into the srcdoc HTML so links without an explicit `target` attribute also open in new tabs instead of navigating inside the iframe.