### PR TITLE
fix(stripe-checkout): resolve lint errors breaking CI

### DIFF
--- a/examples/stripe-checkout/src/app/cart/page.tsx
+++ b/examples/stripe-checkout/src/app/cart/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { Minus, Plus } from "lucide-react";
 import { useCart } from "@/lib/use-cart";
 import { productImages, formatCurrency } from "@/lib/products";
@@ -14,12 +15,12 @@ export default function CartPage() {
       <div className="mx-auto max-w-[1200px] px-6 py-32 text-center">
         <h1 className="font-pixel text-2xl">Your Bag</h1>
         <p className="mt-4 text-sm text-muted-foreground">Your bag is empty</p>
-        <a
+        <Link
           href="/"
           className="mt-8 inline-flex h-10 items-center border border-foreground px-8 text-[10px] tracking-[0.2em] uppercase font-medium transition-colors hover:bg-foreground hover:text-background"
         >
           Continue Shopping
-        </a>
+        </Link>
       </div>
     );
   }
@@ -109,12 +110,12 @@ export default function CartPage() {
       </form>
 
       <div className="mt-4 text-center">
-        <a
+        <Link
           href="/"
           className="text-[10px] tracking-[0.15em] uppercase text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
         >
           Continue Shopping
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/examples/stripe-checkout/src/app/layout.tsx
+++ b/examples/stripe-checkout/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { GeistMono } from "geist/font/mono";
 import { GeistPixelSquare } from "geist/font/pixel";
 import { getCart } from "@/lib/cart";
@@ -24,9 +25,9 @@ export default async function RootLayout({
         <CartProvider initialItems={initialItems}>
           <header className="sticky top-0 z-50 border-b border-border/50 bg-background/90 backdrop-blur-xl">
             <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-6">
-              <a href="/" className="font-pixel text-xl tracking-wide">
+              <Link href="/" className="font-pixel text-xl tracking-wide">
                 emu store
-              </a>
+              </Link>
               <CartButton />
             </div>
           </header>

--- a/examples/stripe-checkout/src/app/success/page.tsx
+++ b/examples/stripe-checkout/src/app/success/page.tsx
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { stripe } from "@/lib/stripe";
 import { getOrder } from "@/lib/orders";
@@ -59,12 +60,12 @@ export default async function SuccessPage({ searchParams }: { searchParams: Prom
       )}
 
       <div className="mt-10 text-center">
-        <a
+        <Link
           href="/"
           className="inline-flex h-10 items-center border border-foreground px-8 text-[10px] tracking-[0.2em] uppercase font-medium transition-colors hover:bg-foreground hover:text-background"
         >
           Continue Shopping
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/examples/stripe-checkout/src/app/v1/[...path]/route.ts
+++ b/examples/stripe-checkout/src/app/v1/[...path]/route.ts
@@ -9,9 +9,8 @@ async function handler(req: Request, ctx: { params: Promise<{ path: string[] }> 
     method: req.method,
     headers: req.headers,
     body: req.body,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     duplex: "half",
-  } as any);
+  } as RequestInit & { duplex: string });
 
   return new Response(res.body, {
     status: res.status,


### PR DESCRIPTION
## Summary

- Replace `<a>` tags with `<Link>` from `next/link` for internal navigation in `cart/page.tsx`, `layout.tsx`, and `success/page.tsx`
- Remove `as any` cast in the Stripe proxy route, replacing it with a proper type assertion (`RequestInit & { duplex: string }`)
- Fixes the CI lint failure on main introduced by #82