### PR TITLE
prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,41 @@
 # Changelog
 
-## 0.4.1
+## 0.5.0
 
 <!-- release:start -->
+### New Features
+
+- **Clerk emulator** — local emulation of Clerk authentication and session management (#38)
+- **Portless integration** — embed emulators directly in your app without dedicated ports, with base URL override support (#78)
+- **Google `hd` claim** — hosted domain claim in ID tokens and userinfo for Google OAuth (#73)
+- **Stripe Checkout example** — full working example of Stripe Checkout with the Stripe emulator (#82)
+- **Resend magic link example** — working example of Resend magic link authentication flow (#51)
+- **Docs landing page** — new landing page for the docs site (#81)
+
+### Improvements
+
+- **Unified UI design system** — all emulator UIs now share a consistent design system with CI quality checks (#50)
+- **Stripe** — added customer sessions and payment methods API (#47)
+
+### Bug Fixes
+
+- Fixed **AWS S3** emulator compatibility with the official AWS SDK wire format (#65, #69)
+- Fixed **Resend** email inbox links not being clickable in preview (#80)
+
+### Contributors
+
+- @ctate
+- @disintegrator
+- @jlucaso1
+- @Railly
+- @tmm
+<!-- release:end -->
+
+## 0.4.1
+
 ### Bug Fixes
 
 - Include README in all `@emulators/*` npm packages
-<!-- release:end -->
 
 ## 0.4.0
 

--- a/examples/stripe-checkout/src/app/cart/page.tsx
+++ b/examples/stripe-checkout/src/app/cart/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { Minus, Plus } from "lucide-react";
 import { useCart } from "@/lib/use-cart";
 import { productImages, formatCurrency } from "@/lib/products";
@@ -14,12 +15,12 @@ export default function CartPage() {
       <div className="mx-auto max-w-[1200px] px-6 py-32 text-center">
         <h1 className="font-pixel text-2xl">Your Bag</h1>
         <p className="mt-4 text-sm text-muted-foreground">Your bag is empty</p>
-        <a
+        <Link
           href="/"
           className="mt-8 inline-flex h-10 items-center border border-foreground px-8 text-[10px] tracking-[0.2em] uppercase font-medium transition-colors hover:bg-foreground hover:text-background"
         >
           Continue Shopping
-        </a>
+        </Link>
       </div>
     );
   }
@@ -109,12 +110,12 @@ export default function CartPage() {
       </form>
 
       <div className="mt-4 text-center">
-        <a
+        <Link
           href="/"
           className="text-[10px] tracking-[0.15em] uppercase text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
         >
           Continue Shopping
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/examples/stripe-checkout/src/app/layout.tsx
+++ b/examples/stripe-checkout/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { GeistMono } from "geist/font/mono";
 import { GeistPixelSquare } from "geist/font/pixel";
 import { getCart } from "@/lib/cart";
@@ -24,9 +25,9 @@ export default async function RootLayout({
         <CartProvider initialItems={initialItems}>
           <header className="sticky top-0 z-50 border-b border-border/50 bg-background/90 backdrop-blur-xl">
             <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-6">
-              <a href="/" className="font-pixel text-xl tracking-wide">
+              <Link href="/" className="font-pixel text-xl tracking-wide">
                 emu store
-              </a>
+              </Link>
               <CartButton />
             </div>
           </header>

--- a/examples/stripe-checkout/src/app/success/page.tsx
+++ b/examples/stripe-checkout/src/app/success/page.tsx
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { stripe } from "@/lib/stripe";
 import { getOrder } from "@/lib/orders";
@@ -59,12 +60,12 @@ export default async function SuccessPage({ searchParams }: { searchParams: Prom
       )}
 
       <div className="mt-10 text-center">
-        <a
+        <Link
           href="/"
           className="inline-flex h-10 items-center border border-foreground px-8 text-[10px] tracking-[0.2em] uppercase font-medium transition-colors hover:bg-foreground hover:text-background"
         >
           Continue Shopping
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/examples/stripe-checkout/src/app/v1/[...path]/route.ts
+++ b/examples/stripe-checkout/src/app/v1/[...path]/route.ts
@@ -9,9 +9,8 @@ async function handler(req: Request, ctx: { params: Promise<{ path: string[] }> 
     method: req.method,
     headers: req.headers,
     body: req.body,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     duplex: "half",
-  } as any);
+  } as RequestInit & { duplex: string });
 
   return new Response(res.body, {
     status: res.status,

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-next",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/apple/package.json
+++ b/packages/@emulators/apple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/apple",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/aws",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/clerk/package.json
+++ b/packages/@emulators/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/clerk",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/core/package.json
+++ b/packages/@emulators/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/github/package.json
+++ b/packages/@emulators/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/github",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/google/package.json
+++ b/packages/@emulators/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/google",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/microsoft/package.json
+++ b/packages/@emulators/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/microsoft",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/mongoatlas/package.json
+++ b/packages/@emulators/mongoatlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/mongoatlas",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/okta/package.json
+++ b/packages/@emulators/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/okta",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/resend/package.json
+++ b/packages/@emulators/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/resend",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/slack/package.json
+++ b/packages/@emulators/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/slack",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/stripe/package.json
+++ b/packages/@emulators/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/stripe",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/vercel/package.json
+++ b/packages/@emulators/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/vercel",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulate",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Local drop-in replacement services for CI and no-network sandboxes",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `emulate` and all 14 `@emulators/*` packages to 0.5.0
- Add changelog entry covering all changes since v0.4.1

When merged, CI will detect the version change and automatically publish to npm with provenance.

## Changelog

### New Features

- **Clerk emulator** — local emulation of Clerk authentication and session management (#38)
- **Portless integration** — embed emulators directly in your app without dedicated ports, with base URL override support (#78)
- **Google `hd` claim** — hosted domain claim in ID tokens and userinfo for Google OAuth (#73)
- **Stripe Checkout example** — full working example of Stripe Checkout with the Stripe emulator (#82)
- **Resend magic link example** — working example of Resend magic link authentication flow (#51)
- **Docs landing page** — new landing page for the docs site (#81)

### Improvements

- **Unified UI design system** — all emulator UIs now share a consistent design system with CI quality checks (#50)
- **Stripe** — added customer sessions and payment methods API (#47)

### Bug Fixes

- Fixed **AWS S3** emulator compatibility with the official AWS SDK wire format (#65, #69)
- Fixed **Resend** email inbox links not being clickable in preview (#80)