### PR TITLE
fix(release): use Node 24 for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Upgrade from Node 22 to Node 24 (ships with npm 11.5.1+ which supports OIDC trusted publishing)
- Remove `registry-url` from `setup-node` (it injects a `NODE_AUTH_TOKEN` that overrides the OIDC flow)

Root cause: npm 10.x (Node 22) does not support trusted publishing, and the `registry-url` config causes `setup-node` to inject auth that conflicts with OIDC. Both issues produce a misleading 404 error. See [npm/cli#9088](https://github.com/npm/cli/issues/9088).