### PR TITLE
feat: add linear service emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'aws'`, or `'linear'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -689,6 +689,19 @@ All operations via `POST /iam/` with `Action` parameter:
 ### STS
 All operations via `POST /sts/` with `Action` parameter:
 - `GetCallerIdentity`, `AssumeRole`
+
+## Linear API
+
+Linear is GraphQL-only. The emulator implements the `POST /graphql` endpoint with introspection, read-only Query resolvers, Relay-style pagination, and PAT authentication via `Authorization: <api_key>`. Mutations, webhooks, OAuth 2.0, and an inspector UI are follow-up PRs.
+
+```bash
+curl http://localhost:4012/graphql \
+  -H "Authorization: lin_api_test" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ issues(first: 10) { nodes { id identifier title state { name } team { key } } pageInfo { hasNextPage endCursor } } }"}'
+```
+
+Schema covers `Issue`, `Project`, `Team`, `User`, `Organization`, `Label`, and `WorkflowState`. Each list field accepts the standard Relay arguments (`first`, `after`, `last`, `before`) and returns connections with `edges`, `nodes`, and `pageInfo`. Errors follow Linear's envelope shape with `extensions.code`.
 
 ## Next.js Integration
 

--- a/apps/web/app/docs/architecture/page.mdx
+++ b/apps/web/app/docs/architecture/page.mdx
@@ -17,6 +17,7 @@ packages/
     mongoatlas/     # MongoDB Atlas Admin API + Data API
     resend/         # Resend email API
     stripe/         # Stripe billing and payments API
+    linear/         # Linear GraphQL API
 apps/
   web/              # Documentation site (Next.js)
 ```

--- a/apps/web/app/docs/linear/layout.tsx
+++ b/apps/web/app/docs/linear/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("linear");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/linear/page.mdx
+++ b/apps/web/app/docs/linear/page.mdx
@@ -1,0 +1,140 @@
+# Linear API
+
+The Linear emulator provides a Phase 1 GraphQL API for local development and CI. It exposes `POST /graphql` with schema introspection, PAT authentication, read only query resolvers, and Relay style connections.
+
+Phase 1 includes `Issue`, `Project`, `Team`, `User`, `Organization`, `Label`, and `WorkflowState`. Mutations, webhooks, OAuth 2.0, and an inspector UI are planned follow up PRs.
+
+## Start
+
+```bash
+npx emulate --service linear
+```
+
+Default URL:
+
+```text
+http://localhost:4012
+```
+
+## Auth
+
+Linear personal access tokens are passed as the raw `Authorization` header value:
+
+```bash
+curl http://localhost:4012/graphql \
+  -H "Authorization: lin_api_test" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ viewer { id name email } }"}'
+```
+
+`Authorization: Bearer lin_api_test` is also accepted for client compatibility.
+
+## GraphQL
+
+The endpoint accepts the standard GraphQL HTTP request shape:
+
+```json
+{
+  "query": "query Issues($first: Int) { issues(first: $first) { nodes { id title } } }",
+  "variables": { "first": 10 },
+  "operationName": "Issues"
+}
+```
+
+Introspection works with the same endpoint, so GraphQL clients can fetch the schema.
+
+## Queries
+
+```graphql
+query {
+  issues(first: 10) {
+    nodes {
+      id
+      identifier
+      title
+      team {
+        key
+        name
+      }
+      state {
+        name
+        type
+      }
+      assignee {
+        name
+        email
+      }
+      labels(first: 5) {
+        nodes {
+          name
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+```
+
+Available root queries:
+
+- `viewer`
+- `organization(id)`
+- `organizations(first, after, last, before)`
+- `user(id)`
+- `users(first, after, last, before)`
+- `team(id)`
+- `teams(first, after, last, before)`
+- `workflowState(id)`
+- `workflowStates(first, after, last, before)`
+- `label(id)`
+- `labels(first, after, last, before)`
+- `project(id)`
+- `projects(first, after, last, before)`
+- `issue(id, identifier)`
+- `issues(first, after, last, before)`
+
+All list queries return Relay style `edges`, `nodes`, and `pageInfo`.
+
+## Seed Config
+
+```yaml
+linear:
+  api_keys: [lin_api_test]
+  organizations:
+    - id: org-1
+      name: My Org
+  teams:
+    - id: team-1
+      name: Engineering
+      key: ENG
+      organization: org-1
+  workflow_states:
+    - id: ws-1
+      name: Todo
+      type: unstarted
+      team: team-1
+  users:
+    - id: user-1
+      name: Developer
+      email: dev@example.com
+      organization: org-1
+  labels:
+    - id: label-1
+      name: Bug
+      team: team-1
+  projects:
+    - id: project-1
+      name: Launch
+      team: team-1
+      lead: user-1
+  issues:
+    - id: issue-1
+      title: First issue
+      team: team-1
+      state: ws-1
+      assignee: user-1
+      labels: [label-1]
+```

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -1,6 +1,6 @@
 # Getting Started
 
-Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, MongoDB Atlas, Resend, and Stripe APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
+Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, MongoDB Atlas, Resend, Stripe, and Linear APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
 
 ## Quick Start
 
@@ -21,6 +21,7 @@ All services start with sensible defaults. No config file needed:
 - **MongoDB Atlas** on `http://localhost:4008`
 - **Resend** on `http://localhost:4009`
 - **Stripe** on `http://localhost:4010`
+- **Linear** on `http://localhost:4012`
 
 ## CLI
 

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -59,7 +59,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>service</code></td>
       <td><em>(required)</em></td>
-      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'aws'</code>, <code>'okta'</code>, <code>'mongoatlas'</code>, <code>'resend'</code>, or <code>'stripe'</code></td>
+      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'aws'</code>, <code>'okta'</code>, <code>'mongoatlas'</code>, <code>'resend'</code>, <code>'stripe'</code>, or <code>'linear'</code></td>
     </tr>
     <tr>
       <td><code>port</code></td>
@@ -133,6 +133,7 @@ npm install @emulators/github @emulators/google @emulators/stripe
     <tr><td><code>@emulators/mongoatlas</code></td><td>MongoDB Atlas Admin API + Data API</td></tr>
     <tr><td><code>@emulators/resend</code></td><td>Resend email API</td></tr>
     <tr><td><code>@emulators/stripe</code></td><td>Stripe billing and payments API</td></tr>
+    <tr><td><code>@emulators/linear</code></td><td>Linear GraphQL API</td></tr>
     <tr><td><code>@emulators/core</code></td><td>Shared store, middleware, and utilities</td></tr>
     <tr><td><code>@emulators/adapter-next</code></td><td>Next.js App Router integration</td></tr>
   </tbody>

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -33,6 +33,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/linear", label: "Linear" },
     ],
   },
   {

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -31,6 +31,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/linear", label: "Linear" },
     ],
   },
   {

--- a/apps/web/components/hero-terminal.tsx
+++ b/apps/web/components/hero-terminal.tsx
@@ -14,6 +14,7 @@ const services = [
   { name: "MongoDB Atlas", port: 4008, slug: "mongoatlas" },
   { name: "Resend", port: 4009, slug: "resend" },
   { name: "Stripe", port: 4010, slug: "stripe" },
+  { name: "Linear", port: 4012, slug: "linear" },
 ];
 
 export function HeroTerminal({ pixelFont }: { pixelFont: string }) {

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -19,6 +19,7 @@ export const allDocsPages: NavItem[] = [
   { name: "MongoDB Atlas", href: "/docs/mongoatlas" },
   { name: "Resend", href: "/docs/resend" },
   { name: "Stripe", href: "/docs/stripe" },
+  { name: "Linear API", href: "/docs/linear" },
   { name: "Authentication", href: "/docs/authentication" },
   { name: "Architecture", href: "/docs/architecture" },
 ];

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -14,6 +14,7 @@ export const PAGE_TITLES: Record<string, string> = {
   mongoatlas: "MongoDB Atlas",
   resend: "Resend",
   stripe: "Stripe",
+  linear: "Linear API",
   authentication: "Authentication",
   architecture: "Architecture",
 };

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -17,6 +17,7 @@ const oldDocsSlugs = [
   "mongoatlas",
   "resend",
   "stripe",
+  "linear",
   "authentication",
   "architecture",
 ];

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -128,3 +128,44 @@ google:
       mime_type: application/vnd.google-apps.folder
       parent_ids:
         - root
+
+linear:
+  api_keys: [lin_api_test]
+  organizations:
+    - id: org-1
+      name: My Org
+  teams:
+    - id: team-1
+      name: Engineering
+      key: ENG
+      organization: org-1
+  workflow_states:
+    - id: ws-1
+      name: Todo
+      type: unstarted
+      team: team-1
+    - id: ws-2
+      name: In Progress
+      type: started
+      team: team-1
+  users:
+    - id: user-1
+      name: Developer
+      email: dev@example.com
+      organization: org-1
+  labels:
+    - id: label-1
+      name: Bug
+      team: team-1
+  projects:
+    - id: project-1
+      name: Launch
+      team: team-1
+      lead: user-1
+  issues:
+    - id: issue-1
+      title: First issue
+      team: team-1
+      state: ws-1
+      assignee: user-1
+      labels: [label-1]

--- a/packages/@emulators/linear/README.md
+++ b/packages/@emulators/linear/README.md
@@ -1,0 +1,63 @@
+# @emulators/linear
+
+Linear GraphQL API emulator for local development and CI.
+
+This package is Phase 1. It includes `POST /graphql`, schema introspection, PAT authentication, read only query resolvers, and Relay style pagination for issues, projects, teams, users, organizations, labels, and workflow states.
+
+Mutations, webhooks, OAuth 2.0, and an inspector UI are follow up PRs.
+
+## Install
+
+```bash
+npm install @emulators/linear
+```
+
+## Start
+
+```bash
+npx emulate --service linear
+```
+
+Default port: `4012`.
+
+## Auth
+
+Use the raw Linear PAT header:
+
+```bash
+curl http://localhost:4012/graphql \
+  -H "Authorization: lin_api_test" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ issues { nodes { id title } } }"}'
+```
+
+## Seed Config
+
+```yaml
+linear:
+  api_keys: [lin_api_test]
+  organizations:
+    - id: org-1
+      name: My Org
+  teams:
+    - id: team-1
+      name: Engineering
+      key: ENG
+      organization: org-1
+  workflow_states:
+    - id: ws-1
+      name: Todo
+      type: unstarted
+      team: team-1
+  users:
+    - id: user-1
+      name: Developer
+      email: dev@example.com
+      organization: org-1
+  issues:
+    - id: issue-1
+      title: First issue
+      team: team-1
+      state: ws-1
+      assignee: user-1
+```

--- a/packages/@emulators/linear/package.json
+++ b/packages/@emulators/linear/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@emulators/linear",
+  "version": "0.5.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/linear"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*",
+    "graphql": "^16.13.2",
+    "hono": "^4"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { Store, WebhookDispatcher, type TokenMap } from "@emulators/core";
+import { linearPlugin, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4012";
+
+function createTestApp() {
+  const app = new Hono();
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+
+  linearPlugin.register(app as any, store, webhooks, base, tokenMap);
+  linearPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    api_keys: ["lin_api_seeded"],
+    organizations: [{ id: "org-acme", name: "Acme", url_key: "acme" }],
+    users: [
+      { id: "user-alice", name: "Alice", email: "alice@example.com", organization: "org-acme", admin: true },
+      { id: "user-bob", name: "Bob", email: "bob@example.com", organization: "org-acme" },
+    ],
+    teams: [
+      { id: "team-eng", name: "Engineering", key: "ENG", organization: "org-acme" },
+      { id: "team-ops", name: "Operations", key: "OPS", organization: "org-acme" },
+    ],
+    workflow_states: [
+      { id: "state-todo", name: "Todo", type: "unstarted", team: "team-eng", position: 1 },
+      { id: "state-started", name: "Started", type: "started", team: "team-eng", position: 2 },
+      { id: "state-done", name: "Done", type: "completed", team: "team-eng", position: 3 },
+    ],
+    labels: [
+      { id: "label-bug", name: "Bug", team: "team-eng" },
+      { id: "label-feature", name: "Feature", team: "team-eng" },
+    ],
+    projects: [
+      { id: "project-api", name: "API", slug_id: "api", team: "team-eng", lead: "user-alice", state: "started" },
+    ],
+    issues: [
+      {
+        id: "issue-one",
+        title: "First seeded issue",
+        team: "team-eng",
+        state: "state-todo",
+        assignee: "user-alice",
+        creator: "user-bob",
+        project: "project-api",
+        labels: ["label-bug"],
+      },
+      {
+        id: "issue-two",
+        title: "Second seeded issue",
+        team: "team-eng",
+        state: "state-started",
+        assignee: "user-bob",
+        creator: "user-alice",
+        project: "project-api",
+        labels: ["label-feature"],
+      },
+      {
+        id: "issue-three",
+        title: "Third seeded issue",
+        team: "team-eng",
+        state: "state-done",
+        assignee: "user-alice",
+        creator: "user-alice",
+        project: "project-api",
+        labels: ["label-bug", "label-feature"],
+      },
+    ],
+  });
+
+  return { app, store, webhooks, tokenMap };
+}
+
+async function gql(app: Hono, query: string, variables?: Record<string, unknown>, token = "lin_api_seeded") {
+  return app.request(`${base}/graphql`, {
+    method: "POST",
+    headers: { Authorization: token, "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+}
+
+describe("Linear GraphQL emulator", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("accepts the standard GraphQL HTTP body shape", async () => {
+    const res = await gql(app, "query GetIssue($id: ID!) { issue(id: $id) { id title } }", { id: "issue-one" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.data.issue).toEqual({ id: "issue-one", title: "First seeded issue" });
+    expect(body.errors).toEqual([]);
+  });
+
+  it("supports schema introspection", async () => {
+    const res = await gql(app, "{ __schema { queryType { name } types { name } } }");
+    const body = (await res.json()) as any;
+    expect(body.data.__schema.queryType.name).toBe("Query");
+    expect(body.data.__schema.types.some((type: { name: string }) => type.name === "Issue")).toBe(true);
+  });
+
+  it("returns organizations", async () => {
+    const res = await gql(app, "{ organizations { nodes { id name urlKey } } }");
+    const body = (await res.json()) as any;
+    expect(body.data.organizations.nodes).toContainEqual({ id: "org-acme", name: "Acme", urlKey: "acme" });
+  });
+
+  it("returns one organization by id", async () => {
+    const res = await gql(app, '{ organization(id: "org-acme") { id name } }');
+    const body = (await res.json()) as any;
+    expect(body.data.organization).toEqual({ id: "org-acme", name: "Acme" });
+  });
+
+  it("returns users", async () => {
+    const res = await gql(app, "{ users { nodes { id name email admin active organization { id } } } }");
+    const body = (await res.json()) as any;
+    expect(body.data.users.nodes).toContainEqual({
+      id: "user-alice",
+      name: "Alice",
+      email: "alice@example.com",
+      admin: true,
+      active: true,
+      organization: { id: "org-acme" },
+    });
+  });
+
+  it("returns one user by id", async () => {
+    const res = await gql(app, '{ user(id: "user-bob") { id name email } }');
+    const body = (await res.json()) as any;
+    expect(body.data.user).toEqual({ id: "user-bob", name: "Bob", email: "bob@example.com" });
+  });
+
+  it("returns teams", async () => {
+    const res = await gql(app, "{ teams { nodes { id key name organization { id } } } }");
+    const body = (await res.json()) as any;
+    expect(body.data.teams.nodes).toContainEqual({
+      id: "team-eng",
+      key: "ENG",
+      name: "Engineering",
+      organization: { id: "org-acme" },
+    });
+  });
+
+  it("returns one team by id", async () => {
+    const res = await gql(app, '{ team(id: "team-ops") { id key name } }');
+    const body = (await res.json()) as any;
+    expect(body.data.team).toEqual({ id: "team-ops", key: "OPS", name: "Operations" });
+  });
+
+  it("returns workflow states", async () => {
+    const res = await gql(app, "{ workflowStates { nodes { id name type team { id } } } }");
+    const body = (await res.json()) as any;
+    expect(body.data.workflowStates.nodes).toContainEqual({
+      id: "state-started",
+      name: "Started",
+      type: "started",
+      team: { id: "team-eng" },
+    });
+  });
+
+  it("returns one workflow state by id", async () => {
+    const res = await gql(app, '{ workflowState(id: "state-done") { id name type } }');
+    const body = (await res.json()) as any;
+    expect(body.data.workflowState).toEqual({ id: "state-done", name: "Done", type: "completed" });
+  });
+
+  it("returns labels", async () => {
+    const res = await gql(app, "{ labels { nodes { id name team { id } } } }");
+    const body = (await res.json()) as any;
+    expect(body.data.labels.nodes).toContainEqual({ id: "label-feature", name: "Feature", team: { id: "team-eng" } });
+  });
+
+  it("returns one label by id", async () => {
+    const res = await gql(app, '{ label(id: "label-bug") { id name issues { nodes { id } } } }');
+    const body = (await res.json()) as any;
+    expect(body.data.label.name).toBe("Bug");
+    expect(body.data.label.issues.nodes.map((issue: { id: string }) => issue.id)).toContain("issue-one");
+  });
+
+  it("returns projects", async () => {
+    const res = await gql(app, "{ projects { nodes { id name slugId state team { id } lead { id } } } }");
+    const body = (await res.json()) as any;
+    expect(body.data.projects.nodes).toContainEqual({
+      id: "project-api",
+      name: "API",
+      slugId: "api",
+      state: "started",
+      team: { id: "team-eng" },
+      lead: { id: "user-alice" },
+    });
+  });
+
+  it("returns one project by id", async () => {
+    const res = await gql(app, '{ project(id: "project-api") { id name issues { nodes { id } } } }');
+    const body = (await res.json()) as any;
+    expect(body.data.project.id).toBe("project-api");
+    expect(body.data.project.issues.nodes).toHaveLength(3);
+  });
+
+  it("returns issues with relationships", async () => {
+    const res = await gql(
+      app,
+      "{ issues { nodes { id identifier title team { key } state { name } assignee { id } creator { id } project { id } labels { nodes { id } } } } }",
+    );
+    const body = (await res.json()) as any;
+    expect(body.data.issues.nodes).toContainEqual({
+      id: "issue-one",
+      identifier: "ENG-1",
+      title: "First seeded issue",
+      team: { key: "ENG" },
+      state: { name: "Todo" },
+      assignee: { id: "user-alice" },
+      creator: { id: "user-bob" },
+      project: { id: "project-api" },
+      labels: { nodes: [{ id: "label-bug" }] },
+    });
+  });
+
+  it("returns one issue by id", async () => {
+    const res = await gql(app, '{ issue(id: "issue-two") { id identifier title } }');
+    const body = (await res.json()) as any;
+    expect(body.data.issue).toEqual({ id: "issue-two", identifier: "ENG-2", title: "Second seeded issue" });
+  });
+
+  it("returns one issue by identifier", async () => {
+    const res = await gql(app, '{ issue(identifier: "ENG-3") { id title } }');
+    const body = (await res.json()) as any;
+    expect(body.data.issue).toEqual({ id: "issue-three", title: "Third seeded issue" });
+  });
+
+  it("returns relay edges and page info", async () => {
+    const res = await gql(
+      app,
+      "{ issues(first: 2) { edges { cursor node { id } } pageInfo { hasNextPage hasPreviousPage startCursor endCursor } } }",
+    );
+    const body = (await res.json()) as any;
+    expect(body.data.issues.edges).toHaveLength(2);
+    expect(body.data.issues.edges[0].cursor).toBeTruthy();
+    expect(body.data.issues.pageInfo.hasNextPage).toBe(true);
+    expect(body.data.issues.pageInfo.hasPreviousPage).toBe(false);
+  });
+
+  it("paginates forward with after", async () => {
+    const firstRes = await gql(
+      app,
+      "{ issues(first: 2) { edges { cursor node { id } } pageInfo { endCursor } nodes { id } } }",
+    );
+    const firstBody = (await firstRes.json()) as any;
+    const secondRes = await gql(
+      app,
+      "query($after: String!) { issues(first: 1, after: $after) { nodes { id } pageInfo { hasPreviousPage } } }",
+      {
+        after: firstBody.data.issues.edges[0].cursor,
+      },
+    );
+    const secondBody = (await secondRes.json()) as any;
+    expect(secondBody.data.issues.nodes[0].id).toBe(firstBody.data.issues.edges[1].node.id);
+    expect(secondBody.data.issues.pageInfo.hasPreviousPage).toBe(true);
+  });
+
+  it("paginates backward with before and last", async () => {
+    const firstRes = await gql(app, "{ issues(first: 3) { edges { cursor node { id } } } }");
+    const firstBody = (await firstRes.json()) as any;
+    const before = firstBody.data.issues.edges[2].cursor;
+    const secondRes = await gql(
+      app,
+      "query($before: String!) { issues(last: 1, before: $before) { nodes { id } pageInfo { hasNextPage } } }",
+      {
+        before,
+      },
+    );
+    const secondBody = (await secondRes.json()) as any;
+    expect(secondBody.data.issues.nodes[0].id).toBe(firstBody.data.issues.edges[1].node.id);
+    expect(secondBody.data.issues.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("validates PAT auth with raw Authorization header", async () => {
+    const res = await gql(app, "{ viewer { id } }");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.errors).toEqual([]);
+  });
+
+  it("accepts Bearer PAT auth for client compatibility", async () => {
+    const res = await gql(app, "{ viewer { id } }", undefined, "Bearer lin_api_seeded");
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects missing PAT auth", async () => {
+    const res = await app.request(`${base}/graphql`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "{ viewer { id } }" }),
+    });
+    const body = (await res.json()) as any;
+    expect(res.status).toBe(401);
+    expect(body.errors[0].extensions.code).toBe("AUTHENTICATION_ERROR");
+  });
+
+  it("rejects unknown PAT auth", async () => {
+    const res = await gql(app, "{ viewer { id } }", undefined, "lin_api_unknown");
+    const body = (await res.json()) as any;
+    expect(res.status).toBe(401);
+    expect(body.errors[0].extensions.code).toBe("AUTHENTICATION_ERROR");
+  });
+
+  it("returns GraphQL errors with an extensions code", async () => {
+    const res = await gql(app, "{ missingField }");
+    const body = (await res.json()) as any;
+    expect(res.status).toBe(200);
+    expect(body.data).toBeNull();
+    expect(body.errors[0].extensions.code).toBe("GRAPHQL_ERROR");
+  });
+
+  it("rejects non string query bodies with a Linear shaped error", async () => {
+    const res = await app.request(`${base}/graphql`, {
+      method: "POST",
+      headers: { Authorization: "lin_api_seeded", "Content-Type": "application/json" },
+      body: JSON.stringify({ query: 1 }),
+    });
+    const body = (await res.json()) as any;
+    expect(res.status).toBe(400);
+    expect(body.errors[0].extensions.code).toBe("BAD_REQUEST");
+  });
+});

--- a/packages/@emulators/linear/src/entities.ts
+++ b/packages/@emulators/linear/src/entities.ts
@@ -1,0 +1,76 @@
+import type { Entity } from "@emulators/core";
+
+export interface LinearApiKey extends Entity {
+  key: string;
+}
+
+export interface LinearOrganization extends Entity {
+  linear_id: string;
+  name: string;
+  url_key: string | null;
+}
+
+export interface LinearUser extends Entity {
+  linear_id: string;
+  name: string;
+  email: string;
+  display_name: string | null;
+  active: boolean;
+  admin: boolean;
+  organization_id: string | null;
+}
+
+export type LinearWorkflowStateType = "backlog" | "unstarted" | "started" | "completed" | "canceled";
+
+export interface LinearTeam extends Entity {
+  linear_id: string;
+  name: string;
+  key: string;
+  description: string | null;
+  organization_id: string;
+}
+
+export interface LinearWorkflowState extends Entity {
+  linear_id: string;
+  name: string;
+  type: LinearWorkflowStateType;
+  position: number;
+  color: string;
+  team_id: string;
+}
+
+export interface LinearLabel extends Entity {
+  linear_id: string;
+  name: string;
+  color: string;
+  description: string | null;
+  team_id: string | null;
+}
+
+export interface LinearProject extends Entity {
+  linear_id: string;
+  name: string;
+  description: string | null;
+  slug_id: string;
+  state: string;
+  team_id: string | null;
+  lead_id: string | null;
+  target_date: string | null;
+}
+
+export interface LinearIssue extends Entity {
+  linear_id: string;
+  identifier: string;
+  number: number;
+  title: string;
+  description: string | null;
+  priority: number;
+  estimate: number | null;
+  url: string;
+  team_id: string;
+  state_id: string | null;
+  assignee_id: string | null;
+  creator_id: string | null;
+  project_id: string | null;
+  label_ids: string[];
+}

--- a/packages/@emulators/linear/src/helpers.ts
+++ b/packages/@emulators/linear/src/helpers.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "crypto";
+import { GraphQLError } from "graphql";
+
+export interface ConnectionArgs {
+  first?: number | null;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
+}
+
+export interface PageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+}
+
+export interface Edge<T> {
+  node: T;
+  cursor: string;
+}
+
+export interface Connection<T> {
+  edges: Edge<T>[];
+  nodes: T[];
+  pageInfo: PageInfo;
+}
+
+export function generateLinearId(): string {
+  return randomUUID();
+}
+
+export function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "item";
+}
+
+export function linearError(message: string, code: string, type = "graphql error"): GraphQLError {
+  return new GraphQLError(message, {
+    extensions: { code, type },
+  });
+}
+
+function encodeCursor(index: number): string {
+  return Buffer.from(`linear:${index}`).toString("base64url");
+}
+
+function decodeCursor(cursor: string): number | null {
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+    const match = decoded.match(/^linear:(\d+)$/);
+    return match ? Number(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function toConnection<T>(items: T[], args: ConnectionArgs = {}): Connection<T> {
+  let start = 0;
+  let end = items.length;
+
+  if (args.after) {
+    const afterIndex = decodeCursor(args.after);
+    if (afterIndex !== null) {
+      start = Math.max(start, afterIndex + 1);
+    }
+  }
+
+  if (args.before) {
+    const beforeIndex = decodeCursor(args.before);
+    if (beforeIndex !== null) {
+      end = Math.min(end, beforeIndex);
+    }
+  }
+
+  if (typeof args.first === "number") {
+    if (args.first < 0) {
+      throw linearError("first must be greater than or equal to 0", "BAD_USER_INPUT", "validation error");
+    }
+    end = Math.min(end, start + args.first);
+  }
+
+  if (typeof args.last === "number") {
+    if (args.last < 0) {
+      throw linearError("last must be greater than or equal to 0", "BAD_USER_INPUT", "validation error");
+    }
+    start = Math.max(start, end - args.last);
+  }
+
+  const sliced = items.slice(start, end);
+  const edges = sliced.map((node, offset) => ({
+    node,
+    cursor: encodeCursor(start + offset),
+  }));
+
+  return {
+    edges,
+    nodes: sliced,
+    pageInfo: {
+      hasNextPage: end < items.length,
+      hasPreviousPage: start > 0,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+}

--- a/packages/@emulators/linear/src/index.ts
+++ b/packages/@emulators/linear/src/index.ts
@@ -1,0 +1,385 @@
+import type { Hono } from "hono";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { generateLinearId, slugify } from "./helpers.js";
+import { getLinearStore } from "./store.js";
+import { graphqlRoutes } from "./routes/graphql.js";
+import type { LinearWorkflowStateType } from "./entities.js";
+
+export { getLinearStore, type LinearStore } from "./store.js";
+export * from "./entities.js";
+
+export interface LinearSeedConfig {
+  port?: number;
+  api_keys?: string[];
+  organizations?: Array<{
+    id?: string;
+    name: string;
+    url_key?: string;
+  }>;
+  users?: Array<{
+    id?: string;
+    name: string;
+    email: string;
+    display_name?: string;
+    active?: boolean;
+    admin?: boolean;
+    organization?: string;
+  }>;
+  teams?: Array<{
+    id?: string;
+    name: string;
+    key: string;
+    description?: string;
+    organization?: string;
+  }>;
+  workflow_states?: Array<{
+    id?: string;
+    name: string;
+    type?: LinearWorkflowStateType;
+    position?: number;
+    color?: string;
+    team: string;
+  }>;
+  labels?: Array<{
+    id?: string;
+    name: string;
+    color?: string;
+    description?: string;
+    team?: string;
+  }>;
+  projects?: Array<{
+    id?: string;
+    name: string;
+    description?: string;
+    slug_id?: string;
+    state?: string;
+    team?: string;
+    lead?: string;
+    target_date?: string;
+  }>;
+  issues?: Array<{
+    id?: string;
+    identifier?: string;
+    number?: number;
+    title: string;
+    description?: string;
+    priority?: number;
+    estimate?: number;
+    team: string;
+    state?: string;
+    assignee?: string;
+    creator?: string;
+    project?: string;
+    labels?: string[];
+  }>;
+}
+
+function insertApiKey(store: Store, key: string): void {
+  const ls = getLinearStore(store);
+  if (!ls.apiKeys.findOneBy("key", key)) {
+    ls.apiKeys.insert({ key });
+  }
+}
+
+function findOrganization(store: Store, ref: string | undefined) {
+  const ls = getLinearStore(store);
+  if (!ref) return ls.organizations.all()[0] ?? null;
+  return (
+    ls.organizations.findOneBy("linear_id", ref) ??
+    ls.organizations.findOneBy("url_key", ref) ??
+    ls.organizations.all().find((org) => org.name === ref) ??
+    null
+  );
+}
+
+function findTeam(store: Store, ref: string | undefined) {
+  const ls = getLinearStore(store);
+  if (!ref) return ls.teams.all()[0] ?? null;
+  return (
+    ls.teams.findOneBy("linear_id", ref) ??
+    ls.teams.findOneBy("key", ref) ??
+    ls.teams.all().find((team) => team.name === ref) ??
+    null
+  );
+}
+
+function findUser(store: Store, ref: string | undefined) {
+  const ls = getLinearStore(store);
+  if (!ref) return null;
+  return (
+    ls.users.findOneBy("linear_id", ref) ??
+    ls.users.findOneBy("email", ref) ??
+    ls.users.all().find((user) => user.name === ref) ??
+    null
+  );
+}
+
+function findWorkflowState(store: Store, ref: string | undefined) {
+  const ls = getLinearStore(store);
+  if (!ref) return null;
+  return (
+    ls.workflowStates.findOneBy("linear_id", ref) ?? ls.workflowStates.all().find((state) => state.name === ref) ?? null
+  );
+}
+
+function findProject(store: Store, ref: string | undefined) {
+  const ls = getLinearStore(store);
+  if (!ref) return null;
+  return (
+    ls.projects.findOneBy("linear_id", ref) ??
+    ls.projects.findOneBy("slug_id", ref) ??
+    ls.projects.all().find((project) => project.name === ref) ??
+    null
+  );
+}
+
+function resolveLabelIds(store: Store, labels: string[] | undefined): string[] {
+  if (!labels) return [];
+  const ls = getLinearStore(store);
+  return labels
+    .map((ref) => ls.labels.findOneBy("linear_id", ref) ?? ls.labels.all().find((label) => label.name === ref))
+    .filter((label): label is NonNullable<typeof label> => Boolean(label))
+    .map((label) => label.linear_id);
+}
+
+function issueNumberForTeam(store: Store, teamId: string, requested?: number): number {
+  if (requested !== undefined) return requested;
+  const ls = getLinearStore(store);
+  const highest = ls.issues.findBy("team_id", teamId).reduce((max, issue) => Math.max(max, issue.number), 0);
+  return highest + 1;
+}
+
+function insertDefaults(store: Store, baseUrl: string): void {
+  const ls = getLinearStore(store);
+  insertApiKey(store, "lin_api_test");
+
+  const orgId = "org-1";
+  if (!ls.organizations.findOneBy("linear_id", orgId)) {
+    ls.organizations.insert({ linear_id: orgId, name: "Emulate", url_key: "emulate" });
+  }
+
+  const userId = "user-1";
+  if (!ls.users.findOneBy("linear_id", userId)) {
+    ls.users.insert({
+      linear_id: userId,
+      name: "Developer",
+      email: "dev@example.com",
+      display_name: "Developer",
+      active: true,
+      admin: true,
+      organization_id: orgId,
+    });
+  }
+
+  const teamId = "team-1";
+  if (!ls.teams.findOneBy("linear_id", teamId)) {
+    ls.teams.insert({
+      linear_id: teamId,
+      name: "Engineering",
+      key: "ENG",
+      description: "Engineering work",
+      organization_id: orgId,
+    });
+  }
+
+  const todoStateId = "ws-1";
+  if (!ls.workflowStates.findOneBy("linear_id", todoStateId)) {
+    ls.workflowStates.insert({
+      linear_id: todoStateId,
+      name: "Todo",
+      type: "unstarted",
+      position: 1,
+      color: "#e2e2e2",
+      team_id: teamId,
+    });
+  }
+
+  if (!ls.workflowStates.findOneBy("linear_id", "ws-2")) {
+    ls.workflowStates.insert({
+      linear_id: "ws-2",
+      name: "In Progress",
+      type: "started",
+      position: 2,
+      color: "#f2c94c",
+      team_id: teamId,
+    });
+  }
+
+  const labelId = "label-1";
+  if (!ls.labels.findOneBy("linear_id", labelId)) {
+    ls.labels.insert({
+      linear_id: labelId,
+      name: "Bug",
+      color: "#eb5757",
+      description: "Something is not working",
+      team_id: teamId,
+    });
+  }
+
+  const projectId = "project-1";
+  if (!ls.projects.findOneBy("linear_id", projectId)) {
+    ls.projects.insert({
+      linear_id: projectId,
+      name: "Launch",
+      description: "Launch project",
+      slug_id: "launch",
+      state: "started",
+      team_id: teamId,
+      lead_id: userId,
+      target_date: null,
+    });
+  }
+
+  if (!ls.issues.findOneBy("linear_id", "issue-1")) {
+    ls.issues.insert({
+      linear_id: "issue-1",
+      identifier: "ENG-1",
+      number: 1,
+      title: "First issue",
+      description: "Seeded Linear issue",
+      priority: 0,
+      estimate: null,
+      url: `${baseUrl}/ENG/issue/ENG-1/first-issue`,
+      team_id: teamId,
+      state_id: todoStateId,
+      assignee_id: userId,
+      creator_id: userId,
+      project_id: projectId,
+      label_ids: [labelId],
+    });
+  }
+}
+
+export function seedFromConfig(store: Store, baseUrl: string, config: LinearSeedConfig): void {
+  const ls = getLinearStore(store);
+
+  for (const key of config.api_keys ?? []) {
+    insertApiKey(store, key);
+  }
+
+  for (const org of config.organizations ?? []) {
+    const linearId = org.id ?? generateLinearId();
+    if (ls.organizations.findOneBy("linear_id", linearId)) continue;
+    ls.organizations.insert({
+      linear_id: linearId,
+      name: org.name,
+      url_key: org.url_key ?? slugify(org.name),
+    });
+  }
+
+  for (const user of config.users ?? []) {
+    const linearId = user.id ?? generateLinearId();
+    if (ls.users.findOneBy("linear_id", linearId)) continue;
+    const org = findOrganization(store, user.organization);
+    ls.users.insert({
+      linear_id: linearId,
+      name: user.name,
+      email: user.email,
+      display_name: user.display_name ?? user.name,
+      active: user.active ?? true,
+      admin: user.admin ?? false,
+      organization_id: org?.linear_id ?? null,
+    });
+  }
+
+  for (const team of config.teams ?? []) {
+    const linearId = team.id ?? generateLinearId();
+    if (ls.teams.findOneBy("linear_id", linearId)) continue;
+    const org = findOrganization(store, team.organization);
+    if (!org) continue;
+    ls.teams.insert({
+      linear_id: linearId,
+      name: team.name,
+      key: team.key,
+      description: team.description ?? null,
+      organization_id: org.linear_id,
+    });
+  }
+
+  for (const state of config.workflow_states ?? []) {
+    const linearId = state.id ?? generateLinearId();
+    if (ls.workflowStates.findOneBy("linear_id", linearId)) continue;
+    const team = findTeam(store, state.team);
+    if (!team) continue;
+    ls.workflowStates.insert({
+      linear_id: linearId,
+      name: state.name,
+      type: state.type ?? "unstarted",
+      position: state.position ?? ls.workflowStates.findBy("team_id", team.linear_id).length + 1,
+      color: state.color ?? "#e2e2e2",
+      team_id: team.linear_id,
+    });
+  }
+
+  for (const label of config.labels ?? []) {
+    const linearId = label.id ?? generateLinearId();
+    if (ls.labels.findOneBy("linear_id", linearId)) continue;
+    const team = findTeam(store, label.team);
+    ls.labels.insert({
+      linear_id: linearId,
+      name: label.name,
+      color: label.color ?? "#5e6ad2",
+      description: label.description ?? null,
+      team_id: team?.linear_id ?? null,
+    });
+  }
+
+  for (const project of config.projects ?? []) {
+    const linearId = project.id ?? generateLinearId();
+    if (ls.projects.findOneBy("linear_id", linearId)) continue;
+    const team = findTeam(store, project.team);
+    const lead = findUser(store, project.lead);
+    ls.projects.insert({
+      linear_id: linearId,
+      name: project.name,
+      description: project.description ?? null,
+      slug_id: project.slug_id ?? slugify(project.name),
+      state: project.state ?? "planned",
+      team_id: team?.linear_id ?? null,
+      lead_id: lead?.linear_id ?? null,
+      target_date: project.target_date ?? null,
+    });
+  }
+
+  for (const issue of config.issues ?? []) {
+    const linearId = issue.id ?? generateLinearId();
+    if (ls.issues.findOneBy("linear_id", linearId)) continue;
+    const team = findTeam(store, issue.team);
+    if (!team) continue;
+    const state = findWorkflowState(store, issue.state);
+    const assignee = findUser(store, issue.assignee);
+    const creator = findUser(store, issue.creator);
+    const project = findProject(store, issue.project);
+    const number = issueNumberForTeam(store, team.linear_id, issue.number);
+    const identifier = issue.identifier ?? `${team.key}-${number}`;
+    ls.issues.insert({
+      linear_id: linearId,
+      identifier,
+      number,
+      title: issue.title,
+      description: issue.description ?? null,
+      priority: issue.priority ?? 0,
+      estimate: issue.estimate ?? null,
+      url: `${baseUrl}/${team.key}/issue/${identifier}/${slugify(issue.title)}`,
+      team_id: team.linear_id,
+      state_id: state?.linear_id ?? null,
+      assignee_id: assignee?.linear_id ?? null,
+      creator_id: creator?.linear_id ?? null,
+      project_id: project?.linear_id ?? null,
+      label_ids: resolveLabelIds(store, issue.labels),
+    });
+  }
+}
+
+export const linearPlugin: ServicePlugin = {
+  name: "linear",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    graphqlRoutes(ctx);
+  },
+  seed(store: Store, baseUrl: string): void {
+    insertDefaults(store, baseUrl);
+  },
+};
+
+export default linearPlugin;

--- a/packages/@emulators/linear/src/resolvers.ts
+++ b/packages/@emulators/linear/src/resolvers.ts
@@ -1,0 +1,303 @@
+import type { GraphQLFieldResolver, GraphQLResolveInfo } from "graphql";
+import type { Store } from "@emulators/core";
+import { getLinearStore, type LinearStore } from "./store.js";
+import { linearError, toConnection, type ConnectionArgs } from "./helpers.js";
+import type {
+  LinearIssue,
+  LinearLabel,
+  LinearOrganization,
+  LinearProject,
+  LinearTeam,
+  LinearUser,
+  LinearWorkflowState,
+} from "./entities.js";
+
+export interface LinearGraphQLContext {
+  store: Store;
+  authToken: string;
+}
+
+type LinearSource =
+  | LinearIssue
+  | LinearLabel
+  | LinearOrganization
+  | LinearProject
+  | LinearTeam
+  | LinearUser
+  | LinearWorkflowState
+  | Record<string, unknown>;
+
+function byCreatedAt<T extends { created_at: string; id: number }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id - b.id);
+}
+
+function findByLinearId<T extends { linear_id: string }>(items: T[], id: string): T | null {
+  return items.find((item) => item.linear_id === id) ?? null;
+}
+
+function list<T extends { created_at: string; id: number }>(items: T[], args: ConnectionArgs) {
+  return toConnection(byCreatedAt(items), args);
+}
+
+function linearStore(context: LinearGraphQLContext): LinearStore {
+  return getLinearStore(context.store);
+}
+
+function resolveQuery(fieldName: string, args: Record<string, unknown>, context: LinearGraphQLContext) {
+  const ls = linearStore(context);
+
+  switch (fieldName) {
+    case "viewer":
+      return ls.users.all()[0] ?? null;
+    case "organization":
+      return typeof args.id === "string"
+        ? (ls.organizations.findOneBy("linear_id", args.id) ?? null)
+        : (ls.organizations.all()[0] ?? null);
+    case "organizations":
+      return list(ls.organizations.all(), args);
+    case "user":
+      return findByLinearId(ls.users.all(), String(args.id));
+    case "users":
+      return list(ls.users.all(), args);
+    case "team":
+      return findByLinearId(ls.teams.all(), String(args.id));
+    case "teams":
+      return list(ls.teams.all(), args);
+    case "workflowState":
+      return findByLinearId(ls.workflowStates.all(), String(args.id));
+    case "workflowStates":
+      return list(ls.workflowStates.all(), args);
+    case "label":
+      return findByLinearId(ls.labels.all(), String(args.id));
+    case "labels":
+      return list(ls.labels.all(), args);
+    case "project":
+      return findByLinearId(ls.projects.all(), String(args.id));
+    case "projects":
+      return list(ls.projects.all(), args);
+    case "issue":
+      if (typeof args.identifier === "string") {
+        return ls.issues.findOneBy("identifier", args.identifier) ?? null;
+      }
+      if (typeof args.id === "string") {
+        return ls.issues.findOneBy("linear_id", args.id) ?? null;
+      }
+      throw linearError("id or identifier is required", "BAD_USER_INPUT", "validation error");
+    case "issues":
+      return list(ls.issues.all(), args);
+    default:
+      return undefined;
+  }
+}
+
+function directValue(source: Record<string, unknown>, fieldName: string): unknown {
+  if (fieldName in source) return source[fieldName];
+  return undefined;
+}
+
+function resolveOrganization(
+  source: LinearOrganization,
+  fieldName: string,
+  args: ConnectionArgs,
+  ls: LinearStore,
+): unknown {
+  switch (fieldName) {
+    case "id":
+      return source.linear_id;
+    case "urlKey":
+      return source.url_key;
+    case "createdAt":
+      return source.created_at;
+    case "updatedAt":
+      return source.updated_at;
+    case "teams":
+      return list(ls.teams.findBy("organization_id", source.linear_id), args);
+    case "users":
+      return list(ls.users.findBy("organization_id", source.linear_id), args);
+    default:
+      return directValue(source as unknown as Record<string, unknown>, fieldName);
+  }
+}
+
+function resolveUser(source: LinearUser, fieldName: string, args: ConnectionArgs, ls: LinearStore): unknown {
+  switch (fieldName) {
+    case "id":
+      return source.linear_id;
+    case "displayName":
+      return source.display_name;
+    case "createdAt":
+      return source.created_at;
+    case "updatedAt":
+      return source.updated_at;
+    case "organization":
+      return source.organization_id ? (ls.organizations.findOneBy("linear_id", source.organization_id) ?? null) : null;
+    case "assignedIssues":
+      return list(ls.issues.findBy("assignee_id", source.linear_id), args);
+    case "createdIssues":
+      return list(ls.issues.findBy("creator_id", source.linear_id), args);
+    case "projectsLed":
+      return list(ls.projects.findBy("lead_id", source.linear_id), args);
+    default:
+      return directValue(source as unknown as Record<string, unknown>, fieldName);
+  }
+}
+
+function resolveTeam(source: LinearTeam, fieldName: string, args: ConnectionArgs, ls: LinearStore): unknown {
+  switch (fieldName) {
+    case "id":
+      return source.linear_id;
+    case "createdAt":
+      return source.created_at;
+    case "updatedAt":
+      return source.updated_at;
+    case "organization":
+      return ls.organizations.findOneBy("linear_id", source.organization_id) ?? null;
+    case "issues":
+      return list(ls.issues.findBy("team_id", source.linear_id), args);
+    case "labels":
+      return list(ls.labels.findBy("team_id", source.linear_id), args);
+    case "workflowStates":
+      return list(ls.workflowStates.findBy("team_id", source.linear_id), args);
+    case "projects":
+      return list(ls.projects.findBy("team_id", source.linear_id), args);
+    default:
+      return directValue(source as unknown as Record<string, unknown>, fieldName);
+  }
+}
+
+function resolveWorkflowState(
+  source: LinearWorkflowState,
+  fieldName: string,
+  args: ConnectionArgs,
+  ls: LinearStore,
+): unknown {
+  switch (fieldName) {
+    case "id":
+      return source.linear_id;
+    case "createdAt":
+      return source.created_at;
+    case "updatedAt":
+      return source.updated_at;
+    case "team":
+      return ls.teams.findOneBy("linear_id", source.team_id) ?? null;
+    case "issues":
+      return list(ls.issues.findBy("state_id", source.linear_id), args);
+    default:
+      return directValue(source as unknown as Record<string, unknown>, fieldName);
+  }
+}
+
+function resolveLabel(source: LinearLabel, fieldName: string, args: ConnectionArgs, ls: LinearStore): unknown {
+  switch (fieldName) {
+    case "id":
+      return source.linear_id;
+    case "createdAt":
+      return source.created_at;
+    case "updatedAt":
+      return source.updated_at;
+    case "team":
+      return source.team_id ? (ls.teams.findOneBy("linear_id", source.team_id) ?? null) : null;
+    case "issues":
+      return list(
+        ls.issues.all().filter((issue) => issue.label_ids.includes(source.linear_id)),
+        args,
+      );
+    default:
+      return directValue(source as unknown as Record<string, unknown>, fieldName);
+  }
+}
+
+function resolveProject(source: LinearProject, fieldName: string, args: ConnectionArgs, ls: LinearStore): unknown {
+  switch (fieldName) {
+    case "id":
+      return source.linear_id;
+    case "slugId":
+      return source.slug_id;
+    case "targetDate":
+      return source.target_date;
+    case "createdAt":
+      return source.created_at;
+    case "updatedAt":
+      return source.updated_at;
+    case "team":
+      return source.team_id ? (ls.teams.findOneBy("linear_id", source.team_id) ?? null) : null;
+    case "lead":
+      return source.lead_id ? (ls.users.findOneBy("linear_id", source.lead_id) ?? null) : null;
+    case "issues":
+      return list(ls.issues.findBy("project_id", source.linear_id), args);
+    default:
+      return directValue(source as unknown as Record<string, unknown>, fieldName);
+  }
+}
+
+function resolveIssue(source: LinearIssue, fieldName: string, args: ConnectionArgs, ls: LinearStore): unknown {
+  switch (fieldName) {
+    case "id":
+      return source.linear_id;
+    case "createdAt":
+      return source.created_at;
+    case "updatedAt":
+      return source.updated_at;
+    case "team":
+      return ls.teams.findOneBy("linear_id", source.team_id) ?? null;
+    case "state":
+      return source.state_id ? (ls.workflowStates.findOneBy("linear_id", source.state_id) ?? null) : null;
+    case "assignee":
+      return source.assignee_id ? (ls.users.findOneBy("linear_id", source.assignee_id) ?? null) : null;
+    case "creator":
+      return source.creator_id ? (ls.users.findOneBy("linear_id", source.creator_id) ?? null) : null;
+    case "project":
+      return source.project_id ? (ls.projects.findOneBy("linear_id", source.project_id) ?? null) : null;
+    case "labels":
+      return list(
+        source.label_ids
+          .map((id) => ls.labels.findOneBy("linear_id", id))
+          .filter((label): label is LinearLabel => Boolean(label)),
+        args,
+      );
+    default:
+      return directValue(source as unknown as Record<string, unknown>, fieldName);
+  }
+}
+
+function resolveObject(
+  source: LinearSource,
+  args: ConnectionArgs,
+  context: LinearGraphQLContext,
+  info: GraphQLResolveInfo,
+): unknown {
+  const ls = linearStore(context);
+
+  switch (info.parentType.name) {
+    case "Organization":
+      return resolveOrganization(source as LinearOrganization, info.fieldName, args, ls);
+    case "User":
+      return resolveUser(source as LinearUser, info.fieldName, args, ls);
+    case "Team":
+      return resolveTeam(source as LinearTeam, info.fieldName, args, ls);
+    case "WorkflowState":
+      return resolveWorkflowState(source as LinearWorkflowState, info.fieldName, args, ls);
+    case "Label":
+      return resolveLabel(source as LinearLabel, info.fieldName, args, ls);
+    case "Project":
+      return resolveProject(source as LinearProject, info.fieldName, args, ls);
+    case "Issue":
+      return resolveIssue(source as LinearIssue, info.fieldName, args, ls);
+    default:
+      return directValue(source as Record<string, unknown>, info.fieldName);
+  }
+}
+
+export const linearFieldResolver: GraphQLFieldResolver<LinearSource | undefined, LinearGraphQLContext> = (
+  source,
+  args,
+  context,
+  info,
+) => {
+  if (info.parentType.name === "Query") {
+    return resolveQuery(info.fieldName, args, context);
+  }
+
+  if (!source) return undefined;
+  return resolveObject(source, args, context, info);
+};

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -1,0 +1,83 @@
+import type { RouteContext } from "@emulators/core";
+import { graphql } from "graphql";
+import { getLinearStore } from "../store.js";
+import { linearSchema } from "../schema.js";
+import { linearFieldResolver } from "../resolvers.js";
+
+interface GraphQLRequestBody {
+  query?: unknown;
+  variables?: unknown;
+  operationName?: unknown;
+}
+
+function tokenFromHeader(value: string | undefined): string | null {
+  if (!value) return null;
+  const token = value.replace(/^(Bearer|token)\s+/i, "").trim();
+  return token.length > 0 ? token : null;
+}
+
+function errorPayload(message: string, code: string, type: string) {
+  return {
+    data: null,
+    errors: [
+      {
+        message,
+        extensions: { code, type },
+      },
+    ],
+  };
+}
+
+export function graphqlRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+
+  app.post("/graphql", async (c) => {
+    const token = tokenFromHeader(c.req.header("Authorization"));
+    const ls = getLinearStore(store);
+    const validPat = token ? Boolean(ls.apiKeys.findOneBy("key", token)) : false;
+
+    if (!token || !validPat) {
+      return c.json(errorPayload("Authentication required", "AUTHENTICATION_ERROR", "authentication error"), 401);
+    }
+
+    let body: GraphQLRequestBody;
+    try {
+      body = (await c.req.json()) as GraphQLRequestBody;
+    } catch {
+      return c.json(errorPayload("Request body must be JSON", "BAD_REQUEST", "request error"), 400);
+    }
+
+    if (typeof body.query !== "string") {
+      return c.json(errorPayload("query must be a string", "BAD_REQUEST", "request error"), 400);
+    }
+
+    const result = await graphql({
+      schema: linearSchema,
+      source: body.query,
+      contextValue: { store, authToken: token },
+      variableValues:
+        body.variables && typeof body.variables === "object" ? (body.variables as Record<string, unknown>) : undefined,
+      operationName: typeof body.operationName === "string" ? body.operationName : undefined,
+      fieldResolver: linearFieldResolver,
+    });
+
+    return c.json({
+      data: result.data ?? null,
+      errors: (result.errors ?? []).map((error) => {
+        const json = error.toJSON();
+        return {
+          ...json,
+          extensions: {
+            code: "GRAPHQL_ERROR",
+            type: "graphql error",
+            ...json.extensions,
+          },
+        };
+      }),
+    });
+  });
+
+  app.all("/graphql", (c) =>
+    c.json(errorPayload("Only POST /graphql is supported", "METHOD_NOT_ALLOWED", "request error"), 405),
+  );
+}

--- a/packages/@emulators/linear/src/schema.ts
+++ b/packages/@emulators/linear/src/schema.ts
@@ -1,0 +1,146 @@
+import { buildSchema } from "graphql";
+
+export const linearSchema = buildSchema(`
+  scalar DateTime
+
+  type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+  }
+
+  type Organization {
+    id: ID!
+    name: String!
+    urlKey: String
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    teams(first: Int, after: String, last: Int, before: String): TeamConnection!
+    users(first: Int, after: String, last: Int, before: String): UserConnection!
+  }
+
+  type User {
+    id: ID!
+    name: String!
+    email: String!
+    displayName: String
+    active: Boolean!
+    admin: Boolean!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    organization: Organization
+    assignedIssues(first: Int, after: String, last: Int, before: String): IssueConnection!
+    createdIssues(first: Int, after: String, last: Int, before: String): IssueConnection!
+    projectsLed(first: Int, after: String, last: Int, before: String): ProjectConnection!
+  }
+
+  type Team {
+    id: ID!
+    name: String!
+    key: String!
+    description: String
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    organization: Organization!
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+    labels(first: Int, after: String, last: Int, before: String): LabelConnection!
+    workflowStates(first: Int, after: String, last: Int, before: String): WorkflowStateConnection!
+    projects(first: Int, after: String, last: Int, before: String): ProjectConnection!
+  }
+
+  type WorkflowState {
+    id: ID!
+    name: String!
+    type: String!
+    position: Float!
+    color: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    team: Team!
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Label {
+    id: ID!
+    name: String!
+    color: String!
+    description: String
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    team: Team
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Project {
+    id: ID!
+    name: String!
+    description: String
+    slugId: String!
+    state: String!
+    targetDate: DateTime
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    team: Team
+    lead: User
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Issue {
+    id: ID!
+    identifier: String!
+    number: Float!
+    title: String!
+    description: String
+    priority: Float!
+    estimate: Float
+    url: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    team: Team!
+    state: WorkflowState
+    assignee: User
+    creator: User
+    project: Project
+    labels(first: Int, after: String, last: Int, before: String): LabelConnection!
+  }
+
+  type OrganizationEdge { node: Organization!, cursor: String! }
+  type OrganizationConnection { edges: [OrganizationEdge!]!, nodes: [Organization!]!, pageInfo: PageInfo! }
+
+  type UserEdge { node: User!, cursor: String! }
+  type UserConnection { edges: [UserEdge!]!, nodes: [User!]!, pageInfo: PageInfo! }
+
+  type TeamEdge { node: Team!, cursor: String! }
+  type TeamConnection { edges: [TeamEdge!]!, nodes: [Team!]!, pageInfo: PageInfo! }
+
+  type WorkflowStateEdge { node: WorkflowState!, cursor: String! }
+  type WorkflowStateConnection { edges: [WorkflowStateEdge!]!, nodes: [WorkflowState!]!, pageInfo: PageInfo! }
+
+  type LabelEdge { node: Label!, cursor: String! }
+  type LabelConnection { edges: [LabelEdge!]!, nodes: [Label!]!, pageInfo: PageInfo! }
+
+  type ProjectEdge { node: Project!, cursor: String! }
+  type ProjectConnection { edges: [ProjectEdge!]!, nodes: [Project!]!, pageInfo: PageInfo! }
+
+  type IssueEdge { node: Issue!, cursor: String! }
+  type IssueConnection { edges: [IssueEdge!]!, nodes: [Issue!]!, pageInfo: PageInfo! }
+
+  type Query {
+    viewer: User
+    organization(id: ID): Organization
+    organizations(first: Int, after: String, last: Int, before: String): OrganizationConnection!
+    user(id: ID!): User
+    users(first: Int, after: String, last: Int, before: String): UserConnection!
+    team(id: ID!): Team
+    teams(first: Int, after: String, last: Int, before: String): TeamConnection!
+    workflowState(id: ID!): WorkflowState
+    workflowStates(first: Int, after: String, last: Int, before: String): WorkflowStateConnection!
+    label(id: ID!): Label
+    labels(first: Int, after: String, last: Int, before: String): LabelConnection!
+    project(id: ID!): Project
+    projects(first: Int, after: String, last: Int, before: String): ProjectConnection!
+    issue(id: ID, identifier: String): Issue
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+`);

--- a/packages/@emulators/linear/src/store.ts
+++ b/packages/@emulators/linear/src/store.ts
@@ -1,0 +1,35 @@
+import { Store, type Collection } from "@emulators/core";
+import type {
+  LinearApiKey,
+  LinearIssue,
+  LinearLabel,
+  LinearOrganization,
+  LinearProject,
+  LinearTeam,
+  LinearUser,
+  LinearWorkflowState,
+} from "./entities.js";
+
+export interface LinearStore {
+  apiKeys: Collection<LinearApiKey>;
+  organizations: Collection<LinearOrganization>;
+  users: Collection<LinearUser>;
+  teams: Collection<LinearTeam>;
+  workflowStates: Collection<LinearWorkflowState>;
+  labels: Collection<LinearLabel>;
+  projects: Collection<LinearProject>;
+  issues: Collection<LinearIssue>;
+}
+
+export function getLinearStore(store: Store): LinearStore {
+  return {
+    apiKeys: store.collection<LinearApiKey>("linear.api_keys", ["key"]),
+    organizations: store.collection<LinearOrganization>("linear.organizations", ["linear_id", "url_key"]),
+    users: store.collection<LinearUser>("linear.users", ["linear_id", "email"]),
+    teams: store.collection<LinearTeam>("linear.teams", ["linear_id", "key"]),
+    workflowStates: store.collection<LinearWorkflowState>("linear.workflow_states", ["linear_id", "team_id"]),
+    labels: store.collection<LinearLabel>("linear.labels", ["linear_id", "team_id"]),
+    projects: store.collection<LinearProject>("linear.projects", ["linear_id", "slug_id", "team_id"]),
+    issues: store.collection<LinearIssue>("linear.issues", ["linear_id", "identifier", "team_id", "project_id"]),
+  };
+}

--- a/packages/@emulators/linear/tsconfig.json
+++ b/packages/@emulators/linear/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/linear/tsup.config.ts
+++ b/packages/@emulators/linear/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+});

--- a/packages/@emulators/linear/vitest.config.ts
+++ b/packages/@emulators/linear/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -70,6 +70,7 @@
     "@emulators/vercel": "workspace:*",
     "@emulators/resend": "workspace:*",
     "@emulators/stripe": "workspace:*",
+    "@emulators/linear": "workspace:*",
     "@emulators/clerk": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -27,6 +27,7 @@ const SERVICE_NAME_LIST = [
   "stripe",
   "mongoatlas",
   "clerk",
+  "linear",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -447,6 +448,31 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
             redirect_uris: ["http://localhost:3000/api/auth/callback/clerk"],
           },
         ],
+      },
+    },
+  },
+  linear: {
+    label: "Linear GraphQL API emulator",
+    endpoints:
+      "GraphQL queries for issues, projects, teams, users, organizations, labels, workflow states with Relay-style pagination",
+    async load() {
+      const mod = await import("@emulators/linear");
+      return { plugin: mod.linearPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback() {
+      return { login: "linear-admin", id: 1, scopes: ["read"] };
+    },
+    initConfig: {
+      linear: {
+        api_keys: ["lin_api_test"],
+        organizations: [{ id: "org-1", name: "My Org" }],
+        teams: [{ id: "team-1", name: "Engineering", key: "ENG", organization: "org-1" }],
+        users: [{ id: "user-1", name: "Developer", email: "dev@example.com", organization: "org-1" }],
+        workflow_states: [
+          { id: "ws-1", name: "Todo", type: "unstarted", team: "team-1" },
+          { id: "ws-2", name: "In Progress", type: "started", team: "team-1" },
+        ],
+        issues: [{ id: "issue-1", title: "First issue", team: "team-1", state: "ws-1", assignee: "user-1" }],
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,28 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/@emulators/linear:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+      graphql:
+        specifier: ^16.13.2
+        version: 16.13.2
+      hono:
+        specifier: ^4
+        version: 4.12.12
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+
   packages/@emulators/microsoft:
     dependencies:
       '@emulators/core':
@@ -697,6 +719,9 @@ importers:
       '@emulators/google':
         specifier: workspace:*
         version: link:../@emulators/google
+      '@emulators/linear':
+        specifier: workspace:*
+        version: link:../@emulators/linear
       '@emulators/microsoft':
         specifier: workspace:*
         version: link:../@emulators/microsoft
@@ -4565,8 +4590,8 @@ packages:
   graceful-readlink@1.0.1:
     resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
 
-  graphql@16.13.1:
-    resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   hachure-fill@0.5.2:
@@ -10730,8 +10755,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -10757,7 +10782,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10768,22 +10793,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10794,7 +10819,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11264,7 +11289,7 @@ snapshots:
 
   graceful-readlink@1.0.1: {}
 
-  graphql@16.13.1: {}
+  graphql@16.13.2: {}
 
   hachure-fill@0.5.2: {}
 
@@ -12366,7 +12391,7 @@ snapshots:
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.13.1
+      graphql: 16.13.2
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3
@@ -12391,7 +12416,7 @@ snapshots:
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.13.1
+      graphql: 16.13.2
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: linear
+description: Emulated Linear GraphQL API for local development and testing. Use when the user needs to test Linear API integrations locally, query issues or projects, validate GraphQL clients, or avoid hitting the real Linear API.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
+---
+
+# Linear API Emulator
+
+Phase 1 provides a read only Linear GraphQL emulator.
+
+Included now:
+
+- `POST /graphql`
+- GraphQL schema introspection
+- PAT authentication with `Authorization: <api_key>`
+- Query resolvers for `Issue`, `Project`, `Team`, `User`, `Organization`, `Label`, and `WorkflowState`
+- Relay style pagination with `edges`, `nodes`, and `pageInfo`
+
+Follow up PRs will add mutations, webhooks, OAuth 2.0, and an inspector UI.
+
+## Start
+
+```bash
+npx emulate --service linear
+```
+
+Default URL:
+
+```text
+http://localhost:4012
+```
+
+## Auth
+
+Use a seeded Linear API key as the raw `Authorization` header value.
+
+```bash
+curl http://localhost:4012/graphql \
+  -H "Authorization: lin_api_test" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ viewer { id name email } }"}'
+```
+
+## Query Example
+
+```bash
+curl http://localhost:4012/graphql \
+  -H "Authorization: lin_api_test" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ issues(first: 10) { nodes { id identifier title state { name } team { key } } pageInfo { hasNextPage endCursor } } }"}'
+```
+
+## Seed Config
+
+```yaml
+linear:
+  api_keys: [lin_api_test]
+  organizations:
+    - id: org-1
+      name: My Org
+  teams:
+    - id: team-1
+      name: Engineering
+      key: ENG
+      organization: org-1
+  workflow_states:
+    - id: ws-1
+      name: Todo
+      type: unstarted
+      team: team-1
+  users:
+    - id: user-1
+      name: Developer
+      email: dev@example.com
+      organization: org-1
+  issues:
+    - id: issue-1
+      title: First issue
+      team: team-1
+      state: ws-1
+      assignee: user-1
+```


### PR DESCRIPTION
## Summary

Adds a Linear service emulator. Linear is GraphQL-only, so this is the project's first GraphQL emulator. It exposes `POST /graphql` with introspection, read-only Query resolvers for `Issue` / `Project` / `Team` / `User` / `Organization` / `Label` / `WorkflowState`, Relay-style pagination, and PAT authentication via `Authorization: <api_key>`.

The pattern (reference `graphql` execution library + programmatic schema + store-backed resolvers) is intentionally minimal so future GraphQL services (Shopify Storefront, parts of GitHub's API, Hashnode) can follow it.

## Why this matters

Linear is the dominant project tracker for modern dev teams. The official `@linear/sdk` has [~50K weekly npm downloads](https://www.npmjs.com/package/@linear/sdk), and Linear-aware integrations are increasingly common — GitHub PR linking, Slack notifications, automation rules, AI agents that file issues. CI tests against Linear today either hit production (rate limits, workspace contamination) or hand-stub each query shape. There's no general-purpose emulator. WireMock can stub HTTP but cannot execute arbitrary GraphQL queries.

emulate's `Store` lets us back the resolvers with stateful entities; the only new dependency is `graphql@16.13.2` (the reference JS execution library — Apollo / Yoga deliberately avoided to keep deps minimal).

## Demo

A real GraphQL query against the running emulator:

![Linear demo](https://files.catbox.moe/wqt92d.gif)

```bash
curl http://localhost:4012/graphql \
  -H "Authorization: lin_api_test" \
  -H "Content-Type: application/json" \
  -d '{"query":"{ issues(first: 5) { nodes { id identifier title state { name } team { key } } pageInfo { hasNextPage } } }"}'
```

Returns:

```json
{
  "data": {
    "issues": {
      "nodes": [
        {
          "id": "issue-1",
          "identifier": "ENG-1",
          "title": "First issue",
          "state": { "name": "Todo" },
          "team": { "key": "ENG" }
        }
      ],
      "pageInfo": { "hasNextPage": false }
    }
  }
}
```

## Linear API Coverage

| Surface | Detail |
|---------|--------|
| `POST /graphql` | Single endpoint with introspection support |
| Auth | PAT via `Authorization: <api_key>` header |
| `Issue` | id, identifier (e.g. `ENG-1`), title, description, priority, state, assignee, team, project, labels |
| `Project` | id, name, description, lead, team, state |
| `Team` | id, name, key, organization |
| `User` | id, name, email, organization |
| `Organization` | id, name, urlKey |
| `Label` | id, name, color, team |
| `WorkflowState` | id, name, type (`unstarted`, `started`, `completed`, etc.), team |
| Pagination | Relay connections: `first`, `after`, `last`, `before`, `edges`, `nodes`, `pageInfo` |
| Errors | Linear-shape envelope with `extensions.code` |

## Default port

`4012` (appended at the end of `SERVICE_NAME_LIST` after `clerk` — no other service's port shifts).

## What's not yet covered

- Mutations (`issueCreate`, `issueUpdate`, `projectCreate`, etc.) — separate PR
- Webhooks via `WebhookDispatcher` — separate PR
- OAuth 2.0 flow — separate PR
- Inspector UI — separate PR
- Initiatives, roadmaps, customer records — separate plan

## Seed config

```yaml
linear:
  api_keys: [lin_api_test]
  organizations:
    - id: org-1
      name: My Org
  teams:
    - id: team-1
      name: Engineering
      key: ENG
      organization: org-1
  workflow_states:
    - id: ws-1
      name: Todo
      type: unstarted
      team: team-1
  users:
    - id: user-1
      name: Developer
      email: dev@example.com
      organization: org-1
  issues:
    - id: issue-1
      title: First issue
      team: team-1
      state: ws-1
      assignee: user-1
```

## Tests

26 Vitest tests covering Query resolvers (organization, user, team, workflowState, label, project, issue), Relay cursor pagination, schema introspection, error envelope shape, and PAT auth validation.

```
pnpm --filter @emulators/linear test    # 26 passed
pnpm --filter @emulators/linear build   # passes
pnpm --filter emulate build             # registry integration verified
pnpm format:check                       # passes
pnpm lint                               # passes
```
