### PR TITLE
Add native Go CLI foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,18 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build
+
+      - run: go test ./...
+
+      - run: go build ./cmd/emulate
 
       - run: node scripts/sync-versions.mjs --check
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+/emulate
 *.tsbuildinfo
 .turbo/
 .pnpm-store/

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -60,6 +60,9 @@ func runStart(args []string, stdout io.Writer, stderr io.Writer) int {
 	defaultPort := getenv("EMULATE_PORT", getenv("PORT", "4000"))
 	fs := flag.NewFlagSet("start", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		printStartHelp(stderr)
+	}
 
 	portValue := fs.String("port", defaultPort, "Base port")
 	fs.StringVar(portValue, "p", defaultPort, "Base port")
@@ -108,6 +111,9 @@ func runStart(args []string, stdout io.Writer, stderr io.Writer) int {
 func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		printInitHelp(stderr)
+	}
 
 	serviceValue := fs.String("service", "all", "Service to generate config for")
 	fs.StringVar(serviceValue, "s", "all", "Service to generate config for")
@@ -156,6 +162,9 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 func runList(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		printListHelp(stderr)
+	}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -185,11 +194,40 @@ func runList(args []string, stdout io.Writer, stderr io.Writer) int {
 func printHelp(w io.Writer) {
 	fmt.Fprintf(w, "emulate %s native Go runtime experimental\n\n", version)
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  npx emulate [start] [--port <port>] [--service <services>] [--seed <file>]")
+	fmt.Fprintln(w, "  npx emulate [start] [options]")
 	fmt.Fprintln(w, "  npx emulate init [--service <service>]")
 	fmt.Fprintln(w, "  npx emulate list")
+	fmt.Fprintln(w, "\nStart options:")
+	fmt.Fprintln(w, "  -p, --port <port>          Base port")
+	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
+	fmt.Fprintln(w, "      --seed <file>          Path to seed config file")
+	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
+	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless")
 	fmt.Fprintln(w, "\nThe published TypeScript CLI remains the default user-facing runtime.")
 	fmt.Fprintln(w, "Use npx emulate for current production behavior.")
+}
+
+func printStartHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  npx emulate [start] [options]")
+	fmt.Fprintln(w, "\nOptions:")
+	fmt.Fprintln(w, "  -p, --port <port>          Base port")
+	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
+	fmt.Fprintln(w, "      --seed <file>          Path to seed config file")
+	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
+	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless")
+}
+
+func printInitHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  npx emulate init [--service <service>]")
+	fmt.Fprintln(w, "\nOptions:")
+	fmt.Fprintln(w, "  -s, --service <service>    Service to generate config for")
+}
+
+func printListHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  npx emulate list")
 }
 
 func validateServices(value string) error {

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -45,7 +45,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "init":
 		return runInit(args[1:], stdout, stderr)
 	case "list", "list-services":
-		return runList(stdout)
+		return runList(args[1:], stdout, stderr)
 	default:
 		if strings.HasPrefix(args[0], "-") {
 			return runStart(args, stdout, stderr)
@@ -137,12 +137,11 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	content, err := json.MarshalIndent(config, "", "  ")
+	content, err := encodeYAML(config)
 	if err != nil {
 		fmt.Fprintf(stderr, "Failed to encode starter config: %v\n", err)
 		return 1
 	}
-	content = append(content, '\n')
 	const targetFilename = "emulate.config.yaml"
 	if err := os.WriteFile(targetFilename, content, 0o644); err != nil {
 		fmt.Fprintf(stderr, "Failed to write %s: %v\n", targetFilename, err)
@@ -154,7 +153,19 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 	return 0
 }
 
-func runList(stdout io.Writer) int {
+func runList(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 1
+	}
+	if hasUnexpectedArg(fs, stderr) {
+		return 1
+	}
+
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Available services:")
 	fmt.Fprintln(stdout)
@@ -218,4 +229,179 @@ func existingConfigFile() (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func encodeYAML(config map[string]any) ([]byte, error) {
+	var b strings.Builder
+	for _, key := range topLevelConfigKeys(config) {
+		if err := writeYAMLField(&b, key, config[key], 0); err != nil {
+			return nil, err
+		}
+	}
+	return []byte(b.String()), nil
+}
+
+func topLevelConfigKeys(config map[string]any) []string {
+	keys := make([]string, 0, len(config))
+	seen := map[string]bool{}
+	if _, ok := config["tokens"]; ok {
+		keys = append(keys, "tokens")
+		seen["tokens"] = true
+	}
+	for _, service := range emuruntime.Services {
+		if _, ok := config[service.Name]; ok {
+			keys = append(keys, service.Name)
+			seen[service.Name] = true
+		}
+	}
+	rest := make([]string, 0)
+	for key := range config {
+		if !seen[key] {
+			rest = append(rest, key)
+		}
+	}
+	sort.Strings(rest)
+	return append(keys, rest...)
+}
+
+func writeYAMLField(b *strings.Builder, key string, value any, indent int) error {
+	writeIndent(b, indent)
+	b.WriteString(key)
+	switch v := value.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			b.WriteString(": {}\n")
+			return nil
+		}
+		b.WriteString(":\n")
+		return writeYAMLMap(b, v, indent+2)
+	case []map[string]any:
+		if len(v) == 0 {
+			b.WriteString(": []\n")
+			return nil
+		}
+		b.WriteString(":\n")
+		return writeYAMLMapSlice(b, v, indent+2)
+	case []string:
+		if len(v) == 0 {
+			b.WriteString(": []\n")
+			return nil
+		}
+		b.WriteString(":\n")
+		for _, item := range v {
+			writeIndent(b, indent+2)
+			b.WriteString("- ")
+			writeYAMLScalar(b, item)
+			b.WriteByte('\n')
+		}
+		return nil
+	default:
+		b.WriteString(": ")
+		if err := writeYAMLScalar(b, v); err != nil {
+			return err
+		}
+		b.WriteByte('\n')
+		return nil
+	}
+}
+
+func writeYAMLMap(b *strings.Builder, value map[string]any, indent int) error {
+	for _, key := range sortedMapKeys(value) {
+		if err := writeYAMLField(b, key, value[key], indent); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeYAMLMapSlice(b *strings.Builder, values []map[string]any, indent int) error {
+	for _, value := range values {
+		keys := sortedMapKeys(value)
+		if len(keys) == 0 {
+			writeIndent(b, indent)
+			b.WriteString("- {}\n")
+			continue
+		}
+		writeIndent(b, indent)
+		b.WriteString("- ")
+		firstKey := keys[0]
+		b.WriteString(firstKey)
+		switch firstValue := value[firstKey].(type) {
+		case map[string]any:
+			if len(firstValue) == 0 {
+				b.WriteString(": {}\n")
+			} else {
+				b.WriteString(":\n")
+				if err := writeYAMLMap(b, firstValue, indent+4); err != nil {
+					return err
+				}
+			}
+		case []map[string]any:
+			if len(firstValue) == 0 {
+				b.WriteString(": []\n")
+			} else {
+				b.WriteString(":\n")
+				if err := writeYAMLMapSlice(b, firstValue, indent+4); err != nil {
+					return err
+				}
+			}
+		case []string:
+			if len(firstValue) == 0 {
+				b.WriteString(": []\n")
+			} else {
+				b.WriteString(":\n")
+				for _, item := range firstValue {
+					writeIndent(b, indent+4)
+					b.WriteString("- ")
+					writeYAMLScalar(b, item)
+					b.WriteByte('\n')
+				}
+			}
+		default:
+			b.WriteString(": ")
+			if err := writeYAMLScalar(b, firstValue); err != nil {
+				return err
+			}
+			b.WriteByte('\n')
+		}
+		for _, key := range keys[1:] {
+			if err := writeYAMLField(b, key, value[key], indent+2); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeYAMLScalar(b *strings.Builder, value any) error {
+	switch v := value.(type) {
+	case string:
+		b.WriteString(strconv.Quote(v))
+	case bool:
+		if v {
+			b.WriteString("true")
+		} else {
+			b.WriteString("false")
+		}
+	case int:
+		b.WriteString(strconv.Itoa(v))
+	default:
+		return fmt.Errorf("unsupported YAML value %T", value)
+	}
+	return nil
+}
+
+func sortedMapKeys(value map[string]any) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func writeIndent(b *strings.Builder, indent int) {
+	for range indent {
+		b.WriteByte(' ')
+	}
 }

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -70,6 +70,9 @@ func runStart(args []string, stdout io.Writer, stderr io.Writer) int {
 	portlessValue := fs.Bool("portless", false, "Serve over HTTPS via portless")
 
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 1
 	}
 
@@ -106,6 +109,9 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 	serviceValue := fs.String("service", "all", "Service to generate config for")
 	fs.StringVar(serviceValue, "s", "all", "Service to generate config for")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 1
 	}
 

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -158,9 +158,15 @@ func runList(stdout io.Writer) int {
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Available services:")
 	fmt.Fprintln(stdout)
+	maxNameLength := 0
 	for _, service := range emuruntime.Services {
-		fmt.Fprintf(stdout, "  %-10s%s\n", service.Name, service.Label)
-		fmt.Fprintf(stdout, "            Endpoints: %s\n\n", service.Endpoints)
+		if len(service.Name) > maxNameLength {
+			maxNameLength = len(service.Name)
+		}
+	}
+	for _, service := range emuruntime.Services {
+		fmt.Fprintf(stdout, "  %-*s  %s\n", maxNameLength, service.Name, service.Label)
+		fmt.Fprintf(stdout, "  %-*s  Endpoints: %s\n\n", maxNameLength, "", service.Endpoints)
 	}
 	return 0
 }

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -75,6 +75,9 @@ func runStart(args []string, stdout io.Writer, stderr io.Writer) int {
 		}
 		return 1
 	}
+	if hasUnexpectedArg(fs, stderr) {
+		return 1
+	}
 
 	port, err := strconv.Atoi(*portValue)
 	if err != nil || port < 1 || port > 65535 {
@@ -112,6 +115,9 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
+		return 1
+	}
+	if hasUnexpectedArg(fs, stderr) {
 		return 1
 	}
 
@@ -187,6 +193,14 @@ func getenv(name string, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func hasUnexpectedArg(fs *flag.FlagSet, stderr io.Writer) bool {
+	if fs.NArg() == 0 {
+		return false
+	}
+	fmt.Fprintf(stderr, "Unexpected argument: %s\n", fs.Arg(0))
+	return true
 }
 
 func existingConfigFile() (string, error) {

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
+)
+
+var version = "dev"
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		return runStart(nil, stdout, stderr)
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printHelp(stdout)
+		return 0
+	case "-v", "--version", "version":
+		fmt.Fprintf(stdout, "emulate %s\n", version)
+		return 0
+	case "start":
+		return runStart(args[1:], stdout, stderr)
+	case "init":
+		return runInit(args[1:], stdout, stderr)
+	case "list", "list-services":
+		return runList(stdout)
+	default:
+		if strings.HasPrefix(args[0], "-") {
+			return runStart(args, stdout, stderr)
+		}
+		fmt.Fprintf(stderr, "Unknown command: %s\n", args[0])
+		printHelp(stderr)
+		return 1
+	}
+}
+
+func runStart(args []string, stdout io.Writer, stderr io.Writer) int {
+	defaultPort := getenv("EMULATE_PORT", getenv("PORT", "4000"))
+	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	portValue := fs.String("port", defaultPort, "Base port")
+	fs.StringVar(portValue, "p", defaultPort, "Base port")
+	serviceValue := fs.String("service", "", "Comma-separated services to enable")
+	fs.StringVar(serviceValue, "s", "", "Comma-separated services to enable")
+	seedValue := fs.String("seed", "", "Path to seed config file")
+	baseURLValue := fs.String("base-url", "", "Override advertised base URL")
+	portlessValue := fs.Bool("portless", false, "Serve over HTTPS via portless")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	port, err := strconv.Atoi(*portValue)
+	if err != nil || port < 1 || port > 65535 {
+		fmt.Fprintf(stderr, "Invalid port: %s\n", *portValue)
+		return 1
+	}
+	if *portlessValue && *baseURLValue != "" {
+		fmt.Fprintln(stderr, "--portless and --base-url are mutually exclusive.")
+		return 1
+	}
+	if err := validateServices(*serviceValue); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "emulate %s native Go runtime is experimental.\n", version)
+	fmt.Fprintf(stdout, "start is not implemented yet in the native Go runtime.\n")
+	fmt.Fprintf(stdout, "Requested base port: %d\n", port)
+	if *serviceValue != "" {
+		fmt.Fprintf(stdout, "Requested services: %s\n", *serviceValue)
+	}
+	if *seedValue != "" {
+		fmt.Fprintf(stdout, "Requested seed: %s\n", *seedValue)
+	}
+	return 1
+}
+
+func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	serviceValue := fs.String("service", "all", "Service to generate config for")
+	fs.StringVar(serviceValue, "s", "all", "Service to generate config for")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	config, err := emuruntime.StarterConfig(*serviceValue)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s. Available: %s, all\n", err, strings.Join(emuruntime.ServiceNames(), ", "))
+		return 1
+	}
+
+	const filename = "emulate.config.json"
+	if _, err := os.Stat(filename); err == nil {
+		fmt.Fprintf(stderr, "Config file already exists: %s\n", filename)
+		return 1
+	} else if !errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(stderr, "Failed to check %s: %v\n", filename, err)
+		return 1
+	}
+
+	content, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		fmt.Fprintf(stderr, "Failed to encode starter config: %v\n", err)
+		return 1
+	}
+	content = append(content, '\n')
+	if err := os.WriteFile(filename, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "Failed to write %s: %v\n", filename, err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Created %s\n", filename)
+	fmt.Fprintln(stdout, "\nRun 'npx emulate' to start the emulator.")
+	return 0
+}
+
+func runList(stdout io.Writer) int {
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Available services:")
+	fmt.Fprintln(stdout)
+	for _, service := range emuruntime.Services {
+		fmt.Fprintf(stdout, "  %-10s%s\n", service.Name, service.Label)
+		fmt.Fprintf(stdout, "            Endpoints: %s\n\n", service.Endpoints)
+	}
+	return 0
+}
+
+func printHelp(w io.Writer) {
+	fmt.Fprintf(w, "emulate %s native Go runtime experimental\n\n", version)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  emulate [start] [--port <port>] [--service <services>] [--seed <file>]")
+	fmt.Fprintln(w, "  emulate init [--service <service>]")
+	fmt.Fprintln(w, "  emulate list")
+	fmt.Fprintln(w, "\nThe published TypeScript CLI remains the default user-facing runtime.")
+	fmt.Fprintln(w, "Use npx emulate for current production behavior.")
+}
+
+func validateServices(value string) error {
+	if value == "" {
+		return nil
+	}
+	for _, service := range strings.Split(value, ",") {
+		name := strings.TrimSpace(service)
+		if _, ok := emuruntime.FindService(name); !ok {
+			return fmt.Errorf("Unknown service: %s", name)
+		}
+	}
+	return nil
+}
+
+func getenv(name string, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -15,6 +15,15 @@ import (
 
 var version = "dev"
 
+var configFilenames = []string{
+	"emulate.config.yaml",
+	"emulate.config.yml",
+	"emulate.config.json",
+	"service-emulator.config.yaml",
+	"service-emulator.config.yml",
+	"service-emulator.config.json",
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
@@ -106,12 +115,13 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	const filename = "emulate.config.json"
-	if _, err := os.Stat(filename); err == nil {
-		fmt.Fprintf(stderr, "Config file already exists: %s\n", filename)
-		return 1
-	} else if !errors.Is(err, os.ErrNotExist) {
+	filename, err := existingConfigFile()
+	if err != nil {
 		fmt.Fprintf(stderr, "Failed to check %s: %v\n", filename, err)
+		return 1
+	}
+	if filename != "" {
+		fmt.Fprintf(stderr, "Config file already exists: %s\n", filename)
 		return 1
 	}
 
@@ -121,12 +131,13 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 	content = append(content, '\n')
-	if err := os.WriteFile(filename, content, 0o644); err != nil {
-		fmt.Fprintf(stderr, "Failed to write %s: %v\n", filename, err)
+	const targetFilename = "emulate.config.yaml"
+	if err := os.WriteFile(targetFilename, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "Failed to write %s: %v\n", targetFilename, err)
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "Created %s\n", filename)
+	fmt.Fprintf(stdout, "Created %s\n", targetFilename)
 	fmt.Fprintln(stdout, "\nRun 'npx emulate' to start the emulator.")
 	return 0
 }
@@ -145,9 +156,9 @@ func runList(stdout io.Writer) int {
 func printHelp(w io.Writer) {
 	fmt.Fprintf(w, "emulate %s native Go runtime experimental\n\n", version)
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  emulate [start] [--port <port>] [--service <services>] [--seed <file>]")
-	fmt.Fprintln(w, "  emulate init [--service <service>]")
-	fmt.Fprintln(w, "  emulate list")
+	fmt.Fprintln(w, "  npx emulate [start] [--port <port>] [--service <services>] [--seed <file>]")
+	fmt.Fprintln(w, "  npx emulate init [--service <service>]")
+	fmt.Fprintln(w, "  npx emulate list")
 	fmt.Fprintln(w, "\nThe published TypeScript CLI remains the default user-facing runtime.")
 	fmt.Fprintln(w, "Use npx emulate for current production behavior.")
 }
@@ -170,4 +181,15 @@ func getenv(name string, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func existingConfigFile() (string, error) {
+	for _, filename := range configFilenames {
+		if _, err := os.Stat(filename); err == nil {
+			return filename, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return filename, err
+		}
+	}
+	return "", nil
 }

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +22,34 @@ func TestRunListIncludesRegisteredServices(t *testing.T) {
 	}
 	if !strings.Contains(out, "  mongoatlas  MongoDB Atlas service emulator") {
 		t.Fatalf("list output did not separate longest service name from label:\n%s", out)
+	}
+}
+
+func TestRunListHelpExitsSuccessfully(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("list help exited with %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Usage of list:") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Available services") {
+		t.Fatalf("list printed services for help:\n%s", stdout.String())
+	}
+}
+
+func TestRunListRejectsUnexpectedArgument(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list", "extra"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("list with unexpected argument exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "Unexpected argument: extra") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Available services") {
+		t.Fatalf("list printed services after unexpected argument:\n%s", stdout.String())
 	}
 }
 
@@ -126,17 +153,17 @@ func TestRunInitWritesStarterConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var config map[string]any
-	if err := json.Unmarshal(raw, &config); err != nil {
-		t.Fatal(err)
+	content := string(raw)
+	if strings.HasPrefix(content, "{") || strings.Contains(content, "\"tokens\"") {
+		t.Fatalf("starter config was written as JSON:\n%s", content)
 	}
-	if _, ok := config["tokens"]; !ok {
-		t.Fatal("starter config missing tokens")
+	if !strings.HasPrefix(content, "tokens:\n") {
+		t.Fatalf("starter config missing tokens YAML section:\n%s", content)
 	}
-	if _, ok := config["aws"]; !ok {
-		t.Fatal("starter config missing aws")
+	if !strings.Contains(content, "\naws:\n") {
+		t.Fatalf("starter config missing aws YAML section:\n%s", content)
 	}
-	if _, ok := config["github"]; ok {
+	if strings.Contains(content, "\ngithub:\n") {
 		t.Fatal("service-specific starter config included github")
 	}
 }

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -21,6 +21,9 @@ func TestRunListIncludesRegisteredServices(t *testing.T) {
 			t.Fatalf("list output missing %q:\n%s", service, out)
 		}
 	}
+	if !strings.Contains(out, "  mongoatlas  MongoDB Atlas service emulator") {
+		t.Fatalf("list output did not separate longest service name from label:\n%s", out)
+	}
 }
 
 func TestRunStartRejectsInvalidPort(t *testing.T) {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -31,7 +31,7 @@ func TestRunListHelpExitsSuccessfully(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("list help exited with %d, stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Usage of list:") {
+	if !strings.Contains(stderr.String(), "npx emulate list") {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "Available services") {
@@ -84,7 +84,45 @@ func TestRunStartHelpExitsSuccessfully(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("start help exited with %d, stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Usage of start:") {
+	help := stderr.String()
+	for _, want := range []string{
+		"npx emulate [start] [options]",
+		"--base-url <url>",
+		"--portless",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("start help missing %q:\n%s", want, help)
+		}
+	}
+	for _, unwanted := range []string{
+		"Usage of start:",
+		"\n  -base-url string",
+		"\n  -portless\n",
+	} {
+		if strings.Contains(help, unwanted) {
+			t.Fatalf("start help included Go flag syntax %q:\n%s", unwanted, help)
+		}
+	}
+}
+
+func TestRunTopLevelHelpIncludesFullStartOptions(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("top-level help exited with %d, stderr: %s", code, stderr.String())
+	}
+	help := stdout.String()
+	for _, want := range []string{
+		"npx emulate [start] [options]",
+		"--seed <file>",
+		"--base-url <url>",
+		"--portless",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("top-level help missing %q:\n%s", want, help)
+		}
+	}
+	if stderr.Len() != 0 {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
 	}
 }
@@ -95,7 +133,7 @@ func TestRunInitHelpExitsSuccessfully(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("init help exited with %d, stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Usage of init:") {
+	if !strings.Contains(stderr.String(), "npx emulate init [--service <service>]") {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
 	}
 }

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -34,6 +34,28 @@ func TestRunStartRejectsInvalidPort(t *testing.T) {
 	}
 }
 
+func TestRunStartHelpExitsSuccessfully(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"start", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start help exited with %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Usage of start:") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestRunInitHelpExitsSuccessfully(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("init help exited with %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Usage of init:") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
 func TestRunInitWritesStarterConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	oldDir, err := os.Getwd()

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunListIncludesRegisteredServices(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("list exited with %d, stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, service := range []string{"github", "aws", "stripe", "clerk"} {
+		if !strings.Contains(out, service) {
+			t.Fatalf("list output missing %q:\n%s", service, out)
+		}
+	}
+}
+
+func TestRunStartRejectsInvalidPort(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"start", "--port", "70000"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("start with invalid port exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "Invalid port: 70000") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestRunInitWritesStarterJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "--service", "aws"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("init exited with %d, stderr: %s", code, stderr.String())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(tempDir, "emulate.config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := config["tokens"]; !ok {
+		t.Fatal("starter config missing tokens")
+	}
+	if _, ok := config["aws"]; !ok {
+		t.Fatal("starter config missing aws")
+	}
+	if _, ok := config["github"]; ok {
+		t.Fatal("service-specific starter config included github")
+	}
+}

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -34,6 +34,20 @@ func TestRunStartRejectsInvalidPort(t *testing.T) {
 	}
 }
 
+func TestRunStartRejectsUnexpectedArgument(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"start", "github", "--port", "4010"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("start with unexpected argument exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "Unexpected argument: github") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Requested base port") {
+		t.Fatalf("start continued after unexpected argument:\n%s", stdout.String())
+	}
+}
+
 func TestRunStartHelpExitsSuccessfully(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"start", "--help"}, &stdout, &stderr)
@@ -53,6 +67,34 @@ func TestRunInitHelpExitsSuccessfully(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "Usage of init:") {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestRunInitRejectsUnexpectedArgument(t *testing.T) {
+	tempDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "aws"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("init with unexpected argument exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "Unexpected argument: aws") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "emulate.config.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected config file stat error: %v", err)
 	}
 }
 

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -34,7 +34,7 @@ func TestRunStartRejectsInvalidPort(t *testing.T) {
 	}
 }
 
-func TestRunInitWritesStarterJSON(t *testing.T) {
+func TestRunInitWritesStarterConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	oldDir, err := os.Getwd()
 	if err != nil {
@@ -55,7 +55,7 @@ func TestRunInitWritesStarterJSON(t *testing.T) {
 		t.Fatalf("init exited with %d, stderr: %s", code, stderr.String())
 	}
 
-	raw, err := os.ReadFile(filepath.Join(tempDir, "emulate.config.json"))
+	raw, err := os.ReadFile(filepath.Join(tempDir, "emulate.config.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,5 +71,35 @@ func TestRunInitWritesStarterJSON(t *testing.T) {
 	}
 	if _, ok := config["github"]; ok {
 		t.Fatal("service-specific starter config included github")
+	}
+}
+
+func TestRunInitRejectsExistingAutoDetectedConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	existing := filepath.Join(tempDir, "emulate.config.yaml")
+	if err := os.WriteFile(existing, []byte("github: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "--service", "aws"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("init with existing config exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "Config file already exists: emulate.config.yaml") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/vercel-labs/emulate
+
+go 1.24

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -1,0 +1,112 @@
+package runtime
+
+import "fmt"
+
+type Service struct {
+	Name       string
+	Label      string
+	Endpoints  string
+	InitConfig map[string]any
+}
+
+var Services = []Service{
+	{
+		Name:      "vercel",
+		Label:     "Vercel REST API emulator",
+		Endpoints: "projects, deployments, domains, env vars, users, teams, file uploads, protection bypass",
+		InitConfig: map[string]any{
+			"users":        []map[string]any{{"username": "developer", "name": "Developer", "email": "dev@example.com"}},
+			"teams":        []map[string]any{{"slug": "my-team", "name": "My Team"}},
+			"projects":     []map[string]any{{"name": "my-app", "team": "my-team", "framework": "nextjs"}},
+			"integrations": []map[string]any{{"client_id": "oac_example_client_id", "client_secret": "example_client_secret", "name": "My Vercel App", "redirect_uris": []string{"http://localhost:3000/api/auth/callback/vercel"}}},
+		},
+	},
+	{
+		Name:      "github",
+		Label:     "GitHub REST API emulator",
+		Endpoints: "users, repos, issues, PRs, comments, reviews, labels, milestones, branches, git data, orgs, teams, releases, webhooks, search, actions, checks, rate limit",
+		InitConfig: map[string]any{
+			"users":      []map[string]any{{"login": "octocat", "name": "The Octocat", "email": "octocat@github.com", "bio": "I am the Octocat", "company": "GitHub", "location": "San Francisco"}},
+			"orgs":       []map[string]any{{"login": "my-org", "name": "My Organization", "description": "A test organization"}},
+			"repos":      []map[string]any{{"owner": "octocat", "name": "hello-world", "description": "My first repository", "language": "JavaScript", "topics": []string{"hello", "world"}, "auto_init": true}, {"owner": "my-org", "name": "org-repo", "description": "An organization repository", "language": "TypeScript", "auto_init": true}},
+			"oauth_apps": []map[string]any{{"client_id": "Iv1.example_client_id", "client_secret": "example_client_secret", "name": "My App", "redirect_uris": []string{"http://localhost:3000/api/auth/callback/github"}}},
+		},
+	},
+	{
+		Name:      "google",
+		Label:     "Google OAuth 2.0 / OpenID Connect + Gmail, Calendar, and Drive emulator",
+		Endpoints: "OAuth authorize, token exchange, userinfo, OIDC discovery, token revocation, Gmail messages/drafts/threads/labels/history/settings, Calendar lists/events/freebusy, Drive files/uploads",
+		InitConfig: map[string]any{
+			"users":           []map[string]any{{"email": "testuser@example.com", "name": "Test User", "picture": "https://lh3.googleusercontent.com/a/default-user", "email_verified": true}},
+			"oauth_clients":   []map[string]any{{"client_id": "example-client-id.apps.googleusercontent.com", "client_secret": "GOCSPX-example_secret", "name": "Code App (Google)", "redirect_uris": []string{"http://localhost:3000/api/auth/callback/google"}}},
+			"labels":          []map[string]any{{"id": "Label_ops", "user_email": "testuser@example.com", "name": "Ops/Review", "color_background": "#DDEEFF", "color_text": "#111111"}},
+			"messages":        []map[string]any{{"id": "msg_welcome", "user_email": "testuser@example.com", "from": "welcome@example.com", "to": "testuser@example.com", "subject": "Welcome to the Gmail emulator", "body_text": "You can now test Gmail, Calendar, and Drive flows locally.", "label_ids": []string{"INBOX", "UNREAD", "CATEGORY_UPDATES"}, "date": "2025-01-04T10:00:00.000Z"}},
+			"calendars":       []map[string]any{{"id": "primary", "user_email": "testuser@example.com", "summary": "testuser@example.com", "primary": true, "selected": true, "time_zone": "UTC"}},
+			"calendar_events": []map[string]any{{"id": "evt_kickoff", "user_email": "testuser@example.com", "calendar_id": "primary", "summary": "Project Kickoff", "start_date_time": "2025-01-10T09:00:00.000Z", "end_date_time": "2025-01-10T09:30:00.000Z"}},
+			"drive_items":     []map[string]any{{"id": "drv_docs", "user_email": "testuser@example.com", "name": "Docs", "mime_type": "application/vnd.google-apps.folder", "parent_ids": []string{"root"}}},
+		},
+	},
+	{Name: "slack", Label: "Slack API emulator", Endpoints: "auth, chat, conversations, users, reactions, team, OAuth, incoming webhooks", InitConfig: map[string]any{"team": map[string]any{"name": "My Workspace", "domain": "my-workspace"}, "users": []map[string]any{{"name": "developer", "real_name": "Developer", "email": "dev@example.com"}}, "channels": []map[string]any{{"name": "general", "topic": "General discussion"}, {"name": "random", "topic": "Random stuff"}}, "bots": []map[string]any{{"name": "my-bot"}}, "oauth_apps": []map[string]any{{"client_id": "12345.67890", "client_secret": "example_client_secret", "name": "My Slack App", "redirect_uris": []string{"http://localhost:3000/api/auth/callback/slack"}}}}},
+	{Name: "apple", Label: "Apple Sign In / OAuth emulator", Endpoints: "OAuth authorize, token exchange, JWKS", InitConfig: map[string]any{"users": []map[string]any{{"email": "testuser@icloud.com", "name": "Test User"}}, "oauth_clients": []map[string]any{{"client_id": "com.example.app", "team_id": "TEAM001", "name": "My Apple App", "redirect_uris": []string{"http://localhost:3000/api/auth/callback/apple"}}}}},
+	{Name: "microsoft", Label: "Microsoft Entra ID OAuth 2.0 / OpenID Connect emulator", Endpoints: "OAuth authorize, token exchange, userinfo, OIDC discovery, Graph /me, logout, token revocation", InitConfig: map[string]any{"users": []map[string]any{{"email": "testuser@outlook.com", "name": "Test User"}}, "oauth_clients": []map[string]any{{"client_id": "example-client-id", "client_secret": "example-client-secret", "name": "My Microsoft App", "redirect_uris": []string{"http://localhost:3000/api/auth/callback/microsoft-entra-id"}}}}},
+	{Name: "okta", Label: "Okta OAuth 2.0 / OpenID Connect + management API emulator", Endpoints: "OIDC discovery, JWKS, OAuth authorize/token/userinfo/introspect/revoke/logout, users, groups, apps, authorization servers", InitConfig: map[string]any{"users": []map[string]any{{"login": "testuser@okta.local", "email": "testuser@okta.local", "first_name": "Test", "last_name": "User"}}, "groups": []map[string]any{{"name": "Everyone", "description": "All users", "type": "BUILT_IN", "okta_id": "00g_everyone"}}, "authorization_servers": []map[string]any{{"id": "default", "name": "default", "audiences": []string{"api://default"}}}, "oauth_clients": []map[string]any{{"client_id": "okta-test-client", "client_secret": "okta-test-secret", "name": "Sample OIDC Client", "redirect_uris": []string{"http://localhost:3000/callback"}, "auth_server_id": "default"}}}},
+	{Name: "aws", Label: "AWS cloud service emulator", Endpoints: "S3 (buckets, objects), SQS (queues, messages), IAM (users, roles, access keys), STS (assume role, caller identity)", InitConfig: map[string]any{"region": "us-east-1", "s3": map[string]any{"buckets": []map[string]any{{"name": "my-app-bucket"}, {"name": "my-app-uploads"}}}, "sqs": map[string]any{"queues": []map[string]any{{"name": "my-app-events"}, {"name": "my-app-dlq"}}}, "iam": map[string]any{"users": []map[string]any{{"user_name": "developer", "create_access_key": true}}, "roles": []map[string]any{{"role_name": "lambda-execution-role", "description": "Role for Lambda function execution"}}}}},
+	{Name: "resend", Label: "Resend email API emulator", Endpoints: "emails, domains, contacts, API keys, inbox UI", InitConfig: map[string]any{"domains": []map[string]any{{"name": "example.com", "region": "us-east-1"}}, "contacts": []map[string]any{{"email": "test@example.com", "first_name": "Test", "last_name": "User"}}}},
+	{Name: "stripe", Label: "Stripe payments emulator", Endpoints: "customers, payment methods, customer sessions, payment intents, charges, products, prices, checkout sessions, webhooks", InitConfig: map[string]any{"customers": []map[string]any{{"email": "test@example.com", "name": "Test Customer"}}, "products": []map[string]any{{"name": "Pro Plan", "description": "Monthly pro subscription"}}, "prices": []map[string]any{{"product_name": "Pro Plan", "currency": "usd", "unit_amount": 2000}}}},
+	{Name: "mongoatlas", Label: "MongoDB Atlas service emulator", Endpoints: "Atlas Admin API v2 (projects, clusters, database users, databases, collections), Atlas Data API v1 (findOne, find, insertOne, insertMany, updateOne, updateMany, deleteOne, deleteMany, aggregate)", InitConfig: map[string]any{"projects": []map[string]any{{"name": "Project0"}}, "clusters": []map[string]any{{"name": "Cluster0", "project": "Project0"}}, "database_users": []map[string]any{{"username": "admin", "project": "Project0"}}, "databases": []map[string]any{{"cluster": "Cluster0", "name": "test", "collections": []string{"items"}}}}},
+	{Name: "clerk", Label: "Clerk authentication and user management emulator", Endpoints: "OIDC discovery, JWKS, OAuth authorize/token/userinfo, users, email addresses, organizations, memberships, invitations, sessions", InitConfig: map[string]any{"users": []map[string]any{{"first_name": "Test", "last_name": "User", "email_addresses": []string{"test@example.com"}, "password": "clerk_test_password"}}, "organizations": []map[string]any{{"name": "My Company", "slug": "my-company", "members": []map[string]any{{"email": "test@example.com", "role": "admin"}}}}, "oauth_applications": []map[string]any{{"client_id": "clerk_emulate_client", "client_secret": "clerk_emulate_secret", "name": "Emulate App", "redirect_uris": []string{"http://localhost:3000/api/auth/callback/clerk"}}}}},
+}
+
+var DefaultTokens = map[string]any{
+	"tokens": map[string]any{
+		"test_token_admin": map[string]any{
+			"login":  "admin",
+			"scopes": []string{"repo", "user", "admin:org", "admin:repo_hook"},
+		},
+		"test_token_user1": map[string]any{
+			"login":  "octocat",
+			"scopes": []string{"repo", "user"},
+		},
+	},
+}
+
+func ServiceNames() []string {
+	names := make([]string, 0, len(Services))
+	for _, service := range Services {
+		names = append(names, service.Name)
+	}
+	return names
+}
+
+func FindService(name string) (Service, bool) {
+	for _, service := range Services {
+		if service.Name == name {
+			return service, true
+		}
+	}
+	return Service{}, false
+}
+
+func StarterConfig(serviceName string) (map[string]any, error) {
+	config := cloneMap(DefaultTokens)
+	if serviceName == "all" {
+		for _, service := range Services {
+			config[service.Name] = service.InitConfig
+		}
+		return config, nil
+	}
+	service, ok := FindService(serviceName)
+	if !ok {
+		return nil, fmt.Errorf("unknown service: %s", serviceName)
+	}
+	config[service.Name] = service.InitConfig
+	return config, nil
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -1,0 +1,38 @@
+package runtime
+
+import "testing"
+
+func TestServiceNamesPreserveRegistryOrder(t *testing.T) {
+	got := ServiceNames()
+	want := []string{"vercel", "github", "google", "slack", "apple", "microsoft", "okta", "aws", "resend", "stripe", "mongoatlas", "clerk"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d services, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("service %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestStarterConfigIncludesTokensAndSelectedService(t *testing.T) {
+	config, err := StarterConfig("aws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := config["tokens"]; !ok {
+		t.Fatal("starter config is missing tokens")
+	}
+	if _, ok := config["aws"]; !ok {
+		t.Fatal("starter config is missing selected service")
+	}
+	if _, ok := config["github"]; ok {
+		t.Fatal("service-specific starter config included an unrelated service")
+	}
+}
+
+func TestStarterConfigRejectsUnknownService(t *testing.T) {
+	if _, err := StarterConfig("unknown"); err == nil {
+		t.Fatal("expected unknown service error")
+	}
+}


### PR DESCRIPTION
- Add an experimental Go CLI shell with list, init, and start validation.

- Seed the Go service registry from the current TypeScript runtime contract.

- Cover the initial CLI and registry behavior with Go tests.