### PR TITLE
Add Go HTTP and store foundation

### DIFF
--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net"
+	nethttp "net/http"
 	"os"
+	"os/signal"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 )
@@ -25,12 +31,18 @@ var configFilenames = []string{
 }
 
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	os.Exit(runWithContext(ctx, os.Args[1:], os.Stdout, os.Stderr))
 }
 
 func run(args []string, stdout io.Writer, stderr io.Writer) int {
+	return runWithContext(context.Background(), args, stdout, stderr)
+}
+
+func runWithContext(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) == 0 {
-		return runStart(nil, stdout, stderr)
+		return runStart(ctx, nil, stdout, stderr)
 	}
 
 	switch args[0] {
@@ -41,14 +53,14 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "emulate %s\n", version)
 		return 0
 	case "start":
-		return runStart(args[1:], stdout, stderr)
+		return runStart(ctx, args[1:], stdout, stderr)
 	case "init":
 		return runInit(args[1:], stdout, stderr)
 	case "list", "list-services":
 		return runList(args[1:], stdout, stderr)
 	default:
 		if strings.HasPrefix(args[0], "-") {
-			return runStart(args, stdout, stderr)
+			return runStart(ctx, args, stdout, stderr)
 		}
 		fmt.Fprintf(stderr, "Unknown command: %s\n", args[0])
 		printHelp(stderr)
@@ -56,7 +68,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 }
 
-func runStart(args []string, stdout io.Writer, stderr io.Writer) int {
+func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
 	defaultPort := getenv("EMULATE_PORT", getenv("PORT", "4000"))
 	fs := flag.NewFlagSet("start", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -91,21 +103,68 @@ func runStart(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "--portless and --base-url are mutually exclusive.")
 		return 1
 	}
-	if err := validateServices(*serviceValue); err != nil {
+	if *portlessValue {
+		fmt.Fprintln(stderr, "The native Go runtime does not support --portless yet.")
+		return 1
+	}
+	if *seedValue != "" {
+		fmt.Fprintln(stderr, "The native Go runtime does not support --seed yet.")
+		return 1
+	}
+	services, err := parseServices(*serviceValue)
+	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
 
+	baseURL := *baseURLValue
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("http://localhost:%d", port)
+	}
+	server := emuruntime.NewServer(emuruntime.ServerOptions{
+		Version:  version,
+		BaseURL:  baseURL,
+		Services: services,
+	})
+	httpServer := &nethttp.Server{
+		Handler:           server.Handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		fmt.Fprintf(stderr, "Failed to listen on port %d: %v\n", port, err)
+		return 1
+	}
+
 	fmt.Fprintf(stdout, "emulate %s native Go runtime is experimental.\n", version)
-	fmt.Fprintf(stdout, "start is not implemented yet in the native Go runtime.\n")
-	fmt.Fprintf(stdout, "Requested base port: %d\n", port)
-	if *serviceValue != "" {
-		fmt.Fprintf(stdout, "Requested services: %s\n", *serviceValue)
+	fmt.Fprintf(stdout, "Listening on %s\n", baseURL)
+	fmt.Fprintf(stdout, "Health check: %s%s\n", strings.TrimRight(baseURL, "/"), emuruntime.HealthPath)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- httpServer.Serve(listener)
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			fmt.Fprintf(stderr, "Failed to shut down server: %v\n", err)
+			return 1
+		}
+		if err := <-errCh; err != nil && !errors.Is(err, nethttp.ErrServerClosed) {
+			fmt.Fprintf(stderr, "Server stopped unexpectedly: %v\n", err)
+			return 1
+		}
+		return 0
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, nethttp.ErrServerClosed) {
+			fmt.Fprintf(stderr, "Server stopped unexpectedly: %v\n", err)
+			return 1
+		}
+		return 0
 	}
-	if *seedValue != "" {
-		fmt.Fprintf(stdout, "Requested seed: %s\n", *seedValue)
-	}
-	return 1
 }
 
 func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -230,17 +289,27 @@ func printListHelp(w io.Writer) {
 	fmt.Fprintln(w, "  npx emulate list")
 }
 
-func validateServices(value string) error {
+func parseServices(value string) ([]string, error) {
 	if value == "" {
-		return nil
+		return emuruntime.ServiceNames(), nil
 	}
+	services := make([]string, 0)
+	seen := map[string]bool{}
 	for _, service := range strings.Split(value, ",") {
 		name := strings.TrimSpace(service)
-		if _, ok := emuruntime.FindService(name); !ok {
-			return fmt.Errorf("Unknown service: %s", name)
+		if name == "" || seen[name] {
+			continue
 		}
+		if _, ok := emuruntime.FindService(name); !ok {
+			return nil, fmt.Errorf("Unknown service: %s", name)
+		}
+		services = append(services, name)
+		seen[name] = true
 	}
-	return nil
+	if len(services) == 0 {
+		return nil, fmt.Errorf("No services selected")
+	}
+	return services, nil
 }
 
 func getenv(name string, fallback string) string {

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -259,9 +259,9 @@ func printHelp(w io.Writer) {
 	fmt.Fprintln(w, "\nStart options:")
 	fmt.Fprintln(w, "  -p, --port <port>          Base port")
 	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
-	fmt.Fprintln(w, "      --seed <file>          Path to seed config file")
+	fmt.Fprintln(w, "      --seed <file>          Path to seed config file (not supported in native Go yet)")
 	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
-	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless")
+	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless (not supported in native Go yet)")
 	fmt.Fprintln(w, "\nThe published TypeScript CLI remains the default user-facing runtime.")
 	fmt.Fprintln(w, "Use npx emulate for current production behavior.")
 }
@@ -272,9 +272,9 @@ func printStartHelp(w io.Writer) {
 	fmt.Fprintln(w, "\nOptions:")
 	fmt.Fprintln(w, "  -p, --port <port>          Base port")
 	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
-	fmt.Fprintln(w, "      --seed <file>          Path to seed config file")
+	fmt.Fprintln(w, "      --seed <file>          Path to seed config file (not supported in native Go yet)")
 	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
-	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless")
+	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless (not supported in native Go yet)")
 }
 
 func printInitHelp(w io.Writer) {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -2,10 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 )
 
 func TestRunListIncludesRegisteredServices(t *testing.T) {
@@ -105,6 +114,50 @@ func TestRunStartHelpExitsSuccessfully(t *testing.T) {
 	}
 }
 
+func TestRunStartServesHealthEndpoint(t *testing.T) {
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--service", "github"}, &stdout, &stderr)
+	}()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath)
+	var body struct {
+		OK       bool     `json:"ok"`
+		Runtime  string   `json:"runtime"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, url, &body)
+
+	if !body.OK || body.Runtime != "go" {
+		t.Fatalf("unexpected health body: %#v", body)
+	}
+	if len(body.Services) != 1 || body.Services[0] != "github" {
+		t.Fatalf("unexpected services: %#v", body.Services)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+
+	if !strings.Contains(stdout.String(), "Health check:") {
+		t.Fatalf("stdout did not include health check:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
 func TestRunTopLevelHelpIncludesFullStartOptions(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"--help"}, &stdout, &stderr)
@@ -125,6 +178,46 @@ func TestRunTopLevelHelpIncludesFullStartOptions(t *testing.T) {
 	if stderr.Len() != 0 {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
 	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener address: %v", listener.Addr())
+	}
+	return addr.Port
+}
+
+func waitForJSON(t *testing.T, url string, target any) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			func() {
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					lastErr = fmt.Errorf("status %d", resp.StatusCode)
+					return
+				}
+				lastErr = json.NewDecoder(resp.Body).Decode(target)
+			}()
+			if lastErr == nil {
+				return
+			}
+		} else {
+			lastErr = err
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("GET %s did not return JSON: %v", url, lastErr)
 }
 
 func TestRunInitHelpExitsSuccessfully(t *testing.T) {

--- a/internal/core/http/router.go
+++ b/internal/core/http/router.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	pathpkg "path"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -89,6 +90,7 @@ type route struct {
 type segment struct {
 	literal string
 	param   string
+	regex   *regexp.Regexp
 }
 
 func NewRouter() *Router {
@@ -194,6 +196,21 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if req.Method == http.MethodHead {
+		for _, route := range routes {
+			if route.method != http.MethodGet {
+				continue
+			}
+			params, ok := route.match(http.MethodGet, req.URL.Path)
+			if !ok {
+				continue
+			}
+			ctx := &Context{Writer: w, Request: req, Params: params, requestID: requestID}
+			chain(route.handler, middleware)(ctx)
+			return
+		}
+	}
+
 	ctx := &Context{Writer: w, Request: req, Params: map[string]string{}, requestID: requestID}
 	chain(notFound, middleware)(ctx)
 }
@@ -206,7 +223,7 @@ func (r *Router) requestID(req *http.Request) string {
 }
 
 func (r route) match(method string, requestPath string) (map[string]string, bool) {
-	if r.method != "*" && r.method != method && !(method == http.MethodHead && r.method == http.MethodGet) {
+	if r.method != "*" && r.method != method {
 		return nil, false
 	}
 	requestPath = normalizePath(requestPath)
@@ -214,29 +231,75 @@ func (r route) match(method string, requestPath string) (map[string]string, bool
 		return map[string]string{}, hasPathPrefix(r.mountPrefix, requestPath)
 	}
 	parts := splitPath(requestPath)
-	hasWildcard := len(r.segments) > 0 && r.segments[len(r.segments)-1].literal == "*"
-	if (!hasWildcard && len(parts) != len(r.segments)) || (hasWildcard && len(parts) < len(r.segments)-1) {
+	params := map[string]string{}
+	if !matchSegments(r.segments, parts, 0, 0, params) {
 		return nil, false
 	}
-	params := map[string]string{}
-	for i, part := range parts {
-		segment := r.segments[i]
-		if segment.literal == "*" {
-			return params, true
-		}
-		if segment.param != "" {
-			decoded, err := url.PathUnescape(part)
-			if err != nil {
-				decoded = part
-			}
-			params[segment.param] = decoded
-			continue
-		}
-		if segment.literal != part {
-			return nil, false
-		}
-	}
 	return params, true
+}
+
+func matchSegments(segments []segment, parts []string, segmentIndex int, partIndex int, params map[string]string) bool {
+	if segmentIndex == len(segments) {
+		return partIndex == len(parts)
+	}
+
+	segment := segments[segmentIndex]
+	if segment.literal == "*" {
+		return true
+	}
+
+	if segment.param != "" && segment.regex != nil {
+		for end := len(parts); end >= partIndex; end-- {
+			value := strings.Join(parts[partIndex:end], "/")
+			if !setMatchedParam(segment, value, params) {
+				continue
+			}
+			if matchSegments(segments, parts, segmentIndex+1, end, params) {
+				return true
+			}
+			delete(params, segment.param)
+		}
+		return false
+	}
+
+	if partIndex >= len(parts) {
+		return false
+	}
+	part := parts[partIndex]
+	if segment.param != "" {
+		if !setMatchedParam(segment, part, params) {
+			return false
+		}
+		if matchSegments(segments, parts, segmentIndex+1, partIndex+1, params) {
+			return true
+		}
+		delete(params, segment.param)
+		return false
+	}
+	if segment.literal != part {
+		return false
+	}
+	return matchSegments(segments, parts, segmentIndex+1, partIndex+1, params)
+}
+
+func setMatchedParam(segment segment, value string, params map[string]string) bool {
+	decoded, ok := segment.matchParam(value)
+	if !ok {
+		return false
+	}
+	params[segment.param] = decoded
+	return true
+}
+
+func (s segment) matchParam(value string) (string, bool) {
+	if s.regex != nil && !s.regex.MatchString(value) {
+		return "", false
+	}
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		decoded = value
+	}
+	return decoded, true
 }
 
 func chain(handler HandlerFunc, middleware []Middleware) HandlerFunc {
@@ -254,7 +317,7 @@ func parseSegments(pattern string) []segment {
 		case part == "*":
 			segments = append(segments, segment{literal: "*"})
 		case strings.HasPrefix(part, ":") && len(part) > 1:
-			segments = append(segments, segment{param: part[1:]})
+			segments = append(segments, parseParamSegment(part))
 		case strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") && len(part) > 2:
 			segments = append(segments, segment{param: part[1 : len(part)-1]})
 		default:
@@ -262,6 +325,19 @@ func parseSegments(pattern string) []segment {
 		}
 	}
 	return segments
+}
+
+func parseParamSegment(part string) segment {
+	name := part[1:]
+	brace := strings.Index(name, "{")
+	if brace <= 0 || !strings.HasSuffix(name, "}") {
+		return segment{param: name}
+	}
+	expr := name[brace+1 : len(name)-1]
+	return segment{
+		param: name[:brace],
+		regex: regexp.MustCompile("^" + expr + "$"),
+	}
 }
 
 func splitPath(value string) []string {

--- a/internal/core/http/router.go
+++ b/internal/core/http/router.go
@@ -1,0 +1,310 @@
+package corehttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	pathpkg "path"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+type HandlerFunc func(*Context)
+
+type Middleware func(HandlerFunc) HandlerFunc
+
+type Context struct {
+	Writer    http.ResponseWriter
+	Request   *http.Request
+	Params    map[string]string
+	requestID string
+}
+
+func (c *Context) Param(name string) string {
+	return c.Params[name]
+}
+
+func (c *Context) Query(name string) string {
+	return c.Request.URL.Query().Get(name)
+}
+
+func (c *Context) Header(name string) string {
+	return c.Request.Header.Get(name)
+}
+
+func (c *Context) RequestID() string {
+	return c.requestID
+}
+
+func (c *Context) JSON(status int, value any) {
+	setDefaultHeader(c.Writer.Header(), "Content-Type", "application/json; charset=utf-8")
+	c.Writer.WriteHeader(status)
+	if err := json.NewEncoder(c.Writer).Encode(value); err != nil {
+		panic(err)
+	}
+}
+
+func (c *Context) Text(status int, value string) {
+	setDefaultHeader(c.Writer.Header(), "Content-Type", "text/plain; charset=utf-8")
+	c.Writer.WriteHeader(status)
+	_, _ = c.Writer.Write([]byte(value))
+}
+
+func (c *Context) HTML(status int, value string) {
+	setDefaultHeader(c.Writer.Header(), "Content-Type", "text/html; charset=utf-8")
+	c.Writer.WriteHeader(status)
+	_, _ = c.Writer.Write([]byte(value))
+}
+
+func (c *Context) Binary(status int, contentType string, value []byte) {
+	if contentType != "" {
+		setDefaultHeader(c.Writer.Header(), "Content-Type", contentType)
+	}
+	c.Writer.WriteHeader(status)
+	_, _ = c.Writer.Write(value)
+}
+
+func (c *Context) Redirect(status int, target string) {
+	http.Redirect(c.Writer, c.Request, target, status)
+}
+
+type Router struct {
+	mu          sync.RWMutex
+	routes      []route
+	middleware  []Middleware
+	notFound    HandlerFunc
+	requestNext atomic.Uint64
+}
+
+type route struct {
+	method      string
+	pattern     string
+	segments    []segment
+	mountPrefix string
+	handler     HandlerFunc
+}
+
+type segment struct {
+	literal string
+	param   string
+}
+
+func NewRouter() *Router {
+	return &Router{
+		notFound: func(c *Context) {
+			c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+		},
+	}
+}
+
+func (r *Router) Use(middleware ...Middleware) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.middleware = append(r.middleware, middleware...)
+}
+
+func (r *Router) Handle(method string, pattern string, handler HandlerFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes = append(r.routes, route{
+		method:   strings.ToUpper(method),
+		pattern:  normalizePath(pattern),
+		segments: parseSegments(pattern),
+		handler:  handler,
+	})
+}
+
+func (r *Router) Get(pattern string, handler HandlerFunc) {
+	r.Handle(http.MethodGet, pattern, handler)
+}
+
+func (r *Router) Post(pattern string, handler HandlerFunc) {
+	r.Handle(http.MethodPost, pattern, handler)
+}
+
+func (r *Router) Put(pattern string, handler HandlerFunc) {
+	r.Handle(http.MethodPut, pattern, handler)
+}
+
+func (r *Router) Patch(pattern string, handler HandlerFunc) {
+	r.Handle(http.MethodPatch, pattern, handler)
+}
+
+func (r *Router) Delete(pattern string, handler HandlerFunc) {
+	r.Handle(http.MethodDelete, pattern, handler)
+}
+
+func (r *Router) Any(pattern string, handler HandlerFunc) {
+	r.Handle("*", pattern, handler)
+}
+
+func (r *Router) Mount(prefix string, handler http.Handler) {
+	cleanPrefix := normalizePath(prefix)
+	mountHandler := func(c *Context) {
+		request := c.Request.Clone(c.Request.Context())
+		copiedURL := *request.URL
+		copiedURL.Path = stripPrefix(cleanPrefix, c.Request.URL.Path)
+		if c.Request.URL.RawPath != "" {
+			copiedURL.RawPath = stripPrefix(cleanPrefix, c.Request.URL.RawPath)
+		}
+		request.URL = &copiedURL
+		handler.ServeHTTP(c.Writer, request)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes = append(r.routes, route{
+		method:      "*",
+		pattern:     cleanPrefix,
+		mountPrefix: cleanPrefix,
+		handler:     mountHandler,
+	})
+}
+
+func (r *Router) NotFound(handler HandlerFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.notFound = handler
+}
+
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	requestID := r.requestID(req)
+	w.Header().Set("X-Request-Id", requestID)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}()
+
+	r.mu.RLock()
+	routes := append([]route(nil), r.routes...)
+	middleware := append([]Middleware(nil), r.middleware...)
+	notFound := r.notFound
+	r.mu.RUnlock()
+
+	for _, route := range routes {
+		params, ok := route.match(req.Method, req.URL.Path)
+		if !ok {
+			continue
+		}
+		ctx := &Context{Writer: w, Request: req, Params: params, requestID: requestID}
+		chain(route.handler, middleware)(ctx)
+		return
+	}
+
+	ctx := &Context{Writer: w, Request: req, Params: map[string]string{}, requestID: requestID}
+	chain(notFound, middleware)(ctx)
+}
+
+func (r *Router) requestID(req *http.Request) string {
+	if requestID := req.Header.Get("X-Request-Id"); requestID != "" {
+		return requestID
+	}
+	return fmt.Sprintf("req_%d", r.requestNext.Add(1))
+}
+
+func (r route) match(method string, requestPath string) (map[string]string, bool) {
+	if r.method != "*" && r.method != method && !(method == http.MethodHead && r.method == http.MethodGet) {
+		return nil, false
+	}
+	requestPath = normalizePath(requestPath)
+	if r.mountPrefix != "" {
+		return map[string]string{}, hasPathPrefix(r.mountPrefix, requestPath)
+	}
+	parts := splitPath(requestPath)
+	hasWildcard := len(r.segments) > 0 && r.segments[len(r.segments)-1].literal == "*"
+	if (!hasWildcard && len(parts) != len(r.segments)) || (hasWildcard && len(parts) < len(r.segments)-1) {
+		return nil, false
+	}
+	params := map[string]string{}
+	for i, part := range parts {
+		segment := r.segments[i]
+		if segment.literal == "*" {
+			return params, true
+		}
+		if segment.param != "" {
+			decoded, err := url.PathUnescape(part)
+			if err != nil {
+				decoded = part
+			}
+			params[segment.param] = decoded
+			continue
+		}
+		if segment.literal != part {
+			return nil, false
+		}
+	}
+	return params, true
+}
+
+func chain(handler HandlerFunc, middleware []Middleware) HandlerFunc {
+	for i := len(middleware) - 1; i >= 0; i-- {
+		handler = middleware[i](handler)
+	}
+	return handler
+}
+
+func parseSegments(pattern string) []segment {
+	parts := splitPath(normalizePath(pattern))
+	segments := make([]segment, 0, len(parts))
+	for _, part := range parts {
+		switch {
+		case part == "*":
+			segments = append(segments, segment{literal: "*"})
+		case strings.HasPrefix(part, ":") && len(part) > 1:
+			segments = append(segments, segment{param: part[1:]})
+		case strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") && len(part) > 2:
+			segments = append(segments, segment{param: part[1 : len(part)-1]})
+		default:
+			segments = append(segments, segment{literal: part})
+		}
+	}
+	return segments
+}
+
+func splitPath(value string) []string {
+	trimmed := strings.Trim(value, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+func normalizePath(value string) string {
+	if value == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(value, "/") {
+		value = "/" + value
+	}
+	return pathpkg.Clean(value)
+}
+
+func stripPrefix(prefix string, requestPath string) string {
+	if prefix == "/" {
+		return requestPath
+	}
+	stripped := strings.TrimPrefix(requestPath, prefix)
+	if stripped == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(stripped, "/") {
+		return "/" + stripped
+	}
+	return stripped
+}
+
+func hasPathPrefix(prefix string, requestPath string) bool {
+	if prefix == "/" {
+		return true
+	}
+	return requestPath == prefix || strings.HasPrefix(requestPath, prefix+"/")
+}
+
+func setDefaultHeader(header http.Header, key string, value string) {
+	if header.Get(key) == "" {
+		header.Set(key, value)
+	}
+}

--- a/internal/core/http/router.go
+++ b/internal/core/http/router.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	pathpkg "path"
 	"regexp"
 	"strings"
 	"sync"
@@ -40,11 +39,13 @@ func (c *Context) RequestID() string {
 }
 
 func (c *Context) JSON(status int, value any) {
-	setDefaultHeader(c.Writer.Header(), "Content-Type", "application/json; charset=utf-8")
-	c.Writer.WriteHeader(status)
-	if err := json.NewEncoder(c.Writer).Encode(value); err != nil {
+	body, err := json.Marshal(value)
+	if err != nil {
 		panic(err)
 	}
+	setDefaultHeader(c.Writer.Header(), "Content-Type", "application/json; charset=utf-8")
+	c.Writer.WriteHeader(status)
+	_, _ = c.Writer.Write(body)
 }
 
 func (c *Context) Text(status int, value string) {
@@ -341,11 +342,11 @@ func parseParamSegment(part string) segment {
 }
 
 func splitPath(value string) []string {
-	trimmed := strings.Trim(value, "/")
-	if trimmed == "" {
+	normalized := normalizePath(value)
+	if normalized == "/" {
 		return nil
 	}
-	return strings.Split(trimmed, "/")
+	return strings.Split(strings.TrimPrefix(normalized, "/"), "/")
 }
 
 func normalizePath(value string) string {
@@ -355,7 +356,7 @@ func normalizePath(value string) string {
 	if !strings.HasPrefix(value, "/") {
 		value = "/" + value
 	}
-	return pathpkg.Clean(value)
+	return value
 }
 
 func stripPrefix(prefix string, requestPath string) string {

--- a/internal/core/http/router_test.go
+++ b/internal/core/http/router_test.go
@@ -1,0 +1,128 @@
+package corehttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRouterMatchesParamsAndRunsMiddleware(t *testing.T) {
+	router := NewRouter()
+	router.Use(func(next HandlerFunc) HandlerFunc {
+		return func(c *Context) {
+			c.Writer.Header().Set("X-Middleware", "ran")
+			next(c)
+		}
+	})
+	router.Get("/users/:id", func(c *Context) {
+		c.JSON(http.StatusCreated, map[string]any{
+			"id":         c.Param("id"),
+			"query":      c.Query("q"),
+			"agent":      c.Header("X-Agent"),
+			"request_id": c.RequestID(),
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/users/alice?q=ok", nil)
+	req.Header.Set("X-Agent", "test")
+	req.Header.Set("X-Request-Id", "req-test")
+	res := httptest.NewRecorder()
+
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Header().Get("X-Middleware") != "ran" {
+		t.Fatalf("middleware header missing: %v", res.Header())
+	}
+	if res.Header().Get("X-Request-Id") != "req-test" {
+		t.Fatalf("request id header mismatch: %v", res.Header())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["id"] != "alice" || body["query"] != "ok" || body["agent"] != "test" || body["request_id"] != "req-test" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestRouterResponseHelpers(t *testing.T) {
+	router := NewRouter()
+	router.Get("/text", func(c *Context) { c.Text(http.StatusAccepted, "hello") })
+	router.Get("/html", func(c *Context) { c.HTML(http.StatusOK, "<strong>hello</strong>") })
+	router.Get("/binary", func(c *Context) { c.Binary(http.StatusOK, "application/octet-stream", []byte{1, 2, 3}) })
+	router.Get("/redirect", func(c *Context) { c.Redirect(http.StatusFound, "/target") })
+
+	tests := []struct {
+		path        string
+		status      int
+		contentType string
+		body        string
+		location    string
+	}{
+		{path: "/text", status: http.StatusAccepted, contentType: "text/plain; charset=utf-8", body: "hello"},
+		{path: "/html", status: http.StatusOK, contentType: "text/html; charset=utf-8", body: "<strong>hello</strong>"},
+		{path: "/binary", status: http.StatusOK, contentType: "application/octet-stream", body: "\x01\x02\x03"},
+		{path: "/redirect", status: http.StatusFound, contentType: "text/html; charset=utf-8", location: "/target"},
+	}
+
+	for _, test := range tests {
+		req := httptest.NewRequest(http.MethodGet, test.path, nil)
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+
+		if res.Code != test.status {
+			t.Fatalf("%s status = %d, body = %s", test.path, res.Code, res.Body.String())
+		}
+		if test.contentType != "" && res.Header().Get("Content-Type") != test.contentType {
+			t.Fatalf("%s content type = %q", test.path, res.Header().Get("Content-Type"))
+		}
+		if test.location != "" && res.Header().Get("Location") != test.location {
+			t.Fatalf("%s location = %q", test.path, res.Header().Get("Location"))
+		}
+		if test.body != "" && res.Body.String() != test.body {
+			t.Fatalf("%s body = %q", test.path, res.Body.String())
+		}
+	}
+}
+
+func TestRouterMountStripsPrefix(t *testing.T) {
+	router := NewRouter()
+	router.Mount("/api", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(r.URL.Path))
+	}))
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/api/v1/health", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Body.String() != "/v1/health" {
+		t.Fatalf("mounted path = %q", res.Body.String())
+	}
+}
+
+func TestRouterNotFoundAndPanicRecovery(t *testing.T) {
+	router := NewRouter()
+	router.Get("/panic", func(c *Context) {
+		panic("boom")
+	})
+
+	missing := httptest.NewRecorder()
+	router.ServeHTTP(missing, httptest.NewRequest(http.MethodGet, "/missing", nil))
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("missing status = %d", missing.Code)
+	}
+
+	panicked := httptest.NewRecorder()
+	router.ServeHTTP(panicked, httptest.NewRequest(http.MethodGet, "/panic", nil))
+	if panicked.Code != http.StatusInternalServerError {
+		t.Fatalf("panic status = %d", panicked.Code)
+	}
+}

--- a/internal/core/http/router_test.go
+++ b/internal/core/http/router_test.go
@@ -50,6 +50,94 @@ func TestRouterMatchesParamsAndRunsMiddleware(t *testing.T) {
 	}
 }
 
+func TestRouterMatchesRegexTailParam(t *testing.T) {
+	router := NewRouter()
+	router.Get("/repos/:owner/:repo/git/ref/:ref{.+}", func(c *Context) {
+		c.JSON(http.StatusOK, map[string]string{
+			"owner": c.Param("owner"),
+			"repo":  c.Param("repo"),
+			"ref":   c.Param("ref"),
+		})
+	})
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/repos/acme/widgets/git/ref/heads/main", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["owner"] != "acme" || body["repo"] != "widgets" || body["ref"] != "heads/main" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestRouterMatchesRegexParamBeforeLiteralSuffix(t *testing.T) {
+	router := NewRouter()
+	router.Get("/repos/:owner/:repo/branches/:branch{.+}/protection", func(c *Context) {
+		c.JSON(http.StatusOK, map[string]string{
+			"branch": c.Param("branch"),
+		})
+	})
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/repos/acme/widgets/branches/feature/auth/protection", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["branch"] != "feature/auth" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestRouterPrefersExplicitHeadOverGetFallback(t *testing.T) {
+	router := NewRouter()
+	router.Get("/object", func(c *Context) {
+		c.Writer.Header().Set("X-Handler", "get")
+		c.Text(http.StatusOK, "get")
+	})
+	router.Handle(http.MethodHead, "/object", func(c *Context) {
+		c.Writer.Header().Set("X-Handler", "head")
+		c.Binary(http.StatusOK, "", nil)
+	})
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodHead, "/object", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Header().Get("X-Handler") != "head" {
+		t.Fatalf("handler = %q", res.Header().Get("X-Handler"))
+	}
+}
+
+func TestRouterFallsBackHeadToGet(t *testing.T) {
+	router := NewRouter()
+	router.Get("/object", func(c *Context) {
+		c.Writer.Header().Set("X-Handler", "get")
+		c.Text(http.StatusOK, "get")
+	})
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodHead, "/object", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Header().Get("X-Handler") != "get" {
+		t.Fatalf("handler = %q", res.Header().Get("X-Handler"))
+	}
+}
+
 func TestRouterResponseHelpers(t *testing.T) {
 	router := NewRouter()
 	router.Get("/text", func(c *Context) { c.Text(http.StatusAccepted, "hello") })

--- a/internal/core/http/router_test.go
+++ b/internal/core/http/router_test.go
@@ -98,6 +98,39 @@ func TestRouterMatchesRegexParamBeforeLiteralSuffix(t *testing.T) {
 	}
 }
 
+func TestRouterPreservesExactPathShape(t *testing.T) {
+	router := NewRouter()
+	router.Get("/iam/", func(c *Context) {
+		c.Text(http.StatusOK, "slash")
+	})
+	router.Get("/files/a/b", func(c *Context) {
+		c.Text(http.StatusOK, "clean")
+	})
+
+	tests := []struct {
+		path   string
+		status int
+		body   string
+	}{
+		{path: "/iam/", status: http.StatusOK, body: "slash"},
+		{path: "/iam", status: http.StatusNotFound},
+		{path: "/files/a/b", status: http.StatusOK, body: "clean"},
+		{path: "/files/a/../b", status: http.StatusNotFound},
+		{path: "/files/a//b", status: http.StatusNotFound},
+	}
+
+	for _, test := range tests {
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, test.path, nil))
+		if res.Code != test.status {
+			t.Fatalf("%s status = %d, body = %s", test.path, res.Code, res.Body.String())
+		}
+		if test.body != "" && res.Body.String() != test.body {
+			t.Fatalf("%s body = %q", test.path, res.Body.String())
+		}
+	}
+}
+
 func TestRouterPrefersExplicitHeadOverGetFallback(t *testing.T) {
 	router := NewRouter()
 	router.Get("/object", func(c *Context) {
@@ -175,6 +208,20 @@ func TestRouterResponseHelpers(t *testing.T) {
 		if test.body != "" && res.Body.String() != test.body {
 			t.Fatalf("%s body = %q", test.path, res.Body.String())
 		}
+	}
+}
+
+func TestRouterJSONEncodeFailureReturnsInternalServerError(t *testing.T) {
+	router := NewRouter()
+	router.Get("/bad-json", func(c *Context) {
+		c.JSON(http.StatusCreated, map[string]any{"bad": make(chan int)})
+	})
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/bad-json", nil))
+
+	if res.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }
 

--- a/internal/core/store/store.go
+++ b/internal/core/store/store.go
@@ -1,0 +1,535 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+type Record map[string]any
+
+type CollectionSnapshot struct {
+	Items       []Record `json:"items"`
+	AutoID      int      `json:"autoId"`
+	IndexFields []string `json:"indexFields"`
+}
+
+type StoreSnapshot struct {
+	Collections map[string]CollectionSnapshot `json:"collections"`
+	Data        map[string]any                `json:"data"`
+}
+
+type Store struct {
+	mu          sync.RWMutex
+	collections map[string]*Collection
+	data        map[string]any
+}
+
+func New() *Store {
+	return &Store{
+		collections: map[string]*Collection{},
+		data:        map[string]any{},
+	}
+}
+
+func (s *Store) Collection(name string, indexFields ...string) (*Collection, error) {
+	requested := normalizeFields(indexFields)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.collections[name]; ok {
+		if len(requested) > 0 && !sameStrings(existing.IndexFields(), requested) {
+			return nil, fmt.Errorf("collection %q already exists with indexes %v but was requested with %v", name, existing.IndexFields(), requested)
+		}
+		return existing, nil
+	}
+
+	collection := newCollection(requested)
+	s.collections[name] = collection
+	return collection, nil
+}
+
+func (s *Store) MustCollection(name string, indexFields ...string) *Collection {
+	collection, err := s.Collection(name, indexFields...)
+	if err != nil {
+		panic(err)
+	}
+	return collection
+}
+
+func (s *Store) SetData(key string, value any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = cloneValue(value)
+}
+
+func (s *Store) GetData(key string) (any, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	value, ok := s.data[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneValue(value), true
+}
+
+func (s *Store) Reset() {
+	s.mu.Lock()
+	collections := make([]*Collection, 0, len(s.collections))
+	for _, collection := range s.collections {
+		collections = append(collections, collection)
+	}
+	s.data = map[string]any{}
+	s.mu.Unlock()
+
+	for _, collection := range collections {
+		collection.Clear()
+	}
+}
+
+func (s *Store) Snapshot() StoreSnapshot {
+	s.mu.RLock()
+	names := make([]string, 0, len(s.collections))
+	for name := range s.collections {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	collections := make(map[string]*Collection, len(s.collections))
+	for _, name := range names {
+		collections[name] = s.collections[name]
+	}
+
+	data := make(map[string]any, len(s.data))
+	for key, value := range s.data {
+		data[key] = cloneValue(value)
+	}
+	s.mu.RUnlock()
+
+	snapshots := make(map[string]CollectionSnapshot, len(collections))
+	for _, name := range names {
+		snapshots[name] = collections[name].Snapshot()
+	}
+
+	return StoreSnapshot{Collections: snapshots, Data: data}
+}
+
+func (s *Store) Restore(snapshot StoreSnapshot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for name := range s.collections {
+		if _, ok := snapshot.Collections[name]; !ok {
+			delete(s.collections, name)
+		}
+	}
+
+	for name, collectionSnapshot := range snapshot.Collections {
+		fields := normalizeFields(collectionSnapshot.IndexFields)
+		collection, ok := s.collections[name]
+		if !ok || !sameStrings(collection.IndexFields(), fields) {
+			collection = newCollection(fields)
+			s.collections[name] = collection
+		}
+		if err := collection.Restore(collectionSnapshot); err != nil {
+			return fmt.Errorf("restore collection %q: %w", name, err)
+		}
+	}
+
+	s.data = make(map[string]any, len(snapshot.Data))
+	for key, value := range snapshot.Data {
+		s.data[key] = cloneValue(value)
+	}
+	return nil
+}
+
+func (s *Store) MarshalSnapshot() ([]byte, error) {
+	return json.MarshalIndent(s.Snapshot(), "", "  ")
+}
+
+func (s *Store) RestoreJSON(raw []byte) error {
+	var snapshot StoreSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return err
+	}
+	return s.Restore(snapshot)
+}
+
+type Collection struct {
+	mu          sync.RWMutex
+	items       map[int]Record
+	indexes     map[string]map[string]map[int]struct{}
+	indexFields []string
+	autoID      int
+}
+
+func newCollection(indexFields []string) *Collection {
+	indexes := make(map[string]map[string]map[int]struct{}, len(indexFields))
+	for _, field := range indexFields {
+		indexes[field] = map[string]map[int]struct{}{}
+	}
+	return &Collection{
+		items:       map[int]Record{},
+		indexes:     indexes,
+		indexFields: append([]string(nil), indexFields...),
+		autoID:      1,
+	}
+}
+
+func (c *Collection) Insert(record Record) Record {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := timestamp()
+	item := cloneRecord(record)
+	id, ok := numericID(item["id"])
+	if !ok || id <= 0 {
+		id = c.autoID
+	}
+	if id >= c.autoID {
+		c.autoID = id + 1
+	}
+
+	if existing, ok := c.items[id]; ok {
+		c.removeFromIndexes(existing)
+	}
+
+	item["id"] = id
+	if _, ok := item["created_at"]; !ok {
+		item["created_at"] = now
+	}
+	item["updated_at"] = now
+	c.items[id] = item
+	c.addToIndexes(item)
+	return cloneRecord(item)
+}
+
+func (c *Collection) Get(id int) (Record, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	item, ok := c.items[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneRecord(item), true
+}
+
+func (c *Collection) Update(id int, patch Record) (Record, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	existing, ok := c.items[id]
+	if !ok {
+		return nil, false
+	}
+	c.removeFromIndexes(existing)
+
+	updated := cloneRecord(existing)
+	for key, value := range patch {
+		if key == "id" {
+			continue
+		}
+		updated[key] = cloneValue(value)
+	}
+	updated["updated_at"] = timestamp()
+	c.items[id] = updated
+	c.addToIndexes(updated)
+	return cloneRecord(updated), true
+}
+
+func (c *Collection) Delete(id int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	existing, ok := c.items[id]
+	if !ok {
+		return false
+	}
+	c.removeFromIndexes(existing)
+	delete(c.items, id)
+	return true
+}
+
+func (c *Collection) All() []Record {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.allLocked()
+}
+
+func (c *Collection) FindBy(field string, value any) []Record {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := indexKey(value)
+	if index, ok := c.indexes[field]; ok {
+		ids := sortedIDs(index[key])
+		records := make([]Record, 0, len(ids))
+		for _, id := range ids {
+			if item, ok := c.items[id]; ok {
+				records = append(records, cloneRecord(item))
+			}
+		}
+		return records
+	}
+
+	records := make([]Record, 0)
+	for _, item := range c.allLocked() {
+		if indexKey(item[field]) == key {
+			records = append(records, item)
+		}
+	}
+	return records
+}
+
+func (c *Collection) Count() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}
+
+func (c *Collection) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = map[int]Record{}
+	for _, index := range c.indexes {
+		for key := range index {
+			delete(index, key)
+		}
+	}
+	c.autoID = 1
+}
+
+func (c *Collection) Snapshot() CollectionSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return CollectionSnapshot{
+		Items:       c.allLocked(),
+		AutoID:      c.autoID,
+		IndexFields: append([]string(nil), c.indexFields...),
+	}
+}
+
+func (c *Collection) Restore(snapshot CollectionSnapshot) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	fields := normalizeFields(snapshot.IndexFields)
+	if !sameStrings(c.indexFields, fields) {
+		c.indexFields = fields
+		c.indexes = map[string]map[string]map[int]struct{}{}
+		for _, field := range fields {
+			c.indexes[field] = map[string]map[int]struct{}{}
+		}
+	}
+
+	c.items = map[int]Record{}
+	for _, index := range c.indexes {
+		for key := range index {
+			delete(index, key)
+		}
+	}
+
+	c.autoID = snapshot.AutoID
+	if c.autoID < 1 {
+		c.autoID = 1
+	}
+	for _, item := range snapshot.Items {
+		id, ok := numericID(item["id"])
+		if !ok || id <= 0 {
+			return fmt.Errorf("record is missing positive numeric id")
+		}
+		record := cloneRecord(item)
+		record["id"] = id
+		c.items[id] = record
+		c.addToIndexes(record)
+		if id >= c.autoID {
+			c.autoID = id + 1
+		}
+	}
+	return nil
+}
+
+func (c *Collection) IndexFields() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return append([]string(nil), c.indexFields...)
+}
+
+func (c *Collection) allLocked() []Record {
+	ids := make([]int, 0, len(c.items))
+	for id := range c.items {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+
+	records := make([]Record, 0, len(ids))
+	for _, id := range ids {
+		records = append(records, cloneRecord(c.items[id]))
+	}
+	return records
+}
+
+func (c *Collection) addToIndexes(item Record) {
+	id, ok := numericID(item["id"])
+	if !ok {
+		return
+	}
+	for field, index := range c.indexes {
+		value, ok := item[field]
+		if !ok || value == nil {
+			continue
+		}
+		key := indexKey(value)
+		if _, ok := index[key]; !ok {
+			index[key] = map[int]struct{}{}
+		}
+		index[key][id] = struct{}{}
+	}
+}
+
+func (c *Collection) removeFromIndexes(item Record) {
+	id, ok := numericID(item["id"])
+	if !ok {
+		return
+	}
+	for field, index := range c.indexes {
+		value, ok := item[field]
+		if !ok || value == nil {
+			continue
+		}
+		key := indexKey(value)
+		delete(index[key], id)
+		if len(index[key]) == 0 {
+			delete(index, key)
+		}
+	}
+}
+
+func normalizeFields(fields []string) []string {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field == "" || seen[field] {
+			continue
+		}
+		seen[field] = true
+		normalized = append(normalized, field)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func sameStrings(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedIDs(ids map[int]struct{}) []int {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]int, 0, len(ids))
+	for id := range ids {
+		out = append(out, id)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func numericID(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int8:
+		return int(v), true
+	case int16:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case uint8:
+		return int(v), true
+	case uint16:
+		return int(v), true
+	case uint32:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	case float64:
+		id := int(v)
+		return id, float64(id) == v
+	case json.Number:
+		id, err := v.Int64()
+		return int(id), err == nil
+	default:
+		return 0, false
+	}
+}
+
+func indexKey(value any) string {
+	return fmt.Sprint(value)
+}
+
+func timestamp() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+func cloneRecord(record Record) Record {
+	if record == nil {
+		return Record{}
+	}
+	out := make(Record, len(record))
+	for key, value := range record {
+		out[key] = cloneValue(value)
+	}
+	return out
+}
+
+func cloneValue(value any) any {
+	switch v := value.(type) {
+	case Record:
+		return cloneRecord(v)
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, nested := range v {
+			out[key] = cloneValue(nested)
+		}
+		return out
+	case []Record:
+		out := make([]Record, len(v))
+		for i, nested := range v {
+			out[i] = cloneRecord(nested)
+		}
+		return out
+	case []map[string]any:
+		out := make([]map[string]any, len(v))
+		for i, nested := range v {
+			out[i] = cloneValue(nested).(map[string]any)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, nested := range v {
+			out[i] = cloneValue(nested)
+		}
+		return out
+	case []string:
+		return append([]string(nil), v...)
+	case []int:
+		return append([]int(nil), v...)
+	default:
+		return v
+	}
+}

--- a/internal/core/store/store.go
+++ b/internal/core/store/store.go
@@ -312,10 +312,26 @@ func (c *Collection) Snapshot() CollectionSnapshot {
 }
 
 func (c *Collection) Restore(snapshot CollectionSnapshot) error {
+	fields := normalizeFields(snapshot.IndexFields)
+	records := make([]Record, 0, len(snapshot.Items))
+	seenIDs := map[int]struct{}{}
+	for _, item := range snapshot.Items {
+		id, ok := numericID(item["id"])
+		if !ok || id <= 0 {
+			return fmt.Errorf("record is missing positive numeric id")
+		}
+		if _, exists := seenIDs[id]; exists {
+			return fmt.Errorf("duplicate record id %d", id)
+		}
+		seenIDs[id] = struct{}{}
+		record := cloneRecord(item)
+		record["id"] = id
+		records = append(records, record)
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	fields := normalizeFields(snapshot.IndexFields)
 	if !sameStrings(c.indexFields, fields) {
 		c.indexFields = fields
 		c.indexes = map[string]map[string]map[int]struct{}{}
@@ -335,13 +351,8 @@ func (c *Collection) Restore(snapshot CollectionSnapshot) error {
 	if c.autoID < 1 {
 		c.autoID = 1
 	}
-	for _, item := range snapshot.Items {
-		id, ok := numericID(item["id"])
-		if !ok || id <= 0 {
-			return fmt.Errorf("record is missing positive numeric id")
-		}
-		record := cloneRecord(item)
-		record["id"] = id
+	for _, record := range records {
+		id, _ := numericID(record["id"])
 		c.items[id] = record
 		c.addToIndexes(record)
 		if id >= c.autoID {

--- a/internal/core/store/store_test.go
+++ b/internal/core/store/store_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCollectionIndexesAndSnapshotRestore(t *testing.T) {
+	store := New()
+	users, err := store.Collection("users", "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alice := users.Insert(Record{"email": "alice@example.com", "name": "Alice"})
+	bob := users.Insert(Record{"email": "bob@example.com", "name": "Bob"})
+	if alice["id"] != 1 || bob["id"] != 2 {
+		t.Fatalf("unexpected ids: %#v %#v", alice["id"], bob["id"])
+	}
+
+	matches := users.FindBy("email", "alice@example.com")
+	if len(matches) != 1 || matches[0]["name"] != "Alice" {
+		t.Fatalf("unexpected indexed matches: %#v", matches)
+	}
+
+	updated, ok := users.Update(1, Record{"email": "alice@new.test"})
+	if !ok || updated["email"] != "alice@new.test" {
+		t.Fatalf("unexpected update: %#v %v", updated, ok)
+	}
+	if oldMatches := users.FindBy("email", "alice@example.com"); len(oldMatches) != 0 {
+		t.Fatalf("old index entry remained: %#v", oldMatches)
+	}
+
+	snapshot := store.Snapshot()
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restored := New()
+	if err := restored.RestoreJSON(raw); err != nil {
+		t.Fatal(err)
+	}
+	restoredUsers, err := restored.Collection("users", "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	restoredMatches := restoredUsers.FindBy("email", "alice@new.test")
+	if len(restoredMatches) != 1 || restoredMatches[0]["id"] != 1 {
+		t.Fatalf("restored index did not work: %#v", restoredMatches)
+	}
+
+	carol := restoredUsers.Insert(Record{"email": "carol@example.com"})
+	if carol["id"] != 3 {
+		t.Fatalf("auto id after restore = %#v", carol["id"])
+	}
+}
+
+func TestStoreResetClearsDataAndPreservesCollections(t *testing.T) {
+	store := New()
+	users := store.MustCollection("users", "email")
+	users.Insert(Record{"email": "alice@example.com"})
+	store.SetData("token", map[string]any{"login": "alice"})
+
+	store.Reset()
+
+	if users.Count() != 0 {
+		t.Fatalf("reset left %d records", users.Count())
+	}
+	if _, ok := store.GetData("token"); ok {
+		t.Fatal("reset left store data")
+	}
+
+	users.Insert(Record{"email": "bob@example.com"})
+	matches := users.FindBy("email", "bob@example.com")
+	if len(matches) != 1 {
+		t.Fatalf("index did not survive reset: %#v", matches)
+	}
+}
+
+func TestStoreRestoreRemovesCollectionsNotInSnapshot(t *testing.T) {
+	store := New()
+	store.MustCollection("users").Insert(Record{"name": "Alice"})
+	store.MustCollection("repos").Insert(Record{"name": "emulate"})
+
+	source := New()
+	source.MustCollection("users").Insert(Record{"name": "Bob"})
+	if err := store.Restore(source.Snapshot()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := store.Snapshot().Collections["repos"]; ok {
+		t.Fatal("restore kept collection that was absent from snapshot")
+	}
+	users, err := store.Collection("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := users.All()
+	if len(all) != 1 || all[0]["name"] != "Bob" {
+		t.Fatalf("unexpected restored users: %#v", all)
+	}
+}
+
+func TestCollectionRejectsMismatchedIndexes(t *testing.T) {
+	store := New()
+	if _, err := store.Collection("users", "email"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Collection("users", "login"); err == nil {
+		t.Fatal("expected mismatched index error")
+	}
+}

--- a/internal/core/store/store_test.go
+++ b/internal/core/store/store_test.go
@@ -102,6 +102,29 @@ func TestStoreRestoreRemovesCollectionsNotInSnapshot(t *testing.T) {
 	}
 }
 
+func TestCollectionRestoreRejectsDuplicateIDs(t *testing.T) {
+	store := New()
+	users := store.MustCollection("users", "email")
+
+	err := users.Restore(CollectionSnapshot{
+		Items: []Record{
+			{"id": 1, "email": "alice@example.com"},
+			{"id": 1, "email": "bob@example.com"},
+		},
+		AutoID:      2,
+		IndexFields: []string{"email"},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate id error")
+	}
+	if users.Count() != 0 {
+		t.Fatalf("restore partially applied %d records", users.Count())
+	}
+	if matches := users.FindBy("email", "alice@example.com"); len(matches) != 0 {
+		t.Fatalf("restore left stale index entries: %#v", matches)
+	}
+}
+
 func TestCollectionRejectsMismatchedIndexes(t *testing.T) {
 	store := New()
 	if _, err := store.Collection("users", "email"); err != nil {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -1,0 +1,73 @@
+package runtime
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	"github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const HealthPath = "/_emulate/health"
+
+type ServerOptions struct {
+	Version  string
+	BaseURL  string
+	Services []string
+	Store    *store.Store
+}
+
+type Server struct {
+	Handler  http.Handler
+	Store    *store.Store
+	Version  string
+	BaseURL  string
+	Services []string
+}
+
+func NewHandler(options ServerOptions) http.Handler {
+	return NewServer(options).Handler
+}
+
+func NewServer(options ServerOptions) *Server {
+	version := options.Version
+	if version == "" {
+		version = "dev"
+	}
+	services := append([]string(nil), options.Services...)
+	if len(services) == 0 {
+		services = ServiceNames()
+	}
+
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = store.New()
+	}
+
+	router := corehttp.NewRouter()
+	router.Get(HealthPath, func(c *corehttp.Context) {
+		c.JSON(http.StatusOK, map[string]any{
+			"ok":       true,
+			"runtime":  "go",
+			"version":  version,
+			"base_url": options.BaseURL,
+			"services": services,
+		})
+	})
+	router.Get("/health", func(c *corehttp.Context) {
+		c.JSON(http.StatusOK, map[string]any{
+			"ok":      true,
+			"runtime": "go",
+		})
+	})
+	router.NotFound(func(c *corehttp.Context) {
+		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+	})
+
+	return &Server{
+		Handler:  router,
+		Store:    runtimeStore,
+		Version:  version,
+		BaseURL:  options.BaseURL,
+		Services: services,
+	}
+}

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -1,0 +1,57 @@
+package runtime
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewHandlerServesHealthEndpoint(t *testing.T) {
+	handler := NewHandler(ServerOptions{
+		Version:  "test",
+		BaseURL:  "http://localhost:4010",
+		Services: []string{"github", "aws"},
+	})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, HealthPath, nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		OK       bool     `json:"ok"`
+		Runtime  string   `json:"runtime"`
+		Version  string   `json:"version"`
+		BaseURL  string   `json:"base_url"`
+		Services []string `json:"services"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.OK || body.Runtime != "go" || body.Version != "test" || body.BaseURL != "http://localhost:4010" {
+		t.Fatalf("unexpected health body: %#v", body)
+	}
+	if len(body.Services) != 2 || body.Services[0] != "github" || body.Services[1] != "aws" {
+		t.Fatalf("unexpected services: %#v", body.Services)
+	}
+}
+
+func TestNewHandlerReturnsJSONNotFound(t *testing.T) {
+	handler := NewHandler(ServerOptions{})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/missing", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["message"] != "Not Found" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+}


### PR DESCRIPTION
- Add a dependency-free Go router with response helpers and prefix mounting.

- Add an in-memory store with indexed collections, snapshots, restore, and reset.

- Wire native start to the reusable runtime handler and health endpoint.