### PR TITLE
Add Go UI and config foundation

### DIFF
--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -10,25 +10,18 @@ import (
 	nethttp "net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	coreconfig "github.com/vercel-labs/emulate/internal/core/config"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 )
 
 var version = "dev"
-
-var configFilenames = []string{
-	"emulate.config.yaml",
-	"emulate.config.yml",
-	"emulate.config.json",
-	"service-emulator.config.yaml",
-	"service-emulator.config.yml",
-	"service-emulator.config.json",
-}
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -328,14 +321,14 @@ func hasUnexpectedArg(fs *flag.FlagSet, stderr io.Writer) bool {
 }
 
 func existingConfigFile() (string, error) {
-	for _, filename := range configFilenames {
-		if _, err := os.Stat(filename); err == nil {
-			return filename, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return filename, err
-		}
+	fullPath, err := coreconfig.Discover(".")
+	if errors.Is(err, coreconfig.ErrNotFound) {
+		return "", nil
 	}
-	return "", nil
+	if err != nil {
+		return "config files", err
+	}
+	return filepath.Base(fullPath), nil
 }
 
 func encodeYAML(config map[string]any) ([]byte, error) {

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type Format string
+
+const (
+	FormatJSON Format = "json"
+	FormatYAML Format = "yaml"
+)
+
+var DefaultFilenames = []string{
+	"emulate.config.yaml",
+	"emulate.config.yml",
+	"emulate.config.json",
+	"service-emulator.config.yaml",
+	"service-emulator.config.yml",
+	"service-emulator.config.json",
+}
+
+var ErrNotFound = errors.New("config file not found")
+
+type UnsupportedFormatError struct {
+	Path   string
+	Format Format
+}
+
+func (e *UnsupportedFormatError) Error() string {
+	if e.Format == FormatYAML {
+		return fmt.Sprintf("unsupported config format for %s: YAML config loading is not implemented in the native Go runtime yet; use JSON config or the current TypeScript runtime", e.Path)
+	}
+	return fmt.Sprintf("unsupported config format for %s", e.Path)
+}
+
+type LoadOptions struct {
+	Path string
+	Dir  string
+}
+
+type LoadResult struct {
+	Path     string
+	Filename string
+	Format   Format
+	Data     map[string]json.RawMessage
+}
+
+func Load(options LoadOptions) (*LoadResult, error) {
+	dir := options.Dir
+	if dir == "" {
+		dir = "."
+	}
+
+	if options.Path != "" {
+		fullPath := options.Path
+		if !filepath.IsAbs(fullPath) {
+			fullPath = filepath.Join(dir, fullPath)
+		}
+		return loadFile(fullPath, options.Path)
+	}
+
+	fullPath, err := Discover(dir)
+	if err != nil {
+		return nil, err
+	}
+	return loadFile(fullPath, filepath.Base(fullPath))
+}
+
+func Discover(dir string) (string, error) {
+	if dir == "" {
+		dir = "."
+	}
+	for _, filename := range DefaultFilenames {
+		fullPath := filepath.Join(dir, filename)
+		if _, err := os.Stat(fullPath); err == nil {
+			return fullPath, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("check %s: %w", filename, err)
+		}
+	}
+	return "", ErrNotFound
+}
+
+func InferServices(data map[string]json.RawMessage, serviceNames []string) []string {
+	services := make([]string, 0)
+	for _, name := range serviceNames {
+		if _, ok := data[name]; ok {
+			services = append(services, name)
+		}
+	}
+	return services
+}
+
+func IsUnsupportedFormat(err error) bool {
+	var unsupported *UnsupportedFormatError
+	return errors.As(err, &unsupported)
+}
+
+func loadFile(fullPath string, sourceName string) (*LoadResult, error) {
+	format, err := FormatForPath(fullPath)
+	if err != nil {
+		return nil, err
+	}
+	if format != FormatJSON {
+		return nil, &UnsupportedFormatError{Path: sourceName, Format: format}
+	}
+
+	raw, err := os.ReadFile(fullPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, sourceName)
+		}
+		return nil, err
+	}
+
+	data := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", sourceName, err)
+	}
+	return &LoadResult{
+		Path:     fullPath,
+		Filename: sourceName,
+		Format:   format,
+		Data:     data,
+	}, nil
+}
+
+func FormatForPath(filename string) (Format, error) {
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".json":
+		return FormatJSON, nil
+	case ".yaml", ".yml":
+		return FormatYAML, nil
+	default:
+		return "", fmt.Errorf("unsupported config extension: %s", filepath.Ext(filename))
+	}
+}
+
+func SortedKeys(data map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/core/config/config_test.go
+++ b/internal/core/config/config_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadExplicitJSONConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "seed.json")
+	if err := os.WriteFile(configPath, []byte(`{"tokens":{"t":{"login":"admin"}},"github":{"users":[]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(LoadOptions{Path: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Format != FormatJSON {
+		t.Fatalf("format = %s", loaded.Format)
+	}
+	if loaded.Filename != configPath {
+		t.Fatalf("filename = %q", loaded.Filename)
+	}
+	if _, ok := loaded.Data["github"]; !ok {
+		t.Fatalf("github config missing: %#v", loaded.Data)
+	}
+}
+
+func TestLoadDiscoversCurrentConfigNamesInOrder(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "service-emulator.config.json"), []byte(`{"stripe":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "emulate.config.json"), []byte(`{"github":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(LoadOptions{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Filename != "emulate.config.json" {
+		t.Fatalf("discovered %q", loaded.Filename)
+	}
+	if services := InferServices(loaded.Data, []string{"github", "stripe"}); len(services) != 1 || services[0] != "github" {
+		t.Fatalf("services = %#v", services)
+	}
+}
+
+func TestLoadReportsYAMLAsUnsupportedForThisPhase(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "emulate.config.yaml"), []byte("github: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(LoadOptions{Dir: dir})
+	if err == nil {
+		t.Fatal("expected unsupported format error")
+	}
+	if !IsUnsupportedFormat(err) {
+		t.Fatalf("expected unsupported format, got %v", err)
+	}
+}
+
+func TestLoadMissingConfig(t *testing.T) {
+	_, err := Load(LoadOptions{Dir: t.TempDir()})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	keys := SortedKeys(map[string]json.RawMessage{
+		"z": nil,
+		"a": nil,
+	})
+	if len(keys) != 2 || keys[0] != "a" || keys[1] != "z" {
+		t.Fatalf("keys = %#v", keys)
+	}
+}

--- a/internal/core/config/testdata/emulate.config.json
+++ b/internal/core/config/testdata/emulate.config.json
@@ -1,0 +1,10 @@
+{
+  "tokens": {
+    "test_token_admin": {
+      "login": "admin"
+    }
+  },
+  "github": {
+    "users": []
+  }
+}

--- a/internal/core/ui/assets/GeistPixel-Square.woff2
+++ b/internal/core/ui/assets/GeistPixel-Square.woff2
@@ -1,0 +1,1 @@
+placeholder pixel font asset for the native Go UI foundation

--- a/internal/core/ui/assets/favicon.ico
+++ b/internal/core/ui/assets/favicon.ico
@@ -1,0 +1,1 @@
+placeholder favicon asset for the native Go UI foundation

--- a/internal/core/ui/assets/geist-sans.woff2
+++ b/internal/core/ui/assets/geist-sans.woff2
@@ -1,0 +1,1 @@
+placeholder font asset for the native Go UI foundation

--- a/internal/core/ui/ui.go
+++ b/internal/core/ui/ui.go
@@ -1,0 +1,323 @@
+package ui
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"path"
+	"sort"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+)
+
+//go:embed assets/*
+var assets embed.FS
+
+type PageOptions struct {
+	Service string
+	Prefix  string
+}
+
+type InspectorTab struct {
+	ID     string
+	Label  string
+	Href   string
+	Active bool
+}
+
+type UserButtonOptions struct {
+	Letter       string
+	Login        string
+	Name         string
+	Email        string
+	FormAction   string
+	HiddenFields map[string]string
+}
+
+func EscapeHTML(value string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+	)
+	return replacer.Replace(value)
+}
+
+func EscapeAttr(value string) string {
+	return strings.ReplaceAll(EscapeHTML(value), "'", "&#39;")
+}
+
+func RenderCardPage(title string, subtitle string, body string, opts PageOptions) string {
+	return head(title, opts) + `<body>
+` + emuBar(opts) + `
+<div class="content">
+  <div class="content-inner">
+    <div class="card-title">` + EscapeHTML(title) + `</div>
+    <div class="card-subtitle">` + subtitle + `</div>
+    ` + body + `
+  </div>
+</div>
+` + poweredBy + `
+</body></html>`
+}
+
+func RenderErrorPage(title string, message string, opts PageOptions) string {
+	return head(title, opts) + `<body>
+` + emuBar(opts) + `
+<div class="content">
+  <div class="content-inner error-card">
+    <div class="error-title">` + EscapeHTML(title) + `</div>
+    <div class="error-msg">` + EscapeHTML(message) + `</div>
+  </div>
+</div>
+` + poweredBy + `
+</body></html>`
+}
+
+func RenderSettingsPage(title string, sidebarHTML string, bodyHTML string, opts PageOptions) string {
+	return head(title, opts) + `<body>
+` + emuBar(opts) + `
+<div class="settings-layout">
+  <nav class="settings-sidebar">` + sidebarHTML + `</nav>
+  <main class="settings-main">` + bodyHTML + `</main>
+</div>
+` + poweredBy + `
+</body></html>`
+}
+
+func RenderInspectorPage(title string, tabs []InspectorTab, activeTab string, body string, opts PageOptions) string {
+	var links strings.Builder
+	for _, tab := range tabs {
+		className := ""
+		if tab.Active || tab.ID == activeTab {
+			className = ` class="active"`
+		}
+		links.WriteString(`<a href="`)
+		links.WriteString(EscapeAttr(tab.Href))
+		links.WriteString(`"`)
+		links.WriteString(className)
+		links.WriteString(`>`)
+		links.WriteString(EscapeHTML(tab.Label))
+		links.WriteString(`</a>`)
+	}
+
+	return head(title, opts) + `<body>
+` + emuBar(opts) + `
+<div class="inspector-layout">
+  <nav class="inspector-tabs">` + links.String() + `</nav>
+  ` + body + `
+</div>
+` + poweredBy + `
+</body></html>`
+}
+
+func RenderFormPostPage(action string, fields map[string]string, opts PageOptions) string {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var hidden strings.Builder
+	for _, key := range keys {
+		hidden.WriteString(`<input type="hidden" name="`)
+		hidden.WriteString(EscapeAttr(key))
+		hidden.WriteString(`" value="`)
+		hidden.WriteString(EscapeAttr(fields[key]))
+		hidden.WriteString(`"/>`)
+		hidden.WriteByte('\n')
+	}
+
+	return head("Redirecting", opts) + `<body onload="document.forms[0].submit()">
+` + emuBar(opts) + `
+<div class="content">
+  <div class="content-inner center">
+    <div class="card-subtitle">Redirecting...</div>
+    <form method="POST" action="` + EscapeAttr(action) + `">
+` + hidden.String() + `    <noscript><button type="submit" class="user-btn continue-btn"><span class="user-login">Continue</span></button></noscript>
+    </form>
+  </div>
+</div>
+` + poweredBy + `
+</body></html>`
+}
+
+func RenderUserButton(opts UserButtonOptions) string {
+	keys := make([]string, 0, len(opts.HiddenFields))
+	for key := range opts.HiddenFields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var hidden strings.Builder
+	for _, key := range keys {
+		hidden.WriteString(`<input type="hidden" name="`)
+		hidden.WriteString(EscapeAttr(key))
+		hidden.WriteString(`" value="`)
+		hidden.WriteString(EscapeAttr(opts.HiddenFields[key]))
+		hidden.WriteString(`"/>`)
+	}
+
+	nameLine := ""
+	if opts.Name != "" {
+		nameLine = `<div class="user-meta">` + EscapeHTML(opts.Name) + `</div>`
+	}
+	emailLine := ""
+	if opts.Email != "" {
+		emailLine = `<div class="user-email">` + EscapeHTML(opts.Email) + `</div>`
+	}
+
+	return `<form class="user-form" method="post" action="` + EscapeAttr(opts.FormAction) + `">
+` + hidden.String() + `
+<button type="submit" class="user-btn">
+  <span class="avatar">` + EscapeHTML(opts.Letter) + `</span>
+  <span class="user-text">
+    <span class="user-login">` + EscapeHTML(opts.Login) + `</span>
+    ` + nameLine + emailLine + `
+  </span>
+</button>
+</form>`
+}
+
+func RegisterAssetRoutes(router *corehttp.Router) {
+	router.Get("/_emulate/fonts/:name", func(c *corehttp.Context) {
+		name := path.Base(c.Param("name"))
+		serveAsset(c, "assets/"+name)
+	})
+	router.Get("/_emulate/favicon.ico", func(c *corehttp.Context) {
+		serveAsset(c, "assets/favicon.ico")
+	})
+}
+
+func AssetFS() fs.FS {
+	sub, err := fs.Sub(assets, "assets")
+	if err != nil {
+		panic(err)
+	}
+	return sub
+}
+
+func serveAsset(c *corehttp.Context, filename string) {
+	raw, err := assets.ReadFile(filename)
+	if err != nil {
+		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+		return
+	}
+	contentType := mimeType(filename)
+	c.Binary(http.StatusOK, contentType, raw)
+}
+
+func head(title string, opts PageOptions) string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<link rel="icon" href="` + EscapeAttr(assetPath(opts, "/_emulate/favicon.ico")) + `"/>
+<title>` + EscapeHTML(title) + ` | emulate</title>
+<style>` + css(opts) + `</style>
+</head>`
+}
+
+func emuBar(opts PageOptions) string {
+	title := "Emulator"
+	if opts.Service != "" {
+		title = opts.Service + " Emulator"
+	}
+	return `<div class="emu-bar">
+  <span class="emu-bar-title">` + EscapeHTML(title) + `</span>
+  <nav class="emu-bar-links">
+    <a href="https://github.com/vercel-labs/emulate/issues" target="_blank" rel="noopener"><span class="full">Report Issue</span><span class="short">Report</span></a>
+    <a href="https://github.com/vercel-labs/emulate" target="_blank" rel="noopener"><span class="full">Source Code</span><span class="short">Source</span></a>
+    <a href="https://emulate.dev" target="_blank" rel="noopener"><span class="full">Learn More</span><span class="short">Learn</span></a>
+  </nav>
+</div>`
+}
+
+func css(opts PageOptions) string {
+	fontPath := assetPath(opts, "/_emulate/fonts/geist-sans.woff2")
+	pixelPath := assetPath(opts, "/_emulate/fonts/GeistPixel-Square.woff2")
+	return `
+@font-face{font-family:'Geist';font-style:normal;font-weight:100 900;font-display:swap;src:url('` + EscapeAttr(fontPath) + `') format('woff2');}
+@font-face{font-family:'Geist Pixel';font-style:normal;font-weight:400;font-display:swap;src:url('` + EscapeAttr(pixelPath) + `') format('woff2');}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Geist',-apple-system,BlinkMacSystemFont,sans-serif;background:#000;color:#33ff00;min-height:100vh;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}
+.emu-bar{border-bottom:1px solid #0a3300;padding:10px 20px;display:flex;align-items:center;gap:10px;font-size:.8125rem;color:#1a8c00;}
+.emu-bar-title{font-weight:600;color:#33ff00;font-family:'Geist Pixel',monospace;}
+.emu-bar-links{margin-left:auto;display:flex;gap:16px;}
+.emu-bar-links a{color:#1a8c00;font-size:.75rem;text-decoration:none;transition:color .15s;}
+.emu-bar-links a:hover{color:#33ff00;}
+.emu-bar-links a .full{display:inline;}.emu-bar-links a .short{display:none;}
+@media(max-width:600px){.emu-bar-links a .full{display:none;}.emu-bar-links a .short{display:inline;}}
+.content{display:flex;align-items:center;justify-content:center;min-height:calc(100vh - 42px);padding:24px 16px;}
+.content-inner{width:100%;max-width:420px;}
+.center{text-align:center;}
+.card-title{font-family:'Geist Pixel',monospace;font-size:1.125rem;font-weight:600;margin-bottom:4px;color:#33ff00;}
+.card-subtitle{color:#1a8c00;font-size:.8125rem;margin-bottom:18px;line-height:1.45;}
+.powered-by{position:fixed;bottom:0;left:0;right:0;text-align:center;padding:12px;font-size:.6875rem;color:#0a3300;font-family:'Geist Pixel',monospace;}
+.powered-by a{color:#1a8c00;text-decoration:none;transition:color .15s;}
+.powered-by a:hover{color:#33ff00;}
+.error-title{font-family:'Geist Pixel',monospace;color:#ff4444;font-size:1.125rem;font-weight:600;margin-bottom:8px;}
+.error-msg{color:#1a8c00;font-size:.875rem;line-height:1.5;}
+.error-card{text-align:center;}
+.user-form{margin-bottom:8px;}.user-form:last-of-type{margin-bottom:0;}
+.user-btn{width:100%;display:flex;align-items:center;gap:12px;padding:10px 12px;border:1px solid #0a3300;border-radius:8px;background:#000;color:inherit;cursor:pointer;text-align:left;font:inherit;transition:border-color .15s;}
+.user-btn:hover{border-color:#33ff00;}
+.continue-btn{margin-top:12px;justify-content:center;}
+.avatar{width:36px;height:36px;border-radius:50%;background:#0a3300;color:#33ff00;font-weight:600;font-size:.875rem;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-family:'Geist Pixel',monospace;}
+.user-text{min-width:0;}.user-login{font-weight:600;font-size:.875rem;display:block;color:#33ff00;}
+.user-meta{color:#1a8c00;font-size:.75rem;margin-top:1px;}
+.user-email{font-size:.6875rem;color:#116600;word-break:break-all;margin-top:1px;}
+.settings-layout{max-width:920px;margin:0 auto;padding:28px 20px;display:flex;gap:28px;}
+.settings-sidebar{width:200px;flex-shrink:0;}
+.settings-sidebar a{display:block;padding:6px 10px;border-radius:6px;color:#1a8c00;text-decoration:none;font-size:.8125rem;transition:color .15s;}
+.settings-sidebar a:hover,.settings-sidebar a.active{color:#33ff00;}
+.settings-main{flex:1;min-width:0;}
+.s-card{padding:18px 0;margin-bottom:14px;border-bottom:1px solid #0a3300;}
+.s-card:last-child{border-bottom:none;}
+.section-heading{font-size:.9375rem;font-weight:600;margin-bottom:10px;color:#33ff00;display:flex;align-items:center;justify-content:space-between;}
+.badge{font-size:.6875rem;padding:1px 7px;border-radius:999px;font-weight:500;background:#0a3300;color:#33ff00;}
+.empty{color:#1a8c00;text-align:center;padding:28px 0;font-size:.875rem;}
+.inspector-layout{max-width:960px;margin:0 auto;padding:28px 20px;}
+.inspector-tabs{display:flex;gap:4px;margin-bottom:20px;}
+.inspector-tabs a{padding:7px 16px;border-radius:6px;text-decoration:none;font-size:.8125rem;color:#1a8c00;border:1px solid transparent;transition:color .15s,border-color .15s;}
+.inspector-tabs a:hover{color:#33ff00;}
+.inspector-tabs a.active{color:#33ff00;font-weight:600;border-color:#0a3300;background:#0a3300;}
+.inspector-section{margin-bottom:24px;}
+.inspector-section h2{font-family:'Geist Pixel',monospace;font-size:1rem;font-weight:600;color:#33ff00;margin-bottom:10px;}
+.inspector-section h3{font-family:'Geist Pixel',monospace;font-size:.875rem;font-weight:600;color:#1a8c00;margin:16px 0 8px;}
+.inspector-table{width:100%;border-collapse:collapse;margin-bottom:12px;}
+.inspector-table th,.inspector-table td{text-align:left;padding:8px 12px;border-bottom:1px solid #0a3300;font-size:.8125rem;}
+.inspector-table th{color:#1a8c00;font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.04em;}
+.inspector-table td{color:#33ff00;}
+.inspector-table tbody tr{transition:background .1s;}
+.inspector-table tbody tr:hover{background:#0a3300;}
+.inspector-empty{color:#1a8c00;text-align:center;padding:20px 0;font-size:.8125rem;}
+`
+}
+
+const poweredBy = `<div class="powered-by">Powered by <a href="https://emulate.dev" target="_blank" rel="noopener">emulate</a></div>`
+
+func assetPath(opts PageOptions, target string) string {
+	prefix := strings.TrimRight(opts.Prefix, "/")
+	if prefix == "" {
+		return target
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	return prefix + target
+}
+
+func mimeType(filename string) string {
+	switch strings.ToLower(path.Ext(filename)) {
+	case ".woff2":
+		return "font/woff2"
+	case ".ico":
+		return "image/x-icon"
+	default:
+		return "application/octet-stream"
+	}
+}

--- a/internal/core/ui/ui_test.go
+++ b/internal/core/ui/ui_test.go
@@ -1,0 +1,106 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+)
+
+func TestRenderCardPageEscapesTitleAndUsesSharedChrome(t *testing.T) {
+	html := RenderCardPage(`<Login>`, `<strong>Choose</strong>`, `<form></form>`, PageOptions{Service: "GitHub", Prefix: "/emulate"})
+
+	for _, want := range []string{
+		"<!DOCTYPE html>",
+		"&lt;Login&gt; | emulate",
+		"GitHub Emulator",
+		"<strong>Choose</strong>",
+		"Powered by",
+		"/emulate/_emulate/fonts/geist-sans.woff2",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered card page missing %q:\n%s", want, html)
+		}
+	}
+}
+
+func TestRenderErrorPageEscapesMessage(t *testing.T) {
+	html := RenderErrorPage("Denied", `bad "scope" <admin>`, PageOptions{})
+	if !strings.Contains(html, `bad &quot;scope&quot; &lt;admin&gt;`) {
+		t.Fatalf("message was not escaped:\n%s", html)
+	}
+}
+
+func TestRenderInspectorPageMarksActiveTab(t *testing.T) {
+	html := RenderInspectorPage("AWS", []InspectorTab{
+		{ID: "s3", Label: "S3", Href: "/_inspector?tab=s3"},
+		{ID: "sqs", Label: "SQS", Href: "/_inspector?tab=sqs"},
+	}, "sqs", `<section class="inspector-section"></section>`, PageOptions{Service: "AWS"})
+
+	if !strings.Contains(html, `<a href="/_inspector?tab=sqs" class="active">SQS</a>`) {
+		t.Fatalf("active tab missing:\n%s", html)
+	}
+	if !strings.Contains(html, `inspector-section`) {
+		t.Fatalf("body missing:\n%s", html)
+	}
+}
+
+func TestRenderFormPostPageSortsAndEscapesHiddenFields(t *testing.T) {
+	html := RenderFormPostPage("/callback", map[string]string{
+		"z": "last",
+		"a": `"first"`,
+	}, PageOptions{})
+
+	first := strings.Index(html, `name="a"`)
+	second := strings.Index(html, `name="z"`)
+	if first < 0 || second < 0 || first > second {
+		t.Fatalf("hidden fields were not sorted:\n%s", html)
+	}
+	if !strings.Contains(html, `value="&quot;first&quot;"`) {
+		t.Fatalf("hidden field was not escaped:\n%s", html)
+	}
+}
+
+func TestRenderUserButtonSortsHiddenFields(t *testing.T) {
+	html := RenderUserButton(UserButtonOptions{
+		Letter:     "A",
+		Login:      "alice",
+		Name:       "Alice",
+		Email:      "alice@example.com",
+		FormAction: "/choose",
+		HiddenFields: map[string]string{
+			"state":       "s1",
+			"client_id":   "c1",
+			"redirect_to": "/dashboard",
+		},
+	})
+
+	if !strings.Contains(html, `class="user-btn"`) || !strings.Contains(html, `alice@example.com`) {
+		t.Fatalf("user button missing content:\n%s", html)
+	}
+	if strings.Index(html, `name="client_id"`) > strings.Index(html, `name="state"`) {
+		t.Fatalf("hidden fields were not stable:\n%s", html)
+	}
+}
+
+func TestAssetRoutesServeEmbeddedPlaceholders(t *testing.T) {
+	router := corehttp.NewRouter()
+	RegisterAssetRoutes(router)
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/_emulate/fonts/geist-sans.woff2", nil))
+	if res.Code != http.StatusOK {
+		t.Fatalf("font status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Header().Get("Content-Type") != "font/woff2" {
+		t.Fatalf("font content type = %q", res.Header().Get("Content-Type"))
+	}
+
+	missing := httptest.NewRecorder()
+	router.ServeHTTP(missing, httptest.NewRequest(http.MethodGet, "/_emulate/fonts/missing.woff2", nil))
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("missing status = %d", missing.Code)
+	}
+}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -5,6 +5,7 @@ import (
 
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
 	"github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
 )
 
 const HealthPath = "/_emulate/health"
@@ -44,6 +45,7 @@ func NewServer(options ServerOptions) *Server {
 	}
 
 	router := corehttp.NewRouter()
+	ui.RegisterAssetRoutes(router)
 	router.Get(HealthPath, func(c *corehttp.Context) {
 		c.JSON(http.StatusOK, map[string]any{
 			"ok":       true,


### PR DESCRIPTION
- Add shared Go UI renderers with embedded placeholder assets and asset routes.

- Add config discovery and JSON loading with explicit YAML handling.

- Reuse shared config discovery in the native CLI and serve UI assets from the runtime handler.