### PR TITLE
Add JS SDK conformance harness skeleton

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,6 +671,8 @@ importers:
         specifier: ^5.7
         version: 5.9.3
 
+  tests/sdk-js: {}
+
 packages:
 
   '@ai-sdk/gateway@3.0.93':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,7 +671,11 @@ importers:
         specifier: ^5.7
         version: 5.9.3
 
-  tests/sdk-js: {}
+  tests/sdk-js:
+    devDependencies:
+      emulate:
+        specifier: workspace:*
+        version: link:../../packages/emulate
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "packages/@emulators/*"
   - "apps/*"
   - "examples/*"
+  - "tests/*"

--- a/tests/sdk-js/package.json
+++ b/tests/sdk-js/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "pretest": "pnpm --dir ../.. --filter emulate... build",
     "test": "node --test test/*.test.mjs"
+  },
+  "devDependencies": {
+    "emulate": "workspace:*"
   }
 }

--- a/tests/sdk-js/package.json
+++ b/tests/sdk-js/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@emulators/sdk-js-conformance",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "pretest": "pnpm --dir ../.. --filter emulate... build",
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/tests/sdk-js/src/harness.mjs
+++ b/tests/sdk-js/src/harness.mjs
@@ -147,12 +147,11 @@ export async function waitForHttp(url, options = {}) {
 
   while (Date.now() <= deadline) {
     try {
-      const response = await fetchWithTimeout(url, requestTimeoutMs);
-      const body = await response.text();
-      if (acceptStatus(response.status, body)) {
-        return { status: response.status, body };
+      const result = await fetchWithTimeout(url, requestTimeoutMs);
+      if (acceptStatus(result.status, result.body)) {
+        return result;
       }
-      lastError = new Error(`GET ${url} returned ${response.status}`);
+      lastError = new Error(`GET ${url} returned ${result.status}`);
     } catch (err) {
       lastError = err;
     }
@@ -309,7 +308,11 @@ async function fetchWithTimeout(url, timeoutMs) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(url, { signal: controller.signal });
+    const response = await fetch(url, { signal: controller.signal });
+    return {
+      status: response.status,
+      body: await response.text(),
+    };
   } finally {
     clearTimeout(timer);
   }

--- a/tests/sdk-js/src/harness.mjs
+++ b/tests/sdk-js/src/harness.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
-import { access } from "node:fs/promises";
+import { access, mkdtemp, rm } from "node:fs/promises";
 import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -78,6 +79,16 @@ export async function startRuntime(options = {}) {
   });
   const logs = captureLogs(child, options.logLimitBytes ?? DEFAULT_LOG_LIMIT_BYTES);
   const exit = waitForExit(child);
+  let stopped = false;
+  const stop = async () => {
+    if (stopped) return;
+    stopped = true;
+    try {
+      await stopChild(child, exit, options.stopTimeoutMs);
+    } finally {
+      await spec.cleanup?.();
+    }
+  };
   const readinessPath = options.readinessPath ?? env.EMULATE_SDK_READY_PATH ?? spec.readinessPath;
   const readyUrl = new URL(readinessPath, `${baseUrl}/`).toString();
 
@@ -93,7 +104,7 @@ export async function startRuntime(options = {}) {
       }),
     ]);
   } catch (err) {
-    await stopChild(child, exit, options.stopTimeoutMs);
+    await stop();
     throw withRuntimeLogs(err, spec.label, logs);
   }
 
@@ -105,7 +116,7 @@ export async function startRuntime(options = {}) {
     readyUrl,
     runtime,
     service,
-    stop: () => stopChild(child, exit, options.stopTimeoutMs),
+    stop,
   };
 }
 
@@ -165,6 +176,7 @@ async function typeScriptCommand(options) {
   const cliPath =
     options.cliPath ?? options.env.EMULATE_TYPESCRIPT_CLI ?? path.join(repoRoot, "packages/emulate/dist/index.js");
   await assertExecutableFile(cliPath, "TypeScript CLI");
+  const workingDirectory = await runtimeWorkingDirectory(options);
   return {
     args: [
       cliPath,
@@ -177,7 +189,8 @@ async function typeScriptCommand(options) {
       options.baseUrl,
     ],
     command: process.execPath,
-    cwd: repoRoot,
+    cwd: workingDirectory.cwd,
+    cleanup: workingDirectory.cleanup,
     label: "TypeScript runtime",
     readinessPath: "/rate_limit",
   };
@@ -189,12 +202,27 @@ async function goCommand(options) {
     throw new Error("Go runtime selected but no binary was provided");
   }
   await assertExecutableFile(binary, "Go runtime binary");
+  const workingDirectory = await runtimeWorkingDirectory(options);
   return {
     args: ["start", "--port", String(options.port), "--service", options.service, "--base-url", options.baseUrl],
     command: binary,
-    cwd: repoRoot,
+    cwd: workingDirectory.cwd,
+    cleanup: workingDirectory.cleanup,
     label: "Go runtime",
     readinessPath: "/_emulate/health",
+  };
+}
+
+async function runtimeWorkingDirectory(options) {
+  if (options.cwd) {
+    return { cwd: options.cwd, cleanup: null };
+  }
+  const cwd = await mkdtemp(path.join(os.tmpdir(), "emulate-sdk-js-"));
+  return {
+    cwd,
+    cleanup: async () => {
+      await rm(cwd, { recursive: true, force: true });
+    },
   };
 }
 

--- a/tests/sdk-js/src/harness.mjs
+++ b/tests/sdk-js/src/harness.mjs
@@ -1,0 +1,303 @@
+import { spawn } from "node:child_process";
+import { access } from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_SERVICE = "github";
+const DEFAULT_READY_TIMEOUT_MS = 15_000;
+const DEFAULT_READY_INTERVAL_MS = 100;
+const DEFAULT_REQUEST_TIMEOUT_MS = 1_000;
+const DEFAULT_LOG_LIMIT_BYTES = 64 * 1024;
+
+const harnessDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const repoRoot = path.resolve(harnessDir, "../..");
+
+export async function allocatePort(host = DEFAULT_HOST) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (!address || typeof address === "string") {
+          reject(new Error("Port allocation did not return a TCP address"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+export function selectRuntime(env = process.env) {
+  if (env.EMULATE_SDK_RUNTIME) return env.EMULATE_SDK_RUNTIME;
+  if (env.EMULATE_TARGET_URL) return "external";
+  return "typescript";
+}
+
+export async function startRuntime(options = {}) {
+  const env = { ...process.env, ...options.env };
+  const runtime = options.runtime ?? selectRuntime(env);
+  if (runtime === "external") {
+    const target = connectRuntime({
+      readinessPath: options.readinessPath ?? env.EMULATE_SDK_READY_PATH,
+      url: options.url ?? options.targetUrl ?? env.EMULATE_TARGET_URL,
+      runtime,
+      service: options.service,
+    });
+    if (target.readyUrl) {
+      await waitForHttp(target.readyUrl, {
+        timeoutMs: options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+        intervalMs: options.readyIntervalMs ?? DEFAULT_READY_INTERVAL_MS,
+        requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      });
+    }
+    return target;
+  }
+
+  const service = options.service ?? DEFAULT_SERVICE;
+  const host = options.host ?? DEFAULT_HOST;
+  const port = options.port ?? (await allocatePort(host));
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? `http://${host}:${port}`);
+  const spec = await runtimeCommand({ ...options, baseUrl, env, host, port, runtime, service });
+  const child = spawn(spec.command, spec.args, {
+    cwd: spec.cwd,
+    env: {
+      ...env,
+      ...options.processEnv,
+      FORCE_COLOR: "0",
+      NO_COLOR: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const logs = captureLogs(child, options.logLimitBytes ?? DEFAULT_LOG_LIMIT_BYTES);
+  const exit = waitForExit(child);
+  const readinessPath = options.readinessPath ?? env.EMULATE_SDK_READY_PATH ?? spec.readinessPath;
+  const readyUrl = new URL(readinessPath, `${baseUrl}/`).toString();
+
+  try {
+    await Promise.race([
+      waitForHttp(readyUrl, {
+        timeoutMs: options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+        intervalMs: options.readyIntervalMs ?? DEFAULT_READY_INTERVAL_MS,
+        requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      }),
+      exit.then((result) => {
+        throw runtimeExitError(spec.label, result);
+      }),
+    ]);
+  } catch (err) {
+    await stopChild(child, exit, options.stopTimeoutMs);
+    throw withRuntimeLogs(err, spec.label, logs);
+  }
+
+  return {
+    baseUrl,
+    child,
+    logs,
+    port,
+    readyUrl,
+    runtime,
+    service,
+    stop: () => stopChild(child, exit, options.stopTimeoutMs),
+  };
+}
+
+export function connectRuntime(options = {}) {
+  const baseUrl = normalizeBaseUrl(options.url ?? options.targetUrl);
+  if (!baseUrl) {
+    throw new Error("External runtime selected but no target URL was provided");
+  }
+  return {
+    baseUrl,
+    child: null,
+    logs: emptyLogs(),
+    port: null,
+    readyUrl: options.readinessPath ? new URL(options.readinessPath, `${baseUrl}/`).toString() : null,
+    runtime: options.runtime ?? "external",
+    service: options.service ?? DEFAULT_SERVICE,
+    stop: async () => {},
+  };
+}
+
+export async function waitForHttp(url, options = {}) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_READY_INTERVAL_MS;
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const acceptStatus = options.acceptStatus ?? ((status) => status >= 200 && status < 500);
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() <= deadline) {
+    try {
+      const response = await fetchWithTimeout(url, requestTimeoutMs);
+      const body = await response.text();
+      if (acceptStatus(response.status, body)) {
+        return { status: response.status, body };
+      }
+      lastError = new Error(`GET ${url} returned ${response.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(intervalMs, remaining));
+  }
+
+  const reason = lastError ? ` Last error: ${formatError(lastError)}` : "";
+  throw new Error(`Timed out waiting for ${url}.${reason}`);
+}
+
+async function runtimeCommand(options) {
+  if (options.runtime === "typescript") return typeScriptCommand(options);
+  if (options.runtime === "go") return goCommand(options);
+  throw new Error(`Unsupported runtime: ${options.runtime}`);
+}
+
+async function typeScriptCommand(options) {
+  const cliPath =
+    options.cliPath ?? options.env.EMULATE_TYPESCRIPT_CLI ?? path.join(repoRoot, "packages/emulate/dist/index.js");
+  await assertExecutableFile(cliPath, "TypeScript CLI");
+  return {
+    args: [
+      cliPath,
+      "start",
+      "--port",
+      String(options.port),
+      "--service",
+      options.service,
+      "--base-url",
+      options.baseUrl,
+    ],
+    command: process.execPath,
+    cwd: repoRoot,
+    label: "TypeScript runtime",
+    readinessPath: "/rate_limit",
+  };
+}
+
+async function goCommand(options) {
+  const binary = options.binary ?? options.env.EMULATE_GO_BINARY;
+  if (!binary) {
+    throw new Error("Go runtime selected but no binary was provided");
+  }
+  await assertExecutableFile(binary, "Go runtime binary");
+  return {
+    args: ["start", "--port", String(options.port), "--service", options.service, "--base-url", options.baseUrl],
+    command: binary,
+    cwd: repoRoot,
+    label: "Go runtime",
+    readinessPath: "/_emulate/health",
+  };
+}
+
+async function assertExecutableFile(filePath, label) {
+  try {
+    await access(filePath);
+  } catch {
+    throw new Error(`${label} not found at ${filePath}`);
+  }
+}
+
+function captureLogs(child, maxBytes) {
+  const logs = {
+    stderr: "",
+    stdout: "",
+    text() {
+      return formatRuntimeLogs(logs);
+    },
+  };
+  child.stdout?.on("data", (chunk) => {
+    logs.stdout = appendBounded(logs.stdout, chunk, maxBytes);
+  });
+  child.stderr?.on("data", (chunk) => {
+    logs.stderr = appendBounded(logs.stderr, chunk, maxBytes);
+  });
+  return logs;
+}
+
+function emptyLogs() {
+  return {
+    stderr: "",
+    stdout: "",
+    text() {
+      return formatRuntimeLogs(this);
+    },
+  };
+}
+
+function appendBounded(current, chunk, maxBytes) {
+  const next = current + Buffer.from(chunk).toString("utf8");
+  if (Buffer.byteLength(next) <= maxBytes) return next;
+  return Buffer.from(next).subarray(-maxBytes).toString("utf8");
+}
+
+function formatRuntimeLogs(logs) {
+  return [
+    "stdout:",
+    logs.stdout.trimEnd() || "(empty)",
+    "",
+    "stderr:",
+    logs.stderr.trimEnd() || "(empty)",
+  ].join("\n");
+}
+
+function waitForExit(child) {
+  return new Promise((resolve) => {
+    child.once("error", (error) => resolve({ error }));
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function runtimeExitError(label, result) {
+  if (result.error) {
+    return new Error(`${label} failed to start: ${formatError(result.error)}`);
+  }
+  return new Error(`${label} exited before it became ready with code ${result.code} and signal ${result.signal}`);
+}
+
+async function stopChild(child, exit, timeoutMs = 5_000) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  const result = await Promise.race([exit, sleep(timeoutMs).then(() => null)]);
+  if (result) return;
+  child.kill("SIGKILL");
+  await exit;
+}
+
+function withRuntimeLogs(err, label, logs) {
+  const message = err instanceof Error ? err.message : String(err);
+  return new Error(`${label} readiness failed: ${message}\n${logs.text()}`);
+}
+
+async function fetchWithTimeout(url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function normalizeBaseUrl(url) {
+  if (!url) return "";
+  return String(url).replace(/\/+$/, "");
+}
+
+function formatError(err) {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/tests/sdk-js/test/lifecycle.test.mjs
+++ b/tests/sdk-js/test/lifecycle.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { connectRuntime, selectRuntime, startRuntime } from "../src/harness.mjs";
+
+test("selectRuntime defaults to the TypeScript runtime", () => {
+  assert.equal(selectRuntime({}), "typescript");
+  assert.equal(selectRuntime({ EMULATE_TARGET_URL: "http://127.0.0.1:4000" }), "external");
+  assert.equal(selectRuntime({ EMULATE_SDK_RUNTIME: "go" }), "go");
+});
+
+test("connectRuntime returns an external target handle", async () => {
+  const target = connectRuntime({ url: "http://127.0.0.1:65535/", service: "github" });
+  assert.equal(target.runtime, "external");
+  assert.equal(target.service, "github");
+  assert.equal(target.baseUrl, "http://127.0.0.1:65535");
+  assert.equal(target.child, null);
+  await target.stop();
+});
+
+test("TypeScript runtime starts and serves the GitHub rate limit route", async (t) => {
+  const target = await startRuntime({ runtime: "typescript", service: "github", readinessPath: "/rate_limit" });
+  t.after(async () => {
+    await target.stop();
+  });
+
+  const response = await fetch(new URL("/rate_limit", `${target.baseUrl}/`));
+  assert.equal(response.status, 200);
+
+  const body = await response.json();
+  assert.equal(body.rate.resource, "core");
+  assert.equal(body.resources.core.limit, 5000);
+});

--- a/tests/sdk-js/test/lifecycle.test.mjs
+++ b/tests/sdk-js/test/lifecycle.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import net from "node:net";
 import test from "node:test";
-import { connectRuntime, selectRuntime, startRuntime } from "../src/harness.mjs";
+import { connectRuntime, selectRuntime, startRuntime, waitForHttp } from "../src/harness.mjs";
 
 test("selectRuntime defaults to the TypeScript runtime", () => {
   assert.equal(selectRuntime({}), "typescript");
@@ -29,4 +30,40 @@ test("TypeScript runtime starts and serves the GitHub rate limit route", async (
   const body = await response.json();
   assert.equal(body.rate.resource, "core");
   assert.equal(body.resources.core.limit, 5000);
+});
+
+test("waitForHttp applies the request timeout while reading the response body", async (t) => {
+  const sockets = new Set();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => {
+      sockets.delete(socket);
+    });
+    socket.write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 100\r\n\r\npartial");
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  t.after(() => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    server.close();
+  });
+
+  const address = server.address();
+  assert(address && typeof address !== "string");
+
+  await assert.rejects(
+    () =>
+      waitForHttp(`http://127.0.0.1:${address.port}/ready`, {
+        intervalMs: 5,
+        requestTimeoutMs: 20,
+        timeoutMs: 75,
+      }),
+    /Timed out waiting/,
+  );
 });


### PR DESCRIPTION
- Adds a dependency-free Node harness for TypeScript, Go, and external runtime targets with random ports, readiness polling, and captured logs.

- Adds lifecycle smoke coverage that starts the TypeScript CLI and verifies GitHub rate-limit readiness.

- Keeps SDK conformance isolated under tests/sdk-js so future official SDK suites can be added as dev-only test dependencies.