### PR TITLE
Add Go AWS gateway parsing foundation

### DIFF
--- a/internal/services/aws/gateway/context.go
+++ b/internal/services/aws/gateway/context.go
@@ -1,0 +1,416 @@
+package gateway
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+)
+
+const (
+	DefaultAccountID = "123456789012"
+	DefaultRegion    = "us-east-1"
+)
+
+type Options struct {
+	DefaultAccountID   string
+	DefaultRegion      string
+	RequestIDGenerator func() string
+}
+
+type AwsRequestContext struct {
+	RequestID string
+	Service   string
+	Action    string
+	Protocol  protocols.Protocol
+	Region    string
+	AccountID string
+
+	RawBody []byte
+	Query   map[string]string
+	Input   map[string]any
+	Target  string
+
+	Credentials Credentials
+	Principal   Principal
+	S3          *protocols.S3Route
+}
+
+type Credentials struct {
+	AccessKeyID string
+	Scope       CredentialScope
+}
+
+type CredentialScope struct {
+	Date     string
+	Region   string
+	Service  string
+	Terminal string
+}
+
+type Principal struct {
+	AccountID string
+	ARN       string
+}
+
+type hostDetection struct {
+	Service string
+	Region  string
+}
+
+var requestIDCounter atomic.Uint64
+
+func BuildContext(req *http.Request, rawBody []byte, options Options) (AwsRequestContext, error) {
+	options = normalizeOptions(options)
+	credentials := ParseCredentials(req)
+	host := detectHost(req.Host)
+	pathService := serviceFromPath(req.URL.Path)
+	region := firstNonEmpty(credentials.Scope.Region, host.Region, options.DefaultRegion)
+	accountID := options.DefaultAccountID
+
+	ctx := AwsRequestContext{
+		RequestID:   options.RequestIDGenerator(),
+		Protocol:    protocols.ProtocolUnknown,
+		Region:      region,
+		AccountID:   accountID,
+		RawBody:     append([]byte(nil), rawBody...),
+		Query:       map[string]string{},
+		Input:       map[string]any{},
+		Credentials: credentials,
+		Principal: Principal{
+			AccountID: accountID,
+		},
+	}
+
+	if target := req.Header.Get("X-Amz-Target"); target != "" {
+		parsed, err := protocols.ParseJSONRPCRequest(target, rawBody)
+		if err != nil {
+			return AwsRequestContext{}, err
+		}
+		ctx.Protocol = protocols.ProtocolJSONRPC
+		ctx.Target = parsed.Target
+		ctx.Service = firstNonEmpty(serviceFromJSONTargetPrefix(parsed.TargetPrefix), host.Service, pathService, credentials.Scope.Service)
+		ctx.Action = parsed.Action
+		ctx.Input = parsed.Input
+		return ctx, nil
+	}
+
+	if host.Service == "s3" || pathService == "s3" {
+		s3Route, err := protocols.ParseS3RESTRequest(req)
+		if err != nil {
+			return AwsRequestContext{}, err
+		}
+		ctx.Protocol = protocols.ProtocolRESTXML
+		ctx.Service = "s3"
+		ctx.Action = s3Route.Action
+		ctx.Query = s3Route.Query
+		ctx.Input = s3Input(s3Route)
+		ctx.S3 = &s3Route
+		return ctx, nil
+	}
+
+	queryReq, err := protocols.ParseQueryRequest(req, rawBody)
+	if err != nil {
+		return AwsRequestContext{}, err
+	}
+	ctx.Query = queryReq.Parameters
+	if queryReq.Action != "" {
+		ctx.Protocol = protocols.ProtocolQuery
+		ctx.Service = firstNonEmpty(pathService, host.Service, credentials.Scope.Service, serviceFromQueryAction(queryReq.Action))
+		ctx.Action = queryReq.Action
+		ctx.Input = queryInput(queryReq.Parameters)
+		return ctx, nil
+	}
+
+	if shouldTreatAsS3(req, host.Service, pathService) {
+		s3Route, err := protocols.ParseS3RESTRequest(req)
+		if err != nil {
+			return AwsRequestContext{}, err
+		}
+		ctx.Protocol = protocols.ProtocolRESTXML
+		ctx.Service = "s3"
+		ctx.Action = s3Route.Action
+		ctx.Query = s3Route.Query
+		ctx.Input = s3Input(s3Route)
+		ctx.S3 = &s3Route
+		return ctx, nil
+	}
+
+	ctx.Service = firstNonEmpty(pathService, host.Service, credentials.Scope.Service)
+	return ctx, nil
+}
+
+func ParseCredentials(req *http.Request) Credentials {
+	credential := credentialValue(req)
+	if credential == "" {
+		return Credentials{}
+	}
+	value, err := url.QueryUnescape(credential)
+	if err != nil {
+		value = credential
+	}
+	parts := strings.Split(value, "/")
+	result := Credentials{AccessKeyID: parts[0]}
+	if len(parts) >= 5 {
+		result.Scope = CredentialScope{
+			Date:     parts[1],
+			Region:   parts[2],
+			Service:  parts[3],
+			Terminal: parts[4],
+		}
+	}
+	return result
+}
+
+func NewRequestID() string {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return strings.ToUpper(hex.EncodeToString(bytes[:]))
+	}
+	return fmt.Sprintf("REQ%016X", requestIDCounter.Add(1))
+}
+
+func normalizeOptions(options Options) Options {
+	if options.DefaultAccountID == "" {
+		options.DefaultAccountID = DefaultAccountID
+	}
+	if options.DefaultRegion == "" {
+		options.DefaultRegion = DefaultRegion
+	}
+	if options.RequestIDGenerator == nil {
+		options.RequestIDGenerator = NewRequestID
+	}
+	return options
+}
+
+func credentialValue(req *http.Request) string {
+	if value := req.URL.Query().Get("X-Amz-Credential"); value != "" {
+		return value
+	}
+	auth := req.Header.Get("Authorization")
+	const marker = "Credential="
+	index := strings.Index(auth, marker)
+	if index < 0 {
+		return ""
+	}
+	value := auth[index+len(marker):]
+	if cut := strings.IndexAny(value, ", "); cut >= 0 {
+		value = value[:cut]
+	}
+	return value
+}
+
+func queryInput(params map[string]string) map[string]any {
+	input := make(map[string]any, len(params))
+	for key, value := range params {
+		input[key] = value
+	}
+	return input
+}
+
+func s3Input(route protocols.S3Route) map[string]any {
+	return map[string]any{
+		"bucket":      route.Bucket,
+		"copySource":  route.CopySource,
+		"key":         route.Key,
+		"query":       route.Query,
+		"subresource": route.Subresource,
+	}
+}
+
+func shouldTreatAsS3(req *http.Request, hostService string, pathService string) bool {
+	if hostService == "s3" || pathService == "s3" {
+		return true
+	}
+	if req.URL.Query().Get("Action") != "" || req.Header.Get("X-Amz-Target") != "" {
+		return false
+	}
+	return hostService == ""
+}
+
+func detectHost(host string) hostDetection {
+	host = normalizeHost(host)
+	if host == "" {
+		return hostDetection{}
+	}
+	labels := strings.Split(host, ".")
+	for index := len(labels) - 1; index >= 0; index-- {
+		label := labels[index]
+		if label == "s3" {
+			return hostDetection{Service: "s3", Region: regionAfterS3Label(labels, index)}
+		}
+		if strings.HasPrefix(label, "s3-") {
+			return hostDetection{Service: "s3", Region: regionFromDashedS3Label(labels, index)}
+		}
+	}
+	if service := knownHostService(labels[0]); service != "" {
+		return hostDetection{Service: service, Region: regionAfterLabel(labels, 0)}
+	}
+	return hostDetection{}
+}
+
+func normalizeHost(host string) string {
+	if value, _, err := net.SplitHostPort(host); err == nil {
+		host = value
+	}
+	return strings.TrimSuffix(strings.ToLower(host), ".")
+}
+
+func regionAfterLabel(labels []string, index int) string {
+	for _, candidate := range labels[index+1:] {
+		if candidate == "amazonaws" {
+			return ""
+		}
+		if looksLikeAWSRegion(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func regionAfterS3Label(labels []string, index int) string {
+	return firstAWSRegionLabelAfter(labels, index)
+}
+
+func regionFromDashedS3Label(labels []string, index int) string {
+	region := strings.TrimPrefix(labels[index], "s3-")
+	if looksLikeAWSRegion(region) {
+		return region
+	}
+	return firstAWSRegionLabelAfter(labels, index)
+}
+
+func firstAWSRegionLabelAfter(labels []string, index int) string {
+	for _, label := range labels[index+1:] {
+		if label == "amazonaws" {
+			return ""
+		}
+		if looksLikeAWSRegion(label) {
+			return label
+		}
+	}
+	return ""
+}
+
+func looksLikeAWSRegion(label string) bool {
+	parts := strings.Split(label, "-")
+	if len(parts) < 3 {
+		return false
+	}
+	last := parts[len(parts)-1]
+	if len(last) != 1 || last[0] < '0' || last[0] > '9' {
+		return false
+	}
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" {
+			return false
+		}
+		for _, char := range part {
+			if char < 'a' || char > 'z' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func serviceFromPath(pathValue string) string {
+	trimmed := strings.Trim(pathValue, "/")
+	if trimmed == "" {
+		return ""
+	}
+	first := strings.Split(trimmed, "/")[0]
+	return knownPathService(strings.ToLower(first))
+}
+
+func serviceFromQueryAction(action string) string {
+	return queryActionServices[action]
+}
+
+func serviceFromJSONTargetPrefix(prefix string) string {
+	for marker, service := range jsonTargetServices {
+		if strings.HasPrefix(prefix, marker) {
+			return service
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func knownHostService(label string) string {
+	return knownServices[label]
+}
+
+func knownPathService(label string) string {
+	return knownServices[label]
+}
+
+var knownServices = map[string]string{
+	"cloudformation": "cloudformation",
+	"dynamodb":       "dynamodb",
+	"events":         "events",
+	"iam":            "iam",
+	"kms":            "kms",
+	"lambda":         "lambda",
+	"logs":           "logs",
+	"s3":             "s3",
+	"secretsmanager": "secretsmanager",
+	"sns":            "sns",
+	"sqs":            "sqs",
+	"ssm":            "ssm",
+	"states":         "states",
+	"sts":            "sts",
+}
+
+var queryActionServices = map[string]string{
+	"AddPermission":      "sqs",
+	"AssumeRole":         "sts",
+	"CreateQueue":        "sqs",
+	"CreateRole":         "iam",
+	"CreateUser":         "iam",
+	"CreateAccessKey":    "iam",
+	"DeleteAccessKey":    "iam",
+	"DeleteMessage":      "sqs",
+	"DeleteQueue":        "sqs",
+	"DeleteRole":         "iam",
+	"DeleteUser":         "iam",
+	"GetCallerIdentity":  "sts",
+	"GetQueueAttributes": "sqs",
+	"GetQueueUrl":        "sqs",
+	"GetRole":            "iam",
+	"GetUser":            "iam",
+	"ListAccessKeys":     "iam",
+	"ListQueues":         "sqs",
+	"ListRoles":          "iam",
+	"ListUsers":          "iam",
+	"PurgeQueue":         "sqs",
+	"ReceiveMessage":     "sqs",
+	"SendMessage":        "sqs",
+}
+
+var jsonTargetServices = map[string]string{
+	"AmazonCloudWatchLogs": "logs",
+	"DynamoDB":             "dynamodb",
+	"Lambda":               "lambda",
+	"AWSEvents":            "events",
+	"SecretsManager":       "secretsmanager",
+	"Logs_20140328":        "logs",
+	"secretsmanager":       "secretsmanager",
+	"AmazonSSM":            "ssm",
+	"TrentService":         "kms",
+	"AWSStepFunctions":     "states",
+}

--- a/internal/services/aws/gateway/context_test.go
+++ b/internal/services/aws/gateway/context_test.go
@@ -355,6 +355,14 @@ func TestBuildContextS3MultipartActions(t *testing.T) {
 			wantAction: "ListMultipartUploads",
 		},
 		{
+			name:       "bucket post uploads is not create multipart upload",
+			method:     http.MethodPost,
+			url:        "http://photos.s3.us-west-2.amazonaws.com/?uploads",
+			wantBucket: "photos",
+			wantKey:    "",
+			wantAction: "PostObject",
+		},
+		{
 			name:       "abort multipart upload",
 			method:     http.MethodDelete,
 			url:        "http://photos.s3.us-west-2.amazonaws.com/docs/readme.txt?uploadId=upload-123",

--- a/internal/services/aws/gateway/context_test.go
+++ b/internal/services/aws/gateway/context_test.go
@@ -1,0 +1,612 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+)
+
+func TestBuildContextS3PathStyleListObjects(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/photos?list-type=2&prefix=raw%2F", nil)
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" {
+		t.Fatalf("service = %q, want s3", ctx.Service)
+	}
+	if ctx.Protocol != protocols.ProtocolRESTXML {
+		t.Fatalf("protocol = %q, want %q", ctx.Protocol, protocols.ProtocolRESTXML)
+	}
+	if ctx.Action != "ListObjectsV2" {
+		t.Fatalf("action = %q, want ListObjectsV2", ctx.Action)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "photos" || ctx.S3.Key != "" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+	if ctx.S3.AddressingStyle != protocols.S3AddressingPathStyle {
+		t.Fatalf("addressing style = %q, want path", ctx.S3.AddressingStyle)
+	}
+	if ctx.Query["prefix"] != "raw/" {
+		t.Fatalf("prefix = %q, want raw/", ctx.Query["prefix"])
+	}
+	if ctx.RequestID != "req-test" {
+		t.Fatalf("request id = %q, want req-test", ctx.RequestID)
+	}
+}
+
+func TestBuildContextS3VirtualHostPutObject(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://photos.s3.us-west-2.amazonaws.com/docs/readme.txt", nil)
+	ctx, err := BuildContext(req, []byte("hello"), fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" || ctx.Action != "PutObject" {
+		t.Fatalf("service/action = %q/%q, want s3/PutObject", ctx.Service, ctx.Action)
+	}
+	if ctx.Region != "us-west-2" {
+		t.Fatalf("region = %q, want us-west-2", ctx.Region)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "photos" || ctx.S3.Key != "docs/readme.txt" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+	if ctx.S3.AddressingStyle != protocols.S3AddressingVirtualHost {
+		t.Fatalf("addressing style = %q, want virtual_host", ctx.S3.AddressingStyle)
+	}
+}
+
+func TestBuildContextS3PathStylePutObjectBodyLooksLikeQuery(t *testing.T) {
+	body := []byte("Action=CreateQueue&QueueName=not-a-query")
+	req := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/photos/docs/readme.txt", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ctx, err := BuildContext(req, body, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" || ctx.Action != "PutObject" {
+		t.Fatalf("service/action = %q/%q, want s3/PutObject", ctx.Service, ctx.Action)
+	}
+	if ctx.Protocol != protocols.ProtocolRESTXML {
+		t.Fatalf("protocol = %q, want %q", ctx.Protocol, protocols.ProtocolRESTXML)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "photos" || ctx.S3.Key != "docs/readme.txt" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+}
+
+func TestBuildContextS3PathStyleBucketNameCanMatchKnownService(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		wantBucket string
+		wantKey    string
+		wantAction string
+	}{
+		{
+			name:       "object in logs bucket",
+			method:     http.MethodPut,
+			url:        "http://127.0.0.1/logs/app.txt",
+			wantBucket: "logs",
+			wantKey:    "app.txt",
+			wantAction: "PutObject",
+		},
+		{
+			name:       "list sqs bucket",
+			method:     http.MethodGet,
+			url:        "http://127.0.0.1/sqs?list-type=2",
+			wantBucket: "sqs",
+			wantKey:    "",
+			wantAction: "ListObjectsV2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(test.method, test.url, nil)
+			ctx, err := BuildContext(req, nil, fixedOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ctx.Service != "s3" || ctx.Action != test.wantAction {
+				t.Fatalf("service/action = %q/%q, want s3/%s", ctx.Service, ctx.Action, test.wantAction)
+			}
+			if ctx.S3 == nil || ctx.S3.Bucket != test.wantBucket || ctx.S3.Key != test.wantKey {
+				t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+			}
+		})
+	}
+}
+
+func TestBuildContextS3CopyObject(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/photos/docs/copy.txt", nil)
+	req.Header.Set("x-amz-copy-source", "/photos/docs/source.txt")
+
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" || ctx.Action != "CopyObject" {
+		t.Fatalf("service/action = %q/%q, want s3/CopyObject", ctx.Service, ctx.Action)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "photos" || ctx.S3.Key != "docs/copy.txt" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+	if ctx.S3.CopySource != "/photos/docs/source.txt" {
+		t.Fatalf("copy source = %q, want /photos/docs/source.txt", ctx.S3.CopySource)
+	}
+	if ctx.Input["copySource"] != "/photos/docs/source.txt" {
+		t.Fatalf("input copySource = %#v, want /photos/docs/source.txt", ctx.Input["copySource"])
+	}
+}
+
+func TestBuildContextS3SubresourceActions(t *testing.T) {
+	tests := []struct {
+		name            string
+		method          string
+		url             string
+		wantAction      string
+		wantBucket      string
+		wantKey         string
+		wantSubresource string
+	}{
+		{
+			name:            "get object acl",
+			method:          http.MethodGet,
+			url:             "http://127.0.0.1/photos/docs/readme.txt?acl",
+			wantAction:      "GetObjectAcl",
+			wantBucket:      "photos",
+			wantKey:         "docs/readme.txt",
+			wantSubresource: "acl",
+		},
+		{
+			name:            "put object tagging",
+			method:          http.MethodPut,
+			url:             "http://127.0.0.1/photos/docs/readme.txt?tagging",
+			wantAction:      "PutObjectTagging",
+			wantBucket:      "photos",
+			wantKey:         "docs/readme.txt",
+			wantSubresource: "tagging",
+		},
+		{
+			name:            "delete object tagging",
+			method:          http.MethodDelete,
+			url:             "http://127.0.0.1/photos/docs/readme.txt?tagging",
+			wantAction:      "DeleteObjectTagging",
+			wantBucket:      "photos",
+			wantKey:         "docs/readme.txt",
+			wantSubresource: "tagging",
+		},
+		{
+			name:            "put bucket acl",
+			method:          http.MethodPut,
+			url:             "http://127.0.0.1/photos?acl",
+			wantAction:      "PutBucketAcl",
+			wantBucket:      "photos",
+			wantKey:         "",
+			wantSubresource: "acl",
+		},
+		{
+			name:            "get bucket tagging",
+			method:          http.MethodGet,
+			url:             "http://127.0.0.1/photos?tagging",
+			wantAction:      "GetBucketTagging",
+			wantBucket:      "photos",
+			wantKey:         "",
+			wantSubresource: "tagging",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(test.method, test.url, nil)
+			ctx, err := BuildContext(req, nil, fixedOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ctx.Service != "s3" || ctx.Action != test.wantAction {
+				t.Fatalf("service/action = %q/%q, want s3/%s", ctx.Service, ctx.Action, test.wantAction)
+			}
+			if ctx.S3 == nil || ctx.S3.Bucket != test.wantBucket || ctx.S3.Key != test.wantKey {
+				t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+			}
+			if ctx.S3.Subresource != test.wantSubresource {
+				t.Fatalf("subresource = %q, want %q", ctx.S3.Subresource, test.wantSubresource)
+			}
+		})
+	}
+}
+
+func TestBuildContextS3VirtualHostDashRegion(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://photos.s3-us-west-2.amazonaws.com/docs/readme.txt", nil)
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" || ctx.Action != "PutObject" {
+		t.Fatalf("service/action = %q/%q, want s3/PutObject", ctx.Service, ctx.Action)
+	}
+	if ctx.Region != "us-west-2" {
+		t.Fatalf("region = %q, want us-west-2", ctx.Region)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "photos" || ctx.S3.Key != "docs/readme.txt" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+}
+
+func TestBuildContextS3EndpointVariantRegionDetection(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantRegion string
+	}{
+		{
+			name:       "accelerate has no host region",
+			url:        "http://photos.s3-accelerate.amazonaws.com/docs/readme.txt",
+			wantRegion: DefaultRegion,
+		},
+		{
+			name:       "accelerate dualstack has no host region",
+			url:        "http://photos.s3-accelerate.dualstack.amazonaws.com/docs/readme.txt",
+			wantRegion: DefaultRegion,
+		},
+		{
+			name:       "access point host region",
+			url:        "http://photos.s3-accesspoint.us-west-2.amazonaws.com/docs/readme.txt",
+			wantRegion: "us-west-2",
+		},
+		{
+			name:       "fips host region",
+			url:        "http://photos.s3-fips.us-gov-west-1.amazonaws.com/docs/readme.txt",
+			wantRegion: "us-gov-west-1",
+		},
+		{
+			name:       "local s3 host uses default region",
+			url:        "http://photos.s3.localhost.example.test/docs/readme.txt",
+			wantRegion: DefaultRegion,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, test.url, nil)
+			ctx, err := BuildContext(req, nil, fixedOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ctx.Service != "s3" || ctx.Action != "PutObject" {
+				t.Fatalf("service/action = %q/%q, want s3/PutObject", ctx.Service, ctx.Action)
+			}
+			if ctx.Region != test.wantRegion {
+				t.Fatalf("region = %q, want %q", ctx.Region, test.wantRegion)
+			}
+			if ctx.S3 == nil || ctx.S3.Bucket != "photos" || ctx.S3.Key != "docs/readme.txt" {
+				t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+			}
+		})
+	}
+}
+
+func TestBuildContextS3VirtualHostDottedBucketContainingS3Label(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://my.s3.bucket.s3.us-west-2.amazonaws.com/docs/readme.txt", nil)
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" || ctx.Action != "PutObject" {
+		t.Fatalf("service/action = %q/%q, want s3/PutObject", ctx.Service, ctx.Action)
+	}
+	if ctx.Region != "us-west-2" {
+		t.Fatalf("region = %q, want us-west-2", ctx.Region)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "my.s3.bucket" || ctx.S3.Key != "docs/readme.txt" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+	if ctx.S3.AddressingStyle != protocols.S3AddressingVirtualHost {
+		t.Fatalf("addressing style = %q, want virtual_host", ctx.S3.AddressingStyle)
+	}
+}
+
+func TestBuildContextS3CreateMultipartUploadForObjectKey(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://photos.s3.us-west-2.amazonaws.com/docs/readme.txt?uploads", nil)
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" || ctx.Action != "CreateMultipartUpload" {
+		t.Fatalf("service/action = %q/%q, want s3/CreateMultipartUpload", ctx.Service, ctx.Action)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "photos" || ctx.S3.Key != "docs/readme.txt" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+}
+
+func TestBuildContextS3MultipartActions(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		wantBucket string
+		wantKey    string
+		wantAction string
+	}{
+		{
+			name:       "list multipart uploads",
+			method:     http.MethodGet,
+			url:        "http://photos.s3.us-west-2.amazonaws.com/?uploads",
+			wantBucket: "photos",
+			wantKey:    "",
+			wantAction: "ListMultipartUploads",
+		},
+		{
+			name:       "abort multipart upload",
+			method:     http.MethodDelete,
+			url:        "http://photos.s3.us-west-2.amazonaws.com/docs/readme.txt?uploadId=upload-123",
+			wantBucket: "photos",
+			wantKey:    "docs/readme.txt",
+			wantAction: "AbortMultipartUpload",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(test.method, test.url, nil)
+			ctx, err := BuildContext(req, nil, fixedOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ctx.Service != "s3" || ctx.Action != test.wantAction {
+				t.Fatalf("service/action = %q/%q, want s3/%s", ctx.Service, ctx.Action, test.wantAction)
+			}
+			if ctx.S3 == nil || ctx.S3.Bucket != test.wantBucket || ctx.S3.Key != test.wantKey {
+				t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+			}
+		})
+	}
+}
+
+func TestBuildContextSQSQueryRequest(t *testing.T) {
+	body := "Action=CreateQueue&Version=2012-11-05&QueueName=jobs&Attribute.1.Name=VisibilityTimeout&Attribute.1.Value=45"
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260518/us-west-2/sqs/aws4_request, SignedHeaders=host, Signature=abc")
+
+	ctx, err := BuildContext(req, []byte(body), fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "sqs" || ctx.Action != "CreateQueue" {
+		t.Fatalf("service/action = %q/%q, want sqs/CreateQueue", ctx.Service, ctx.Action)
+	}
+	if ctx.Protocol != protocols.ProtocolQuery {
+		t.Fatalf("protocol = %q, want %q", ctx.Protocol, protocols.ProtocolQuery)
+	}
+	if ctx.Region != "us-west-2" {
+		t.Fatalf("region = %q, want us-west-2", ctx.Region)
+	}
+	if ctx.Credentials.AccessKeyID != "AKIAEXAMPLE" || ctx.Credentials.Scope.Service != "sqs" {
+		t.Fatalf("unexpected credentials: %#v", ctx.Credentials)
+	}
+	if ctx.Query["Attribute.1.Value"] != "45" {
+		t.Fatalf("attribute value = %q, want 45", ctx.Query["Attribute.1.Value"])
+	}
+}
+
+func TestBuildContextIAMQueryActionFallbacks(t *testing.T) {
+	tests := []string{
+		"CreateAccessKey",
+		"DeleteAccessKey",
+		"DeleteRole",
+		"DeleteUser",
+	}
+
+	for _, action := range tests {
+		t.Run(action, func(t *testing.T) {
+			body := "Action=" + action + "&Version=2010-05-08"
+			req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			ctx, err := BuildContext(req, []byte(body), fixedOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ctx.Service != "iam" || ctx.Action != action {
+				t.Fatalf("service/action = %q/%q, want iam/%s", ctx.Service, ctx.Action, action)
+			}
+		})
+	}
+}
+
+func TestBuildContextIAMQueryRequest(t *testing.T) {
+	body := "Action=ListUsers&Version=2010-05-08"
+	req := httptest.NewRequest(http.MethodPost, "https://iam.amazonaws.com/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ctx, err := BuildContext(req, []byte(body), fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "iam" || ctx.Action != "ListUsers" {
+		t.Fatalf("service/action = %q/%q, want iam/ListUsers", ctx.Service, ctx.Action)
+	}
+	if ctx.Region != DefaultRegion {
+		t.Fatalf("region = %q, want %q", ctx.Region, DefaultRegion)
+	}
+}
+
+func TestBuildContextSTSQueryRequest(t *testing.T) {
+	body := "Action=GetCallerIdentity&Version=2011-06-15"
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIASTS/20260518/eu-central-1/sts/aws4_request, SignedHeaders=host, Signature=abc")
+
+	ctx, err := BuildContext(req, []byte(body), fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "sts" || ctx.Action != "GetCallerIdentity" {
+		t.Fatalf("service/action = %q/%q, want sts/GetCallerIdentity", ctx.Service, ctx.Action)
+	}
+	if ctx.Region != "eu-central-1" {
+		t.Fatalf("region = %q, want eu-central-1", ctx.Region)
+	}
+}
+
+func TestBuildContextNonS3HostRegionDetection(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		body        string
+		target      string
+		contentType string
+		wantService string
+		wantAction  string
+		wantRegion  string
+	}{
+		{
+			name:        "localhost suffix falls back to default region",
+			url:         "http://sqs.localhost/",
+			body:        "Action=ListQueues&Version=2012-11-05",
+			contentType: "application/x-www-form-urlencoded",
+			wantService: "sqs",
+			wantAction:  "ListQueues",
+			wantRegion:  DefaultRegion,
+		},
+		{
+			name:        "dualstack host skips to aws region label",
+			url:         "https://dynamodb.dualstack.us-west-2.amazonaws.com/",
+			body:        `{"Limit":1}`,
+			target:      "DynamoDB_20120810.ListTables",
+			contentType: "application/x-amz-json-1.0",
+			wantService: "dynamodb",
+			wantAction:  "ListTables",
+			wantRegion:  "us-west-2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := []byte(test.body)
+			req := httptest.NewRequest(http.MethodPost, test.url, strings.NewReader(test.body))
+			req.Header.Set("Content-Type", test.contentType)
+			if test.target != "" {
+				req.Header.Set("X-Amz-Target", test.target)
+			}
+
+			ctx, err := BuildContext(req, body, fixedOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ctx.Service != test.wantService || ctx.Action != test.wantAction {
+				t.Fatalf("service/action = %q/%q, want %s/%s", ctx.Service, ctx.Action, test.wantService, test.wantAction)
+			}
+			if ctx.Region != test.wantRegion {
+				t.Fatalf("region = %q, want %q", ctx.Region, test.wantRegion)
+			}
+		})
+	}
+}
+
+func TestBuildContextJSONRPCRequest(t *testing.T) {
+	body := []byte(`{"Limit":10}`)
+	req := httptest.NewRequest(http.MethodPost, "https://dynamodb.us-east-1.amazonaws.com/", strings.NewReader(string(body)))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.ListTables")
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+
+	ctx, err := BuildContext(req, body, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "dynamodb" || ctx.Action != "ListTables" {
+		t.Fatalf("service/action = %q/%q, want dynamodb/ListTables", ctx.Service, ctx.Action)
+	}
+	if ctx.Protocol != protocols.ProtocolJSONRPC {
+		t.Fatalf("protocol = %q, want %q", ctx.Protocol, protocols.ProtocolJSONRPC)
+	}
+	limit, ok := ctx.Input["Limit"].(json.Number)
+	if !ok || limit.String() != "10" {
+		t.Fatalf("Limit = %#v, want json.Number(10)", ctx.Input["Limit"])
+	}
+}
+
+func TestBuildContextJSONRPCTargetOnlyServicePrefixes(t *testing.T) {
+	tests := []struct {
+		name       string
+		target     string
+		want       string
+		wantAction string
+	}{
+		{
+			name:       "cloudwatch logs",
+			target:     "Logs_20140328.DescribeLogGroups",
+			want:       "logs",
+			wantAction: "DescribeLogGroups",
+		},
+		{
+			name:       "secrets manager",
+			target:     "secretsmanager.GetSecretValue",
+			want:       "secretsmanager",
+			wantAction: "GetSecretValue",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", strings.NewReader(`{}`))
+			req.Header.Set("X-Amz-Target", test.target)
+			req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+
+			ctx, err := BuildContext(req, []byte(`{}`), fixedOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ctx.Service != test.want || ctx.Action != test.wantAction {
+				t.Fatalf("service/action = %q/%q, want %s/%s", ctx.Service, ctx.Action, test.want, test.wantAction)
+			}
+			if ctx.Protocol != protocols.ProtocolJSONRPC {
+				t.Fatalf("protocol = %q, want %q", ctx.Protocol, protocols.ProtocolJSONRPC)
+			}
+		})
+	}
+}
+
+func TestNewRequestIDReturnsAWSStyleOpaqueID(t *testing.T) {
+	id := NewRequestID()
+	if matched := regexp.MustCompile(`^[A-F0-9]{32}$`).MatchString(id); !matched {
+		t.Fatalf("request id = %q, want 32 uppercase hex characters", id)
+	}
+}
+
+func fixedOptions() Options {
+	return Options{
+		DefaultAccountID: DefaultAccountID,
+		DefaultRegion:    DefaultRegion,
+		RequestIDGenerator: func() string {
+			return "req-test"
+		},
+	}
+}

--- a/internal/services/aws/protocols/jsonrpc.go
+++ b/internal/services/aws/protocols/jsonrpc.go
@@ -1,0 +1,58 @@
+package protocols
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type JSONRPCRequest struct {
+	Target       string
+	TargetPrefix string
+	Action       string
+	Input        map[string]any
+}
+
+func ParseJSONRPCRequest(target string, body []byte) (JSONRPCRequest, error) {
+	prefix, action, err := ParseJSONRPCTarget(target)
+	if err != nil {
+		return JSONRPCRequest{}, err
+	}
+
+	input := map[string]any{}
+	if len(bytes.TrimSpace(body)) > 0 {
+		decoder := json.NewDecoder(bytes.NewReader(body))
+		decoder.UseNumber()
+		if err := decoder.Decode(&input); err != nil {
+			return JSONRPCRequest{}, fmt.Errorf("parse JSON RPC body: %w", err)
+		}
+		var extra any
+		if err := decoder.Decode(&extra); err != io.EOF {
+			if err != nil {
+				return JSONRPCRequest{}, fmt.Errorf("parse JSON RPC body: %w", err)
+			}
+			return JSONRPCRequest{}, fmt.Errorf("parse JSON RPC body: unexpected trailing data")
+		}
+	}
+
+	return JSONRPCRequest{
+		Target:       target,
+		TargetPrefix: prefix,
+		Action:       action,
+		Input:        input,
+	}, nil
+}
+
+func ParseJSONRPCTarget(target string) (string, string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", "", fmt.Errorf("missing JSON RPC target")
+	}
+	index := strings.LastIndex(target, ".")
+	if index <= 0 || index == len(target)-1 {
+		return "", "", fmt.Errorf("invalid JSON RPC target %q", target)
+	}
+	return target[:index], target[index+1:], nil
+}

--- a/internal/services/aws/protocols/jsonrpc_test.go
+++ b/internal/services/aws/protocols/jsonrpc_test.go
@@ -1,0 +1,35 @@
+package protocols
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseJSONRPCRequestRejectsTrailingData(t *testing.T) {
+	tests := []string{
+		`{"Limit":10} garbage`,
+		`{"Limit":10} {"Next":true}`,
+	}
+
+	for _, body := range tests {
+		t.Run(body, func(t *testing.T) {
+			_, err := ParseJSONRPCRequest("DynamoDB_20120810.ListTables", []byte(body))
+			if err == nil {
+				t.Fatal("expected trailing data error")
+			}
+			if !strings.Contains(err.Error(), "parse JSON RPC body") {
+				t.Fatalf("error = %q, want JSON RPC parse error", err)
+			}
+		})
+	}
+}
+
+func TestParseJSONRPCRequestAllowsTrailingWhitespace(t *testing.T) {
+	parsed, err := ParseJSONRPCRequest("DynamoDB_20120810.ListTables", []byte("{\"Limit\":10}\n\t "))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Action != "ListTables" {
+		t.Fatalf("action = %q, want ListTables", parsed.Action)
+	}
+}

--- a/internal/services/aws/protocols/query.go
+++ b/internal/services/aws/protocols/query.go
@@ -1,0 +1,83 @@
+package protocols
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type Protocol string
+
+const (
+	ProtocolUnknown Protocol = "unknown"
+	ProtocolRESTXML Protocol = "rest_xml"
+	ProtocolQuery   Protocol = "query"
+	ProtocolJSONRPC Protocol = "json_rpc"
+)
+
+type QueryRequest struct {
+	Parameters map[string]string
+	Action     string
+	Version    string
+}
+
+func ParseQueryString(raw string) (map[string]string, error) {
+	raw = strings.TrimPrefix(raw, "?")
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return nil, err
+	}
+	return flattenValues(values), nil
+}
+
+func ParseQueryRequest(req *http.Request, body []byte) (QueryRequest, error) {
+	params := map[string]string{}
+	queryParams, err := ParseQueryString(req.URL.RawQuery)
+	if err != nil {
+		return QueryRequest{}, err
+	}
+	mergeParams(params, queryParams)
+
+	if shouldParseQueryBody(req, body) {
+		bodyParams, err := ParseQueryString(string(body))
+		if err != nil {
+			return QueryRequest{}, err
+		}
+		mergeParams(params, bodyParams)
+	}
+
+	return QueryRequest{
+		Parameters: params,
+		Action:     params["Action"],
+		Version:    params["Version"],
+	}, nil
+}
+
+func flattenValues(values url.Values) map[string]string {
+	params := make(map[string]string, len(values))
+	for key, value := range values {
+		if len(value) == 0 {
+			params[key] = ""
+			continue
+		}
+		params[key] = value[0]
+	}
+	return params
+}
+
+func mergeParams(target map[string]string, source map[string]string) {
+	for key, value := range source {
+		target[key] = value
+	}
+}
+
+func shouldParseQueryBody(req *http.Request, body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	if req.Method != http.MethodPost {
+		return false
+	}
+	contentType := strings.ToLower(req.Header.Get("Content-Type"))
+	return strings.Contains(contentType, "application/x-www-form-urlencoded")
+}

--- a/internal/services/aws/protocols/s3.go
+++ b/internal/services/aws/protocols/s3.go
@@ -128,8 +128,6 @@ func DetectS3Action(route S3Route) string {
 			switch {
 			case hasQueryKey(route.Query, "delete"):
 				return "DeleteObjects"
-			case hasQueryKey(route.Query, "uploads"):
-				return "CreateMultipartUpload"
 			default:
 				return "PostObject"
 			}

--- a/internal/services/aws/protocols/s3.go
+++ b/internal/services/aws/protocols/s3.go
@@ -1,0 +1,263 @@
+package protocols
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type S3AddressingStyle string
+
+const (
+	S3AddressingUnknown     S3AddressingStyle = ""
+	S3AddressingPathStyle   S3AddressingStyle = "path"
+	S3AddressingVirtualHost S3AddressingStyle = "virtual_host"
+)
+
+type S3Route struct {
+	Method          string
+	Bucket          string
+	Key             string
+	Action          string
+	Subresource     string
+	CopySource      string
+	Query           map[string]string
+	AddressingStyle S3AddressingStyle
+}
+
+func ParseS3RESTRequest(req *http.Request) (S3Route, error) {
+	query, err := ParseQueryString(req.URL.RawQuery)
+	if err != nil {
+		return S3Route{}, err
+	}
+
+	host := normalizeHost(req.Host)
+	bucket, style := virtualHostBucket(host)
+	key := ""
+	if bucket != "" {
+		key = cleanS3Path(req.URL.EscapedPath())
+	} else {
+		bucket, key = pathStyleBucketAndKey(req.URL.EscapedPath())
+		if bucket != "" {
+			style = S3AddressingPathStyle
+		}
+	}
+
+	route := S3Route{
+		Method:          req.Method,
+		Bucket:          bucket,
+		Key:             key,
+		Query:           query,
+		Subresource:     firstS3Subresource(query),
+		CopySource:      req.Header.Get("x-amz-copy-source"),
+		AddressingStyle: style,
+	}
+	route.Action = DetectS3Action(route)
+	return route, nil
+}
+
+func DetectS3Action(route S3Route) string {
+	if route.Bucket == "" {
+		if route.Method == http.MethodGet {
+			return "ListBuckets"
+		}
+		return ""
+	}
+
+	if route.Key == "" {
+		switch route.Method {
+		case http.MethodGet:
+			switch {
+			case hasQueryKey(route.Query, "location"):
+				return "GetBucketLocation"
+			case hasQueryKey(route.Query, "acl"):
+				return "GetBucketAcl"
+			case hasQueryKey(route.Query, "lifecycle"):
+				return "GetBucketLifecycleConfiguration"
+			case hasQueryKey(route.Query, "notification"):
+				return "GetBucketNotificationConfiguration"
+			case hasQueryKey(route.Query, "policy"):
+				return "GetBucketPolicy"
+			case hasQueryKey(route.Query, "tagging"):
+				return "GetBucketTagging"
+			case hasQueryKey(route.Query, "versioning"):
+				return "GetBucketVersioning"
+			case hasQueryKey(route.Query, "website"):
+				return "GetBucketWebsite"
+			case hasQueryKey(route.Query, "uploads"):
+				return "ListMultipartUploads"
+			case route.Query["list-type"] == "2":
+				return "ListObjectsV2"
+			default:
+				return "ListObjects"
+			}
+		case http.MethodHead:
+			return "HeadBucket"
+		case http.MethodPut:
+			switch {
+			case hasQueryKey(route.Query, "acl"):
+				return "PutBucketAcl"
+			case hasQueryKey(route.Query, "lifecycle"):
+				return "PutBucketLifecycleConfiguration"
+			case hasQueryKey(route.Query, "notification"):
+				return "PutBucketNotificationConfiguration"
+			case hasQueryKey(route.Query, "policy"):
+				return "PutBucketPolicy"
+			case hasQueryKey(route.Query, "tagging"):
+				return "PutBucketTagging"
+			case hasQueryKey(route.Query, "versioning"):
+				return "PutBucketVersioning"
+			case hasQueryKey(route.Query, "website"):
+				return "PutBucketWebsite"
+			}
+			return "CreateBucket"
+		case http.MethodDelete:
+			switch {
+			case hasQueryKey(route.Query, "lifecycle"):
+				return "DeleteBucketLifecycle"
+			case hasQueryKey(route.Query, "policy"):
+				return "DeleteBucketPolicy"
+			case hasQueryKey(route.Query, "tagging"):
+				return "DeleteBucketTagging"
+			case hasQueryKey(route.Query, "website"):
+				return "DeleteBucketWebsite"
+			}
+			return "DeleteBucket"
+		case http.MethodPost:
+			switch {
+			case hasQueryKey(route.Query, "delete"):
+				return "DeleteObjects"
+			case hasQueryKey(route.Query, "uploads"):
+				return "CreateMultipartUpload"
+			default:
+				return "PostObject"
+			}
+		}
+		return ""
+	}
+
+	switch route.Method {
+	case http.MethodGet:
+		switch {
+		case hasQueryKey(route.Query, "acl"):
+			return "GetObjectAcl"
+		case hasQueryKey(route.Query, "tagging"):
+			return "GetObjectTagging"
+		}
+		return "GetObject"
+	case http.MethodHead:
+		return "HeadObject"
+	case http.MethodPut:
+		switch {
+		case hasQueryKey(route.Query, "acl"):
+			return "PutObjectAcl"
+		case hasQueryKey(route.Query, "tagging"):
+			return "PutObjectTagging"
+		}
+		if hasQueryKey(route.Query, "partNumber") || hasQueryKey(route.Query, "uploadId") {
+			if route.CopySource != "" {
+				return "UploadPartCopy"
+			}
+			return "UploadPart"
+		}
+		if route.CopySource != "" {
+			return "CopyObject"
+		}
+		return "PutObject"
+	case http.MethodDelete:
+		if hasQueryKey(route.Query, "tagging") {
+			return "DeleteObjectTagging"
+		}
+		if hasQueryKey(route.Query, "uploadId") {
+			return "AbortMultipartUpload"
+		}
+		return "DeleteObject"
+	case http.MethodPost:
+		if hasQueryKey(route.Query, "uploads") {
+			return "CreateMultipartUpload"
+		}
+		if hasQueryKey(route.Query, "uploadId") {
+			return "CompleteMultipartUpload"
+		}
+		return "PostObject"
+	}
+	return ""
+}
+
+func cleanS3Path(escapedPath string) string {
+	trimmed := strings.TrimPrefix(escapedPath, "/")
+	if trimmed == "" {
+		return ""
+	}
+	value, err := url.PathUnescape(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	return value
+}
+
+func pathStyleBucketAndKey(escapedPath string) (string, string) {
+	pathValue := cleanS3Path(escapedPath)
+	if pathValue == "" {
+		return "", ""
+	}
+	parts := strings.Split(pathValue, "/")
+	if parts[0] == "s3" {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 || parts[0] == "" {
+		return "", ""
+	}
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], strings.Join(parts[1:], "/")
+}
+
+func virtualHostBucket(host string) (string, S3AddressingStyle) {
+	labels := strings.Split(host, ".")
+	for index := len(labels) - 1; index >= 0; index-- {
+		label := labels[index]
+		if label == "s3" || strings.HasPrefix(label, "s3-") {
+			if index == 0 {
+				return "", S3AddressingUnknown
+			}
+			return strings.Join(labels[:index], "."), S3AddressingVirtualHost
+		}
+	}
+	return "", S3AddressingUnknown
+}
+
+func firstS3Subresource(query map[string]string) string {
+	for _, key := range []string{
+		"acl",
+		"delete",
+		"lifecycle",
+		"location",
+		"notification",
+		"policy",
+		"tagging",
+		"uploadId",
+		"uploads",
+		"versioning",
+		"website",
+	} {
+		if hasQueryKey(query, key) {
+			return key
+		}
+	}
+	return ""
+}
+
+func hasQueryKey(query map[string]string, key string) bool {
+	_, ok := query[key]
+	return ok
+}
+
+func normalizeHost(host string) string {
+	if value, _, err := net.SplitHostPort(host); err == nil {
+		host = value
+	}
+	return strings.TrimSuffix(strings.ToLower(host), ".")
+}


### PR DESCRIPTION
- Adds a normalized AWS request context with request ids, region/account defaults, credential-scope parsing, and service/action detection across host, path, query, and target metadata.

- Adds dependency-free AWS Query, JSON RPC, and S3 REST route parsers for future native service handlers.

- Covers representative S3, SQS, IAM, STS, and JSON RPC requests in Go unit tests.