### PR TITLE
Add AWS auth and error foundations

### DIFF
--- a/internal/services/aws/auth/credentials.go
+++ b/internal/services/aws/auth/credentials.go
@@ -1,0 +1,36 @@
+package auth
+
+type Credential struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	AccountID       string
+	PrincipalARN    string
+	Disabled        bool
+}
+
+type Store struct {
+	credentials map[string]Credential
+}
+
+func NewStore(credentials ...Credential) *Store {
+	store := &Store{credentials: map[string]Credential{}}
+	for _, credential := range credentials {
+		if credential.AccessKeyID == "" {
+			continue
+		}
+		store.credentials[credential.AccessKeyID] = credential
+	}
+	return store
+}
+
+func (store *Store) Resolve(accessKeyID string) (Credential, bool) {
+	if store == nil || accessKeyID == "" {
+		return Credential{}, false
+	}
+	credential, ok := store.credentials[accessKeyID]
+	if !ok || credential.Disabled {
+		return Credential{}, false
+	}
+	return credential, true
+}

--- a/internal/services/aws/auth/mode.go
+++ b/internal/services/aws/auth/mode.go
@@ -31,7 +31,7 @@ func NormalizeMode(mode Mode) Mode {
 	if mode.Valid() {
 		return mode
 	}
-	return ModeRelaxed
+	return mode
 }
 
 func (mode Mode) Valid() bool {

--- a/internal/services/aws/auth/mode.go
+++ b/internal/services/aws/auth/mode.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Mode string
+
+const (
+	ModeRelaxed   Mode = "relaxed"
+	ModeKnownKeys Mode = "known-keys"
+	ModeStrict    Mode = "strict"
+)
+
+func ParseMode(value string) (Mode, error) {
+	mode := Mode(strings.TrimSpace(strings.ToLower(value)))
+	if mode == "" {
+		return ModeRelaxed, nil
+	}
+	if mode.Valid() {
+		return mode, nil
+	}
+	return "", fmt.Errorf("unknown AWS auth mode %q", value)
+}
+
+func NormalizeMode(mode Mode) Mode {
+	if mode == "" {
+		return ModeRelaxed
+	}
+	if mode.Valid() {
+		return mode
+	}
+	return ModeRelaxed
+}
+
+func (mode Mode) Valid() bool {
+	switch mode {
+	case ModeRelaxed, ModeKnownKeys, ModeStrict:
+		return true
+	default:
+		return false
+	}
+}
+
+func (mode Mode) String() string {
+	return string(mode)
+}

--- a/internal/services/aws/auth/resolve.go
+++ b/internal/services/aws/auth/resolve.go
@@ -1,0 +1,110 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const DefaultAccountID = "123456789012"
+
+type Status string
+
+const (
+	StatusMissing    Status = "missing"
+	StatusRelaxed    Status = "relaxed"
+	StatusKnown      Status = "known"
+	StatusUnknownKey Status = "unknown_key"
+	StatusInvalid    Status = "invalid"
+)
+
+type Error struct {
+	Code       string
+	Message    string
+	StatusCode int
+}
+
+type Context struct {
+	Mode                      Mode
+	Status                    Status
+	Signature                 Signature
+	Credential                *Credential
+	AccountID                 string
+	PrincipalARN              string
+	Error                     *Error
+	StrictSignatureValidation bool
+}
+
+type Options struct {
+	Mode                Mode
+	Store               *Store
+	DefaultAccountID    string
+	DefaultPrincipalARN string
+}
+
+func Resolve(req *http.Request, options Options) Context {
+	mode := NormalizeMode(options.Mode)
+	accountID := firstNonEmpty(options.DefaultAccountID, DefaultAccountID)
+	ctx := Context{
+		Mode:                      mode,
+		AccountID:                 accountID,
+		PrincipalARN:              firstNonEmpty(options.DefaultPrincipalARN, defaultPrincipalARN(accountID)),
+		StrictSignatureValidation: false,
+	}
+
+	signature, err := ParseSigV4(req)
+	if err != nil {
+		ctx.Status = StatusInvalid
+		ctx.Error = &Error{
+			Code:       "AuthorizationHeaderMalformed",
+			Message:    err.Error(),
+			StatusCode: http.StatusBadRequest,
+		}
+		return ctx
+	}
+	ctx.Signature = signature
+	if !signature.Present {
+		ctx.Status = StatusMissing
+		if mode != ModeRelaxed {
+			ctx.Error = &Error{
+				Code:       "MissingAuthenticationToken",
+				Message:    "Request is missing AWS authentication credentials.",
+				StatusCode: http.StatusForbidden,
+			}
+		}
+		return ctx
+	}
+
+	if credential, ok := options.Store.Resolve(signature.AccessKeyID); ok {
+		ctx.Status = StatusKnown
+		ctx.Credential = &credential
+		ctx.AccountID = firstNonEmpty(credential.AccountID, ctx.AccountID)
+		ctx.PrincipalARN = firstNonEmpty(credential.PrincipalARN, defaultPrincipalARN(ctx.AccountID))
+		return ctx
+	}
+
+	if mode == ModeRelaxed {
+		ctx.Status = StatusRelaxed
+		return ctx
+	}
+
+	ctx.Status = StatusUnknownKey
+	ctx.Error = &Error{
+		Code:       "InvalidAccessKeyId",
+		Message:    "The AWS access key Id you provided does not exist in our records.",
+		StatusCode: http.StatusForbidden,
+	}
+	return ctx
+}
+
+func defaultPrincipalARN(accountID string) string {
+	return fmt.Sprintf("arn:aws:iam::%s:user/emulate", accountID)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/services/aws/auth/resolve.go
+++ b/internal/services/aws/auth/resolve.go
@@ -50,6 +50,15 @@ func Resolve(req *http.Request, options Options) Context {
 		PrincipalARN:              firstNonEmpty(options.DefaultPrincipalARN, defaultPrincipalARN(accountID)),
 		StrictSignatureValidation: false,
 	}
+	if !mode.Valid() {
+		ctx.Status = StatusInvalid
+		ctx.Error = &Error{
+			Code:       "InvalidAuthMode",
+			Message:    fmt.Sprintf("Configured AWS auth mode %q is invalid.", options.Mode),
+			StatusCode: http.StatusInternalServerError,
+		}
+		return ctx
+	}
 
 	signature, err := ParseSigV4(req)
 	if err != nil {
@@ -75,6 +84,15 @@ func Resolve(req *http.Request, options Options) Context {
 	}
 
 	if credential, ok := options.Store.Resolve(signature.AccessKeyID); ok {
+		if credential.SessionToken != "" && signature.SessionToken != credential.SessionToken {
+			ctx.Status = StatusInvalid
+			ctx.Error = &Error{
+				Code:       "InvalidToken",
+				Message:    "The provided token is malformed or otherwise invalid.",
+				StatusCode: http.StatusForbidden,
+			}
+			return ctx
+		}
 		ctx.Status = StatusKnown
 		ctx.Credential = &credential
 		ctx.AccountID = firstNonEmpty(credential.AccountID, ctx.AccountID)

--- a/internal/services/aws/auth/sigv4.go
+++ b/internal/services/aws/auth/sigv4.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const AlgorithmSigV4 = "AWS4-HMAC-SHA256"
+
+type Scope struct {
+	Date     string
+	Region   string
+	Service  string
+	Terminal string
+}
+
+type Signature struct {
+	Present        bool
+	Algorithm      string
+	AccessKeyID    string
+	Scope          Scope
+	SignedHeaders  []string
+	SignatureValue string
+	SessionToken   string
+	Presigned      bool
+	RawCredential  string
+}
+
+func ParseSigV4(req *http.Request) (Signature, error) {
+	if hasPresignParameters(req) {
+		return parsePresignedSigV4(req)
+	}
+	return parseAuthorizationHeader(req)
+}
+
+func ParseCredentialScope(value string) (string, Scope, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", Scope{}, fmt.Errorf("missing SigV4 credential")
+	}
+	unescaped, err := url.QueryUnescape(value)
+	if err == nil {
+		value = unescaped
+	}
+	parts := strings.Split(value, "/")
+	if parts[0] == "" {
+		return "", Scope{}, fmt.Errorf("missing SigV4 access key id")
+	}
+	if len(parts) == 1 {
+		return parts[0], Scope{}, nil
+	}
+	if len(parts) < 5 {
+		return "", Scope{}, fmt.Errorf("invalid SigV4 credential scope")
+	}
+	return parts[0], Scope{
+		Date:     parts[1],
+		Region:   parts[2],
+		Service:  parts[3],
+		Terminal: parts[4],
+	}, nil
+}
+
+func hasPresignParameters(req *http.Request) bool {
+	query := req.URL.Query()
+	return query.Get("X-Amz-Algorithm") != "" ||
+		query.Get("X-Amz-Credential") != "" ||
+		query.Get("X-Amz-Signature") != ""
+}
+
+func parsePresignedSigV4(req *http.Request) (Signature, error) {
+	query := req.URL.Query()
+	algorithm := strings.TrimSpace(query.Get("X-Amz-Algorithm"))
+	if algorithm == "" {
+		algorithm = AlgorithmSigV4
+	}
+	if algorithm != AlgorithmSigV4 {
+		return Signature{}, fmt.Errorf("unsupported SigV4 algorithm %q", algorithm)
+	}
+	rawCredential := query.Get("X-Amz-Credential")
+	accessKeyID, scope, err := ParseCredentialScope(rawCredential)
+	if err != nil {
+		return Signature{}, err
+	}
+	return Signature{
+		Present:        true,
+		Algorithm:      algorithm,
+		AccessKeyID:    accessKeyID,
+		Scope:          scope,
+		SignedHeaders:  splitSignedHeaders(query.Get("X-Amz-SignedHeaders")),
+		SignatureValue: query.Get("X-Amz-Signature"),
+		SessionToken:   query.Get("X-Amz-Security-Token"),
+		Presigned:      true,
+		RawCredential:  rawCredential,
+	}, nil
+}
+
+func parseAuthorizationHeader(req *http.Request) (Signature, error) {
+	header := strings.TrimSpace(req.Header.Get("Authorization"))
+	if header == "" {
+		return Signature{}, nil
+	}
+	fields := strings.Fields(header)
+	if len(fields) == 0 {
+		return Signature{}, nil
+	}
+	algorithm := fields[0]
+	if algorithm != AlgorithmSigV4 {
+		return Signature{}, fmt.Errorf("unsupported SigV4 algorithm %q", algorithm)
+	}
+	params := parseAuthorizationParams(strings.TrimSpace(strings.TrimPrefix(header, algorithm)))
+	rawCredential := params["Credential"]
+	accessKeyID, scope, err := ParseCredentialScope(rawCredential)
+	if err != nil {
+		return Signature{}, err
+	}
+	return Signature{
+		Present:        true,
+		Algorithm:      algorithm,
+		AccessKeyID:    accessKeyID,
+		Scope:          scope,
+		SignedHeaders:  splitSignedHeaders(params["SignedHeaders"]),
+		SignatureValue: params["Signature"],
+		SessionToken:   req.Header.Get("X-Amz-Security-Token"),
+		RawCredential:  rawCredential,
+	}, nil
+}
+
+func parseAuthorizationParams(value string) map[string]string {
+	params := map[string]string{}
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		params[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return params
+}
+
+func splitSignedHeaders(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ";")
+	headers := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(strings.ToLower(part))
+		if part != "" {
+			headers = append(headers, part)
+		}
+	}
+	return headers
+}

--- a/internal/services/aws/auth/sigv4.go
+++ b/internal/services/aws/auth/sigv4.go
@@ -45,13 +45,16 @@ func ParseCredentialScope(value string) (string, Scope, error) {
 		value = unescaped
 	}
 	parts := strings.Split(value, "/")
+	if len(parts) != 5 {
+		return "", Scope{}, fmt.Errorf("invalid SigV4 credential scope")
+	}
 	if parts[0] == "" {
 		return "", Scope{}, fmt.Errorf("missing SigV4 access key id")
 	}
-	if len(parts) == 1 {
-		return parts[0], Scope{}, nil
+	if parts[1] == "" || parts[2] == "" || parts[3] == "" || parts[4] == "" {
+		return "", Scope{}, fmt.Errorf("invalid SigV4 credential scope")
 	}
-	if len(parts) < 5 {
+	if parts[4] != "aws4_request" {
 		return "", Scope{}, fmt.Errorf("invalid SigV4 credential scope")
 	}
 	return parts[0], Scope{

--- a/internal/services/aws/auth/sigv4.go
+++ b/internal/services/aws/auth/sigv4.go
@@ -76,7 +76,7 @@ func parsePresignedSigV4(req *http.Request) (Signature, error) {
 	query := req.URL.Query()
 	algorithm := strings.TrimSpace(query.Get("X-Amz-Algorithm"))
 	if algorithm == "" {
-		algorithm = AlgorithmSigV4
+		return Signature{}, fmt.Errorf("missing SigV4 algorithm")
 	}
 	if algorithm != AlgorithmSigV4 {
 		return Signature{}, fmt.Errorf("unsupported SigV4 algorithm %q", algorithm)
@@ -86,13 +86,21 @@ func parsePresignedSigV4(req *http.Request) (Signature, error) {
 	if err != nil {
 		return Signature{}, err
 	}
+	signedHeaders := splitSignedHeaders(query.Get("X-Amz-SignedHeaders"))
+	if len(signedHeaders) == 0 {
+		return Signature{}, fmt.Errorf("missing SigV4 signed headers")
+	}
+	signatureValue := strings.TrimSpace(query.Get("X-Amz-Signature"))
+	if signatureValue == "" {
+		return Signature{}, fmt.Errorf("missing SigV4 signature")
+	}
 	return Signature{
 		Present:        true,
 		Algorithm:      algorithm,
 		AccessKeyID:    accessKeyID,
 		Scope:          scope,
-		SignedHeaders:  splitSignedHeaders(query.Get("X-Amz-SignedHeaders")),
-		SignatureValue: query.Get("X-Amz-Signature"),
+		SignedHeaders:  signedHeaders,
+		SignatureValue: signatureValue,
 		SessionToken:   query.Get("X-Amz-Security-Token"),
 		Presigned:      true,
 		RawCredential:  rawCredential,
@@ -118,13 +126,21 @@ func parseAuthorizationHeader(req *http.Request) (Signature, error) {
 	if err != nil {
 		return Signature{}, err
 	}
+	signedHeaders := splitSignedHeaders(params["SignedHeaders"])
+	if len(signedHeaders) == 0 {
+		return Signature{}, fmt.Errorf("missing SigV4 signed headers")
+	}
+	signatureValue := strings.TrimSpace(params["Signature"])
+	if signatureValue == "" {
+		return Signature{}, fmt.Errorf("missing SigV4 signature")
+	}
 	return Signature{
 		Present:        true,
 		Algorithm:      algorithm,
 		AccessKeyID:    accessKeyID,
 		Scope:          scope,
-		SignedHeaders:  splitSignedHeaders(params["SignedHeaders"]),
-		SignatureValue: params["Signature"],
+		SignedHeaders:  signedHeaders,
+		SignatureValue: signatureValue,
 		SessionToken:   req.Header.Get("X-Amz-Security-Token"),
 		RawCredential:  rawCredential,
 	}, nil

--- a/internal/services/aws/auth/sigv4_test.go
+++ b/internal/services/aws/auth/sigv4_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestParseSigV4Header(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sqs.us-west-2.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-west-2/sqs/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	req.Header.Set("X-Amz-Security-Token", "token-123")
+
+	signature, err := ParseSigV4(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !signature.Present {
+		t.Fatal("signature should be present")
+	}
+	if signature.AccessKeyID != "AKIAEXAMPLE" {
+		t.Fatalf("access key = %q, want AKIAEXAMPLE", signature.AccessKeyID)
+	}
+	if signature.Scope.Region != "us-west-2" || signature.Scope.Service != "sqs" {
+		t.Fatalf("scope = %#v, want us-west-2/sqs", signature.Scope)
+	}
+	if !reflect.DeepEqual(signature.SignedHeaders, []string{"host", "x-amz-date"}) {
+		t.Fatalf("signed headers = %#v", signature.SignedHeaders)
+	}
+	if signature.SignatureValue != "abcdef" || signature.SessionToken != "token-123" {
+		t.Fatalf("unexpected signature fields: %#v", signature)
+	}
+}
+
+func TestParseSigV4PresignedURL(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://s3.us-east-1.amazonaws.com/photos?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAPRE%2F20260519%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=123456", nil)
+
+	signature, err := ParseSigV4(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !signature.Presigned {
+		t.Fatal("signature should be marked as presigned")
+	}
+	if signature.AccessKeyID != "AKIAPRE" || signature.Scope.Region != "eu-central-1" || signature.Scope.Service != "s3" {
+		t.Fatalf("unexpected signature: %#v", signature)
+	}
+}
+
+func TestResolveRelaxedAllowsUnknownKey(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAUNKNOWN/20260519/us-east-2/sts/aws4_request, SignedHeaders=host, Signature=abcdef")
+
+	ctx := Resolve(req, Options{Mode: ModeRelaxed})
+
+	if ctx.Status != StatusRelaxed {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusRelaxed)
+	}
+	if ctx.Error != nil {
+		t.Fatalf("error = %#v, want nil", ctx.Error)
+	}
+	if ctx.AccountID != DefaultAccountID {
+		t.Fatalf("account id = %q, want %q", ctx.AccountID, DefaultAccountID)
+	}
+}
+
+func TestResolveKnownKeysUsesCredentialIdentity(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAKNOWN/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")
+	store := NewStore(Credential{
+		AccessKeyID:     "AKIAKNOWN",
+		SecretAccessKey: "secret",
+		AccountID:       "210987654321",
+		PrincipalARN:    "arn:aws:iam::210987654321:user/tester",
+	})
+
+	ctx := Resolve(req, Options{Mode: ModeKnownKeys, Store: store})
+
+	if ctx.Status != StatusKnown {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusKnown)
+	}
+	if ctx.AccountID != "210987654321" {
+		t.Fatalf("account id = %q, want 210987654321", ctx.AccountID)
+	}
+	if ctx.PrincipalARN != "arn:aws:iam::210987654321:user/tester" {
+		t.Fatalf("principal ARN = %q", ctx.PrincipalARN)
+	}
+}
+
+func TestResolveKnownKeysUnknownKeyIsExplicit(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAMISSING/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")
+
+	ctx := Resolve(req, Options{Mode: ModeKnownKeys, Store: NewStore()})
+
+	if ctx.Status != StatusUnknownKey {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusUnknownKey)
+	}
+	if ctx.Error == nil || ctx.Error.Code != "InvalidAccessKeyId" {
+		t.Fatalf("error = %#v, want InvalidAccessKeyId", ctx.Error)
+	}
+}
+
+func TestResolveKnownKeysMissingAuthIsExplicit(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+
+	ctx := Resolve(req, Options{Mode: ModeKnownKeys})
+
+	if ctx.Status != StatusMissing {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusMissing)
+	}
+	if ctx.Error == nil || ctx.Error.Code != "MissingAuthenticationToken" {
+		t.Fatalf("error = %#v, want MissingAuthenticationToken", ctx.Error)
+	}
+}
+
+func TestResolveStrictDoesNotRequireSignatureValidationYet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIASTRICT/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=not-checked")
+	store := NewStore(Credential{AccessKeyID: "AKIASTRICT"})
+
+	ctx := Resolve(req, Options{Mode: ModeStrict, Store: store})
+
+	if ctx.Status != StatusKnown {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusKnown)
+	}
+	if ctx.Error != nil {
+		t.Fatalf("error = %#v, want nil", ctx.Error)
+	}
+	if ctx.StrictSignatureValidation {
+		t.Fatal("strict mode should not require cryptographic validation yet")
+	}
+}

--- a/internal/services/aws/auth/sigv4_test.go
+++ b/internal/services/aws/auth/sigv4_test.go
@@ -90,6 +90,43 @@ func TestResolveKnownKeysUsesCredentialIdentity(t *testing.T) {
 	}
 }
 
+func TestResolveKnownKeysRequiresStoredSessionToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIATEMP/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")
+	store := NewStore(Credential{
+		AccessKeyID:  "AKIATEMP",
+		SessionToken: "session-123",
+	})
+
+	ctx := Resolve(req, Options{Mode: ModeKnownKeys, Store: store})
+
+	if ctx.Status != StatusInvalid {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusInvalid)
+	}
+	if ctx.Error == nil || ctx.Error.Code != "InvalidToken" {
+		t.Fatalf("error = %#v, want InvalidToken", ctx.Error)
+	}
+}
+
+func TestResolveKnownKeysAcceptsStoredSessionToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIATEMP/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")
+	req.Header.Set("X-Amz-Security-Token", "session-123")
+	store := NewStore(Credential{
+		AccessKeyID:  "AKIATEMP",
+		SessionToken: "session-123",
+	})
+
+	ctx := Resolve(req, Options{Mode: ModeKnownKeys, Store: store})
+
+	if ctx.Status != StatusKnown {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusKnown)
+	}
+	if ctx.Error != nil {
+		t.Fatalf("error = %#v, want nil", ctx.Error)
+	}
+}
+
 func TestResolveKnownKeysUnknownKeyIsExplicit(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
 	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAMISSING/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")
@@ -114,6 +151,39 @@ func TestResolveKnownKeysMissingAuthIsExplicit(t *testing.T) {
 	}
 	if ctx.Error == nil || ctx.Error.Code != "MissingAuthenticationToken" {
 		t.Fatalf("error = %#v, want MissingAuthenticationToken", ctx.Error)
+	}
+}
+
+func TestResolveKnownKeysRejectsBareCredentialScope(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAKNOWN, SignedHeaders=host, Signature=abcdef")
+	store := NewStore(Credential{AccessKeyID: "AKIAKNOWN"})
+
+	ctx := Resolve(req, Options{Mode: ModeKnownKeys, Store: store})
+
+	if ctx.Status != StatusInvalid {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusInvalid)
+	}
+	if ctx.Error == nil || ctx.Error.Code != "AuthorizationHeaderMalformed" {
+		t.Fatalf("error = %#v, want AuthorizationHeaderMalformed", ctx.Error)
+	}
+}
+
+func TestResolveInvalidModeIsExplicit(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAKNOWN/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")
+	store := NewStore(Credential{AccessKeyID: "AKIAKNOWN"})
+
+	ctx := Resolve(req, Options{Mode: Mode("typo"), Store: store})
+
+	if ctx.Mode != Mode("typo") {
+		t.Fatalf("mode = %q, want typo", ctx.Mode)
+	}
+	if ctx.Status != StatusInvalid {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusInvalid)
+	}
+	if ctx.Error == nil || ctx.Error.Code != "InvalidAuthMode" {
+		t.Fatalf("error = %#v, want InvalidAuthMode", ctx.Error)
 	}
 }
 

--- a/internal/services/aws/auth/sigv4_test.go
+++ b/internal/services/aws/auth/sigv4_test.go
@@ -169,6 +169,75 @@ func TestResolveKnownKeysRejectsBareCredentialScope(t *testing.T) {
 	}
 }
 
+func TestResolveKnownKeysRejectsIncompleteHeaderSignature(t *testing.T) {
+	tests := []struct {
+		name          string
+		authorization string
+	}{
+		{
+			name:          "missing signed headers",
+			authorization: "AWS4-HMAC-SHA256 Credential=AKIAKNOWN/20260519/us-east-1/sts/aws4_request, Signature=abcdef",
+		},
+		{
+			name:          "missing signature",
+			authorization: "AWS4-HMAC-SHA256 Credential=AKIAKNOWN/20260519/us-east-1/sts/aws4_request, SignedHeaders=host",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+			req.Header.Set("Authorization", test.authorization)
+			store := NewStore(Credential{AccessKeyID: "AKIAKNOWN"})
+
+			ctx := Resolve(req, Options{Mode: ModeKnownKeys, Store: store})
+
+			if ctx.Status != StatusInvalid {
+				t.Fatalf("status = %q, want %q", ctx.Status, StatusInvalid)
+			}
+			if ctx.Error == nil || ctx.Error.Code != "AuthorizationHeaderMalformed" {
+				t.Fatalf("error = %#v, want AuthorizationHeaderMalformed", ctx.Error)
+			}
+		})
+	}
+}
+
+func TestResolveKnownKeysRejectsIncompletePresignedSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "missing algorithm",
+			url:  "https://s3.us-east-1.amazonaws.com/photos?X-Amz-Credential=AKIAKNOWN%2F20260519%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=abcdef",
+		},
+		{
+			name: "missing signed headers",
+			url:  "https://s3.us-east-1.amazonaws.com/photos?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAKNOWN%2F20260519%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=abcdef",
+		},
+		{
+			name: "missing signature",
+			url:  "https://s3.us-east-1.amazonaws.com/photos?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAKNOWN%2F20260519%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, test.url, nil)
+			store := NewStore(Credential{AccessKeyID: "AKIAKNOWN"})
+
+			ctx := Resolve(req, Options{Mode: ModeKnownKeys, Store: store})
+
+			if ctx.Status != StatusInvalid {
+				t.Fatalf("status = %q, want %q", ctx.Status, StatusInvalid)
+			}
+			if ctx.Error == nil || ctx.Error.Code != "AuthorizationHeaderMalformed" {
+				t.Fatalf("error = %#v, want AuthorizationHeaderMalformed", ctx.Error)
+			}
+		})
+	}
+}
+
 func TestResolveInvalidModeIsExplicit(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
 	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAKNOWN/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")

--- a/internal/services/aws/gateway/context.go
+++ b/internal/services/aws/gateway/context.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync/atomic"
 
+	"github.com/vercel-labs/emulate/internal/services/aws/auth"
 	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
 )
 
@@ -22,6 +22,8 @@ type Options struct {
 	DefaultAccountID   string
 	DefaultRegion      string
 	RequestIDGenerator func() string
+	AuthMode           auth.Mode
+	CredentialStore    *auth.Store
 }
 
 type AwsRequestContext struct {
@@ -39,6 +41,7 @@ type AwsRequestContext struct {
 
 	Credentials Credentials
 	Principal   Principal
+	Auth        auth.Context
 	S3          *protocols.S3Route
 }
 
@@ -68,11 +71,16 @@ var requestIDCounter atomic.Uint64
 
 func BuildContext(req *http.Request, rawBody []byte, options Options) (AwsRequestContext, error) {
 	options = normalizeOptions(options)
-	credentials := ParseCredentials(req)
+	authContext := auth.Resolve(req, auth.Options{
+		Mode:             options.AuthMode,
+		Store:            options.CredentialStore,
+		DefaultAccountID: options.DefaultAccountID,
+	})
+	credentials := credentialsFromSignature(authContext.Signature)
 	host := detectHost(req.Host)
 	pathService := serviceFromPath(req.URL.Path)
 	region := firstNonEmpty(credentials.Scope.Region, host.Region, options.DefaultRegion)
-	accountID := options.DefaultAccountID
+	accountID := firstNonEmpty(authContext.AccountID, options.DefaultAccountID)
 
 	ctx := AwsRequestContext{
 		RequestID:   options.RequestIDGenerator(),
@@ -83,8 +91,10 @@ func BuildContext(req *http.Request, rawBody []byte, options Options) (AwsReques
 		Query:       map[string]string{},
 		Input:       map[string]any{},
 		Credentials: credentials,
+		Auth:        authContext,
 		Principal: Principal{
 			AccountID: accountID,
+			ARN:       authContext.PrincipalARN,
 		},
 	}
 
@@ -147,25 +157,26 @@ func BuildContext(req *http.Request, rawBody []byte, options Options) (AwsReques
 }
 
 func ParseCredentials(req *http.Request) Credentials {
-	credential := credentialValue(req)
-	if credential == "" {
+	signature, err := auth.ParseSigV4(req)
+	if err != nil || !signature.Present {
 		return Credentials{}
 	}
-	value, err := url.QueryUnescape(credential)
-	if err != nil {
-		value = credential
+	return credentialsFromSignature(signature)
+}
+
+func credentialsFromSignature(signature auth.Signature) Credentials {
+	if !signature.Present {
+		return Credentials{}
 	}
-	parts := strings.Split(value, "/")
-	result := Credentials{AccessKeyID: parts[0]}
-	if len(parts) >= 5 {
-		result.Scope = CredentialScope{
-			Date:     parts[1],
-			Region:   parts[2],
-			Service:  parts[3],
-			Terminal: parts[4],
-		}
+	return Credentials{
+		AccessKeyID: signature.AccessKeyID,
+		Scope: CredentialScope{
+			Date:     signature.Scope.Date,
+			Region:   signature.Scope.Region,
+			Service:  signature.Scope.Service,
+			Terminal: signature.Scope.Terminal,
+		},
 	}
-	return result
 }
 
 func NewRequestID() string {
@@ -187,23 +198,6 @@ func normalizeOptions(options Options) Options {
 		options.RequestIDGenerator = NewRequestID
 	}
 	return options
-}
-
-func credentialValue(req *http.Request) string {
-	if value := req.URL.Query().Get("X-Amz-Credential"); value != "" {
-		return value
-	}
-	auth := req.Header.Get("Authorization")
-	const marker = "Credential="
-	index := strings.Index(auth, marker)
-	if index < 0 {
-		return ""
-	}
-	value := auth[index+len(marker):]
-	if cut := strings.IndexAny(value, ", "); cut >= 0 {
-		value = value[:cut]
-	}
-	return value
 }
 
 func queryInput(params map[string]string) map[string]any {

--- a/internal/services/aws/gateway/context_test.go
+++ b/internal/services/aws/gateway/context_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vercel-labs/emulate/internal/services/aws/auth"
 	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
 )
 
@@ -478,6 +479,64 @@ func TestBuildContextSTSQueryRequest(t *testing.T) {
 	}
 	if ctx.Region != "eu-central-1" {
 		t.Fatalf("region = %q, want eu-central-1", ctx.Region)
+	}
+}
+
+func TestBuildContextKnownKeyAuthContext(t *testing.T) {
+	body := "Action=GetCallerIdentity&Version=2011-06-15"
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAKNOWN/20260519/ap-southeast-2/sts/aws4_request, SignedHeaders=host, Signature=abc")
+	options := fixedOptions()
+	options.AuthMode = auth.ModeKnownKeys
+	options.CredentialStore = auth.NewStore(auth.Credential{
+		AccessKeyID:  "AKIAKNOWN",
+		AccountID:    "210987654321",
+		PrincipalARN: "arn:aws:iam::210987654321:user/tester",
+	})
+
+	ctx, err := BuildContext(req, []byte(body), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Auth.Status != auth.StatusKnown {
+		t.Fatalf("auth status = %q, want %q", ctx.Auth.Status, auth.StatusKnown)
+	}
+	if ctx.AccountID != "210987654321" || ctx.Principal.AccountID != "210987654321" {
+		t.Fatalf("account context = %#v/%#v", ctx.AccountID, ctx.Principal)
+	}
+	if ctx.Principal.ARN != "arn:aws:iam::210987654321:user/tester" {
+		t.Fatalf("principal ARN = %q", ctx.Principal.ARN)
+	}
+	if ctx.Region != "ap-southeast-2" {
+		t.Fatalf("region = %q, want ap-southeast-2", ctx.Region)
+	}
+	if ctx.Credentials.AccessKeyID != "AKIAKNOWN" || ctx.Credentials.Scope.Service != "sts" {
+		t.Fatalf("unexpected credentials: %#v", ctx.Credentials)
+	}
+}
+
+func TestBuildContextKnownKeyMissingAuthIsExplicit(t *testing.T) {
+	body := "Action=ListUsers&Version=2010-05-08"
+	req := httptest.NewRequest(http.MethodPost, "https://iam.amazonaws.com/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	options := fixedOptions()
+	options.AuthMode = auth.ModeKnownKeys
+
+	ctx, err := BuildContext(req, []byte(body), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Auth.Status != auth.StatusMissing {
+		t.Fatalf("auth status = %q, want %q", ctx.Auth.Status, auth.StatusMissing)
+	}
+	if ctx.Auth.Error == nil || ctx.Auth.Error.Code != "MissingAuthenticationToken" {
+		t.Fatalf("auth error = %#v, want MissingAuthenticationToken", ctx.Auth.Error)
+	}
+	if ctx.AccountID != DefaultAccountID || ctx.Principal.AccountID != DefaultAccountID {
+		t.Fatalf("account context = %#v/%#v", ctx.AccountID, ctx.Principal)
 	}
 }
 

--- a/internal/services/aws/protocols/errors.go
+++ b/internal/services/aws/protocols/errors.go
@@ -1,0 +1,133 @@
+package protocols
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"strings"
+)
+
+type AWSError struct {
+	Code       string
+	Message    string
+	Type       string
+	RequestID  string
+	Resource   string
+	Service    string
+	StatusCode int
+}
+
+type ErrorResponse struct {
+	StatusCode  int
+	ContentType string
+	Headers     map[string]string
+	Body        []byte
+}
+
+func SerializeXMLError(awsError AWSError) ErrorResponse {
+	awsError = normalizeAWSError(awsError)
+	body, _ := xml.Marshal(queryXMLErrorResponse{
+		Error: queryXMLError{
+			Type:    awsError.Type,
+			Code:    awsError.Code,
+			Message: awsError.Message,
+		},
+		RequestID: awsError.RequestID,
+	})
+	return ErrorResponse{
+		StatusCode:  awsError.StatusCode,
+		ContentType: "application/xml",
+		Headers:     errorHeaders(awsError, "application/xml"),
+		Body:        append([]byte(xml.Header), body...),
+	}
+}
+
+func SerializeRESTXMLError(awsError AWSError) ErrorResponse {
+	awsError = normalizeAWSError(awsError)
+	body, _ := xml.Marshal(restXMLError{
+		Code:      awsError.Code,
+		Message:   awsError.Message,
+		Resource:  awsError.Resource,
+		RequestID: awsError.RequestID,
+	})
+	headers := errorHeaders(awsError, "application/xml")
+	if awsError.RequestID != "" {
+		headers["x-amz-request-id"] = awsError.RequestID
+	}
+	return ErrorResponse{
+		StatusCode:  awsError.StatusCode,
+		ContentType: "application/xml",
+		Headers:     headers,
+		Body:        append([]byte(xml.Header), body...),
+	}
+}
+
+func SerializeJSONError(awsError AWSError) ErrorResponse {
+	awsError = normalizeAWSError(awsError)
+	errorType := awsError.Code
+	if awsError.Service != "" && !strings.Contains(errorType, "#") {
+		errorType = awsError.Service + "#" + errorType
+	}
+	body, _ := json.Marshal(map[string]string{
+		"__type":  errorType,
+		"message": awsError.Message,
+	})
+	headers := errorHeaders(awsError, "application/x-amz-json-1.0")
+	headers["x-amzn-errortype"] = awsError.Code
+	return ErrorResponse{
+		StatusCode:  awsError.StatusCode,
+		ContentType: "application/x-amz-json-1.0",
+		Headers:     headers,
+		Body:        body,
+	}
+}
+
+type queryXMLErrorResponse struct {
+	XMLName   xml.Name      `xml:"ErrorResponse"`
+	Error     queryXMLError `xml:"Error"`
+	RequestID string        `xml:"RequestId,omitempty"`
+}
+
+type queryXMLError struct {
+	Type    string `xml:"Type,omitempty"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
+type restXMLError struct {
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+	Resource  string   `xml:"Resource,omitempty"`
+	RequestID string   `xml:"RequestId,omitempty"`
+}
+
+func normalizeAWSError(awsError AWSError) AWSError {
+	if awsError.Code == "" {
+		awsError.Code = "InternalFailure"
+	}
+	if awsError.Message == "" {
+		awsError.Message = "An internal error occurred."
+	}
+	if awsError.StatusCode == 0 {
+		awsError.StatusCode = http.StatusBadRequest
+	}
+	if awsError.Type == "" {
+		if awsError.StatusCode >= 500 {
+			awsError.Type = "Receiver"
+		} else {
+			awsError.Type = "Sender"
+		}
+	}
+	return awsError
+}
+
+func errorHeaders(awsError AWSError, contentType string) map[string]string {
+	headers := map[string]string{
+		"Content-Type": contentType,
+	}
+	if awsError.RequestID != "" {
+		headers["x-amzn-requestid"] = awsError.RequestID
+	}
+	return headers
+}

--- a/internal/services/aws/protocols/errors.go
+++ b/internal/services/aws/protocols/errors.go
@@ -110,7 +110,11 @@ func normalizeAWSError(awsError AWSError) AWSError {
 		awsError.Message = "An internal error occurred."
 	}
 	if awsError.StatusCode == 0 {
-		awsError.StatusCode = http.StatusBadRequest
+		if awsError.Code == "InternalFailure" {
+			awsError.StatusCode = http.StatusInternalServerError
+		} else {
+			awsError.StatusCode = http.StatusBadRequest
+		}
 	}
 	if awsError.Type == "" {
 		if awsError.StatusCode >= 500 {

--- a/internal/services/aws/protocols/errors_test.go
+++ b/internal/services/aws/protocols/errors_test.go
@@ -1,0 +1,103 @@
+package protocols
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"testing"
+)
+
+func TestSerializeXMLErrorUsesQueryShape(t *testing.T) {
+	response := SerializeXMLError(AWSError{
+		Code:       "AccessDenied",
+		Message:    "denied",
+		RequestID:  "req-123",
+		StatusCode: http.StatusForbidden,
+	})
+
+	if response.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusForbidden)
+	}
+	if response.ContentType != "application/xml" || response.Headers["Content-Type"] != "application/xml" {
+		t.Fatalf("unexpected content type: %#v", response)
+	}
+	if response.Headers["x-amzn-requestid"] != "req-123" {
+		t.Fatalf("request header = %q, want req-123", response.Headers["x-amzn-requestid"])
+	}
+
+	var parsed struct {
+		Error struct {
+			Type    string `xml:"Type"`
+			Code    string `xml:"Code"`
+			Message string `xml:"Message"`
+		} `xml:"Error"`
+		RequestID string `xml:"RequestId"`
+	}
+	if err := xml.Unmarshal(response.Body, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Error.Type != "Sender" || parsed.Error.Code != "AccessDenied" || parsed.Error.Message != "denied" {
+		t.Fatalf("unexpected parsed error: %#v", parsed.Error)
+	}
+	if parsed.RequestID != "req-123" {
+		t.Fatalf("request id = %q, want req-123", parsed.RequestID)
+	}
+}
+
+func TestSerializeRESTXMLErrorUsesS3Shape(t *testing.T) {
+	response := SerializeRESTXMLError(AWSError{
+		Code:       "NoSuchBucket",
+		Message:    "missing bucket",
+		RequestID:  "req-s3",
+		Resource:   "/photos",
+		StatusCode: http.StatusNotFound,
+	})
+
+	if response.Headers["x-amz-request-id"] != "req-s3" {
+		t.Fatalf("S3 request header = %q, want req-s3", response.Headers["x-amz-request-id"])
+	}
+
+	var parsed struct {
+		Code      string `xml:"Code"`
+		Message   string `xml:"Message"`
+		Resource  string `xml:"Resource"`
+		RequestID string `xml:"RequestId"`
+	}
+	if err := xml.Unmarshal(response.Body, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Code != "NoSuchBucket" || parsed.Message != "missing bucket" || parsed.Resource != "/photos" {
+		t.Fatalf("unexpected parsed error: %#v", parsed)
+	}
+}
+
+func TestSerializeJSONErrorIncludesSDKErrorType(t *testing.T) {
+	response := SerializeJSONError(AWSError{
+		Code:       "ResourceNotFoundException",
+		Message:    "missing table",
+		RequestID:  "req-json",
+		Service:    "com.amazonaws.dynamodb.v20120810",
+		StatusCode: http.StatusBadRequest,
+	})
+
+	if response.ContentType != "application/x-amz-json-1.0" {
+		t.Fatalf("content type = %q", response.ContentType)
+	}
+	if response.Headers["x-amzn-errortype"] != "ResourceNotFoundException" {
+		t.Fatalf("error type header = %q", response.Headers["x-amzn-errortype"])
+	}
+	if response.Headers["x-amzn-requestid"] != "req-json" {
+		t.Fatalf("request id header = %q", response.Headers["x-amzn-requestid"])
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal(response.Body, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["__type"] != "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException" {
+		t.Fatalf("__type = %q", parsed["__type"])
+	}
+	if parsed["message"] != "missing table" {
+		t.Fatalf("message = %q", parsed["message"])
+	}
+}

--- a/internal/services/aws/protocols/errors_test.go
+++ b/internal/services/aws/protocols/errors_test.go
@@ -44,6 +44,27 @@ func TestSerializeXMLErrorUsesQueryShape(t *testing.T) {
 	}
 }
 
+func TestSerializeXMLErrorDefaultsInternalFailureToReceiver(t *testing.T) {
+	response := SerializeXMLError(AWSError{})
+
+	if response.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusInternalServerError)
+	}
+
+	var parsed struct {
+		Error struct {
+			Type string `xml:"Type"`
+			Code string `xml:"Code"`
+		} `xml:"Error"`
+	}
+	if err := xml.Unmarshal(response.Body, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Error.Type != "Receiver" || parsed.Error.Code != "InternalFailure" {
+		t.Fatalf("unexpected parsed error: %#v", parsed.Error)
+	}
+}
+
 func TestSerializeRESTXMLErrorUsesS3Shape(t *testing.T) {
 	response := SerializeRESTXMLError(AWSError{
 		Code:       "NoSuchBucket",


### PR DESCRIPTION
- Adds dependency-free SigV4 parsing, known-key auth modes, explicit missing and unknown auth states, and gateway identity context.

- Adds AWS XML, S3 REST XML, and JSON error serializers for SDK-compatible service failures.

- Covers header, presigned, relaxed, known-key, strict, gateway, and error serialization behavior in Go tests.