### PR TITLE
Add Go binary asset store foundation

### DIFF
--- a/internal/core/assets/store.go
+++ b/internal/core/assets/store.go
@@ -1,0 +1,260 @@
+package assets
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultContentType = "application/octet-stream"
+	ReferenceDriver    = "memory"
+)
+
+type Store struct {
+	mu     sync.RWMutex
+	assets map[string]asset
+	now    func() time.Time
+}
+
+type Option func(*Store)
+
+type PutOptions struct {
+	Purpose      string
+	ContentType  string
+	ETag         string
+	LastModified time.Time
+	UserMetadata map[string]string
+}
+
+type Metadata struct {
+	ID             string            `json:"id"`
+	Purpose        string            `json:"purpose,omitempty"`
+	ContentType    string            `json:"contentType"`
+	ContentLength  int64             `json:"contentLength"`
+	ChecksumMD5    string            `json:"checksumMd5"`
+	ChecksumSHA256 string            `json:"checksumSha256"`
+	ETag           string            `json:"etag"`
+	LastModified   time.Time         `json:"lastModified"`
+	UserMetadata   map[string]string `json:"userMetadata,omitempty"`
+}
+
+type Reference struct {
+	Purpose        string `json:"purpose,omitempty"`
+	Driver         string `json:"driver"`
+	Key            string `json:"key"`
+	ContentLength  int64  `json:"contentLength"`
+	ChecksumSHA256 string `json:"checksumSha256"`
+}
+
+type AssetSnapshot struct {
+	Metadata  Metadata  `json:"metadata"`
+	Reference Reference `json:"reference"`
+}
+
+type StoreSnapshot struct {
+	Assets []AssetSnapshot `json:"assets"`
+}
+
+type asset struct {
+	metadata Metadata
+	body     []byte
+}
+
+func New(options ...Option) *Store {
+	store := &Store{
+		assets: map[string]asset{},
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+	for _, option := range options {
+		option(store)
+	}
+	return store
+}
+
+func WithClock(now func() time.Time) Option {
+	return func(store *Store) {
+		if now != nil {
+			store.now = now
+		}
+	}
+}
+
+func (store *Store) Put(id string, reader io.Reader, options PutOptions) (Metadata, error) {
+	if reader == nil {
+		reader = bytes.NewReader(nil)
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("read asset body: %w", err)
+	}
+	return store.PutBytes(id, body, options)
+}
+
+func (store *Store) PutBytes(id string, body []byte, options PutOptions) (Metadata, error) {
+	if id == "" {
+		return Metadata{}, fmt.Errorf("asset id is required")
+	}
+	metadata := buildMetadata(id, body, options, store.now)
+	stored := asset{
+		metadata: cloneMetadata(metadata),
+		body:     append([]byte(nil), body...),
+	}
+
+	store.mu.Lock()
+	store.assets[id] = stored
+	store.mu.Unlock()
+
+	return cloneMetadata(metadata), nil
+}
+
+func (store *Store) Get(id string) (Metadata, bool) {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	asset, ok := store.assets[id]
+	if !ok {
+		return Metadata{}, false
+	}
+	return cloneMetadata(asset.metadata), true
+}
+
+func (store *Store) Bytes(id string) ([]byte, Metadata, bool) {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	asset, ok := store.assets[id]
+	if !ok {
+		return nil, Metadata{}, false
+	}
+	return append([]byte(nil), asset.body...), cloneMetadata(asset.metadata), true
+}
+
+func (store *Store) Open(id string) (io.ReadCloser, Metadata, bool) {
+	body, metadata, ok := store.Bytes(id)
+	if !ok {
+		return nil, Metadata{}, false
+	}
+	return io.NopCloser(bytes.NewReader(body)), metadata, true
+}
+
+func (store *Store) Delete(id string) bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	if _, ok := store.assets[id]; !ok {
+		return false
+	}
+	delete(store.assets, id)
+	return true
+}
+
+func (store *Store) Reset() {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.assets = map[string]asset{}
+}
+
+func (store *Store) Count() int {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	return len(store.assets)
+}
+
+func (store *Store) List() []Metadata {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	ids := store.sortedIDsLocked()
+	items := make([]Metadata, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, cloneMetadata(store.assets[id].metadata))
+	}
+	return items
+}
+
+func (store *Store) Snapshot() StoreSnapshot {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	ids := store.sortedIDsLocked()
+	snapshot := StoreSnapshot{Assets: make([]AssetSnapshot, 0, len(ids))}
+	for _, id := range ids {
+		asset := store.assets[id]
+		metadata := cloneMetadata(asset.metadata)
+		snapshot.Assets = append(snapshot.Assets, AssetSnapshot{
+			Metadata: metadata,
+			Reference: Reference{
+				Purpose:        metadata.Purpose,
+				Driver:         ReferenceDriver,
+				Key:            metadata.ID,
+				ContentLength:  metadata.ContentLength,
+				ChecksumSHA256: metadata.ChecksumSHA256,
+			},
+		})
+	}
+	return snapshot
+}
+
+func (store *Store) sortedIDsLocked() []string {
+	ids := make([]string, 0, len(store.assets))
+	for id := range store.assets {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func buildMetadata(id string, body []byte, options PutOptions, now func() time.Time) Metadata {
+	md5sum := md5.Sum(body)
+	sha256sum := sha256.Sum256(body)
+	contentType := options.ContentType
+	if contentType == "" {
+		contentType = DefaultContentType
+	}
+	lastModified := options.LastModified
+	if lastModified.IsZero() {
+		lastModified = now()
+	}
+	lastModified = lastModified.UTC()
+	etag := options.ETag
+	if etag == "" {
+		etag = fmt.Sprintf("%q", hex.EncodeToString(md5sum[:]))
+	}
+
+	return Metadata{
+		ID:             id,
+		Purpose:        options.Purpose,
+		ContentType:    contentType,
+		ContentLength:  int64(len(body)),
+		ChecksumMD5:    hex.EncodeToString(md5sum[:]),
+		ChecksumSHA256: hex.EncodeToString(sha256sum[:]),
+		ETag:           etag,
+		LastModified:   lastModified,
+		UserMetadata:   cloneStringMap(options.UserMetadata),
+	}
+}
+
+func cloneMetadata(metadata Metadata) Metadata {
+	metadata.UserMetadata = cloneStringMap(metadata.UserMetadata)
+	return metadata
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/core/assets/store_test.go
+++ b/internal/core/assets/store_test.go
@@ -1,0 +1,219 @@
+package assets
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestStoreBytesRoundTripIsBinarySafe(t *testing.T) {
+	store := New(WithClock(fixedClock()))
+	body := []byte{0x00, 0xff, 0x10, 'a', '\n'}
+
+	metadata, err := store.PutBytes("s3/photos/raw.bin", body, PutOptions{
+		ContentType: "application/octet-stream",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body[1] = 0x01
+
+	readBody, readMetadata, ok := store.Bytes("s3/photos/raw.bin")
+	if !ok {
+		t.Fatal("asset was not stored")
+	}
+	want := []byte{0x00, 0xff, 0x10, 'a', '\n'}
+	if !bytes.Equal(readBody, want) {
+		t.Fatalf("body = %v, want %v", readBody, want)
+	}
+	readBody[0] = 0x7f
+	secondRead, _, ok := store.Bytes("s3/photos/raw.bin")
+	if !ok {
+		t.Fatal("asset was not stored on second read")
+	}
+	if !bytes.Equal(secondRead, want) {
+		t.Fatalf("second read body = %v, want %v", secondRead, want)
+	}
+
+	if metadata.ContentLength != int64(len(want)) || readMetadata.ContentLength != int64(len(want)) {
+		t.Fatalf("content length metadata = %#v %#v", metadata, readMetadata)
+	}
+	if metadata.ChecksumMD5 != hexDigestMD5(want) {
+		t.Fatalf("md5 = %q, want %q", metadata.ChecksumMD5, hexDigestMD5(want))
+	}
+	if metadata.ChecksumSHA256 != hexDigestSHA256(want) {
+		t.Fatalf("sha256 = %q, want %q", metadata.ChecksumSHA256, hexDigestSHA256(want))
+	}
+	if metadata.ETag != `"`+hexDigestMD5(want)+`"` {
+		t.Fatalf("etag = %q", metadata.ETag)
+	}
+}
+
+func TestStoreStreamingWriteAndRead(t *testing.T) {
+	store := New(WithClock(fixedClock()))
+	userMetadata := map[string]string{"source": "upload"}
+
+	metadata, err := store.Put("lambda/function.zip", bytes.NewReader([]byte("zip-bytes")), PutOptions{
+		Purpose:      "aws.lambda.package",
+		ContentType:  "application/zip",
+		UserMetadata: userMetadata,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	userMetadata["source"] = "mutated"
+
+	reader, readMetadata, ok := store.Open("lambda/function.zip")
+	if !ok {
+		t.Fatal("asset was not stored")
+	}
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != "zip-bytes" {
+		t.Fatalf("body = %q, want zip-bytes", body)
+	}
+	if metadata.ContentType != "application/zip" || readMetadata.ContentType != "application/zip" {
+		t.Fatalf("content type metadata = %#v %#v", metadata, readMetadata)
+	}
+	if readMetadata.Purpose != "aws.lambda.package" {
+		t.Fatalf("purpose = %q, want aws.lambda.package", readMetadata.Purpose)
+	}
+	if readMetadata.LastModified != fixedTime() {
+		t.Fatalf("last modified = %s, want %s", readMetadata.LastModified, fixedTime())
+	}
+	if readMetadata.UserMetadata["source"] != "upload" {
+		t.Fatalf("user metadata = %#v", readMetadata.UserMetadata)
+	}
+	readMetadata.UserMetadata["source"] = "changed"
+	storedMetadata, ok := store.Get("lambda/function.zip")
+	if !ok {
+		t.Fatal("asset was not stored after metadata read")
+	}
+	if storedMetadata.UserMetadata["source"] != "upload" {
+		t.Fatalf("stored metadata was mutated: %#v", storedMetadata.UserMetadata)
+	}
+}
+
+func TestStoreDefaultsAndOverrides(t *testing.T) {
+	store := New(WithClock(fixedClock()))
+	customModified := time.Date(2026, 5, 19, 6, 30, 0, 0, time.FixedZone("offset", -5*60*60))
+
+	metadata, err := store.PutBytes("custom", []byte("body"), PutOptions{
+		ETag:         `"custom-etag"`,
+		LastModified: customModified,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if metadata.ContentType != DefaultContentType {
+		t.Fatalf("content type = %q, want %q", metadata.ContentType, DefaultContentType)
+	}
+	if metadata.ETag != `"custom-etag"` {
+		t.Fatalf("etag = %q, want custom", metadata.ETag)
+	}
+	if metadata.LastModified.Location() != time.UTC {
+		t.Fatalf("last modified location = %s, want UTC", metadata.LastModified.Location())
+	}
+	if metadata.LastModified != customModified.UTC() {
+		t.Fatalf("last modified = %s, want %s", metadata.LastModified, customModified.UTC())
+	}
+}
+
+func TestStoreSnapshotUsesStableReferences(t *testing.T) {
+	store := New(WithClock(fixedClock()))
+	if _, err := store.PutBytes("zeta", []byte("z-body"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.PutBytes("alpha", []byte("a-body"), PutOptions{
+		Purpose:     "aws.s3.object",
+		ContentType: "text/plain",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := store.Snapshot()
+	if len(snapshot.Assets) != 2 {
+		t.Fatalf("snapshot asset count = %d, want 2", len(snapshot.Assets))
+	}
+	if snapshot.Assets[0].Metadata.ID != "alpha" || snapshot.Assets[1].Metadata.ID != "zeta" {
+		t.Fatalf("snapshot order = %#v", snapshot.Assets)
+	}
+	if snapshot.Assets[0].Reference.Driver != ReferenceDriver || snapshot.Assets[0].Reference.Key != "alpha" {
+		t.Fatalf("reference = %#v", snapshot.Assets[0].Reference)
+	}
+	if snapshot.Assets[0].Reference.Purpose != "aws.s3.object" {
+		t.Fatalf("reference purpose = %q", snapshot.Assets[0].Reference.Purpose)
+	}
+	if snapshot.Assets[0].Reference.ContentLength != int64(len("a-body")) {
+		t.Fatalf("reference length = %d", snapshot.Assets[0].Reference.ContentLength)
+	}
+	if snapshot.Assets[0].Reference.ChecksumSHA256 != hexDigestSHA256([]byte("a-body")) {
+		t.Fatalf("reference sha256 = %q", snapshot.Assets[0].Reference.ChecksumSHA256)
+	}
+
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("a-body")) || bytes.Contains(raw, []byte("z-body")) {
+		t.Fatalf("snapshot serialized body bytes: %s", raw)
+	}
+}
+
+func TestStoreListDeleteAndReset(t *testing.T) {
+	store := New(WithClock(fixedClock()))
+	if _, err := store.PutBytes("b", []byte("b"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.PutBytes("a", []byte("a"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	items := store.List()
+	gotIDs := []string{items[0].ID, items[1].ID}
+	if !reflect.DeepEqual(gotIDs, []string{"a", "b"}) {
+		t.Fatalf("ids = %#v", gotIDs)
+	}
+	if !store.Delete("a") || store.Delete("a") {
+		t.Fatal("delete did not report expected state")
+	}
+	if store.Count() != 1 {
+		t.Fatalf("count = %d, want 1", store.Count())
+	}
+
+	store.Reset()
+	if store.Count() != 0 {
+		t.Fatalf("count after reset = %d, want 0", store.Count())
+	}
+}
+
+func fixedClock() func() time.Time {
+	return func() time.Time {
+		return fixedTime()
+	}
+}
+
+func fixedTime() time.Time {
+	return time.Date(2026, 5, 19, 12, 0, 0, 123, time.UTC)
+}
+
+func hexDigestMD5(body []byte) string {
+	sum := md5.Sum(body)
+	return hex.EncodeToString(sum[:])
+}
+
+func hexDigestSHA256(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/services/aws/assets/ids.go
+++ b/internal/services/aws/assets/ids.go
@@ -5,13 +5,11 @@ import (
 	"strings"
 )
 
-type Purpose string
-
 const (
-	PurposeS3Object               Purpose = "aws.s3.object"
-	PurposeLambdaPackage          Purpose = "aws.lambda.package"
-	PurposeLambdaLayer            Purpose = "aws.lambda.layer"
-	PurposeCloudFormationTemplate Purpose = "aws.cloudformation.template"
+	PurposeS3Object               = "aws.s3.object"
+	PurposeLambdaPackage          = "aws.lambda.package"
+	PurposeLambdaLayer            = "aws.lambda.layer"
+	PurposeCloudFormationTemplate = "aws.cloudformation.template"
 )
 
 func S3ObjectID(bucket string, key string) string {

--- a/internal/services/aws/assets/ids.go
+++ b/internal/services/aws/assets/ids.go
@@ -1,0 +1,39 @@
+package assets
+
+import (
+	"net/url"
+	"strings"
+)
+
+type Purpose string
+
+const (
+	PurposeS3Object               Purpose = "aws.s3.object"
+	PurposeLambdaPackage          Purpose = "aws.lambda.package"
+	PurposeLambdaLayer            Purpose = "aws.lambda.layer"
+	PurposeCloudFormationTemplate Purpose = "aws.cloudformation.template"
+)
+
+func S3ObjectID(bucket string, key string) string {
+	return join("aws", "s3", "buckets", bucket, "objects", key)
+}
+
+func LambdaPackageID(functionName string, revision string) string {
+	return join("aws", "lambda", "functions", functionName, "packages", revision)
+}
+
+func LambdaLayerID(layerName string, version string) string {
+	return join("aws", "lambda", "layers", layerName, "versions", version)
+}
+
+func CloudFormationTemplateID(stackName string, templateID string) string {
+	return join("aws", "cloudformation", "stacks", stackName, "templates", templateID)
+}
+
+func join(parts ...string) string {
+	escaped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		escaped = append(escaped, url.PathEscape(part))
+	}
+	return strings.Join(escaped, "/")
+}

--- a/internal/services/aws/assets/ids_test.go
+++ b/internal/services/aws/assets/ids_test.go
@@ -1,0 +1,35 @@
+package assets
+
+import "testing"
+
+func TestS3ObjectIDEscapesBucketAndKey(t *testing.T) {
+	id := S3ObjectID("photos.archive", "raw/2026 05/image.bin")
+
+	if id != "aws/s3/buckets/photos.archive/objects/raw%2F2026%2005%2Fimage.bin" {
+		t.Fatalf("id = %q", id)
+	}
+}
+
+func TestAWSAssetIDsSeparateServicePurposes(t *testing.T) {
+	s3ID := S3ObjectID("function", "code.zip")
+	packageID := LambdaPackageID("function", "code.zip")
+	layerID := LambdaLayerID("function", "1")
+	templateID := CloudFormationTemplateID("function", "code.zip")
+
+	ids := map[string]bool{}
+	for _, id := range []string{s3ID, packageID, layerID, templateID} {
+		if ids[id] {
+			t.Fatalf("duplicate id %q", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestPurposeNamesAreStable(t *testing.T) {
+	if PurposeS3Object != "aws.s3.object" {
+		t.Fatalf("S3 purpose = %q", PurposeS3Object)
+	}
+	if PurposeLambdaPackage != "aws.lambda.package" {
+		t.Fatalf("lambda package purpose = %q", PurposeLambdaPackage)
+	}
+}


### PR DESCRIPTION
- Adds a dependency-free in-memory asset store with binary-safe byte storage, streaming helpers, metadata, checksums, ETags, and snapshot references.

- Adds stable AWS asset identifiers for S3 objects, Lambda packages, Lambda layers, and CloudFormation templates.

- Covers binary round trips, metadata cloning, defaults, stable snapshots, and AWS asset id behavior in Go tests.