### PR TITLE
Add Go AWS service shell

### DIFF
--- a/internal/core/http/router.go
+++ b/internal/core/http/router.go
@@ -76,6 +76,7 @@ type Router struct {
 	mu          sync.RWMutex
 	routes      []route
 	middleware  []Middleware
+	fallback    HandlerFunc
 	notFound    HandlerFunc
 	requestNext atomic.Uint64
 }
@@ -166,6 +167,12 @@ func (r *Router) Mount(prefix string, handler http.Handler) {
 	})
 }
 
+func (r *Router) Fallback(handler HandlerFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fallback = handler
+}
+
 func (r *Router) NotFound(handler HandlerFunc) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -184,6 +191,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.mu.RLock()
 	routes := append([]route(nil), r.routes...)
 	middleware := append([]Middleware(nil), r.middleware...)
+	fallback := r.fallback
 	notFound := r.notFound
 	r.mu.RUnlock()
 
@@ -210,6 +218,12 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			chain(route.handler, middleware)(ctx)
 			return
 		}
+	}
+
+	if fallback != nil {
+		ctx := &Context{Writer: w, Request: req, Params: map[string]string{}, requestID: requestID}
+		chain(fallback, middleware)(ctx)
+		return
 	}
 
 	ctx := &Context{Writer: w, Request: req, Params: map[string]string{}, requestID: requestID}

--- a/internal/core/http/router_test.go
+++ b/internal/core/http/router_test.go
@@ -171,6 +171,38 @@ func TestRouterFallsBackHeadToGet(t *testing.T) {
 	}
 }
 
+func TestRouterFallsBackHeadToGetBeforeFallbackHandler(t *testing.T) {
+	router := NewRouter()
+	router.Get("/object", func(c *Context) {
+		c.Writer.Header().Set("X-Handler", "get")
+		c.Text(http.StatusOK, "get")
+	})
+	router.Fallback(func(c *Context) {
+		c.Writer.Header().Set("X-Handler", "fallback")
+		c.Text(http.StatusTeapot, "fallback")
+	})
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodHead, "/object", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Header().Get("X-Handler") != "get" {
+		t.Fatalf("handler = %q", res.Header().Get("X-Handler"))
+	}
+
+	missing := httptest.NewRecorder()
+	router.ServeHTTP(missing, httptest.NewRequest(http.MethodGet, "/missing", nil))
+
+	if missing.Code != http.StatusTeapot {
+		t.Fatalf("missing status = %d, body = %s", missing.Code, missing.Body.String())
+	}
+	if missing.Header().Get("X-Handler") != "fallback" {
+		t.Fatalf("missing handler = %q", missing.Header().Get("X-Handler"))
+	}
+}
+
 func TestRouterResponseHelpers(t *testing.T) {
 	router := NewRouter()
 	router.Get("/text", func(c *Context) { c.Text(http.StatusAccepted, "hello") })

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -64,7 +64,8 @@ func NewServer(options ServerOptions) *Server {
 	})
 	if serviceEnabled(services, "aws") {
 		aws.Register(router, aws.Options{
-			Store: runtimeStore,
+			Store:          runtimeStore,
+			S3PathFallback: len(services) == 1,
 		})
 	}
 	router.NotFound(func(c *corehttp.Context) {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -6,6 +6,7 @@ import (
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
 	"github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/core/ui"
+	"github.com/vercel-labs/emulate/internal/services/aws"
 )
 
 const HealthPath = "/_emulate/health"
@@ -61,6 +62,11 @@ func NewServer(options ServerOptions) *Server {
 			"runtime": "go",
 		})
 	})
+	if serviceEnabled(services, "aws") {
+		aws.Register(router, aws.Options{
+			Store: runtimeStore,
+		})
+	}
 	router.NotFound(func(c *corehttp.Context) {
 		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
 	})
@@ -72,4 +78,13 @@ func NewServer(options ServerOptions) *Server {
 		BaseURL:  options.BaseURL,
 		Services: services,
 	}
+}
+
+func serviceEnabled(services []string, name string) bool {
+	for _, service := range services {
+		if service == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -75,6 +75,17 @@ func TestNewHandlerMountsAWSWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerAWSDoesNotShadowHeadHealth(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"aws"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodHead, HealthPath, nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestNewHandlerDoesNotMountAWSWhenDisabled(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"github"}})
 	req := httptest.NewRequest(http.MethodPost, "/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -107,6 +107,27 @@ func TestNewHandlerAWSOnlyUsesS3PathFallback(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMultiServiceDoesNotTreatNestedKnownServicePathAsS3(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"aws", "github"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/sqs/foo", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["message"] != "Not Found" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+	if strings.Contains(res.Body.String(), "s3.GetObject") {
+		t.Fatalf("unexpected S3 fallback response: %s", res.Body.String())
+	}
+}
+
 func TestNewHandlerAWSDoesNotShadowHeadHealth(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"aws"}})
 

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -43,7 +43,7 @@ func TestNewHandlerReturnsJSONNotFound(t *testing.T) {
 	handler := NewHandler(ServerOptions{})
 
 	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, httptest.NewRequest(http.MethodTrace, "/missing", nil))
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/missing", nil))
 
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
@@ -54,6 +54,24 @@ func TestNewHandlerReturnsJSONNotFound(t *testing.T) {
 	}
 	if body["message"] != "Not Found" {
 		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestNewHandlerMountsAWSInConservativeModeByDefault(t *testing.T) {
+	handler := NewHandler(ServerOptions{})
+	req := httptest.NewRequest(http.MethodPost, "/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-east-1/sqs/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	req.Header.Set("X-Amz-Date", "20260519T000000Z")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "sqs.CreateQueue") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }
 
@@ -71,6 +89,20 @@ func TestNewHandlerMountsAWSWhenEnabled(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	if !strings.Contains(res.Body.String(), "sqs.CreateQueue") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerAWSOnlyUsesS3PathFallback(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"aws"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/photos", nil))
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "s3.ListObjects") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -107,6 +107,20 @@ func TestNewHandlerAWSOnlyUsesS3PathFallback(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMultiServiceKeepsLegacyS3Path(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"aws", "github"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/s3/photos", nil))
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "s3.ListObjects") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestNewHandlerMultiServiceDoesNotTreatNestedKnownServicePathAsS3(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"aws", "github"}})
 

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -53,5 +54,38 @@ func TestNewHandlerReturnsJSONNotFound(t *testing.T) {
 	}
 	if body["message"] != "Not Found" {
 		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestNewHandlerMountsAWSWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"aws"}})
+	req := httptest.NewRequest(http.MethodPost, "/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-east-1/sqs/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	req.Header.Set("X-Amz-Date", "20260519T000000Z")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "sqs.CreateQueue") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountAWSWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"github"}})
+	req := httptest.NewRequest(http.MethodPost, "/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-east-1/sqs/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	req.Header.Set("X-Amz-Date", "20260519T000000Z")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -43,7 +43,7 @@ func TestNewHandlerReturnsJSONNotFound(t *testing.T) {
 	handler := NewHandler(ServerOptions{})
 
 	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/missing", nil))
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodTrace, "/missing", nil))
 
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())

--- a/internal/services/aws/auth/sigv4.go
+++ b/internal/services/aws/auth/sigv4.go
@@ -117,6 +117,9 @@ func parseAuthorizationHeader(req *http.Request) (Signature, error) {
 		return Signature{}, nil
 	}
 	algorithm := fields[0]
+	if isTokenAuthorizationScheme(algorithm) {
+		return Signature{}, nil
+	}
 	if algorithm != AlgorithmSigV4 {
 		return Signature{}, fmt.Errorf("unsupported SigV4 algorithm %q", algorithm)
 	}
@@ -175,4 +178,13 @@ func splitSignedHeaders(value string) []string {
 		}
 	}
 	return headers
+}
+
+func isTokenAuthorizationScheme(algorithm string) bool {
+	switch strings.ToLower(algorithm) {
+	case "bearer", "token":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/services/aws/auth/sigv4_test.go
+++ b/internal/services/aws/auth/sigv4_test.go
@@ -67,6 +67,20 @@ func TestResolveRelaxedAllowsUnknownKey(t *testing.T) {
 	}
 }
 
+func TestResolveRelaxedAllowsBearerToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+
+	ctx := Resolve(req, Options{Mode: ModeRelaxed})
+
+	if ctx.Status != StatusMissing {
+		t.Fatalf("status = %q, want %q", ctx.Status, StatusMissing)
+	}
+	if ctx.Error != nil {
+		t.Fatalf("error = %#v, want nil", ctx.Error)
+	}
+}
+
 func TestResolveKnownKeysUsesCredentialIdentity(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
 	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAKNOWN/20260519/us-east-1/sts/aws4_request, SignedHeaders=host, Signature=abcdef")

--- a/internal/services/aws/gateway/context.go
+++ b/internal/services/aws/gateway/context.go
@@ -138,7 +138,7 @@ func BuildContext(req *http.Request, rawBody []byte, options Options) (AwsReques
 		return ctx, nil
 	}
 
-	if shouldTreatAsS3(req, host.Service, pathService) {
+	if shouldTreatAsS3(req, host.Service, pathService, credentials.Scope.Service) {
 		s3Route, err := protocols.ParseS3RESTRequest(req)
 		if err != nil {
 			return AwsRequestContext{}, err
@@ -218,11 +218,14 @@ func s3Input(route protocols.S3Route) map[string]any {
 	}
 }
 
-func shouldTreatAsS3(req *http.Request, hostService string, pathService string) bool {
-	if hostService == "s3" || pathService == "s3" {
+func shouldTreatAsS3(req *http.Request, hostService string, pathService string, credentialService string) bool {
+	if hostService == "s3" || pathService == "s3" || credentialService == "s3" {
 		return true
 	}
 	if req.URL.Query().Get("Action") != "" || req.Header.Get("X-Amz-Target") != "" {
+		return false
+	}
+	if credentialService != "" {
 		return false
 	}
 	return hostService == ""

--- a/internal/services/aws/gateway/context.go
+++ b/internal/services/aws/gateway/context.go
@@ -228,7 +228,44 @@ func shouldTreatAsS3(req *http.Request, hostService string, pathService string, 
 	if credentialService != "" {
 		return false
 	}
+	if pathService != "" && isServiceRootPath(req.URL.Path) && !hasS3RequestHint(req) {
+		return false
+	}
 	return hostService == ""
+}
+
+func isServiceRootPath(pathValue string) bool {
+	trimmed := strings.Trim(pathValue, "/")
+	if trimmed == "" {
+		return false
+	}
+	_, rest, _ := strings.Cut(trimmed, "/")
+	return rest == ""
+}
+
+func hasS3RequestHint(req *http.Request) bool {
+	query := req.URL.Query()
+	if query.Get("list-type") == "2" {
+		return true
+	}
+	for _, key := range []string{
+		"acl",
+		"delete",
+		"lifecycle",
+		"location",
+		"notification",
+		"policy",
+		"tagging",
+		"uploadId",
+		"uploads",
+		"versioning",
+		"website",
+	} {
+		if _, ok := query[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func detectHost(host string) hostDetection {

--- a/internal/services/aws/gateway/context_test.go
+++ b/internal/services/aws/gateway/context_test.go
@@ -129,6 +129,46 @@ func TestBuildContextS3PathStyleBucketNameCanMatchKnownService(t *testing.T) {
 	}
 }
 
+func TestBuildContextSignedS3PathStyleBucketNameCanMatchKnownService(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/logs/app.txt", nil)
+	signRequestForService(req, "s3")
+
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "s3" || ctx.Action != "PutObject" {
+		t.Fatalf("service/action = %q/%q, want s3/PutObject", ctx.Service, ctx.Action)
+	}
+	if ctx.S3 == nil || ctx.S3.Bucket != "logs" || ctx.S3.Key != "app.txt" {
+		t.Fatalf("unexpected S3 route: %#v", ctx.S3)
+	}
+}
+
+func TestBuildContextSignedNonS3ServicePathDoesNotFallBackToS3(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/lambda/2015-03-31/functions", nil)
+	signRequestForService(req, "lambda")
+
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "lambda" {
+		t.Fatalf("service = %q, want lambda", ctx.Service)
+	}
+	if ctx.Protocol != protocols.ProtocolUnknown {
+		t.Fatalf("protocol = %q, want %q", ctx.Protocol, protocols.ProtocolUnknown)
+	}
+	if ctx.Action != "" {
+		t.Fatalf("action = %q, want empty", ctx.Action)
+	}
+	if ctx.S3 != nil {
+		t.Fatalf("S3 route = %#v, want nil", ctx.S3)
+	}
+}
+
 func TestBuildContextS3CopyObject(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/photos/docs/copy.txt", nil)
 	req.Header.Set("x-amz-copy-source", "/photos/docs/source.txt")
@@ -676,4 +716,9 @@ func fixedOptions() Options {
 			return "req-test"
 		},
 	}
+}
+
+func signRequestForService(req *http.Request, service string) {
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-east-1/"+service+"/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	req.Header.Set("X-Amz-Date", "20260519T000000Z")
 }

--- a/internal/services/aws/gateway/context_test.go
+++ b/internal/services/aws/gateway/context_test.go
@@ -169,6 +169,28 @@ func TestBuildContextSignedNonS3ServicePathDoesNotFallBackToS3(t *testing.T) {
 	}
 }
 
+func TestBuildContextKnownNonS3ServiceRootDoesNotFallBackToS3(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/lambda", nil)
+
+	ctx, err := BuildContext(req, nil, fixedOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.Service != "lambda" {
+		t.Fatalf("service = %q, want lambda", ctx.Service)
+	}
+	if ctx.Protocol != protocols.ProtocolUnknown {
+		t.Fatalf("protocol = %q, want %q", ctx.Protocol, protocols.ProtocolUnknown)
+	}
+	if ctx.Action != "" {
+		t.Fatalf("action = %q, want empty", ctx.Action)
+	}
+	if ctx.S3 != nil {
+		t.Fatalf("S3 route = %#v, want nil", ctx.S3)
+	}
+}
+
 func TestBuildContextS3CopyObject(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/photos/docs/copy.txt", nil)
 	req.Header.Set("x-amz-copy-source", "/photos/docs/source.txt")

--- a/internal/services/aws/inspector.go
+++ b/internal/services/aws/inspector.go
@@ -1,0 +1,178 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+var inspectorTabs = []ui.InspectorTab{
+	{ID: "s3", Label: "S3", Href: "/_inspector?tab=s3"},
+	{ID: "sqs", Label: "SQS", Href: "/_inspector?tab=sqs"},
+	{ID: "iam", Label: "IAM", Href: "/_inspector?tab=iam"},
+}
+
+func (s *Service) handleInspector(c *corehttp.Context) {
+	tab := c.Query("tab")
+	if tab != "s3" && tab != "sqs" && tab != "iam" {
+		tab = "s3"
+	}
+	tabs := make([]ui.InspectorTab, len(inspectorTabs))
+	for index, item := range inspectorTabs {
+		tabs[index] = item
+		tabs[index].Active = item.ID == tab
+	}
+
+	var body string
+	switch tab {
+	case "sqs":
+		body = s.renderSQSInspector()
+	case "iam":
+		body = s.renderIAMInspector()
+	default:
+		body = s.renderS3Inspector()
+	}
+
+	c.HTML(200, ui.RenderInspectorPage("Inspector", tabs, tab, body, ui.PageOptions{Service: "AWS"}))
+}
+
+func (s *Service) renderS3Inspector() string {
+	buckets := s.store.S3Buckets.All()
+	var rows strings.Builder
+	for _, bucket := range buckets {
+		name := stringField(bucket, "bucket_name")
+		objects := s.store.S3Objects.FindBy("bucket_name", name)
+		rows.WriteString(`<tr><td>`)
+		rows.WriteString(ui.EscapeHTML(name))
+		rows.WriteString(`</td><td>`)
+		rows.WriteString(fmt.Sprint(len(objects)))
+		rows.WriteString(`</td><td>`)
+		rows.WriteString(ui.EscapeHTML(stringField(bucket, "region")))
+		rows.WriteString(`</td><td>`)
+		rows.WriteString(ui.EscapeHTML(stringField(bucket, "creation_date")))
+		rows.WriteString(`</td></tr>`)
+	}
+	return `<div class="inspector-section">
+  <h2>S3 Buckets (` + fmt.Sprint(len(buckets)) + `)</h2>
+  <table class="inspector-table">
+    <thead><tr><th>Bucket</th><th>Objects</th><th>Region</th><th>Created</th></tr></thead>
+    <tbody>` + rowsOrEmpty(rows.String(), 4, "No buckets") + `</tbody>
+  </table>
+</div>`
+}
+
+func (s *Service) renderSQSInspector() string {
+	queues := s.store.SQSQueues.All()
+	var rows strings.Builder
+	for _, queue := range queues {
+		name := stringField(queue, "queue_name")
+		messages := s.store.SQSMessages.FindBy("queue_name", name)
+		rows.WriteString(`<tr><td>`)
+		rows.WriteString(ui.EscapeHTML(name))
+		rows.WriteString(`</td><td>`)
+		rows.WriteString(fmt.Sprint(len(messages)))
+		rows.WriteString(`</td><td>`)
+		rows.WriteString(yesNo(boolField(queue, "fifo")))
+		rows.WriteString(`</td><td>`)
+		rows.WriteString(ui.EscapeHTML(stringField(queue, "visibility_timeout")))
+		rows.WriteString(`</td></tr>`)
+	}
+	return `<div class="inspector-section">
+  <h2>SQS Queues (` + fmt.Sprint(len(queues)) + `)</h2>
+  <table class="inspector-table">
+    <thead><tr><th>Queue</th><th>Messages</th><th>FIFO</th><th>Visibility Timeout</th></tr></thead>
+    <tbody>` + rowsOrEmpty(rows.String(), 4, "No queues") + `</tbody>
+  </table>
+</div>`
+}
+
+func (s *Service) renderIAMInspector() string {
+	users := s.store.IAMUsers.All()
+	roles := s.store.IAMRoles.All()
+	var userRows strings.Builder
+	for _, user := range users {
+		userRows.WriteString(`<tr><td>`)
+		userRows.WriteString(ui.EscapeHTML(stringField(user, "user_name")))
+		userRows.WriteString(`</td><td>`)
+		userRows.WriteString(ui.EscapeHTML(stringField(user, "user_id")))
+		userRows.WriteString(`</td><td>`)
+		userRows.WriteString(fmt.Sprint(accessKeyCount(user)))
+		userRows.WriteString(`</td><td>`)
+		userRows.WriteString(ui.EscapeHTML(stringField(user, "arn")))
+		userRows.WriteString(`</td></tr>`)
+	}
+	var roleRows strings.Builder
+	for _, role := range roles {
+		roleRows.WriteString(`<tr><td>`)
+		roleRows.WriteString(ui.EscapeHTML(stringField(role, "role_name")))
+		roleRows.WriteString(`</td><td>`)
+		roleRows.WriteString(ui.EscapeHTML(stringField(role, "role_id")))
+		roleRows.WriteString(`</td><td>`)
+		roleRows.WriteString(ui.EscapeHTML(stringField(role, "description")))
+		roleRows.WriteString(`</td><td>`)
+		roleRows.WriteString(ui.EscapeHTML(stringField(role, "arn")))
+		roleRows.WriteString(`</td></tr>`)
+	}
+	return `<div class="inspector-section">
+  <h2>IAM Users (` + fmt.Sprint(len(users)) + `)</h2>
+  <table class="inspector-table">
+    <thead><tr><th>User</th><th>User ID</th><th>Access Keys</th><th>ARN</th></tr></thead>
+    <tbody>` + rowsOrEmpty(userRows.String(), 4, "No users") + `</tbody>
+  </table>
+</div>
+<div class="inspector-section">
+  <h2>IAM Roles (` + fmt.Sprint(len(roles)) + `)</h2>
+  <table class="inspector-table">
+    <thead><tr><th>Role</th><th>Role ID</th><th>Description</th><th>ARN</th></tr></thead>
+    <tbody>` + rowsOrEmpty(roleRows.String(), 4, "No roles") + `</tbody>
+  </table>
+</div>`
+}
+
+func rowsOrEmpty(rows string, columns int, label string) string {
+	if rows != "" {
+		return rows
+	}
+	return `<tr><td colspan="` + fmt.Sprint(columns) + `"><div class="inspector-empty">` + ui.EscapeHTML(label) + `</div></td></tr>`
+}
+
+func stringField(record corestore.Record, name string) string {
+	switch value := record[name].(type) {
+	case string:
+		return value
+	case int:
+		return fmt.Sprint(value)
+	case int64:
+		return fmt.Sprint(value)
+	case float64:
+		return fmt.Sprint(value)
+	default:
+		return ""
+	}
+}
+
+func boolField(record corestore.Record, name string) bool {
+	value, _ := record[name].(bool)
+	return value
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "Yes"
+	}
+	return "No"
+}
+
+func accessKeyCount(record corestore.Record) int {
+	switch value := record["access_keys"].(type) {
+	case []any:
+		return len(value)
+	case []map[string]any:
+		return len(value)
+	default:
+		return 0
+	}
+}

--- a/internal/services/aws/responses.go
+++ b/internal/services/aws/responses.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+)
+
+func readRequestBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	defer req.Body.Close()
+	return io.ReadAll(req.Body)
+}
+
+func awsAuthError(ctx gateway.AwsRequestContext) protocols.AWSError {
+	return protocols.AWSError{
+		Code:       ctx.Auth.Error.Code,
+		Message:    ctx.Auth.Error.Message,
+		RequestID:  ctx.RequestID,
+		Service:    jsonErrorService(ctx.Service),
+		StatusCode: ctx.Auth.Error.StatusCode,
+	}
+}
+
+func notImplementedError(ctx gateway.AwsRequestContext) protocols.AWSError {
+	message := "AWS operation is not implemented in the native Go runtime yet."
+	if ctx.Service != "" && ctx.Action != "" {
+		message = fmt.Sprintf("%s.%s is not implemented in the native Go runtime yet.", ctx.Service, ctx.Action)
+	}
+	code := "NotImplemented"
+	if ctx.Protocol == protocols.ProtocolJSONRPC {
+		code = "NotImplementedException"
+	}
+	return protocols.AWSError{
+		Code:       code,
+		Message:    message,
+		RequestID:  ctx.RequestID,
+		Resource:   requestResource(ctx),
+		Service:    jsonErrorService(ctx.Service),
+		StatusCode: http.StatusNotImplemented,
+	}
+}
+
+func (s *Service) writeParseError(c *corehttp.Context, err error) {
+	response := protocols.SerializeJSONError(protocols.AWSError{
+		Code:       "InvalidRequestException",
+		Message:    err.Error(),
+		RequestID:  gateway.NewRequestID(),
+		StatusCode: http.StatusBadRequest,
+	})
+	writeErrorResponse(c, response)
+}
+
+func (s *Service) writeAWSError(c *corehttp.Context, ctx gateway.AwsRequestContext, awsError protocols.AWSError) {
+	var response protocols.ErrorResponse
+	switch ctx.Protocol {
+	case protocols.ProtocolRESTXML:
+		response = protocols.SerializeRESTXMLError(awsError)
+	case protocols.ProtocolQuery:
+		response = protocols.SerializeXMLError(awsError)
+	case protocols.ProtocolJSONRPC:
+		response = protocols.SerializeJSONError(awsError)
+	default:
+		response = protocols.SerializeJSONError(awsError)
+	}
+	writeErrorResponse(c, response)
+}
+
+func writeErrorResponse(c *corehttp.Context, response protocols.ErrorResponse) {
+	for key, value := range response.Headers {
+		c.Writer.Header().Set(key, value)
+	}
+	c.Binary(response.StatusCode, response.ContentType, response.Body)
+}
+
+func requestResource(ctx gateway.AwsRequestContext) string {
+	if ctx.S3 == nil {
+		return ""
+	}
+	var parts []string
+	if ctx.S3.Bucket != "" {
+		parts = append(parts, ctx.S3.Bucket)
+	}
+	if ctx.S3.Key != "" {
+		parts = append(parts, ctx.S3.Key)
+	}
+	if len(parts) == 0 {
+		return "/"
+	}
+	return "/" + strings.Join(parts, "/")
+}
+
+func jsonErrorService(service string) string {
+	switch service {
+	case "dynamodb":
+		return "com.amazonaws.dynamodb.v20120810"
+	case "events":
+		return "com.amazonaws.events"
+	case "lambda":
+		return "com.amazonaws.lambda"
+	case "logs":
+		return "com.amazonaws.logs"
+	case "secretsmanager":
+		return "com.amazonaws.secretsmanager"
+	case "ssm":
+		return "com.amazonaws.ssm"
+	case "states":
+		return "com.amazonaws.stepfunctions"
+	default:
+		return service
+	}
+}

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -16,6 +16,7 @@ type Options struct {
 	DefaultRegion    string
 	AuthMode         auth.Mode
 	CredentialStore  *auth.Store
+	S3PathFallback   bool
 }
 
 type Service struct {
@@ -24,6 +25,7 @@ type Service struct {
 	defaultRegion    string
 	authMode         auth.Mode
 	credentialStore  *auth.Store
+	s3PathFallback   bool
 }
 
 func Register(router *corehttp.Router, options Options) {
@@ -51,11 +53,12 @@ func New(options Options) *Service {
 		defaultRegion:    defaultRegion,
 		authMode:         options.AuthMode,
 		credentialStore:  options.CredentialStore,
+		s3PathFallback:   options.S3PathFallback,
 	}
 }
 
 func (s *Service) handleAWS(c *corehttp.Context) {
-	if !looksLikeAWSRequest(c.Request) {
+	if !s.looksLikeAWSRequest(c.Request) {
 		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
 		return
 	}
@@ -84,11 +87,11 @@ func (s *Service) handleAWS(c *corehttp.Context) {
 	s.writeAWSError(c, ctx, notImplementedError(ctx))
 }
 
-func looksLikeAWSRequest(req *http.Request) bool {
+func (s *Service) looksLikeAWSRequest(req *http.Request) bool {
 	if req.URL.Query().Get("Action") != "" || req.URL.Query().Get("X-Amz-Algorithm") != "" {
 		return true
 	}
-	if req.Header.Get("X-Amz-Target") != "" || req.Header.Get("X-Amz-Date") != "" || req.Header.Get("X-Amz-Content-Sha256") != "" {
+	if hasAWSHeader(req) {
 		return true
 	}
 	if strings.HasPrefix(req.Header.Get("Authorization"), "AWS4-HMAC-SHA256") {
@@ -101,7 +104,16 @@ func looksLikeAWSRequest(req *http.Request) bool {
 	if hasKnownServicePath(req.URL.Path) {
 		return true
 	}
-	return looksLikeS3RESTRequest(req)
+	return looksLikeS3RESTRequest(req, s.s3PathFallback)
+}
+
+func hasAWSHeader(req *http.Request) bool {
+	for key := range req.Header {
+		if strings.HasPrefix(strings.ToLower(key), "x-amz-") {
+			return true
+		}
+	}
+	return false
 }
 
 func hasKnownServicePath(pathValue string) bool {
@@ -114,9 +126,12 @@ func hasKnownServicePath(pathValue string) bool {
 	}
 }
 
-func looksLikeS3RESTRequest(req *http.Request) bool {
+func looksLikeS3RESTRequest(req *http.Request, pathFallback bool) bool {
 	first := firstPathSegment(req.URL.Path)
 	if strings.HasPrefix(first, "_") {
+		return false
+	}
+	if !pathFallback && !hasS3RequestHint(req) {
 		return false
 	}
 	switch req.Method {
@@ -125,6 +140,33 @@ func looksLikeS3RESTRequest(req *http.Request) bool {
 	default:
 		return false
 	}
+}
+
+func hasS3RequestHint(req *http.Request) bool {
+	query := req.URL.Query()
+	for _, key := range []string{
+		"acl",
+		"continuation-token",
+		"delete",
+		"delimiter",
+		"list-type",
+		"location",
+		"max-keys",
+		"partNumber",
+		"policy",
+		"prefix",
+		"start-after",
+		"tagging",
+		"uploadId",
+		"uploads",
+		"versioning",
+		"website",
+	} {
+		if _, ok := query[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func hasKnownServiceLabel(host string) bool {

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -88,7 +88,7 @@ func (s *Service) handleAWS(c *corehttp.Context) {
 }
 
 func (s *Service) looksLikeAWSRequest(req *http.Request) bool {
-	if req.URL.Query().Get("Action") != "" || req.URL.Query().Get("X-Amz-Algorithm") != "" {
+	if req.URL.Query().Get("Action") != "" || hasAWSPresignQuery(req) {
 		return true
 	}
 	if hasAWSHeader(req) {
@@ -105,6 +105,16 @@ func (s *Service) looksLikeAWSRequest(req *http.Request) bool {
 		return true
 	}
 	return looksLikeS3RESTRequest(req, s.s3PathFallback)
+}
+
+func hasAWSPresignQuery(req *http.Request) bool {
+	query := req.URL.Query()
+	for _, key := range []string{"X-Amz-Algorithm", "X-Amz-Credential", "X-Amz-Signature"} {
+		if query.Get(key) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func hasAWSHeader(req *http.Request) bool {
@@ -144,18 +154,16 @@ func looksLikeS3RESTRequest(req *http.Request, pathFallback bool) bool {
 
 func hasS3RequestHint(req *http.Request) bool {
 	query := req.URL.Query()
+	if query.Get("list-type") == "2" {
+		return true
+	}
 	for _, key := range []string{
 		"acl",
-		"continuation-token",
 		"delete",
-		"delimiter",
-		"list-type",
+		"lifecycle",
 		"location",
-		"max-keys",
-		"partNumber",
+		"notification",
 		"policy",
-		"prefix",
-		"start-after",
 		"tagging",
 		"uploadId",
 		"uploads",

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -101,7 +101,7 @@ func (s *Service) looksLikeAWSRequest(req *http.Request) bool {
 	if strings.Contains(host, "amazonaws.com") || hasKnownServiceLabel(host) {
 		return true
 	}
-	if hasKnownServicePath(req.URL.Path) {
+	if hasKnownServiceEndpointPath(req.URL.Path) {
 		return true
 	}
 	return looksLikeS3RESTRequest(req, s.s3PathFallback)
@@ -126,8 +126,11 @@ func hasAWSHeader(req *http.Request) bool {
 	return false
 }
 
-func hasKnownServicePath(pathValue string) bool {
-	first := firstPathSegment(pathValue)
+func hasKnownServiceEndpointPath(pathValue string) bool {
+	first, rest := splitFirstPathSegment(pathValue)
+	if rest != "" {
+		return false
+	}
 	switch first {
 	case "cloudformation", "dynamodb", "events", "iam", "kms", "lambda", "logs", "s3", "secretsmanager", "sns", "sqs", "ssm", "states", "sts":
 		return true
@@ -188,9 +191,15 @@ func hasKnownServiceLabel(host string) bool {
 }
 
 func firstPathSegment(pathValue string) string {
+	first, _ := splitFirstPathSegment(pathValue)
+	return first
+}
+
+func splitFirstPathSegment(pathValue string) (string, string) {
 	trimmed := strings.Trim(pathValue, "/")
 	if trimmed == "" {
-		return ""
+		return "", ""
 	}
-	return strings.ToLower(strings.Split(trimmed, "/")[0])
+	first, rest, _ := strings.Cut(trimmed, "/")
+	return strings.ToLower(first), rest
 }

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -29,7 +29,7 @@ type Service struct {
 func Register(router *corehttp.Router, options Options) {
 	service := New(options)
 	router.Get("/_inspector", service.handleInspector)
-	router.Any("*", service.handleAWS)
+	router.Fallback(service.handleAWS)
 }
 
 func New(options Options) *Service {

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -98,13 +98,29 @@ func looksLikeAWSRequest(req *http.Request) bool {
 	if strings.Contains(host, "amazonaws.com") || hasKnownServiceLabel(host) {
 		return true
 	}
-	return hasKnownServicePath(req.URL.Path)
+	if hasKnownServicePath(req.URL.Path) {
+		return true
+	}
+	return looksLikeS3RESTRequest(req)
 }
 
 func hasKnownServicePath(pathValue string) bool {
 	first := firstPathSegment(pathValue)
 	switch first {
 	case "cloudformation", "dynamodb", "events", "iam", "kms", "lambda", "logs", "s3", "secretsmanager", "sns", "sqs", "ssm", "states", "sts":
+		return true
+	default:
+		return false
+	}
+}
+
+func looksLikeS3RESTRequest(req *http.Request) bool {
+	first := firstPathSegment(req.URL.Path)
+	if strings.HasPrefix(first, "_") {
+		return false
+	}
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost, http.MethodDelete:
 		return true
 	default:
 		return false

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -1,0 +1,130 @@
+package aws
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/services/aws/auth"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+)
+
+type Options struct {
+	Store            *corestore.Store
+	DefaultAccountID string
+	DefaultRegion    string
+	AuthMode         auth.Mode
+	CredentialStore  *auth.Store
+}
+
+type Service struct {
+	store            Store
+	defaultAccountID string
+	defaultRegion    string
+	authMode         auth.Mode
+	credentialStore  *auth.Store
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	router.Get("/_inspector", service.handleInspector)
+	router.Any("*", service.handleAWS)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	defaultAccountID := options.DefaultAccountID
+	if defaultAccountID == "" {
+		defaultAccountID = gateway.DefaultAccountID
+	}
+	defaultRegion := options.DefaultRegion
+	if defaultRegion == "" {
+		defaultRegion = gateway.DefaultRegion
+	}
+	return &Service{
+		store:            NewStore(runtimeStore),
+		defaultAccountID: defaultAccountID,
+		defaultRegion:    defaultRegion,
+		authMode:         options.AuthMode,
+		credentialStore:  options.CredentialStore,
+	}
+}
+
+func (s *Service) handleAWS(c *corehttp.Context) {
+	if !looksLikeAWSRequest(c.Request) {
+		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+		return
+	}
+
+	rawBody, err := readRequestBody(c.Request)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, map[string]any{"message": "Failed to read request body"})
+		return
+	}
+
+	ctx, err := gateway.BuildContext(c.Request, rawBody, gateway.Options{
+		DefaultAccountID: s.defaultAccountID,
+		DefaultRegion:    s.defaultRegion,
+		AuthMode:         s.authMode,
+		CredentialStore:  s.credentialStore,
+	})
+	if err != nil {
+		s.writeParseError(c, err)
+		return
+	}
+	if ctx.Auth.Error != nil {
+		s.writeAWSError(c, ctx, awsAuthError(ctx))
+		return
+	}
+
+	s.writeAWSError(c, ctx, notImplementedError(ctx))
+}
+
+func looksLikeAWSRequest(req *http.Request) bool {
+	if req.URL.Query().Get("Action") != "" || req.URL.Query().Get("X-Amz-Algorithm") != "" {
+		return true
+	}
+	if req.Header.Get("X-Amz-Target") != "" || req.Header.Get("X-Amz-Date") != "" || req.Header.Get("X-Amz-Content-Sha256") != "" {
+		return true
+	}
+	if strings.HasPrefix(req.Header.Get("Authorization"), "AWS4-HMAC-SHA256") {
+		return true
+	}
+	host := strings.ToLower(req.Host)
+	if strings.Contains(host, "amazonaws.com") || hasKnownServiceLabel(host) {
+		return true
+	}
+	return hasKnownServicePath(req.URL.Path)
+}
+
+func hasKnownServicePath(pathValue string) bool {
+	first := firstPathSegment(pathValue)
+	switch first {
+	case "cloudformation", "dynamodb", "events", "iam", "kms", "lambda", "logs", "s3", "secretsmanager", "sns", "sqs", "ssm", "states", "sts":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasKnownServiceLabel(host string) bool {
+	label := strings.Split(strings.TrimSuffix(host, "."), ".")[0]
+	switch label {
+	case "cloudformation", "dynamodb", "events", "iam", "kms", "lambda", "logs", "s3", "secretsmanager", "sns", "sqs", "ssm", "states", "sts":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstPathSegment(pathValue string) string {
+	trimmed := strings.Trim(pathValue, "/")
+	if trimmed == "" {
+		return ""
+	}
+	return strings.ToLower(strings.Split(trimmed, "/")[0])
+}

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -128,6 +128,9 @@ func hasAWSHeader(req *http.Request) bool {
 
 func hasKnownServiceEndpointPath(pathValue string) bool {
 	first, rest := splitFirstPathSegment(pathValue)
+	if first == "s3" {
+		return true
+	}
 	if rest != "" {
 		return false
 	}

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -171,6 +171,32 @@ func TestServiceReturnsJSONRPCNotImplemented(t *testing.T) {
 	}
 }
 
+func TestServiceDoesNotTreatSignedNonS3ServicePathAsS3(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/lambda/2015-03-31/functions", nil)
+	signAWSRequest(req, "lambda")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/x-amz-json-1.0" {
+		t.Fatalf("content type = %q", got)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["__type"] != "com.amazonaws.lambda#NotImplemented" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+	if strings.Contains(res.Body.String(), "s3.GetObject") {
+		t.Fatalf("unexpected S3 fallback response: %s", res.Body.String())
+	}
+}
+
 func TestServicePassesThroughNonAWSNotFound(t *testing.T) {
 	handler := newTestHandler()
 	res := httptest.NewRecorder()

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -131,7 +131,7 @@ func TestServiceReturnsJSONRPCNotImplemented(t *testing.T) {
 func TestServicePassesThroughNonAWSNotFound(t *testing.T) {
 	handler := newTestHandler()
 	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, httptest.NewRequest(http.MethodTrace, "/missing", nil))
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/missing", nil))
 
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -54,6 +54,49 @@ func TestServiceReturnsUnsignedPathStyleS3NotImplemented(t *testing.T) {
 	}
 }
 
+func TestServiceReturnsUnsignedS3SubresourceNotImplemented(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		target     string
+		wantAction string
+	}{
+		{
+			name:       "bucket lifecycle",
+			method:     http.MethodGet,
+			target:     "http://127.0.0.1/photos?lifecycle",
+			wantAction: "s3.GetBucketLifecycleConfiguration",
+		},
+		{
+			name:       "bucket notification",
+			method:     http.MethodPut,
+			target:     "http://127.0.0.1/photos?notification",
+			wantAction: "s3.PutBucketNotificationConfiguration",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := newTestHandler()
+			req := httptest.NewRequest(test.method, test.target, nil)
+
+			res := httptest.NewRecorder()
+			handler.ServeHTTP(res, req)
+
+			if res.Code != http.StatusNotImplemented {
+				t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+			}
+			if got := res.Header().Get("Content-Type"); got != "application/xml" {
+				t.Fatalf("content type = %q", got)
+			}
+			body := res.Body.String()
+			if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, test.wantAction) {
+				t.Fatalf("unexpected body: %s", body)
+			}
+		})
+	}
+}
+
 func TestServiceReturnsQueryXMLNotImplemented(t *testing.T) {
 	handler := newTestHandler()
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
@@ -142,6 +185,35 @@ func TestServicePassesThroughNonAWSNotFound(t *testing.T) {
 	}
 	if body["message"] != "Not Found" {
 		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestServicePassesThroughGenericListQueryParams(t *testing.T) {
+	handler := newTestHandler()
+	for _, target := range []string{
+		"/users?continuation-token=abc",
+		"/users?delimiter=/",
+		"/users?list-type=1",
+		"/users?max-keys=10",
+		"/users?partNumber=1",
+		"/users?prefix=a",
+		"/users?start-after=a",
+	} {
+		t.Run(target, func(t *testing.T) {
+			res := httptest.NewRecorder()
+			handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, target, nil))
+
+			if res.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+			}
+			var body map[string]string
+			if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if body["message"] != "Not Found" {
+				t.Fatalf("unexpected body: %#v", body)
+			}
+		})
 	}
 }
 

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -214,6 +214,26 @@ func TestServicePassesThroughNonAWSNotFound(t *testing.T) {
 	}
 }
 
+func TestServicePassesThroughNestedKnownServicePathWithoutAWSHints(t *testing.T) {
+	handler := newTestHandler()
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/sqs/foo", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["message"] != "Not Found" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+	if strings.Contains(res.Body.String(), "s3.GetObject") {
+		t.Fatalf("unexpected S3 fallback response: %s", res.Body.String())
+	}
+}
+
 func TestServicePassesThroughGenericListQueryParams(t *testing.T) {
 	handler := newTestHandler()
 	for _, target := range []string{

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -1,0 +1,154 @@
+package aws
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+func TestServiceReturnsS3RESTXMLNotImplemented(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
+	signAWSRequest(req, "s3")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/xml" {
+		t.Fatalf("content type = %q", got)
+	}
+	if got := res.Header().Get("x-amz-request-id"); got == "" {
+		t.Fatal("missing x-amz-request-id")
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "s3.ListBuckets") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestServiceReturnsQueryXMLNotImplemented(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	signAWSRequest(req, "sqs")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/xml" {
+		t.Fatalf("content type = %q", got)
+	}
+	if got := res.Header().Get("x-amzn-requestid"); got == "" {
+		t.Fatal("missing x-amzn-requestid")
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "sqs.CreateQueue") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestServiceReturnsJSONRPCNotImplemented(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", strings.NewReader(`{"TableName":"items"}`))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+	signAWSRequest(req, "dynamodb")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/x-amz-json-1.0" {
+		t.Fatalf("content type = %q", got)
+	}
+	if got := res.Header().Get("x-amzn-errortype"); got != "NotImplementedException" {
+		t.Fatalf("error type = %q", got)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["__type"] != "com.amazonaws.dynamodb.v20120810#NotImplementedException" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+	if !strings.Contains(body["message"], "dynamodb.DescribeTable") {
+		t.Fatalf("unexpected message: %#v", body)
+	}
+}
+
+func TestServicePassesThroughNonAWSNotFound(t *testing.T) {
+	handler := newTestHandler()
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/missing", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["message"] != "Not Found" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestServiceRendersEmptyInspector(t *testing.T) {
+	handler := newTestHandler()
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/_inspector?tab=iam", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	body := res.Body.String()
+	for _, expected := range []string{"AWS Emulator", "S3", "SQS", "IAM", "IAM Users (0)", "IAM Roles (0)", "No users", "No roles"} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("inspector missing %q in %s", expected, body)
+		}
+	}
+}
+
+func TestNewStoreCreatesAWSCollections(t *testing.T) {
+	runtimeStore := corestore.New()
+	awsStore := NewStore(runtimeStore)
+
+	awsStore.S3Buckets.Insert(corestore.Record{"bucket_name": "photos"})
+	awsStore.SQSQueues.Insert(corestore.Record{"queue_name": "jobs", "queue_url": "http://localhost/sqs/jobs"})
+	awsStore.IAMUsers.Insert(corestore.Record{"user_name": "developer", "user_id": "AIDAEXAMPLE"})
+
+	snapshot := runtimeStore.Snapshot()
+	for _, name := range []string{"aws.s3_buckets", "aws.s3_objects", "aws.sqs_queues", "aws.sqs_messages", "aws.iam_users", "aws.iam_roles"} {
+		if _, ok := snapshot.Collections[name]; !ok {
+			t.Fatalf("missing collection %s", name)
+		}
+	}
+}
+
+func newTestHandler() http.Handler {
+	router := corehttp.NewRouter()
+	ui.RegisterAssetRoutes(router)
+	Register(router, Options{Store: corestore.New()})
+	router.NotFound(func(c *corehttp.Context) {
+		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+	})
+	return router
+}
+
+func signAWSRequest(req *http.Request, service string) {
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-east-1/"+service+"/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	req.Header.Set("X-Amz-Date", "20260519T000000Z")
+}

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -54,6 +54,25 @@ func TestServiceReturnsUnsignedPathStyleS3NotImplemented(t *testing.T) {
 	}
 }
 
+func TestServiceReturnsLegacyS3PathStyleNotImplementedInConservativeMode(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/s3/photos", nil)
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/xml" {
+		t.Fatalf("content type = %q", got)
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "s3.ListObjects") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
 func TestServiceReturnsUnsignedS3SubresourceNotImplemented(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -193,6 +212,31 @@ func TestServiceDoesNotTreatSignedNonS3ServicePathAsS3(t *testing.T) {
 		t.Fatalf("unexpected body: %#v", body)
 	}
 	if strings.Contains(res.Body.String(), "s3.GetObject") {
+		t.Fatalf("unexpected S3 fallback response: %s", res.Body.String())
+	}
+}
+
+func TestServiceDoesNotTreatKnownNonS3ServiceRootAsS3(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/lambda", nil)
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/x-amz-json-1.0" {
+		t.Fatalf("content type = %q", got)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["__type"] != "com.amazonaws.lambda#NotImplemented" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+	if strings.Contains(res.Body.String(), "s3.ListObjects") {
 		t.Fatalf("unexpected S3 fallback response: %s", res.Body.String())
 	}
 }

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -35,6 +35,25 @@ func TestServiceReturnsS3RESTXMLNotImplemented(t *testing.T) {
 	}
 }
 
+func TestServiceReturnsUnsignedPathStyleS3NotImplemented(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/photos?list-type=2", nil)
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/xml" {
+		t.Fatalf("content type = %q", got)
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "s3.ListObjectsV2") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
 func TestServiceReturnsQueryXMLNotImplemented(t *testing.T) {
 	handler := newTestHandler()
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
@@ -55,6 +74,26 @@ func TestServiceReturnsQueryXMLNotImplemented(t *testing.T) {
 	}
 	body := res.Body.String()
 	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "sqs.CreateQueue") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestServiceAcceptsBearerTokenForQueryShell(t *testing.T) {
+	handler := newTestHandler()
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/xml" {
+		t.Fatalf("content type = %q", got)
+	}
+	if body := res.Body.String(); !strings.Contains(body, "sqs.CreateQueue") {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }
@@ -92,7 +131,7 @@ func TestServiceReturnsJSONRPCNotImplemented(t *testing.T) {
 func TestServicePassesThroughNonAWSNotFound(t *testing.T) {
 	handler := newTestHandler()
 	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/missing", nil))
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodTrace, "/missing", nil))
 
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())

--- a/internal/services/aws/store.go
+++ b/internal/services/aws/store.go
@@ -1,0 +1,23 @@
+package aws
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	S3Buckets   *corestore.Collection
+	S3Objects   *corestore.Collection
+	SQSQueues   *corestore.Collection
+	SQSMessages *corestore.Collection
+	IAMUsers    *corestore.Collection
+	IAMRoles    *corestore.Collection
+}
+
+func NewStore(runtimeStore *corestore.Store) Store {
+	return Store{
+		S3Buckets:   runtimeStore.MustCollection("aws.s3_buckets", "bucket_name"),
+		S3Objects:   runtimeStore.MustCollection("aws.s3_objects", "key", "bucket_name"),
+		SQSQueues:   runtimeStore.MustCollection("aws.sqs_queues", "queue_name", "queue_url"),
+		SQSMessages: runtimeStore.MustCollection("aws.sqs_messages", "message_id", "queue_name"),
+		IAMUsers:    runtimeStore.MustCollection("aws.iam_users", "user_name", "user_id"),
+		IAMRoles:    runtimeStore.MustCollection("aws.iam_roles", "role_name", "role_id"),
+	}
+}


### PR DESCRIPTION
- Mounts the native AWS service through the Go runtime when the aws service is enabled.

- Adds protocol-shaped not-implemented responses for S3 REST XML, AWS Query, and JSON RPC requests.

- Adds an AWS inspector shell backed by shared UI helpers and empty native AWS store collections.