### PR TITLE
Add native Go S3 current parity

### DIFF
--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -66,6 +66,7 @@ func NewServer(options ServerOptions) *Server {
 		aws.Register(router, aws.Options{
 			Store:          runtimeStore,
 			S3PathFallback: len(services) == 1,
+			BaseURL:        options.BaseURL,
 		})
 	}
 	router.NotFound(func(c *corehttp.Context) {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -97,12 +97,12 @@ func TestNewHandlerAWSOnlyUsesS3PathFallback(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"aws"}})
 
 	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/photos", nil))
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/emulate-default", nil))
 
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "s3.ListObjects") {
+	if !strings.Contains(res.Body.String(), "<ListBucketResult>") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }
@@ -111,12 +111,12 @@ func TestNewHandlerMultiServiceKeepsLegacyS3Path(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"aws", "github"}})
 
 	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/s3/photos", nil))
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/s3/emulate-default", nil))
 
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "s3.ListObjects") {
+	if !strings.Contains(res.Body.String(), "<ListBucketResult>") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }

--- a/internal/services/aws/defaults.go
+++ b/internal/services/aws/defaults.go
@@ -1,0 +1,20 @@
+package aws
+
+import (
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func seedS3Defaults(store Store, region string) {
+	if len(store.S3Buckets.FindBy("bucket_name", "emulate-default")) > 0 {
+		return
+	}
+	store.S3Buckets.Insert(corestore.Record{
+		"bucket_name":        "emulate-default",
+		"region":             region,
+		"creation_date":      time.Now().UTC().Format(time.RFC3339Nano),
+		"acl":                "private",
+		"versioning_enabled": false,
+	})
+}

--- a/internal/services/aws/s3/handler.go
+++ b/internal/services/aws/s3/handler.go
@@ -158,22 +158,10 @@ func (h *Handler) listObjects(bucketName string, query map[string]string) protoc
 	if marker == "" {
 		marker = startAfter
 	}
-	if marker != "" {
-		start := len(filtered)
-		for index, object := range filtered {
-			if stringField(object, "key") > marker {
-				start = index
-				break
-			}
-		}
-		filtered = filtered[start:]
-	}
 
-	commonPrefixes := []string{}
-	contents := filtered
+	entries := make([]listEntry, 0, len(filtered))
 	if delimiter != "" {
 		prefixSet := map[string]struct{}{}
-		contents = []corestore.Record{}
 		for _, object := range filtered {
 			key := stringField(object, "key")
 			remaining := strings.TrimPrefix(key, prefix)
@@ -181,26 +169,52 @@ func (h *Handler) listObjects(bucketName string, query map[string]string) protoc
 				prefixSet[prefix+remaining[:index+len(delimiter)]] = struct{}{}
 				continue
 			}
-			contents = append(contents, object)
+			entries = append(entries, listEntry{kind: listEntryObject, key: key, object: object})
 		}
 		for prefixValue := range prefixSet {
-			commonPrefixes = append(commonPrefixes, prefixValue)
+			entries = append(entries, listEntry{kind: listEntryPrefix, key: prefixValue})
 		}
-		sort.Strings(commonPrefixes)
+	} else {
+		for _, object := range filtered {
+			entries = append(entries, listEntry{kind: listEntryObject, key: stringField(object, "key"), object: object})
+		}
+	}
+	sort.Slice(entries, func(i int, j int) bool {
+		return entries[i].key < entries[j].key
+	})
+
+	if marker != "" {
+		start := len(entries)
+		for index, entry := range entries {
+			if entry.key > marker {
+				start = index
+				break
+			}
+		}
+		entries = entries[start:]
 	}
 
-	truncated := len(contents) > maxKeys
-	page := contents
+	truncated := len(entries) > maxKeys
+	page := entries
 	if len(page) > maxKeys {
 		page = page[:maxKeys]
 	}
 	nextToken := ""
 	if truncated && len(page) > 0 {
-		nextToken = stringField(page[len(page)-1], "key")
+		nextToken = page[len(page)-1].key
 	}
 
 	var contentsXML strings.Builder
-	for _, object := range page {
+	var prefixesXML strings.Builder
+	for _, entry := range page {
+		if entry.kind == listEntryPrefix {
+			prefixesXML.WriteString(`  <CommonPrefixes><Prefix>`)
+			prefixesXML.WriteString(xmlEscape(entry.key))
+			prefixesXML.WriteString(`</Prefix></CommonPrefixes>
+`)
+			continue
+		}
+		object := entry.object
 		contentsXML.WriteString(`  <Contents>
     <Key>`)
 		contentsXML.WriteString(xmlEscape(stringField(object, "key")))
@@ -219,14 +233,6 @@ func (h *Handler) listObjects(bucketName string, query map[string]string) protoc
 `)
 	}
 
-	var prefixesXML strings.Builder
-	for _, prefixValue := range commonPrefixes {
-		prefixesXML.WriteString(`  <CommonPrefixes><Prefix>`)
-		prefixesXML.WriteString(xmlEscape(prefixValue))
-		prefixesXML.WriteString(`</Prefix></CommonPrefixes>
-`)
-	}
-
 	body := `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult>
   <Name>` + xmlEscape(bucketName) + `</Name>
@@ -238,6 +244,17 @@ func (h *Handler) listObjects(bucketName string, query map[string]string) protoc
 ` + strings.TrimRight(prefixesXML.String(), "\n") + `
 </ListBucketResult>`
 	return xmlResponse(http.StatusOK, body, nil)
+}
+
+const (
+	listEntryObject = "object"
+	listEntryPrefix = "prefix"
+)
+
+type listEntry struct {
+	kind   string
+	key    string
+	object corestore.Record
 }
 
 func (h *Handler) putObject(req *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
@@ -325,6 +342,9 @@ func (h *Handler) getObject(bucketName string, key string, head bool) protocols.
 }
 
 func (h *Handler) deleteObject(bucketName string, key string) protocols.ErrorResponse {
+	if _, ok := h.findBucket(bucketName); !ok {
+		return h.xmlError("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound, requestResource(bucketName, key))
+	}
 	if object, ok := h.findObject(bucketName, key); ok {
 		h.Objects.Delete(intField(object, "id"))
 		if assetID := stringField(object, "asset_id"); assetID != "" {
@@ -355,7 +375,7 @@ func (h *Handler) postObject(req *http.Request, ctx gateway.AwsRequestContext) p
 	if err != nil {
 		return h.xmlError("InvalidArgument", err.Error(), http.StatusBadRequest, requestResource(ctx.S3.Bucket, key))
 	}
-	if err := validatePolicy(firstFormValueAnyCase(form, "Policy"), form, int64(len(body))); err != nil {
+	if err := validatePolicy(firstFormValueAnyCase(form, "Policy"), form, ctx.S3.Bucket, int64(len(body))); err != nil {
 		return h.xmlError(err.code, err.message, err.status, requestResource(ctx.S3.Bucket, key))
 	}
 	contentType := firstFormValue(form, "Content-Type")
@@ -617,7 +637,7 @@ type policyError struct {
 	status  int
 }
 
-func validatePolicy(raw string, form *multipart.Form, size int64) *policyError {
+func validatePolicy(raw string, form *multipart.Form, bucketName string, size int64) *policyError {
 	if raw == "" {
 		return nil
 	}
@@ -642,39 +662,94 @@ func validatePolicy(raw string, form *multipart.Form, size int64) *policyError {
 		}
 	}
 	for _, condition := range policy.Conditions {
-		values, ok := condition.([]any)
-		if !ok || len(values) == 0 {
-			continue
-		}
-		operator, _ := values[0].(string)
-		switch operator {
-		case "content-length-range":
-			if len(values) < 3 {
-				continue
-			}
-			min, minOK := numberValue(values[1])
-			max, maxOK := numberValue(values[2])
-			if minOK && maxOK && (size < min || size > max) {
-				return &policyError{code: "EntityTooLarge", message: "Your proposed upload exceeds the maximum allowed size.", status: http.StatusBadRequest}
-			}
-		case "starts-with":
-			if len(values) < 3 {
-				continue
-			}
-			field, _ := values[1].(string)
-			prefix, _ := values[2].(string)
-			field = strings.TrimPrefix(field, "$")
-			value := firstFormValue(form, field)
-			if !strings.HasPrefix(value, prefix) {
-				return &policyError{
-					code:    "AccessDenied",
-					message: `Invalid according to Policy: Policy Condition failed: ["starts-with", "$` + field + `", "` + prefix + `"]`,
-					status:  http.StatusForbidden,
+		switch values := condition.(type) {
+		case map[string]any:
+			for field, expected := range values {
+				expectedValue, ok := stringValue(expected)
+				if !ok {
+					continue
 				}
+				if policyFieldValue(form, bucketName, field) != expectedValue {
+					return policyConditionFailed(condition)
+				}
+			}
+		case []any:
+			if err := validatePolicyArrayCondition(values, form, bucketName, size); err != nil {
+				return err
 			}
 		}
 	}
 	return nil
+}
+
+func validatePolicyArrayCondition(values []any, form *multipart.Form, bucketName string, size int64) *policyError {
+	if len(values) == 0 {
+		return nil
+	}
+	operator, _ := values[0].(string)
+	switch operator {
+	case "content-length-range":
+		if len(values) < 3 {
+			return nil
+		}
+		min, minOK := numberValue(values[1])
+		max, maxOK := numberValue(values[2])
+		if minOK && maxOK && (size < min || size > max) {
+			return &policyError{code: "EntityTooLarge", message: "Your proposed upload exceeds the maximum allowed size.", status: http.StatusBadRequest}
+		}
+	case "starts-with":
+		if len(values) < 3 {
+			return nil
+		}
+		field, _ := values[1].(string)
+		prefix, _ := values[2].(string)
+		value := policyFieldValue(form, bucketName, field)
+		if !strings.HasPrefix(value, prefix) {
+			return policyConditionFailed(values)
+		}
+	case "eq":
+		if len(values) < 3 {
+			return nil
+		}
+		field, _ := values[1].(string)
+		expected, ok := stringValue(values[2])
+		if !ok {
+			return nil
+		}
+		if policyFieldValue(form, bucketName, field) != expected {
+			return policyConditionFailed(values)
+		}
+	}
+	return nil
+}
+
+func policyFieldValue(form *multipart.Form, bucketName string, field string) string {
+	field = strings.TrimPrefix(field, "$")
+	if field == "bucket" {
+		return bucketName
+	}
+	return firstFormValueAnyCase(form, field)
+}
+
+func stringValue(value any) (string, bool) {
+	switch v := value.(type) {
+	case string:
+		return v, true
+	default:
+		return "", false
+	}
+}
+
+func policyConditionFailed(condition any) *policyError {
+	conditionText := fmt.Sprint(condition)
+	if raw, err := json.Marshal(condition); err == nil {
+		conditionText = string(raw)
+	}
+	return &policyError{
+		code:    "AccessDenied",
+		message: "Invalid according to Policy: Policy Condition failed: " + conditionText,
+		status:  http.StatusForbidden,
+	}
 }
 
 func numberValue(value any) (int64, bool) {

--- a/internal/services/aws/s3/handler.go
+++ b/internal/services/aws/s3/handler.go
@@ -1,0 +1,793 @@
+package s3
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	coreassets "github.com/vercel-labs/emulate/internal/core/assets"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	awsassets "github.com/vercel-labs/emulate/internal/services/aws/assets"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+)
+
+type Handler struct {
+	Buckets *corestore.Collection
+	Objects *corestore.Collection
+	Assets  *coreassets.Store
+	BaseURL string
+	Region  string
+	Now     func() time.Time
+}
+
+func (h *Handler) Handle(req *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	if ctx.S3 == nil {
+		return withRequestID(h.notImplemented(ctx), ctx.RequestID)
+	}
+	var response protocols.ErrorResponse
+	switch ctx.Action {
+	case "ListBuckets":
+		response = h.listBuckets()
+	case "CreateBucket":
+		response = h.createBucket(ctx.S3.Bucket)
+	case "DeleteBucket":
+		response = h.deleteBucket(ctx.S3.Bucket)
+	case "HeadBucket":
+		response = h.headBucket(ctx.S3.Bucket)
+	case "ListObjects", "ListObjectsV2":
+		response = h.listObjects(ctx.S3.Bucket, ctx.S3.Query)
+	case "PostObject":
+		response = h.postObject(req, ctx)
+	case "PutObject":
+		response = h.putObject(req, ctx)
+	case "CopyObject":
+		response = h.copyObject(ctx)
+	case "GetObject":
+		response = h.getObject(ctx.S3.Bucket, ctx.S3.Key, false)
+	case "HeadObject":
+		response = h.getObject(ctx.S3.Bucket, ctx.S3.Key, true)
+	case "DeleteObject":
+		response = h.deleteObject(ctx.S3.Bucket, ctx.S3.Key)
+	default:
+		response = h.notImplemented(ctx)
+	}
+	return withRequestID(response, ctx.RequestID)
+}
+
+func (h *Handler) listBuckets() protocols.ErrorResponse {
+	buckets := h.Buckets.All()
+	var rows strings.Builder
+	for _, bucket := range buckets {
+		rows.WriteString(`    <Bucket>
+      <Name>`)
+		rows.WriteString(xmlEscape(stringField(bucket, "bucket_name")))
+		rows.WriteString(`</Name>
+      <CreationDate>`)
+		rows.WriteString(xmlEscape(stringField(bucket, "creation_date")))
+		rows.WriteString(`</CreationDate>
+    </Bucket>
+`)
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult>
+  <Owner>
+    <ID>owner-id</ID>
+    <DisplayName>emulate</DisplayName>
+  </Owner>
+  <Buckets>
+` + strings.TrimRight(rows.String(), "\n") + `
+  </Buckets>
+</ListAllMyBucketsResult>`
+	return xmlResponse(http.StatusOK, body, nil)
+}
+
+func (h *Handler) createBucket(bucketName string) protocols.ErrorResponse {
+	if bucketName == "" {
+		return h.xmlError("InvalidBucketName", "The specified bucket is not valid.", http.StatusBadRequest, "")
+	}
+	if _, ok := h.findBucket(bucketName); ok {
+		return h.xmlError("BucketAlreadyOwnedByYou", "Your previous request to create the named bucket succeeded and you already own it.", http.StatusConflict, "/"+bucketName)
+	}
+	region := h.Region
+	if region == "" {
+		region = gateway.DefaultRegion
+	}
+	h.Buckets.Insert(corestore.Record{
+		"bucket_name":        bucketName,
+		"region":             region,
+		"creation_date":      h.now().Format(time.RFC3339Nano),
+		"acl":                "private",
+		"versioning_enabled": false,
+	})
+	return response(http.StatusOK, "", nil, map[string]string{"Location": "/" + bucketName})
+}
+
+func (h *Handler) deleteBucket(bucketName string) protocols.ErrorResponse {
+	bucket, ok := h.findBucket(bucketName)
+	if !ok {
+		return h.xmlError("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound, "/"+bucketName)
+	}
+	if len(h.Objects.FindBy("bucket_name", bucketName)) > 0 {
+		return h.xmlError("BucketNotEmpty", "The bucket you tried to delete is not empty.", http.StatusConflict, "/"+bucketName)
+	}
+	h.Buckets.Delete(intField(bucket, "id"))
+	return response(http.StatusNoContent, "", nil, nil)
+}
+
+func (h *Handler) headBucket(bucketName string) protocols.ErrorResponse {
+	bucket, ok := h.findBucket(bucketName)
+	if !ok {
+		return response(http.StatusNotFound, "", nil, nil)
+	}
+	return response(http.StatusOK, "", nil, map[string]string{"x-amz-bucket-region": stringField(bucket, "region")})
+}
+
+func (h *Handler) listObjects(bucketName string, query map[string]string) protocols.ErrorResponse {
+	if _, ok := h.findBucket(bucketName); !ok {
+		return h.xmlError("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound, "/"+bucketName)
+	}
+	prefix := query["prefix"]
+	delimiter := query["delimiter"]
+	maxKeys := parseMaxKeys(query["max-keys"])
+	continuationToken := query["continuation-token"]
+	startAfter := query["start-after"]
+
+	objects := h.Objects.FindBy("bucket_name", bucketName)
+	filtered := make([]corestore.Record, 0, len(objects))
+	for _, object := range objects {
+		if strings.HasPrefix(stringField(object, "key"), prefix) {
+			filtered = append(filtered, object)
+		}
+	}
+	sort.Slice(filtered, func(i int, j int) bool {
+		return stringField(filtered[i], "key") < stringField(filtered[j], "key")
+	})
+
+	marker := continuationToken
+	if marker == "" {
+		marker = startAfter
+	}
+	if marker != "" {
+		start := len(filtered)
+		for index, object := range filtered {
+			if stringField(object, "key") > marker {
+				start = index
+				break
+			}
+		}
+		filtered = filtered[start:]
+	}
+
+	commonPrefixes := []string{}
+	contents := filtered
+	if delimiter != "" {
+		prefixSet := map[string]struct{}{}
+		contents = []corestore.Record{}
+		for _, object := range filtered {
+			key := stringField(object, "key")
+			remaining := strings.TrimPrefix(key, prefix)
+			if index := strings.Index(remaining, delimiter); index >= 0 {
+				prefixSet[prefix+remaining[:index+len(delimiter)]] = struct{}{}
+				continue
+			}
+			contents = append(contents, object)
+		}
+		for prefixValue := range prefixSet {
+			commonPrefixes = append(commonPrefixes, prefixValue)
+		}
+		sort.Strings(commonPrefixes)
+	}
+
+	truncated := len(contents) > maxKeys
+	page := contents
+	if len(page) > maxKeys {
+		page = page[:maxKeys]
+	}
+	nextToken := ""
+	if truncated && len(page) > 0 {
+		nextToken = stringField(page[len(page)-1], "key")
+	}
+
+	var contentsXML strings.Builder
+	for _, object := range page {
+		contentsXML.WriteString(`  <Contents>
+    <Key>`)
+		contentsXML.WriteString(xmlEscape(stringField(object, "key")))
+		contentsXML.WriteString(`</Key>
+    <LastModified>`)
+		contentsXML.WriteString(xmlEscape(stringField(object, "last_modified")))
+		contentsXML.WriteString(`</LastModified>
+    <ETag>"`)
+		contentsXML.WriteString(xmlEscape(stringField(object, "etag")))
+		contentsXML.WriteString(`"</ETag>
+    <Size>`)
+		contentsXML.WriteString(strconv.FormatInt(int64Field(object, "content_length"), 10))
+		contentsXML.WriteString(`</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+`)
+	}
+
+	var prefixesXML strings.Builder
+	for _, prefixValue := range commonPrefixes {
+		prefixesXML.WriteString(`  <CommonPrefixes><Prefix>`)
+		prefixesXML.WriteString(xmlEscape(prefixValue))
+		prefixesXML.WriteString(`</Prefix></CommonPrefixes>
+`)
+	}
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Name>` + xmlEscape(bucketName) + `</Name>
+  <Prefix>` + xmlEscape(prefix) + `</Prefix>
+  <MaxKeys>` + strconv.Itoa(maxKeys) + `</MaxKeys>
+  <IsTruncated>` + strconv.FormatBool(truncated) + `</IsTruncated>
+  <KeyCount>` + strconv.Itoa(len(page)) + `</KeyCount>` + optionalElement("ContinuationToken", continuationToken) + optionalElement("NextContinuationToken", nextToken) + optionalElement("StartAfter", startAfter) + `
+` + strings.TrimRight(contentsXML.String(), "\n") + `
+` + strings.TrimRight(prefixesXML.String(), "\n") + `
+</ListBucketResult>`
+	return xmlResponse(http.StatusOK, body, nil)
+}
+
+func (h *Handler) putObject(req *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	if _, ok := h.findBucket(ctx.S3.Bucket); !ok {
+		return h.xmlError("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound, requestResource(ctx.S3.Bucket, ctx.S3.Key))
+	}
+	metadata := userMetadata(req)
+	contentType := req.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = coreassets.DefaultContentType
+	}
+	stored, err := h.storeObject(ctx.S3.Bucket, ctx.S3.Key, ctx.RawBody, contentType, metadata)
+	if err != nil {
+		return h.xmlError("InternalFailure", err.Error(), http.StatusInternalServerError, requestResource(ctx.S3.Bucket, ctx.S3.Key))
+	}
+	return response(http.StatusOK, "", nil, map[string]string{"ETag": quotedETag(stringField(stored, "etag"))})
+}
+
+func (h *Handler) copyObject(ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	if _, ok := h.findBucket(ctx.S3.Bucket); !ok {
+		return h.xmlError("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound, requestResource(ctx.S3.Bucket, ctx.S3.Key))
+	}
+	sourceBucket, sourceKey, ok := parseCopySource(ctx.S3.CopySource)
+	if !ok {
+		return h.xmlError("InvalidArgument", "Invalid copy source.", http.StatusBadRequest, requestResource(ctx.S3.Bucket, ctx.S3.Key))
+	}
+	source, ok := h.findObject(sourceBucket, sourceKey)
+	if !ok {
+		return h.xmlError("NoSuchKey", "The specified source key does not exist.", http.StatusNotFound, requestResource(sourceBucket, sourceKey))
+	}
+	body, _, ok := h.assetBytes(source)
+	if !ok {
+		return h.xmlError("NoSuchKey", "The specified source key does not exist.", http.StatusNotFound, requestResource(sourceBucket, sourceKey))
+	}
+	stored, err := h.storeObject(ctx.S3.Bucket, ctx.S3.Key, body, stringField(source, "content_type"), stringMapField(source, "metadata"))
+	if err != nil {
+		return h.xmlError("InternalFailure", err.Error(), http.StatusInternalServerError, requestResource(ctx.S3.Bucket, ctx.S3.Key))
+	}
+	lastModified := stringField(stored, "last_modified")
+	bodyXML := `<?xml version="1.0" encoding="UTF-8"?>
+<CopyObjectResult>
+  <ETag>"` + xmlEscape(stringField(stored, "etag")) + `"</ETag>
+  <LastModified>` + xmlEscape(lastModified) + `</LastModified>
+</CopyObjectResult>`
+	return xmlResponse(http.StatusOK, bodyXML, map[string]string{"Last-Modified": httpTime(lastModified)})
+}
+
+func (h *Handler) getObject(bucketName string, key string, head bool) protocols.ErrorResponse {
+	if _, ok := h.findBucket(bucketName); !ok {
+		if head {
+			return response(http.StatusNotFound, "", nil, nil)
+		}
+		return h.xmlError("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound, requestResource(bucketName, key))
+	}
+	object, ok := h.findObject(bucketName, key)
+	if !ok {
+		if head {
+			return response(http.StatusNotFound, "", nil, nil)
+		}
+		return h.xmlError("NoSuchKey", "The specified key does not exist.", http.StatusNotFound, requestResource(bucketName, key))
+	}
+	body, assetMetadata, ok := h.assetBytes(object)
+	if !ok {
+		if head {
+			return response(http.StatusNotFound, "", nil, nil)
+		}
+		return h.xmlError("NoSuchKey", "The specified key does not exist.", http.StatusNotFound, requestResource(bucketName, key))
+	}
+	headers := map[string]string{
+		"Content-Length": strconv.FormatInt(assetMetadata.ContentLength, 10),
+		"ETag":           quotedETag(stringField(object, "etag")),
+		"Last-Modified":  assetMetadata.LastModified.UTC().Format(http.TimeFormat),
+	}
+	contentType := stringField(object, "content_type")
+	if contentType != "" {
+		headers["Content-Type"] = contentType
+	}
+	for key, value := range stringMapField(object, "metadata") {
+		headers["x-amz-meta-"+key] = value
+	}
+	if head {
+		return response(http.StatusOK, "", nil, headers)
+	}
+	return response(http.StatusOK, contentType, body, headers)
+}
+
+func (h *Handler) deleteObject(bucketName string, key string) protocols.ErrorResponse {
+	if object, ok := h.findObject(bucketName, key); ok {
+		h.Objects.Delete(intField(object, "id"))
+		if assetID := stringField(object, "asset_id"); assetID != "" {
+			h.assets().Delete(assetID)
+		}
+	}
+	return response(http.StatusNoContent, "", nil, nil)
+}
+
+func (h *Handler) postObject(req *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	if _, ok := h.findBucket(ctx.S3.Bucket); !ok {
+		return h.xmlError("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound, requestResource(ctx.S3.Bucket, ""))
+	}
+	form, err := parseMultipartForm(req, ctx.RawBody)
+	if err != nil {
+		return h.xmlError("InvalidArgument", err.Error(), http.StatusBadRequest, requestResource(ctx.S3.Bucket, ""))
+	}
+	defer form.RemoveAll()
+	key := firstFormValue(form, "key")
+	if key == "" {
+		return h.xmlError("InvalidArgument", "Bucket POST must contain a field named 'key'.", http.StatusBadRequest, requestResource(ctx.S3.Bucket, ""))
+	}
+	fileHeader := firstFormFile(form, "file")
+	if fileHeader == nil {
+		return h.xmlError("InvalidArgument", "Bucket POST must contain a file field.", http.StatusBadRequest, requestResource(ctx.S3.Bucket, key))
+	}
+	body, err := readMultipartFile(fileHeader)
+	if err != nil {
+		return h.xmlError("InvalidArgument", err.Error(), http.StatusBadRequest, requestResource(ctx.S3.Bucket, key))
+	}
+	if err := validatePolicy(firstFormValueAnyCase(form, "Policy"), form, int64(len(body))); err != nil {
+		return h.xmlError(err.code, err.message, err.status, requestResource(ctx.S3.Bucket, key))
+	}
+	contentType := firstFormValue(form, "Content-Type")
+	if contentType == "" {
+		contentType = fileHeader.Header.Get("Content-Type")
+	}
+	if contentType == "" {
+		contentType = coreassets.DefaultContentType
+	}
+	stored, err := h.storeObject(ctx.S3.Bucket, key, body, contentType, nil)
+	if err != nil {
+		return h.xmlError("InternalFailure", err.Error(), http.StatusInternalServerError, requestResource(ctx.S3.Bucket, key))
+	}
+	if firstFormValue(form, "success_action_status") == "201" {
+		bodyXML := `<?xml version="1.0" encoding="UTF-8"?>
+<PostResponse>
+  <Location>` + xmlEscape(strings.TrimRight(h.baseURL(req), "/")+"/"+ctx.S3.Bucket+"/"+key) + `</Location>
+  <Bucket>` + xmlEscape(ctx.S3.Bucket) + `</Bucket>
+  <Key>` + xmlEscape(key) + `</Key>
+  <ETag>"` + xmlEscape(stringField(stored, "etag")) + `"</ETag>
+</PostResponse>`
+		return xmlResponse(http.StatusCreated, bodyXML, nil)
+	}
+	return response(http.StatusNoContent, "", nil, nil)
+}
+
+func (h *Handler) storeObject(bucketName string, key string, body []byte, contentType string, metadata map[string]string) (corestore.Record, error) {
+	now := h.now()
+	assetID := awsassets.S3ObjectID(bucketName, key)
+	assetMetadata, err := h.assets().PutBytes(assetID, body, coreassets.PutOptions{
+		Purpose:      awsassets.PurposeS3Object,
+		ContentType:  contentType,
+		LastModified: now,
+		UserMetadata: metadata,
+	})
+	if err != nil {
+		return nil, err
+	}
+	record := corestore.Record{
+		"bucket_name":    bucketName,
+		"key":            key,
+		"asset_id":       assetID,
+		"content_type":   assetMetadata.ContentType,
+		"content_length": assetMetadata.ContentLength,
+		"etag":           strings.Trim(assetMetadata.ETag, `"`),
+		"last_modified":  assetMetadata.LastModified.Format(time.RFC3339Nano),
+		"metadata":       stringMapRecord(metadata),
+	}
+	if existing, ok := h.findObject(bucketName, key); ok {
+		updated, _ := h.Objects.Update(intField(existing, "id"), record)
+		return updated, nil
+	}
+	return h.Objects.Insert(record), nil
+}
+
+func (h *Handler) findBucket(bucketName string) (corestore.Record, bool) {
+	for _, bucket := range h.Buckets.FindBy("bucket_name", bucketName) {
+		return bucket, true
+	}
+	return nil, false
+}
+
+func (h *Handler) findObject(bucketName string, key string) (corestore.Record, bool) {
+	for _, object := range h.Objects.FindBy("bucket_name", bucketName) {
+		if stringField(object, "key") == key {
+			return object, true
+		}
+	}
+	return nil, false
+}
+
+func (h *Handler) assetBytes(object corestore.Record) ([]byte, coreassets.Metadata, bool) {
+	assetID := stringField(object, "asset_id")
+	if assetID == "" {
+		return nil, coreassets.Metadata{}, false
+	}
+	return h.assets().Bytes(assetID)
+}
+
+func (h *Handler) xmlError(code string, message string, status int, resource string) protocols.ErrorResponse {
+	return protocols.SerializeRESTXMLError(protocols.AWSError{
+		Code:       code,
+		Message:    message,
+		Resource:   resource,
+		RequestID:  gateway.NewRequestID(),
+		StatusCode: status,
+	})
+}
+
+func (h *Handler) notImplemented(ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	message := "AWS operation is not implemented in the native Go runtime yet."
+	if ctx.Service != "" && ctx.Action != "" {
+		message = fmt.Sprintf("%s.%s is not implemented in the native Go runtime yet.", ctx.Service, ctx.Action)
+	}
+	bucket := ""
+	key := ""
+	if ctx.S3 != nil {
+		bucket = ctx.S3.Bucket
+		key = ctx.S3.Key
+	}
+	return h.xmlError("NotImplemented", message, http.StatusNotImplemented, requestResource(bucket, key))
+}
+
+func (h *Handler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (h *Handler) baseURL(req *http.Request) string {
+	if h.BaseURL != "" {
+		return h.BaseURL
+	}
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + req.Host
+}
+
+func response(status int, contentType string, body []byte, headers map[string]string) protocols.ErrorResponse {
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	return protocols.ErrorResponse{
+		StatusCode:  status,
+		ContentType: contentType,
+		Headers:     headers,
+		Body:        body,
+	}
+}
+
+func xmlResponse(status int, body string, headers map[string]string) protocols.ErrorResponse {
+	return response(status, "application/xml", []byte(body), headers)
+}
+
+func withRequestID(response protocols.ErrorResponse, requestID string) protocols.ErrorResponse {
+	if requestID == "" {
+		return response
+	}
+	if response.Headers == nil {
+		response.Headers = map[string]string{}
+	}
+	if response.Headers["x-amz-request-id"] == "" {
+		response.Headers["x-amz-request-id"] = requestID
+	}
+	return response
+}
+
+func parseMaxKeys(raw string) int {
+	if raw == "" {
+		return 1000
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return 1000
+	}
+	if value > 1000 {
+		return 1000
+	}
+	return value
+}
+
+func optionalElement(name string, value string) string {
+	if value == "" {
+		return ""
+	}
+	return "\n  <" + name + ">" + xmlEscape(value) + "</" + name + ">"
+}
+
+func parseCopySource(value string) (string, string, bool) {
+	value = strings.TrimPrefix(value, "/")
+	if unescaped, err := url.PathUnescape(value); err == nil {
+		value = unescaped
+	}
+	bucket, key, ok := strings.Cut(value, "/")
+	return bucket, key, ok && bucket != "" && key != ""
+}
+
+func userMetadata(req *http.Request) map[string]string {
+	metadata := map[string]string{}
+	for name, values := range req.Header {
+		lower := strings.ToLower(name)
+		if !strings.HasPrefix(lower, "x-amz-meta-") || len(values) == 0 {
+			continue
+		}
+		metadata[lower[len("x-amz-meta-"):]] = values[0]
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func (h *Handler) assets() *coreassets.Store {
+	if h.Assets == nil {
+		h.Assets = coreassets.New()
+	}
+	return h.Assets
+}
+
+func parseMultipartForm(req *http.Request, body []byte) (*multipart.Form, error) {
+	contentType := req.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil || !strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+		return nil, fmt.Errorf("Bucket POST must use multipart form data.")
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil, fmt.Errorf("Bucket POST multipart form is missing a boundary.")
+	}
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	form, err := reader.ReadForm(32 << 20)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid multipart form: %v", err)
+	}
+	return form, nil
+}
+
+func firstFormValue(form *multipart.Form, key string) string {
+	if values := form.Value[key]; len(values) > 0 {
+		return values[0]
+	}
+	return ""
+}
+
+func firstFormValueAnyCase(form *multipart.Form, key string) string {
+	if value := firstFormValue(form, key); value != "" {
+		return value
+	}
+	for candidate, values := range form.Value {
+		if strings.EqualFold(candidate, key) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func firstFormFile(form *multipart.Form, key string) *multipart.FileHeader {
+	if values := form.File[key]; len(values) > 0 {
+		return values[0]
+	}
+	return nil
+}
+
+func readMultipartFile(header *multipart.FileHeader) ([]byte, error) {
+	file, err := header.Open()
+	if err != nil {
+		return nil, fmt.Errorf("read file field: %w", err)
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}
+
+type policyError struct {
+	code    string
+	message string
+	status  int
+}
+
+func validatePolicy(raw string, form *multipart.Form, size int64) *policyError {
+	if raw == "" {
+		return nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		decoded, err = base64.RawStdEncoding.DecodeString(raw)
+	}
+	if err != nil {
+		return &policyError{code: "InvalidPolicyDocument", message: "Invalid Policy: Invalid base64.", status: http.StatusBadRequest}
+	}
+	var policy struct {
+		Expiration string `json:"expiration"`
+		Conditions []any  `json:"conditions"`
+	}
+	if err := json.Unmarshal(decoded, &policy); err != nil {
+		return &policyError{code: "InvalidPolicyDocument", message: "Invalid Policy: Invalid JSON.", status: http.StatusBadRequest}
+	}
+	if policy.Expiration != "" {
+		expires, err := time.Parse(time.RFC3339, policy.Expiration)
+		if err == nil && expires.Before(time.Now()) {
+			return &policyError{code: "AccessDenied", message: "Invalid according to Policy: Policy expired.", status: http.StatusForbidden}
+		}
+	}
+	for _, condition := range policy.Conditions {
+		values, ok := condition.([]any)
+		if !ok || len(values) == 0 {
+			continue
+		}
+		operator, _ := values[0].(string)
+		switch operator {
+		case "content-length-range":
+			if len(values) < 3 {
+				continue
+			}
+			min, minOK := numberValue(values[1])
+			max, maxOK := numberValue(values[2])
+			if minOK && maxOK && (size < min || size > max) {
+				return &policyError{code: "EntityTooLarge", message: "Your proposed upload exceeds the maximum allowed size.", status: http.StatusBadRequest}
+			}
+		case "starts-with":
+			if len(values) < 3 {
+				continue
+			}
+			field, _ := values[1].(string)
+			prefix, _ := values[2].(string)
+			field = strings.TrimPrefix(field, "$")
+			value := firstFormValue(form, field)
+			if !strings.HasPrefix(value, prefix) {
+				return &policyError{
+					code:    "AccessDenied",
+					message: `Invalid according to Policy: Policy Condition failed: ["starts-with", "$` + field + `", "` + prefix + `"]`,
+					status:  http.StatusForbidden,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func numberValue(value any) (int64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int64(v), true
+	case json.Number:
+		n, err := v.Int64()
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func stringField(record corestore.Record, name string) string {
+	switch value := record[name].(type) {
+	case string:
+		return value
+	default:
+		if value == nil {
+			return ""
+		}
+		return fmt.Sprint(value)
+	}
+}
+
+func intField(record corestore.Record, name string) int {
+	switch value := record[name].(type) {
+	case int:
+		return value
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func int64Field(record corestore.Record, name string) int64 {
+	switch value := record[name].(type) {
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	case float64:
+		return int64(value)
+	default:
+		return 0
+	}
+}
+
+func stringMapRecord(values map[string]string) corestore.Record {
+	if len(values) == 0 {
+		return corestore.Record{}
+	}
+	record := corestore.Record{}
+	for key, value := range values {
+		record[key] = value
+	}
+	return record
+}
+
+func stringMapField(record corestore.Record, name string) map[string]string {
+	out := map[string]string{}
+	switch values := record[name].(type) {
+	case corestore.Record:
+		for key, value := range values {
+			out[key] = fmt.Sprint(value)
+		}
+	case map[string]any:
+		for key, value := range values {
+			out[key] = fmt.Sprint(value)
+		}
+	case map[string]string:
+		for key, value := range values {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func quotedETag(value string) string {
+	value = strings.Trim(value, `"`)
+	return `"` + value + `"`
+}
+
+func httpTime(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return ""
+	}
+	return parsed.UTC().Format(http.TimeFormat)
+}
+
+func requestResource(bucket string, key string) string {
+	if bucket == "" {
+		return "/"
+	}
+	if key == "" {
+		return "/" + bucket
+	}
+	return "/" + bucket + "/" + key
+}
+
+func xmlEscape(value string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&apos;",
+	)
+	return replacer.Replace(value)
+}

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -4,10 +4,13 @@ import (
 	"net/http"
 	"strings"
 
+	coreassets "github.com/vercel-labs/emulate/internal/core/assets"
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
 	corestore "github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/services/aws/auth"
 	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+	awss3 "github.com/vercel-labs/emulate/internal/services/aws/s3"
 )
 
 type Options struct {
@@ -17,15 +20,19 @@ type Options struct {
 	AuthMode         auth.Mode
 	CredentialStore  *auth.Store
 	S3PathFallback   bool
+	AssetStore       *coreassets.Store
+	BaseURL          string
 }
 
 type Service struct {
 	store            Store
+	assets           *coreassets.Store
 	defaultAccountID string
 	defaultRegion    string
 	authMode         auth.Mode
 	credentialStore  *auth.Store
 	s3PathFallback   bool
+	s3               awss3.Handler
 }
 
 func Register(router *corehttp.Router, options Options) {
@@ -47,13 +54,27 @@ func New(options Options) *Service {
 	if defaultRegion == "" {
 		defaultRegion = gateway.DefaultRegion
 	}
+	assetStore := options.AssetStore
+	if assetStore == nil {
+		assetStore = coreassets.New()
+	}
+	awsStore := NewStore(runtimeStore)
+	seedS3Defaults(awsStore, defaultRegion)
 	return &Service{
-		store:            NewStore(runtimeStore),
+		store:            awsStore,
+		assets:           assetStore,
 		defaultAccountID: defaultAccountID,
 		defaultRegion:    defaultRegion,
 		authMode:         options.AuthMode,
 		credentialStore:  options.CredentialStore,
 		s3PathFallback:   options.S3PathFallback,
+		s3: awss3.Handler{
+			Buckets: awsStore.S3Buckets,
+			Objects: awsStore.S3Objects,
+			Assets:  assetStore,
+			BaseURL: options.BaseURL,
+			Region:  defaultRegion,
+		},
 	}
 }
 
@@ -81,6 +102,11 @@ func (s *Service) handleAWS(c *corehttp.Context) {
 	}
 	if ctx.Auth.Error != nil {
 		s.writeAWSError(c, ctx, awsAuthError(ctx))
+		return
+	}
+
+	if ctx.Service == "s3" && ctx.Protocol == protocols.ProtocolRESTXML {
+		writeErrorResponse(c, s.s3.Handle(c.Request, ctx))
 		return
 	}
 

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,15 +13,11 @@ import (
 	"github.com/vercel-labs/emulate/internal/core/ui"
 )
 
-func TestServiceReturnsS3RESTXMLNotImplemented(t *testing.T) {
+func TestServiceHandlesS3ListBuckets(t *testing.T) {
 	handler := newTestHandler()
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
-	signAWSRequest(req, "s3")
+	res := executeAWSRequest(handler, http.MethodGet, "http://127.0.0.1/", nil, "s3", nil)
 
-	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, req)
-
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	if got := res.Header().Get("Content-Type"); got != "application/xml" {
@@ -30,46 +27,159 @@ func TestServiceReturnsS3RESTXMLNotImplemented(t *testing.T) {
 		t.Fatal("missing x-amz-request-id")
 	}
 	body := res.Body.String()
-	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "s3.ListBuckets") {
+	if !strings.Contains(body, "<ListAllMyBucketsResult>") || !strings.Contains(body, "<Name>emulate-default</Name>") {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }
 
-func TestServiceReturnsUnsignedPathStyleS3NotImplemented(t *testing.T) {
+func TestServiceHandlesUnsignedPathStyleS3ListObjects(t *testing.T) {
 	handler := newTestHandler()
 	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/photos?list-type=2", nil)
 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	if got := res.Header().Get("Content-Type"); got != "application/xml" {
 		t.Fatalf("content type = %q", got)
 	}
 	body := res.Body.String()
-	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "s3.ListObjectsV2") {
+	if !strings.Contains(body, "<Code>NoSuchBucket</Code>") {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }
 
-func TestServiceReturnsLegacyS3PathStyleNotImplementedInConservativeMode(t *testing.T) {
+func TestServiceHandlesLegacyS3PathStyleInConservativeMode(t *testing.T) {
 	handler := newTestHandler()
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/s3/photos", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/s3/emulate-default", nil)
 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	if got := res.Header().Get("Content-Type"); got != "application/xml" {
 		t.Fatalf("content type = %q", got)
 	}
 	body := res.Body.String()
-	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "s3.ListObjects") {
+	if !strings.Contains(body, "<ListBucketResult>") || !strings.Contains(body, "<Name>emulate-default</Name>") {
 		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestServiceHandlesS3BucketLifecycle(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSRequest(handler, http.MethodPut, "http://127.0.0.1/photos", nil, "s3", nil)
+	if res.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Location"); got != "/photos" {
+		t.Fatalf("location = %q", got)
+	}
+
+	res = executeAWSRequest(handler, http.MethodHead, "http://127.0.0.1/photos", nil, "s3", nil)
+	if res.Code != http.StatusOK {
+		t.Fatalf("head status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("x-amz-bucket-region"); got != "us-east-1" {
+		t.Fatalf("bucket region = %q", got)
+	}
+
+	res = executeAWSRequest(handler, http.MethodDelete, "http://127.0.0.1/photos", nil, "s3", nil)
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSRequest(handler, http.MethodHead, "http://127.0.0.1/photos", nil, "s3", nil)
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("missing head status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestServiceHandlesS3ObjectLifecycleWithBinaryBodyAndMetadata(t *testing.T) {
+	handler := newTestHandler()
+	body := []byte{0, 1, 2, 3, 255, 'o', 'k'}
+
+	res := executeAWSRequest(handler, http.MethodPut, "http://127.0.0.1/emulate-default/docs/data.bin", body, "s3", map[string]string{
+		"Content-Type":      "application/octet-stream",
+		"x-amz-meta-origin": "native-test",
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("put status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("ETag"); got == "" || !strings.HasPrefix(got, `"`) {
+		t.Fatalf("etag = %q", got)
+	}
+
+	res = executeAWSRequest(handler, http.MethodGet, "http://127.0.0.1/emulate-default/docs/data.bin", nil, "s3", nil)
+	if res.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !bytes.Equal(res.Body.Bytes(), body) {
+		t.Fatalf("body = %v, want %v", res.Body.Bytes(), body)
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("content type = %q", got)
+	}
+	if got := res.Header().Get("x-amz-meta-origin"); got != "native-test" {
+		t.Fatalf("metadata = %q", got)
+	}
+
+	res = executeAWSRequest(handler, http.MethodHead, "http://127.0.0.1/emulate-default/docs/data.bin", nil, "s3", nil)
+	if res.Code != http.StatusOK {
+		t.Fatalf("head status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Body.Len() != 0 {
+		t.Fatalf("head body length = %d", res.Body.Len())
+	}
+	if got := res.Header().Get("Content-Length"); got != "7" {
+		t.Fatalf("content length = %q", got)
+	}
+
+	res = executeAWSRequest(handler, http.MethodDelete, "http://127.0.0.1/emulate-default/docs/data.bin", nil, "s3", nil)
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSRequest(handler, http.MethodGet, "http://127.0.0.1/emulate-default/docs/data.bin", nil, "s3", nil)
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("missing get status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "<Code>NoSuchKey</Code>") {
+		t.Fatalf("unexpected missing body: %s", res.Body.String())
+	}
+}
+
+func TestServiceHandlesS3CopyObject(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSRequest(handler, http.MethodPut, "http://127.0.0.1/emulate-default/docs/source.txt", []byte("copy me"), "s3", map[string]string{
+		"Content-Type": "text/plain",
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("put status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSRequest(handler, http.MethodPut, "http://127.0.0.1/emulate-default/docs/copy.txt", nil, "s3", map[string]string{
+		"x-amz-copy-source": "/emulate-default/docs/source.txt",
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("copy status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "<CopyObjectResult>") {
+		t.Fatalf("unexpected copy body: %s", res.Body.String())
+	}
+
+	res = executeAWSRequest(handler, http.MethodGet, "http://127.0.0.1/emulate-default/docs/copy.txt", nil, "s3", nil)
+	if res.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Body.String(); got != "copy me" {
+		t.Fatalf("body = %q", got)
 	}
 }
 
@@ -347,6 +457,25 @@ func newTestHandler() http.Handler {
 		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
 	})
 	return router
+}
+
+func executeAWSRequest(handler http.Handler, method string, target string, body []byte, service string, headers map[string]string) *httptest.ResponseRecorder {
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		reader = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, target, reader)
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	if service != "" {
+		signAWSRequest(req, service)
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
 }
 
 func signAWSRequest(req *http.Request, service string) {

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -2,11 +2,14 @@ package aws
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
 	corestore "github.com/vercel-labs/emulate/internal/core/store"
@@ -180,6 +183,94 @@ func TestServiceHandlesS3CopyObject(t *testing.T) {
 	}
 	if got := res.Body.String(); got != "copy me" {
 		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestServicePaginatesS3CommonPrefixes(t *testing.T) {
+	handler := newTestHandler()
+	for _, key := range []string{"a/file.txt", "b/file.txt", "c.txt"} {
+		res := executeAWSRequest(handler, http.MethodPut, "http://127.0.0.1/emulate-default/"+key, []byte(key), "s3", nil)
+		if res.Code != http.StatusOK {
+			t.Fatalf("put %s status = %d, body = %s", key, res.Code, res.Body.String())
+		}
+	}
+
+	page1 := executeAWSRequest(handler, http.MethodGet, "http://127.0.0.1/emulate-default?list-type=2&delimiter=/&max-keys=1", nil, "s3", nil)
+	if page1.Code != http.StatusOK {
+		t.Fatalf("page1 status = %d, body = %s", page1.Code, page1.Body.String())
+	}
+	body := page1.Body.String()
+	for _, expected := range []string{"<IsTruncated>true</IsTruncated>", "<KeyCount>1</KeyCount>", "<Prefix>a/</Prefix>", "<NextContinuationToken>a/</NextContinuationToken>"} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("page1 missing %q in %s", expected, body)
+		}
+	}
+	if strings.Contains(body, "<Prefix>b/</Prefix>") || strings.Contains(body, "<Key>c.txt</Key>") {
+		t.Fatalf("page1 contains entries beyond max-keys: %s", body)
+	}
+
+	page2 := executeAWSRequest(handler, http.MethodGet, "http://127.0.0.1/emulate-default?list-type=2&delimiter=/&max-keys=1&continuation-token=a%2F", nil, "s3", nil)
+	if page2.Code != http.StatusOK {
+		t.Fatalf("page2 status = %d, body = %s", page2.Code, page2.Body.String())
+	}
+	body = page2.Body.String()
+	if !strings.Contains(body, "<Prefix>b/</Prefix>") || strings.Contains(body, "<Prefix>a/</Prefix>") {
+		t.Fatalf("unexpected page2 body: %s", body)
+	}
+}
+
+func TestServiceRejectsS3PostObjectWhenPolicyExactMatchFails(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []any
+	}{
+		{
+			name: "object condition",
+			conditions: []any{
+				map[string]string{"bucket": "emulate-default"},
+				map[string]string{"key": "locked.txt"},
+			},
+		},
+		{
+			name: "eq condition",
+			conditions: []any{
+				[]any{"eq", "$key", "locked-eq.txt"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := newTestHandler()
+			res := executeS3MultipartPost(t, handler, "http://127.0.0.1/emulate-default", map[string]string{
+				"key":    "tampered.txt",
+				"Policy": encodePostPolicy(t, test.conditions),
+			}, []byte("tampered"))
+
+			if res.Code != http.StatusForbidden {
+				t.Fatalf("post status = %d, body = %s", res.Code, res.Body.String())
+			}
+			if !strings.Contains(res.Body.String(), "<Code>AccessDenied</Code>") {
+				t.Fatalf("unexpected body: %s", res.Body.String())
+			}
+
+			res = executeAWSRequest(handler, http.MethodGet, "http://127.0.0.1/emulate-default/tampered.txt", nil, "s3", nil)
+			if res.Code != http.StatusNotFound {
+				t.Fatalf("tampered object status = %d, body = %s", res.Code, res.Body.String())
+			}
+		})
+	}
+}
+
+func TestServiceReturnsNoSuchBucketForDeleteObjectInMissingBucket(t *testing.T) {
+	handler := newTestHandler()
+	res := executeAWSRequest(handler, http.MethodDelete, "http://127.0.0.1/missing/docs/data.bin", nil, "s3", nil)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "<Code>NoSuchBucket</Code>") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }
 
@@ -476,6 +567,42 @@ func executeAWSRequest(handler http.Handler, method string, target string, body 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 	return res
+}
+
+func executeS3MultipartPost(t *testing.T, handler http.Handler, target string, fields map[string]string, fileBody []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for key, value := range fields {
+		if err := writer.WriteField(key, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	part, err := writer.CreateFormFile("file", "upload.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write(fileBody); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return executeAWSRequest(handler, http.MethodPost, target, body.Bytes(), "s3", map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	})
+}
+
+func encodePostPolicy(t *testing.T, conditions []any) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"expiration": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		"conditions": conditions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
 }
 
 func signAWSRequest(req *http.Request, service string) {


### PR DESCRIPTION
- Implements S3 bucket and object operations in the native AWS service with binary-safe asset storage.

- Supports list pagination, copy object, metadata, ETags, last-modified headers, and presigned POST uploads.

- Extends Go service and runtime tests and validates against the AWS SDK v3 S3 E2E suite.