### PR TITLE
Add native Go SQS current parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,22 @@ jobs:
 
       - run: go build ./cmd/emulate
 
+      - name: Native SQS SDK E2E
+        run: |
+          go build -o /tmp/emulate-native ./cmd/emulate
+          /tmp/emulate-native start --service aws --port 4017 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+          for attempt in {1..50}; do
+            if curl -fsS http://127.0.0.1:4017/_emulate/health >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 0.2
+          done
+          test "${ready:-}" = "1"
+          AWS_EMULATOR_E2E_URL=http://127.0.0.1:4017 pnpm --dir packages/@emulators/aws exec vitest run src/__tests__/aws-sdk.e2e.test.ts -t sqs
+
       - run: node scripts/sync-versions.mjs --check
 
       - run: pnpm format:check

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 
 ## AWS
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. Query and REST XML operations return AWS-compatible XML. The native Go runtime also accepts current AWS SDK JSON requests for SQS and returns JSON responses.
 
 ### S3
 
@@ -675,7 +675,7 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 - `DELETE /:bucket/:key` - delete object
 
 ### SQS
-Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
+Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. In the native Go runtime, `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
 
 - `CreateQueue`, `ListQueues`, `GetQueueUrl`, `GetQueueAttributes`
 - `SendMessage`, `ReceiveMessage`, `DeleteMessage`

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 
 ## AWS
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/IAM/STS endpoints. All responses use AWS-compatible XML.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
 
 ### S3
 
@@ -675,7 +675,8 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 - `DELETE /:bucket/:key` - delete object
 
 ### SQS
-All operations via `POST /sqs/` with `Action` parameter:
+Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
+
 - `CreateQueue`, `ListQueues`, `GetQueueUrl`, `GetQueueAttributes`
 - `SendMessage`, `ReceiveMessage`, `DeleteMessage`
 - `PurgeQueue`, `DeleteQueue`

--- a/apps/web/app/docs/aws/page.mdx
+++ b/apps/web/app/docs/aws/page.mdx
@@ -1,6 +1,6 @@
 # AWS
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. All state is in-memory. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime also accepts current AWS SDK JSON requests for SQS and returns JSON responses.
 
 ## S3
 
@@ -20,7 +20,7 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 
 ## SQS
 
-Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
+Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. In the native Go runtime, `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
 
 - `CreateQueue` - create queue (with optional attributes like `VisibilityTimeout`)
 - `ListQueues` - list queues (supports `QueueNamePrefix` filter)

--- a/apps/web/app/docs/aws/page.mdx
+++ b/apps/web/app/docs/aws/page.mdx
@@ -1,6 +1,6 @@
 # AWS
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/IAM/STS endpoints. All state is in-memory, and responses use AWS-compatible XML.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. All state is in-memory. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
 
 ## S3
 
@@ -20,7 +20,7 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 
 ## SQS
 
-All SQS operations use `POST /sqs/` with an `Action` form parameter.
+Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
 
 - `CreateQueue` - create queue (with optional attributes like `VisibilityTimeout`)
 - `ListQueues` - list queues (supports `QueueNamePrefix` filter)

--- a/internal/core/store/store.go
+++ b/internal/core/store/store.go
@@ -240,6 +240,37 @@ func (c *Collection) Update(id int, patch Record) (Record, bool) {
 	return cloneRecord(updated), true
 }
 
+func (c *Collection) UpdateFunc(id int, fn func(Record) (Record, bool)) (Record, bool) {
+	if fn == nil {
+		return nil, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	existing, ok := c.items[id]
+	if !ok {
+		return nil, false
+	}
+	patch, ok := fn(cloneRecord(existing))
+	if !ok {
+		return nil, false
+	}
+	c.removeFromIndexes(existing)
+
+	updated := cloneRecord(existing)
+	for key, value := range patch {
+		if key == "id" {
+			continue
+		}
+		updated[key] = cloneValue(value)
+	}
+	updated["updated_at"] = timestamp()
+	c.items[id] = updated
+	c.addToIndexes(updated)
+	return cloneRecord(updated), true
+}
+
 func (c *Collection) Delete(id int) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/core/store/store_test.go
+++ b/internal/core/store/store_test.go
@@ -134,3 +134,35 @@ func TestCollectionRejectsMismatchedIndexes(t *testing.T) {
 		t.Fatal("expected mismatched index error")
 	}
 }
+
+func TestCollectionUpdateFuncCanRejectStaleRecord(t *testing.T) {
+	store := New()
+	tasks := store.MustCollection("tasks", "status")
+	task := tasks.Insert(Record{"status": "ready", "attempts": 0})
+
+	updated, ok := tasks.UpdateFunc(task["id"].(int), func(current Record) (Record, bool) {
+		if current["status"] != "ready" {
+			return nil, false
+		}
+		return Record{"status": "locked", "attempts": current["attempts"].(int) + 1}, true
+	})
+	if !ok || updated["status"] != "locked" || updated["attempts"] != 1 {
+		t.Fatalf("unexpected update: %#v %v", updated, ok)
+	}
+
+	rejected, ok := tasks.UpdateFunc(task["id"].(int), func(current Record) (Record, bool) {
+		if current["status"] != "ready" {
+			return nil, false
+		}
+		return Record{"status": "locked"}, true
+	})
+	if ok || rejected != nil {
+		t.Fatalf("stale update succeeded: %#v %v", rejected, ok)
+	}
+	if ready := tasks.FindBy("status", "ready"); len(ready) != 0 {
+		t.Fatalf("old index entry remained: %#v", ready)
+	}
+	if locked := tasks.FindBy("status", "locked"); len(locked) != 1 {
+		t.Fatalf("locked index missing record: %#v", locked)
+	}
+}

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -67,10 +67,10 @@ func TestNewHandlerMountsAWSInConservativeModeByDefault(t *testing.T) {
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "sqs.CreateQueue") {
+	if !strings.Contains(res.Body.String(), "<CreateQueueResponse>") || !strings.Contains(res.Body.String(), "jobs") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }
@@ -85,10 +85,10 @@ func TestNewHandlerMountsAWSWhenEnabled(t *testing.T) {
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "sqs.CreateQueue") {
+	if !strings.Contains(res.Body.String(), "<CreateQueueResponse>") || !strings.Contains(res.Body.String(), "jobs") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }

--- a/internal/services/aws/defaults.go
+++ b/internal/services/aws/defaults.go
@@ -1,9 +1,11 @@
 package aws
 
 import (
+	"strings"
 	"time"
 
 	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
 )
 
 func seedS3Defaults(store Store, region string) {
@@ -16,5 +18,32 @@ func seedS3Defaults(store Store, region string) {
 		"creation_date":      time.Now().UTC().Format(time.RFC3339Nano),
 		"acl":                "private",
 		"versioning_enabled": false,
+	})
+}
+
+func seedSQSDefaults(store Store, baseURL string, accountID string, region string) {
+	if len(store.SQSQueues.FindBy("queue_name", "emulate-default-queue")) > 0 {
+		return
+	}
+	if accountID == "" {
+		accountID = gateway.DefaultAccountID
+	}
+	if region == "" {
+		region = gateway.DefaultRegion
+	}
+	if baseURL == "" {
+		baseURL = "http://127.0.0.1"
+	}
+	queueName := "emulate-default-queue"
+	store.SQSQueues.Insert(corestore.Record{
+		"queue_name":                queueName,
+		"queue_url":                 strings.TrimRight(baseURL, "/") + "/sqs/" + accountID + "/" + queueName,
+		"arn":                       "arn:aws:sqs:" + region + ":" + accountID + ":" + queueName,
+		"visibility_timeout":        30,
+		"delay_seconds":             0,
+		"max_message_size":          262144,
+		"message_retention_period":  345600,
+		"receive_message_wait_time": 0,
+		"fifo":                      false,
 	})
 }

--- a/internal/services/aws/gateway/context.go
+++ b/internal/services/aws/gateway/context.go
@@ -438,6 +438,7 @@ var queryActionServices = map[string]string{
 
 var jsonTargetServices = map[string]string{
 	"AmazonCloudWatchLogs": "logs",
+	"AmazonSQS":            "sqs",
 	"DynamoDB":             "dynamodb",
 	"Lambda":               "lambda",
 	"AWSEvents":            "events",

--- a/internal/services/aws/gateway/context_test.go
+++ b/internal/services/aws/gateway/context_test.go
@@ -700,6 +700,12 @@ func TestBuildContextJSONRPCTargetOnlyServicePrefixes(t *testing.T) {
 			want:       "secretsmanager",
 			wantAction: "GetSecretValue",
 		},
+		{
+			name:       "sqs",
+			target:     "AmazonSQS.ListQueues",
+			want:       "sqs",
+			wantAction: "ListQueues",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
 	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
 	awss3 "github.com/vercel-labs/emulate/internal/services/aws/s3"
+	awssqs "github.com/vercel-labs/emulate/internal/services/aws/sqs"
 )
 
 type Options struct {
@@ -33,6 +34,7 @@ type Service struct {
 	credentialStore  *auth.Store
 	s3PathFallback   bool
 	s3               awss3.Handler
+	sqs              awssqs.Handler
 }
 
 func Register(router *corehttp.Router, options Options) {
@@ -60,6 +62,7 @@ func New(options Options) *Service {
 	}
 	awsStore := NewStore(runtimeStore)
 	seedS3Defaults(awsStore, defaultRegion)
+	seedSQSDefaults(awsStore, options.BaseURL, defaultAccountID, defaultRegion)
 	return &Service{
 		store:            awsStore,
 		assets:           assetStore,
@@ -74,6 +77,13 @@ func New(options Options) *Service {
 			Assets:  assetStore,
 			BaseURL: options.BaseURL,
 			Region:  defaultRegion,
+		},
+		sqs: awssqs.Handler{
+			Queues:    awsStore.SQSQueues,
+			Messages:  awsStore.SQSMessages,
+			BaseURL:   options.BaseURL,
+			AccountID: defaultAccountID,
+			Region:    defaultRegion,
 		},
 	}
 }
@@ -107,6 +117,10 @@ func (s *Service) handleAWS(c *corehttp.Context) {
 
 	if ctx.Service == "s3" && ctx.Protocol == protocols.ProtocolRESTXML {
 		writeErrorResponse(c, s.s3.Handle(c.Request, ctx))
+		return
+	}
+	if ctx.Service == "sqs" && (ctx.Protocol == protocols.ProtocolQuery || ctx.Protocol == protocols.ProtocolJSONRPC) {
+		writeErrorResponse(c, s.sqs.Handle(c.Request, ctx))
 		return
 	}
 

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -513,20 +513,28 @@ func TestServiceReturnsSQSQueryMessageAttributes(t *testing.T) {
 	if res.Code != http.StatusOK {
 		t.Fatalf("send status = %d, body = %s", res.Code, res.Body.String())
 	}
+	sentAttributesMD5 := xmlElement(res.Body.String(), "MD5OfMessageAttributes")
+	if sentAttributesMD5 == "" {
+		t.Fatalf("send missing MD5OfMessageAttributes in %s", res.Body.String())
+	}
 
 	values = url.Values{}
 	values.Set("Action", "ReceiveMessage")
 	values.Set("QueueUrl", queueURL)
 	values.Set("MessageAttributeName.1", "All")
+	values.Set("AttributeName.1", "All")
 	res = executeAWSQueryRequest(handler, "sqs", values.Encode())
 	if res.Code != http.StatusOK {
 		t.Fatalf("receive status = %d, body = %s", res.Code, res.Body.String())
 	}
 	body := res.Body.String()
-	for _, expected := range []string{"<MessageAttribute>", "<Name>color</Name>", "<DataType>String</DataType>", "<StringValue>blue</StringValue>"} {
+	for _, expected := range []string{"<MessageAttribute>", "<Name>color</Name>", "<DataType>String</DataType>", "<StringValue>blue</StringValue>", "<Name>SenderId</Name>", "<Value>123456789012</Value>"} {
 		if !strings.Contains(body, expected) {
 			t.Fatalf("receive missing %q in %s", expected, body)
 		}
+	}
+	if got := xmlElement(body, "MD5OfMessageAttributes"); got != sentAttributesMD5 {
+		t.Fatalf("receive MD5OfMessageAttributes = %q, want %q in %s", got, sentAttributesMD5, body)
 	}
 }
 
@@ -557,17 +565,29 @@ func TestServiceHandlesSQSJSONMessageAttributes(t *testing.T) {
 	if res.Code != http.StatusOK {
 		t.Fatalf("send status = %d, body = %s", res.Code, res.Body.String())
 	}
+	var sent struct {
+		MD5OfMessageAttributes string `json:"MD5OfMessageAttributes"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &sent); err != nil {
+		t.Fatal(err)
+	}
+	if sent.MD5OfMessageAttributes == "" {
+		t.Fatalf("send missing MD5OfMessageAttributes in %s", res.Body.String())
+	}
 
 	res = executeAWSJSONRequest(t, handler, "ReceiveMessage", map[string]any{
-		"QueueUrl":              created.QueueURL,
-		"MessageAttributeNames": []string{"All"},
+		"QueueUrl":                    created.QueueURL,
+		"MessageAttributeNames":       []string{"All"},
+		"MessageSystemAttributeNames": []string{"All"},
 	})
 	if res.Code != http.StatusOK {
 		t.Fatalf("receive status = %d, body = %s", res.Code, res.Body.String())
 	}
 	var received struct {
 		Messages []struct {
-			MessageAttributes map[string]struct {
+			Attributes             map[string]string `json:"Attributes"`
+			MD5OfMessageAttributes string            `json:"MD5OfMessageAttributes"`
+			MessageAttributes      map[string]struct {
 				DataType    string `json:"DataType"`
 				StringValue string `json:"StringValue"`
 			} `json:"MessageAttributes"`
@@ -582,6 +602,12 @@ func TestServiceHandlesSQSJSONMessageAttributes(t *testing.T) {
 	color := received.Messages[0].MessageAttributes["color"]
 	if color.DataType != "String" || color.StringValue != "blue" {
 		t.Fatalf("message attributes = %#v", received.Messages[0].MessageAttributes)
+	}
+	if received.Messages[0].MD5OfMessageAttributes != sent.MD5OfMessageAttributes {
+		t.Fatalf("message attribute md5 = %q, want %q", received.Messages[0].MD5OfMessageAttributes, sent.MD5OfMessageAttributes)
+	}
+	if received.Messages[0].Attributes["SenderId"] != "123456789012" {
+		t.Fatalf("system attributes = %#v", received.Messages[0].Attributes)
 	}
 }
 

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -317,16 +318,11 @@ func TestServiceReturnsUnsignedS3SubresourceNotImplemented(t *testing.T) {
 	}
 }
 
-func TestServiceReturnsQueryXMLNotImplemented(t *testing.T) {
+func TestServiceHandlesSQSCreateQueue(t *testing.T) {
 	handler := newTestHandler()
-	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	signAWSRequest(req, "sqs")
+	res := executeAWSQueryRequest(handler, "sqs", "Action=CreateQueue&QueueName=jobs")
 
-	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, req)
-
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	if got := res.Header().Get("Content-Type"); got != "application/xml" {
@@ -336,12 +332,12 @@ func TestServiceReturnsQueryXMLNotImplemented(t *testing.T) {
 		t.Fatal("missing x-amzn-requestid")
 	}
 	body := res.Body.String()
-	if !strings.Contains(body, "<Code>NotImplemented</Code>") || !strings.Contains(body, "sqs.CreateQueue") {
+	if !strings.Contains(body, "<CreateQueueResponse>") || !strings.Contains(body, "<QueueUrl>") || !strings.Contains(body, "jobs") {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }
 
-func TestServiceAcceptsBearerTokenForQueryShell(t *testing.T) {
+func TestServiceAcceptsBearerTokenForSQSQuery(t *testing.T) {
 	handler := newTestHandler()
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", strings.NewReader("Action=CreateQueue&QueueName=jobs"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -350,14 +346,118 @@ func TestServiceAcceptsBearerTokenForQueryShell(t *testing.T) {
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
-	if res.Code != http.StatusNotImplemented {
+	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	if got := res.Header().Get("Content-Type"); got != "application/xml" {
 		t.Fatalf("content type = %q", got)
 	}
-	if body := res.Body.String(); !strings.Contains(body, "sqs.CreateQueue") {
+	if body := res.Body.String(); !strings.Contains(body, "<CreateQueueResponse>") {
 		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestServiceHandlesSQSLifecycle(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSQueryRequest(handler, "sqs", "Action=ListQueues")
+	if res.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body := res.Body.String(); !strings.Contains(body, "emulate-default-queue") {
+		t.Fatalf("list missing default queue: %s", body)
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=GetQueueUrl&QueueName=emulate-default-queue")
+	if res.Code != http.StatusOK {
+		t.Fatalf("get url status = %d, body = %s", res.Code, res.Body.String())
+	}
+	queueURL := xmlElement(res.Body.String(), "QueueUrl")
+	if queueURL == "" {
+		t.Fatalf("missing queue url in %s", res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=GetQueueAttributes&QueueUrl="+url.QueryEscape(queueURL))
+	if res.Code != http.StatusOK {
+		t.Fatalf("attributes status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body := res.Body.String(); !strings.Contains(body, "<Name>QueueArn</Name>") || !strings.Contains(body, "<Name>VisibilityTimeout</Name>") {
+		t.Fatalf("unexpected attributes body: %s", body)
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=SendMessage&QueueUrl="+url.QueryEscape(queueURL)+"&MessageBody=test+message")
+	if res.Code != http.StatusOK {
+		t.Fatalf("send status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body := res.Body.String(); !strings.Contains(body, "<SendMessageResponse>") || !strings.Contains(body, "<MessageId>") {
+		t.Fatalf("unexpected send body: %s", body)
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=ReceiveMessage&QueueUrl="+url.QueryEscape(queueURL)+"&MaxNumberOfMessages=1")
+	if res.Code != http.StatusOK {
+		t.Fatalf("receive status = %d, body = %s", res.Code, res.Body.String())
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "<Body>test message</Body>") || !strings.Contains(body, "<ReceiptHandle>") {
+		t.Fatalf("unexpected receive body: %s", body)
+	}
+	receiptHandle := xmlElement(body, "ReceiptHandle")
+	if receiptHandle == "" {
+		t.Fatalf("missing receipt handle in %s", body)
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=DeleteMessage&QueueUrl="+url.QueryEscape(queueURL)+"&ReceiptHandle="+url.QueryEscape(receiptHandle))
+	if res.Code != http.StatusOK {
+		t.Fatalf("delete message status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body := res.Body.String(); !strings.Contains(body, "<DeleteMessageResponse>") {
+		t.Fatalf("unexpected delete message body: %s", body)
+	}
+}
+
+func TestServiceHandlesSQSPurgeAndDeleteQueue(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSQueryRequest(handler, "sqs", "Action=CreateQueue&QueueName=jobs")
+	if res.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+	queueURL := xmlElement(res.Body.String(), "QueueUrl")
+	if queueURL == "" {
+		t.Fatalf("missing queue url in %s", res.Body.String())
+	}
+
+	for _, body := range []string{"one", "two"} {
+		res = executeAWSQueryRequest(handler, "sqs", "Action=SendMessage&QueueUrl="+url.QueryEscape(queueURL)+"&MessageBody="+url.QueryEscape(body))
+		if res.Code != http.StatusOK {
+			t.Fatalf("send %s status = %d, body = %s", body, res.Code, res.Body.String())
+		}
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=PurgeQueue&QueueUrl="+url.QueryEscape(queueURL))
+	if res.Code != http.StatusOK {
+		t.Fatalf("purge status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=ReceiveMessage&QueueUrl="+url.QueryEscape(queueURL))
+	if res.Code != http.StatusOK {
+		t.Fatalf("receive after purge status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if strings.Contains(res.Body.String(), "<Message>") {
+		t.Fatalf("purged queue returned messages: %s", res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=DeleteQueue&QueueUrl="+url.QueryEscape(queueURL))
+	if res.Code != http.StatusOK {
+		t.Fatalf("delete queue status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "sqs", "Action=GetQueueUrl&QueueName=jobs")
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("get deleted queue status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "<Code>AWS.SimpleQueueService.NonExistentQueue</Code>") {
+		t.Fatalf("unexpected missing queue body: %s", res.Body.String())
 	}
 }
 
@@ -569,6 +669,12 @@ func executeAWSRequest(handler http.Handler, method string, target string, body 
 	return res
 }
 
+func executeAWSQueryRequest(handler http.Handler, service string, body string) *httptest.ResponseRecorder {
+	return executeAWSRequest(handler, http.MethodPost, "http://127.0.0.1/"+service+"/", []byte(body), service, map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+}
+
 func executeS3MultipartPost(t *testing.T, handler http.Handler, target string, fields map[string]string, fileBody []byte) *httptest.ResponseRecorder {
 	t.Helper()
 	var body bytes.Buffer
@@ -603,6 +709,21 @@ func encodePostPolicy(t *testing.T, conditions []any) string {
 		t.Fatal(err)
 	}
 	return base64.StdEncoding.EncodeToString(raw)
+}
+
+func xmlElement(body string, name string) string {
+	startToken := "<" + name + ">"
+	endToken := "</" + name + ">"
+	start := strings.Index(body, startToken)
+	if start < 0 {
+		return ""
+	}
+	start += len(startToken)
+	end := strings.Index(body[start:], endToken)
+	if end < 0 {
+		return ""
+	}
+	return body[start : start+end]
 }
 
 func signAWSRequest(req *http.Request, service string) {

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -461,6 +461,171 @@ func TestServiceHandlesSQSPurgeAndDeleteQueue(t *testing.T) {
 	}
 }
 
+func TestServiceHonorsSQSMessageDelaySeconds(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSQueryRequest(handler, "sqs", "Action=CreateQueue&QueueName=delayed-query")
+	if res.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+	queueURL := xmlElement(res.Body.String(), "QueueUrl")
+
+	values := url.Values{}
+	values.Set("Action", "SendMessage")
+	values.Set("QueueUrl", queueURL)
+	values.Set("MessageBody", "wait for it")
+	values.Set("DelaySeconds", "5")
+	res = executeAWSQueryRequest(handler, "sqs", values.Encode())
+	if res.Code != http.StatusOK {
+		t.Fatalf("send status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	values = url.Values{}
+	values.Set("Action", "ReceiveMessage")
+	values.Set("QueueUrl", queueURL)
+	values.Set("MaxNumberOfMessages", "1")
+	res = executeAWSQueryRequest(handler, "sqs", values.Encode())
+	if res.Code != http.StatusOK {
+		t.Fatalf("receive status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if strings.Contains(res.Body.String(), "<Message>") {
+		t.Fatalf("delayed message was visible immediately: %s", res.Body.String())
+	}
+}
+
+func TestServiceReturnsSQSQueryMessageAttributes(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSQueryRequest(handler, "sqs", "Action=CreateQueue&QueueName=query-attrs")
+	if res.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+	queueURL := xmlElement(res.Body.String(), "QueueUrl")
+
+	values := url.Values{}
+	values.Set("Action", "SendMessage")
+	values.Set("QueueUrl", queueURL)
+	values.Set("MessageBody", "with attrs")
+	values.Set("MessageAttribute.1.Name", "color")
+	values.Set("MessageAttribute.1.Value.DataType", "String")
+	values.Set("MessageAttribute.1.Value.StringValue", "blue")
+	res = executeAWSQueryRequest(handler, "sqs", values.Encode())
+	if res.Code != http.StatusOK {
+		t.Fatalf("send status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	values = url.Values{}
+	values.Set("Action", "ReceiveMessage")
+	values.Set("QueueUrl", queueURL)
+	values.Set("MessageAttributeName.1", "All")
+	res = executeAWSQueryRequest(handler, "sqs", values.Encode())
+	if res.Code != http.StatusOK {
+		t.Fatalf("receive status = %d, body = %s", res.Code, res.Body.String())
+	}
+	body := res.Body.String()
+	for _, expected := range []string{"<MessageAttribute>", "<Name>color</Name>", "<DataType>String</DataType>", "<StringValue>blue</StringValue>"} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("receive missing %q in %s", expected, body)
+		}
+	}
+}
+
+func TestServiceHandlesSQSJSONMessageAttributes(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSJSONRequest(t, handler, "CreateQueue", map[string]any{"QueueName": "json-attrs"})
+	if res.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var created struct {
+		QueueURL string `json:"QueueUrl"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	res = executeAWSJSONRequest(t, handler, "SendMessage", map[string]any{
+		"QueueUrl":    created.QueueURL,
+		"MessageBody": "with attrs",
+		"MessageAttributes": map[string]any{
+			"color": map[string]any{
+				"DataType":    "String",
+				"StringValue": "blue",
+			},
+		},
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("send status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSJSONRequest(t, handler, "ReceiveMessage", map[string]any{
+		"QueueUrl":              created.QueueURL,
+		"MessageAttributeNames": []string{"All"},
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("receive status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var received struct {
+		Messages []struct {
+			MessageAttributes map[string]struct {
+				DataType    string `json:"DataType"`
+				StringValue string `json:"StringValue"`
+			} `json:"MessageAttributes"`
+		} `json:"Messages"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &received); err != nil {
+		t.Fatal(err)
+	}
+	if len(received.Messages) != 1 {
+		t.Fatalf("messages = %#v", received.Messages)
+	}
+	color := received.Messages[0].MessageAttributes["color"]
+	if color.DataType != "String" || color.StringValue != "blue" {
+		t.Fatalf("message attributes = %#v", received.Messages[0].MessageAttributes)
+	}
+}
+
+func TestServiceHonorsSQSJSONMessageDelaySeconds(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSJSONRequest(t, handler, "CreateQueue", map[string]any{"QueueName": "json-delay"})
+	if res.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var created struct {
+		QueueURL string `json:"QueueUrl"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	res = executeAWSJSONRequest(t, handler, "SendMessage", map[string]any{
+		"QueueUrl":     created.QueueURL,
+		"MessageBody":  "wait for it",
+		"DelaySeconds": json.Number("5"),
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("send status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSJSONRequest(t, handler, "ReceiveMessage", map[string]any{
+		"QueueUrl":            created.QueueURL,
+		"MaxNumberOfMessages": json.Number("1"),
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("receive status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var received struct {
+		Messages []map[string]any `json:"Messages"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &received); err != nil {
+		t.Fatal(err)
+	}
+	if len(received.Messages) != 0 {
+		t.Fatalf("delayed message was visible immediately: %#v", received.Messages)
+	}
+}
+
 func TestServiceReturnsJSONRPCNotImplemented(t *testing.T) {
 	handler := newTestHandler()
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", strings.NewReader(`{"TableName":"items"}`))
@@ -673,6 +838,21 @@ func executeAWSQueryRequest(handler http.Handler, service string, body string) *
 	return executeAWSRequest(handler, http.MethodPost, "http://127.0.0.1/"+service+"/", []byte(body), service, map[string]string{
 		"Content-Type": "application/x-www-form-urlencoded",
 	})
+}
+
+func executeAWSJSONRequest(t *testing.T, handler http.Handler, action string, payload map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/sqs/", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AmazonSQS."+action)
+	signAWSRequest(req, "sqs")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
 }
 
 func executeS3MultipartPost(t *testing.T, handler http.Handler, target string, fields map[string]string, fileBody []byte) *httptest.ResponseRecorder {

--- a/internal/services/aws/sqs/handler.go
+++ b/internal/services/aws/sqs/handler.go
@@ -279,13 +279,10 @@ func (h *Handler) receiveMessage(params map[string]string, requestID string) pro
 		if int64Field(message, "visible_after") > now {
 			continue
 		}
-		receiptHandle := h.generateReceiptHandle()
-		receiveCount := intField(message, "receive_count") + 1
-		updated, _ := h.Messages.Update(intField(message, "id"), corestore.Record{
-			"receipt_handle": receiptHandle,
-			"visible_after":  now + int64(visibilityTimeout)*1000,
-			"receive_count":  receiveCount,
-		})
+		updated, ok := h.reserveVisibleMessage(message, now, visibilityTimeout)
+		if !ok {
+			continue
+		}
 		batch = append(batch, updated)
 		if len(batch) == maxMessages {
 			break
@@ -506,13 +503,10 @@ func (h *Handler) receiveMessageJSON(params map[string]string) protocols.ErrorRe
 		if int64Field(message, "visible_after") > now {
 			continue
 		}
-		receiptHandle := h.generateReceiptHandle()
-		receiveCount := intField(message, "receive_count") + 1
-		updated, _ := h.Messages.Update(intField(message, "id"), corestore.Record{
-			"receipt_handle": receiptHandle,
-			"visible_after":  now + int64(visibilityTimeout)*1000,
-			"receive_count":  receiveCount,
-		})
+		updated, ok := h.reserveVisibleMessage(message, now, visibilityTimeout)
+		if !ok {
+			continue
+		}
 		item := map[string]any{
 			"MessageId":     stringField(updated, "message_id"),
 			"ReceiptHandle": stringField(updated, "receipt_handle"),
@@ -806,6 +800,20 @@ func parseMessageAttributes(params map[string]string) corestore.Record {
 
 func messageDelaySeconds(params map[string]string, queue corestore.Record) int {
 	return intParam(params["DelaySeconds"], intField(queue, "delay_seconds"))
+}
+
+func (h *Handler) reserveVisibleMessage(message corestore.Record, now int64, visibilityTimeout int) (corestore.Record, bool) {
+	receiptHandle := h.generateReceiptHandle()
+	return h.Messages.UpdateFunc(intField(message, "id"), func(current corestore.Record) (corestore.Record, bool) {
+		if int64Field(current, "visible_after") > now {
+			return nil, false
+		}
+		return corestore.Record{
+			"receipt_handle": receiptHandle,
+			"visible_after":  now + int64(visibilityTimeout)*1000,
+			"receive_count":  intField(current, "receive_count") + 1,
+		}, true
+	})
 }
 
 func selectedMessageAttributes(message corestore.Record, params map[string]string) corestore.Record {

--- a/internal/services/aws/sqs/handler.go
+++ b/internal/services/aws/sqs/handler.go
@@ -4,9 +4,11 @@ import (
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"net/http"
 	"sort"
 	"strconv"
@@ -230,29 +232,38 @@ func (h *Handler) sendMessage(params map[string]string, requestID string) protoc
 	}
 	messageID := h.generateID()
 	bodyMD5 := md5Hex(messageBody)
+	messageAttributes := parseMessageAttributes(params)
+	messageAttributesMD5 := md5OfMessageAttributes(messageAttributes)
 	now := h.nowMillis()
 	h.Messages.Insert(corestore.Record{
-		"queue_name":     stringField(queue, "queue_name"),
-		"message_id":     messageID,
-		"receipt_handle": h.generateReceiptHandle(),
-		"body":           messageBody,
-		"md5_of_body":    bodyMD5,
+		"queue_name":                stringField(queue, "queue_name"),
+		"message_id":                messageID,
+		"receipt_handle":            h.generateReceiptHandle(),
+		"body":                      messageBody,
+		"md5_of_body":               bodyMD5,
+		"md5_of_message_attributes": messageAttributesMD5,
+		"first_receive_timestamp":   int64(0),
 		"attributes": corestore.Record{
 			"SentTimestamp":                    strconv.FormatInt(now, 10),
 			"ApproximateReceiveCount":          "0",
 			"ApproximateFirstReceiveTimestamp": "",
 			"SenderId":                         h.accountID(),
 		},
-		"message_attributes": parseMessageAttributes(params),
+		"message_attributes": messageAttributes,
 		"visible_after":      now + int64(messageDelaySeconds(params, queue))*1000,
 		"sent_timestamp":     now,
 		"receive_count":      0,
 	})
+	messageAttributesMD5XML := ""
+	if messageAttributesMD5 != "" {
+		messageAttributesMD5XML = `
+    <MD5OfMessageAttributes>` + messageAttributesMD5 + `</MD5OfMessageAttributes>`
+	}
 	body := `<?xml version="1.0" encoding="UTF-8"?>
 <SendMessageResponse>
   <SendMessageResult>
     <MessageId>` + xmlEscape(messageID) + `</MessageId>
-    <MD5OfMessageBody>` + bodyMD5 + `</MD5OfMessageBody>
+    <MD5OfMessageBody>` + bodyMD5 + `</MD5OfMessageBody>` + messageAttributesMD5XML + `
   </SendMessageResult>
   <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
 </SendMessageResponse>`
@@ -303,16 +314,8 @@ func (h *Handler) receiveMessage(params map[string]string, requestID string) pro
       <Body>`)
 		rows.WriteString(xmlEscape(stringField(message, "body")))
 		rows.WriteString(`</Body>
-      <Attribute><Name>SentTimestamp</Name><Value>`)
-		rows.WriteString(strconv.FormatInt(int64Field(message, "sent_timestamp"), 10))
-		rows.WriteString(`</Value></Attribute>
-      <Attribute><Name>ApproximateReceiveCount</Name><Value>`)
-		rows.WriteString(strconv.Itoa(intField(message, "receive_count")))
-		rows.WriteString(`</Value></Attribute>
-      <Attribute><Name>ApproximateFirstReceiveTimestamp</Name><Value>`)
-		rows.WriteString(strconv.FormatInt(int64Field(message, "sent_timestamp"), 10))
-		rows.WriteString(`</Value></Attribute>
 `)
+		writeSystemAttributesXML(&rows, message, params)
 		writeMessageAttributesXML(&rows, message, params)
 		rows.WriteString(`    </Message>
 `)
@@ -460,28 +463,36 @@ func (h *Handler) sendMessageJSON(params map[string]string) protocols.ErrorRespo
 	}
 	messageID := h.generateID()
 	bodyMD5 := md5Hex(messageBody)
+	messageAttributes := parseMessageAttributes(params)
+	messageAttributesMD5 := md5OfMessageAttributes(messageAttributes)
 	now := h.nowMillis()
 	h.Messages.Insert(corestore.Record{
-		"queue_name":     stringField(queue, "queue_name"),
-		"message_id":     messageID,
-		"receipt_handle": h.generateReceiptHandle(),
-		"body":           messageBody,
-		"md5_of_body":    bodyMD5,
+		"queue_name":                stringField(queue, "queue_name"),
+		"message_id":                messageID,
+		"receipt_handle":            h.generateReceiptHandle(),
+		"body":                      messageBody,
+		"md5_of_body":               bodyMD5,
+		"md5_of_message_attributes": messageAttributesMD5,
+		"first_receive_timestamp":   int64(0),
 		"attributes": corestore.Record{
 			"SentTimestamp":                    strconv.FormatInt(now, 10),
 			"ApproximateReceiveCount":          "0",
 			"ApproximateFirstReceiveTimestamp": "",
 			"SenderId":                         h.accountID(),
 		},
-		"message_attributes": parseMessageAttributes(params),
+		"message_attributes": messageAttributes,
 		"visible_after":      now + int64(messageDelaySeconds(params, queue))*1000,
 		"sent_timestamp":     now,
 		"receive_count":      0,
 	})
-	return jsonResponse(http.StatusOK, map[string]any{
+	response := map[string]any{
 		"MD5OfMessageBody": bodyMD5,
 		"MessageId":        messageID,
-	})
+	}
+	if messageAttributesMD5 != "" {
+		response["MD5OfMessageAttributes"] = messageAttributesMD5
+	}
+	return jsonResponse(http.StatusOK, response)
 }
 
 func (h *Handler) receiveMessageJSON(params map[string]string) protocols.ErrorResponse {
@@ -512,14 +523,15 @@ func (h *Handler) receiveMessageJSON(params map[string]string) protocols.ErrorRe
 			"ReceiptHandle": stringField(updated, "receipt_handle"),
 			"MD5OfBody":     stringField(updated, "md5_of_body"),
 			"Body":          stringField(updated, "body"),
-			"Attributes": map[string]string{
-				"SentTimestamp":                    strconv.FormatInt(int64Field(updated, "sent_timestamp"), 10),
-				"ApproximateReceiveCount":          strconv.Itoa(intField(updated, "receive_count")),
-				"ApproximateFirstReceiveTimestamp": strconv.FormatInt(int64Field(updated, "sent_timestamp"), 10),
-			},
+		}
+		if attrs := selectedSystemAttributes(updated, params); len(attrs) > 0 {
+			item["Attributes"] = attrs
 		}
 		if attrs := selectedMessageAttributes(updated, params); len(attrs) > 0 {
 			item["MessageAttributes"] = attrs
+			if md5Value := stringField(updated, "md5_of_message_attributes"); md5Value != "" {
+				item["MD5OfMessageAttributes"] = md5Value
+			}
 		}
 		messages = append(messages, item)
 		if len(messages) == maxMessages {
@@ -808,12 +820,69 @@ func (h *Handler) reserveVisibleMessage(message corestore.Record, now int64, vis
 		if int64Field(current, "visible_after") > now {
 			return nil, false
 		}
-		return corestore.Record{
+		patch := corestore.Record{
 			"receipt_handle": receiptHandle,
 			"visible_after":  now + int64(visibilityTimeout)*1000,
 			"receive_count":  intField(current, "receive_count") + 1,
-		}, true
+		}
+		if int64Field(current, "first_receive_timestamp") == 0 {
+			patch["first_receive_timestamp"] = now
+		}
+		return patch, true
 	})
+}
+
+var systemAttributeOrder = []string{
+	"SenderId",
+	"SentTimestamp",
+	"ApproximateReceiveCount",
+	"ApproximateFirstReceiveTimestamp",
+}
+
+func selectedSystemAttributes(message corestore.Record, params map[string]string) map[string]string {
+	requested := indexedNames(params, "AttributeName")
+	requested = append(requested, indexedNames(params, "MessageSystemAttributeName")...)
+	if len(requested) == 0 {
+		return map[string]string{}
+	}
+	available := systemAttributes(message)
+	selected := map[string]string{}
+	for _, request := range requested {
+		if request == "All" || request == ".*" {
+			for name, value := range available {
+				selected[name] = value
+			}
+			continue
+		}
+		if strings.HasSuffix(request, ".*") {
+			prefix := strings.TrimSuffix(request, ".*")
+			for name, value := range available {
+				if strings.HasPrefix(name, prefix) {
+					selected[name] = value
+				}
+			}
+			continue
+		}
+		if value, ok := available[request]; ok {
+			selected[request] = value
+		}
+	}
+	return selected
+}
+
+func systemAttributes(message corestore.Record) map[string]string {
+	firstReceiveTimestamp := int64Field(message, "first_receive_timestamp")
+	if firstReceiveTimestamp == 0 {
+		firstReceiveTimestamp = int64Field(message, "sent_timestamp")
+	}
+	attributes := recordField(message, "attributes")
+	senderID := stringField(attributes, "SenderId")
+	return map[string]string{
+		"SenderId":                         senderID,
+		"SentTimestamp":                    strconv.FormatInt(int64Field(message, "sent_timestamp"), 10),
+		"ApproximateReceiveCount":          strconv.Itoa(intField(message, "receive_count")),
+		"ApproximateFirstReceiveTimestamp": strconv.FormatInt(firstReceiveTimestamp, 10),
+	}
 }
 
 func selectedMessageAttributes(message corestore.Record, params map[string]string) corestore.Record {
@@ -861,8 +930,32 @@ func indexedNames(params map[string]string, prefix string) []string {
 	return names
 }
 
+func writeSystemAttributesXML(rows *strings.Builder, message corestore.Record, params map[string]string) {
+	attrs := selectedSystemAttributes(message, params)
+	for _, name := range systemAttributeOrder {
+		value, ok := attrs[name]
+		if !ok {
+			continue
+		}
+		rows.WriteString(`      <Attribute><Name>`)
+		rows.WriteString(xmlEscape(name))
+		rows.WriteString(`</Name><Value>`)
+		rows.WriteString(xmlEscape(value))
+		rows.WriteString(`</Value></Attribute>
+`)
+	}
+}
+
 func writeMessageAttributesXML(rows *strings.Builder, message corestore.Record, params map[string]string) {
 	attrs := selectedMessageAttributes(message, params)
+	if len(attrs) > 0 {
+		if md5Value := stringField(message, "md5_of_message_attributes"); md5Value != "" {
+			rows.WriteString(`      <MD5OfMessageAttributes>`)
+			rows.WriteString(md5Value)
+			rows.WriteString(`</MD5OfMessageAttributes>
+`)
+		}
+	}
 	names := sortedRecordKeys(attrs)
 	for _, name := range names {
 		value := recordValue(attrs[name])
@@ -973,6 +1066,58 @@ func boolField(record corestore.Record, name string) bool {
 func md5Hex(value string) string {
 	sum := md5.Sum([]byte(value))
 	return hex.EncodeToString(sum[:])
+}
+
+func md5OfMessageAttributes(attrs corestore.Record) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+	hasher := md5.New()
+	for _, name := range sortedRecordKeys(attrs) {
+		value := recordValue(attrs[name])
+		dataType := stringField(value, "DataType")
+		if dataType == "" {
+			dataType = "String"
+		}
+		writeMD5LengthPrefixedString(hasher, name)
+		writeMD5LengthPrefixedString(hasher, dataType)
+		if strings.HasPrefix(dataType, "Binary") {
+			hasher.Write([]byte{2})
+			writeMD5LengthPrefixedBytes(hasher, messageAttributeBinaryBytes(stringField(value, "BinaryValue")))
+			continue
+		}
+		hasher.Write([]byte{1})
+		writeMD5LengthPrefixedString(hasher, stringField(value, "StringValue"))
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func writeMD5LengthPrefixedString(hasher hash.Hash, value string) {
+	writeMD5LengthPrefixedBytes(hasher, []byte(value))
+}
+
+func writeMD5LengthPrefixedBytes(hasher hash.Hash, value []byte) {
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], uint32(len(value)))
+	hasher.Write(length[:])
+	hasher.Write(value)
+}
+
+func messageAttributeBinaryBytes(value string) []byte {
+	if value == "" {
+		return nil
+	}
+	for _, encoding := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	} {
+		if decoded, err := encoding.DecodeString(value); err == nil {
+			return decoded
+		}
+	}
+	return []byte(value)
 }
 
 type nameValue struct {

--- a/internal/services/aws/sqs/handler.go
+++ b/internal/services/aws/sqs/handler.go
@@ -1,0 +1,847 @@
+package sqs
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+)
+
+type Handler struct {
+	Queues           *corestore.Collection
+	Messages         *corestore.Collection
+	BaseURL          string
+	AccountID        string
+	Region           string
+	Now              func() time.Time
+	IDGenerator      func() string
+	ReceiptGenerator func() string
+}
+
+var fallbackIDCounter atomic.Uint64
+
+func (h *Handler) Handle(req *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	if ctx.Protocol == protocols.ProtocolJSONRPC {
+		return h.handleJSON(req, ctx)
+	}
+	requestID := ctx.RequestID
+	if requestID == "" {
+		requestID = h.generateID()
+	}
+	var response protocols.ErrorResponse
+	switch ctx.Action {
+	case "CreateQueue":
+		response = h.createQueue(req, ctx.Query, requestID)
+	case "DeleteQueue":
+		response = h.deleteQueue(ctx.Query, requestID)
+	case "ListQueues":
+		response = h.listQueues(ctx.Query, requestID)
+	case "GetQueueUrl":
+		response = h.getQueueURL(ctx.Query, requestID)
+	case "GetQueueAttributes":
+		response = h.getQueueAttributes(ctx.Query, requestID)
+	case "SendMessage":
+		response = h.sendMessage(ctx.Query, requestID)
+	case "ReceiveMessage":
+		response = h.receiveMessage(ctx.Query, requestID)
+	case "DeleteMessage":
+		response = h.deleteMessage(ctx.Query, requestID)
+	case "PurgeQueue":
+		response = h.purgeQueue(ctx.Query, requestID)
+	default:
+		action := ctx.Action
+		response = h.queryError("InvalidAction", "The action "+action+" is not valid for this endpoint.", http.StatusBadRequest, requestID)
+	}
+	return withRequestID(response, requestID)
+}
+
+func (h *Handler) handleJSON(req *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	requestID := ctx.RequestID
+	if requestID == "" {
+		requestID = h.generateID()
+	}
+	params := jsonParams(ctx.Input)
+	var response protocols.ErrorResponse
+	switch ctx.Action {
+	case "CreateQueue":
+		response = h.createQueueJSON(req, params)
+	case "DeleteQueue":
+		response = h.deleteQueueJSON(params)
+	case "ListQueues":
+		response = h.listQueuesJSON(params)
+	case "GetQueueUrl":
+		response = h.getQueueURLJSON(params)
+	case "GetQueueAttributes":
+		response = h.getQueueAttributesJSON(params)
+	case "SendMessage":
+		response = h.sendMessageJSON(params)
+	case "ReceiveMessage":
+		response = h.receiveMessageJSON(params)
+	case "DeleteMessage":
+		response = h.deleteMessageJSON(params)
+	case "PurgeQueue":
+		response = h.purgeQueueJSON(params)
+	default:
+		response = jsonResponse(http.StatusBadRequest, map[string]any{"__type": "InvalidAction", "message": "The action " + ctx.Action + " is not valid for this endpoint."})
+	}
+	return withRequestID(response, requestID)
+}
+
+func (h *Handler) createQueue(req *http.Request, params map[string]string, requestID string) protocols.ErrorResponse {
+	queueName := params["QueueName"]
+	if queueName == "" {
+		return h.queryError("MissingParameter", "The request must contain the parameter QueueName.", http.StatusBadRequest, requestID)
+	}
+	if existing, ok := h.findQueueByName(queueName); ok {
+		return h.queueURLResponse("CreateQueue", stringField(existing, "queue_url"), requestID)
+	}
+	attrs := indexedAttributes(params, "Attribute")
+	region := h.region()
+	accountID := h.accountID()
+	queueURL := strings.TrimRight(h.baseURL(req), "/") + "/sqs/" + accountID + "/" + queueName
+	queue := h.Queues.Insert(corestore.Record{
+		"queue_name":                queueName,
+		"queue_url":                 queueURL,
+		"arn":                       "arn:aws:sqs:" + region + ":" + accountID + ":" + queueName,
+		"visibility_timeout":        intParam(attrs["VisibilityTimeout"], 30),
+		"delay_seconds":             intParam(attrs["DelaySeconds"], 0),
+		"max_message_size":          intParam(attrs["MaximumMessageSize"], 262144),
+		"message_retention_period":  intParam(attrs["MessageRetentionPeriod"], 345600),
+		"receive_message_wait_time": intParam(attrs["ReceiveMessageWaitTimeSeconds"], 0),
+		"fifo":                      strings.HasSuffix(queueName, ".fifo"),
+	})
+	return h.queueURLResponse("CreateQueue", stringField(queue, "queue_url"), requestID)
+}
+
+func (h *Handler) deleteQueue(params map[string]string, requestID string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFound(requestID)
+	}
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		h.Messages.Delete(intField(message, "id"))
+	}
+	h.Queues.Delete(intField(queue, "id"))
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<DeleteQueueResponse>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</DeleteQueueResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) listQueues(params map[string]string, requestID string) protocols.ErrorResponse {
+	prefix := params["QueueNamePrefix"]
+	var rows strings.Builder
+	for _, queue := range h.Queues.All() {
+		if prefix != "" && !strings.HasPrefix(stringField(queue, "queue_name"), prefix) {
+			continue
+		}
+		rows.WriteString(`    <QueueUrl>`)
+		rows.WriteString(xmlEscape(stringField(queue, "queue_url")))
+		rows.WriteString(`</QueueUrl>
+`)
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ListQueuesResponse>
+  <ListQueuesResult>
+` + strings.TrimRight(rows.String(), "\n") + `
+  </ListQueuesResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</ListQueuesResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) getQueueURL(params map[string]string, requestID string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByName(params["QueueName"])
+	if !ok {
+		return h.queueNotFound(requestID)
+	}
+	return h.queueURLResponse("GetQueueUrl", stringField(queue, "queue_url"), requestID)
+}
+
+func (h *Handler) getQueueAttributes(params map[string]string, requestID string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFound(requestID)
+	}
+	now := h.nowMillis()
+	visibleCount := 0
+	inFlightCount := 0
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		if int64Field(message, "visible_after") <= now {
+			visibleCount++
+		} else {
+			inFlightCount++
+		}
+	}
+	attrs := []nameValue{
+		{"QueueArn", stringField(queue, "arn")},
+		{"ApproximateNumberOfMessages", strconv.Itoa(visibleCount)},
+		{"ApproximateNumberOfMessagesNotVisible", strconv.Itoa(inFlightCount)},
+		{"VisibilityTimeout", strconv.Itoa(intField(queue, "visibility_timeout"))},
+		{"MaximumMessageSize", strconv.Itoa(intField(queue, "max_message_size"))},
+		{"MessageRetentionPeriod", strconv.Itoa(intField(queue, "message_retention_period"))},
+		{"DelaySeconds", strconv.Itoa(intField(queue, "delay_seconds"))},
+		{"ReceiveMessageWaitTimeSeconds", strconv.Itoa(intField(queue, "receive_message_wait_time"))},
+		{"FifoQueue", strconv.FormatBool(boolField(queue, "fifo"))},
+	}
+	var rows strings.Builder
+	for _, attr := range attrs {
+		rows.WriteString(`    <Attribute><Name>`)
+		rows.WriteString(xmlEscape(attr.Name))
+		rows.WriteString(`</Name><Value>`)
+		rows.WriteString(xmlEscape(attr.Value))
+		rows.WriteString(`</Value></Attribute>
+`)
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<GetQueueAttributesResponse>
+  <GetQueueAttributesResult>
+` + strings.TrimRight(rows.String(), "\n") + `
+  </GetQueueAttributesResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</GetQueueAttributesResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) sendMessage(params map[string]string, requestID string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFound(requestID)
+	}
+	messageBody := params["MessageBody"]
+	if messageBody == "" {
+		return h.queryError("MissingParameter", "The request must contain the parameter MessageBody.", http.StatusBadRequest, requestID)
+	}
+	if len([]byte(messageBody)) > intField(queue, "max_message_size") {
+		return h.queryError("InvalidParameterValue", "One or more parameters are invalid. Reason: Message must be shorter than "+strconv.Itoa(intField(queue, "max_message_size"))+" bytes.", http.StatusBadRequest, requestID)
+	}
+	messageID := h.generateID()
+	bodyMD5 := md5Hex(messageBody)
+	now := h.nowMillis()
+	h.Messages.Insert(corestore.Record{
+		"queue_name":     stringField(queue, "queue_name"),
+		"message_id":     messageID,
+		"receipt_handle": h.generateReceiptHandle(),
+		"body":           messageBody,
+		"md5_of_body":    bodyMD5,
+		"attributes": corestore.Record{
+			"SentTimestamp":                    strconv.FormatInt(now, 10),
+			"ApproximateReceiveCount":          "0",
+			"ApproximateFirstReceiveTimestamp": "",
+			"SenderId":                         h.accountID(),
+		},
+		"message_attributes": parseMessageAttributes(params),
+		"visible_after":      now + int64(intField(queue, "delay_seconds"))*1000,
+		"sent_timestamp":     now,
+		"receive_count":      0,
+	})
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<SendMessageResponse>
+  <SendMessageResult>
+    <MessageId>` + xmlEscape(messageID) + `</MessageId>
+    <MD5OfMessageBody>` + bodyMD5 + `</MD5OfMessageBody>
+  </SendMessageResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</SendMessageResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) receiveMessage(params map[string]string, requestID string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFound(requestID)
+	}
+	maxMessages := intParam(params["MaxNumberOfMessages"], 1)
+	if maxMessages > 10 {
+		maxMessages = 10
+	}
+	if maxMessages < 1 {
+		maxMessages = 1
+	}
+	visibilityTimeout := intParam(params["VisibilityTimeout"], intField(queue, "visibility_timeout"))
+	now := h.nowMillis()
+	allMessages := h.Messages.FindBy("queue_name", stringField(queue, "queue_name"))
+	batch := make([]corestore.Record, 0, maxMessages)
+	for _, message := range allMessages {
+		if int64Field(message, "visible_after") > now {
+			continue
+		}
+		receiptHandle := h.generateReceiptHandle()
+		receiveCount := intField(message, "receive_count") + 1
+		updated, _ := h.Messages.Update(intField(message, "id"), corestore.Record{
+			"receipt_handle": receiptHandle,
+			"visible_after":  now + int64(visibilityTimeout)*1000,
+			"receive_count":  receiveCount,
+		})
+		batch = append(batch, updated)
+		if len(batch) == maxMessages {
+			break
+		}
+	}
+	var rows strings.Builder
+	for _, message := range batch {
+		rows.WriteString(`    <Message>
+      <MessageId>`)
+		rows.WriteString(xmlEscape(stringField(message, "message_id")))
+		rows.WriteString(`</MessageId>
+      <ReceiptHandle>`)
+		rows.WriteString(xmlEscape(stringField(message, "receipt_handle")))
+		rows.WriteString(`</ReceiptHandle>
+      <MD5OfBody>`)
+		rows.WriteString(xmlEscape(stringField(message, "md5_of_body")))
+		rows.WriteString(`</MD5OfBody>
+      <Body>`)
+		rows.WriteString(xmlEscape(stringField(message, "body")))
+		rows.WriteString(`</Body>
+      <Attribute><Name>SentTimestamp</Name><Value>`)
+		rows.WriteString(strconv.FormatInt(int64Field(message, "sent_timestamp"), 10))
+		rows.WriteString(`</Value></Attribute>
+      <Attribute><Name>ApproximateReceiveCount</Name><Value>`)
+		rows.WriteString(strconv.Itoa(intField(message, "receive_count")))
+		rows.WriteString(`</Value></Attribute>
+      <Attribute><Name>ApproximateFirstReceiveTimestamp</Name><Value>`)
+		rows.WriteString(strconv.FormatInt(int64Field(message, "sent_timestamp"), 10))
+		rows.WriteString(`</Value></Attribute>
+    </Message>
+`)
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ReceiveMessageResponse>
+  <ReceiveMessageResult>
+` + strings.TrimRight(rows.String(), "\n") + `
+  </ReceiveMessageResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</ReceiveMessageResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) deleteMessage(params map[string]string, requestID string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFound(requestID)
+	}
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		if stringField(message, "receipt_handle") == params["ReceiptHandle"] {
+			h.Messages.Delete(intField(message, "id"))
+			break
+		}
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<DeleteMessageResponse>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</DeleteMessageResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) purgeQueue(params map[string]string, requestID string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFound(requestID)
+	}
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		h.Messages.Delete(intField(message, "id"))
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<PurgeQueueResponse>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</PurgeQueueResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) createQueueJSON(req *http.Request, params map[string]string) protocols.ErrorResponse {
+	queueName := params["QueueName"]
+	if queueName == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]any{"__type": "MissingParameter", "message": "The request must contain the parameter QueueName."})
+	}
+	if existing, ok := h.findQueueByName(queueName); ok {
+		return jsonResponse(http.StatusOK, map[string]any{"QueueUrl": stringField(existing, "queue_url")})
+	}
+	attrs := indexedAttributes(params, "Attribute")
+	region := h.region()
+	accountID := h.accountID()
+	queueURL := strings.TrimRight(h.baseURL(req), "/") + "/sqs/" + accountID + "/" + queueName
+	h.Queues.Insert(corestore.Record{
+		"queue_name":                queueName,
+		"queue_url":                 queueURL,
+		"arn":                       "arn:aws:sqs:" + region + ":" + accountID + ":" + queueName,
+		"visibility_timeout":        intParam(attrs["VisibilityTimeout"], 30),
+		"delay_seconds":             intParam(attrs["DelaySeconds"], 0),
+		"max_message_size":          intParam(attrs["MaximumMessageSize"], 262144),
+		"message_retention_period":  intParam(attrs["MessageRetentionPeriod"], 345600),
+		"receive_message_wait_time": intParam(attrs["ReceiveMessageWaitTimeSeconds"], 0),
+		"fifo":                      strings.HasSuffix(queueName, ".fifo"),
+	})
+	return jsonResponse(http.StatusOK, map[string]any{"QueueUrl": queueURL})
+}
+
+func (h *Handler) deleteQueueJSON(params map[string]string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFoundJSON()
+	}
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		h.Messages.Delete(intField(message, "id"))
+	}
+	h.Queues.Delete(intField(queue, "id"))
+	return jsonResponse(http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) listQueuesJSON(params map[string]string) protocols.ErrorResponse {
+	prefix := params["QueueNamePrefix"]
+	queueURLs := []string{}
+	for _, queue := range h.Queues.All() {
+		if prefix != "" && !strings.HasPrefix(stringField(queue, "queue_name"), prefix) {
+			continue
+		}
+		queueURLs = append(queueURLs, stringField(queue, "queue_url"))
+	}
+	return jsonResponse(http.StatusOK, map[string]any{"QueueUrls": queueURLs})
+}
+
+func (h *Handler) getQueueURLJSON(params map[string]string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByName(params["QueueName"])
+	if !ok {
+		return h.queueNotFoundJSON()
+	}
+	return jsonResponse(http.StatusOK, map[string]any{"QueueUrl": stringField(queue, "queue_url")})
+}
+
+func (h *Handler) getQueueAttributesJSON(params map[string]string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFoundJSON()
+	}
+	now := h.nowMillis()
+	visibleCount := 0
+	inFlightCount := 0
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		if int64Field(message, "visible_after") <= now {
+			visibleCount++
+		} else {
+			inFlightCount++
+		}
+	}
+	return jsonResponse(http.StatusOK, map[string]any{"Attributes": map[string]string{
+		"QueueArn":                              stringField(queue, "arn"),
+		"ApproximateNumberOfMessages":           strconv.Itoa(visibleCount),
+		"ApproximateNumberOfMessagesNotVisible": strconv.Itoa(inFlightCount),
+		"VisibilityTimeout":                     strconv.Itoa(intField(queue, "visibility_timeout")),
+		"MaximumMessageSize":                    strconv.Itoa(intField(queue, "max_message_size")),
+		"MessageRetentionPeriod":                strconv.Itoa(intField(queue, "message_retention_period")),
+		"DelaySeconds":                          strconv.Itoa(intField(queue, "delay_seconds")),
+		"ReceiveMessageWaitTimeSeconds":         strconv.Itoa(intField(queue, "receive_message_wait_time")),
+		"FifoQueue":                             strconv.FormatBool(boolField(queue, "fifo")),
+	}})
+}
+
+func (h *Handler) sendMessageJSON(params map[string]string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFoundJSON()
+	}
+	messageBody := params["MessageBody"]
+	if messageBody == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]any{"__type": "MissingParameter", "message": "The request must contain the parameter MessageBody."})
+	}
+	if len([]byte(messageBody)) > intField(queue, "max_message_size") {
+		return jsonResponse(http.StatusBadRequest, map[string]any{"__type": "InvalidParameterValue", "message": "One or more parameters are invalid. Reason: Message must be shorter than " + strconv.Itoa(intField(queue, "max_message_size")) + " bytes."})
+	}
+	messageID := h.generateID()
+	bodyMD5 := md5Hex(messageBody)
+	now := h.nowMillis()
+	h.Messages.Insert(corestore.Record{
+		"queue_name":     stringField(queue, "queue_name"),
+		"message_id":     messageID,
+		"receipt_handle": h.generateReceiptHandle(),
+		"body":           messageBody,
+		"md5_of_body":    bodyMD5,
+		"attributes": corestore.Record{
+			"SentTimestamp":                    strconv.FormatInt(now, 10),
+			"ApproximateReceiveCount":          "0",
+			"ApproximateFirstReceiveTimestamp": "",
+			"SenderId":                         h.accountID(),
+		},
+		"message_attributes": parseMessageAttributes(params),
+		"visible_after":      now + int64(intField(queue, "delay_seconds"))*1000,
+		"sent_timestamp":     now,
+		"receive_count":      0,
+	})
+	return jsonResponse(http.StatusOK, map[string]any{
+		"MD5OfMessageBody": bodyMD5,
+		"MessageId":        messageID,
+	})
+}
+
+func (h *Handler) receiveMessageJSON(params map[string]string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFoundJSON()
+	}
+	maxMessages := intParam(params["MaxNumberOfMessages"], 1)
+	if maxMessages > 10 {
+		maxMessages = 10
+	}
+	if maxMessages < 1 {
+		maxMessages = 1
+	}
+	visibilityTimeout := intParam(params["VisibilityTimeout"], intField(queue, "visibility_timeout"))
+	now := h.nowMillis()
+	messages := make([]map[string]any, 0, maxMessages)
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		if int64Field(message, "visible_after") > now {
+			continue
+		}
+		receiptHandle := h.generateReceiptHandle()
+		receiveCount := intField(message, "receive_count") + 1
+		updated, _ := h.Messages.Update(intField(message, "id"), corestore.Record{
+			"receipt_handle": receiptHandle,
+			"visible_after":  now + int64(visibilityTimeout)*1000,
+			"receive_count":  receiveCount,
+		})
+		messages = append(messages, map[string]any{
+			"MessageId":     stringField(updated, "message_id"),
+			"ReceiptHandle": stringField(updated, "receipt_handle"),
+			"MD5OfBody":     stringField(updated, "md5_of_body"),
+			"Body":          stringField(updated, "body"),
+			"Attributes": map[string]string{
+				"SentTimestamp":                    strconv.FormatInt(int64Field(updated, "sent_timestamp"), 10),
+				"ApproximateReceiveCount":          strconv.Itoa(intField(updated, "receive_count")),
+				"ApproximateFirstReceiveTimestamp": strconv.FormatInt(int64Field(updated, "sent_timestamp"), 10),
+			},
+		})
+		if len(messages) == maxMessages {
+			break
+		}
+	}
+	return jsonResponse(http.StatusOK, map[string]any{"Messages": messages})
+}
+
+func (h *Handler) deleteMessageJSON(params map[string]string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFoundJSON()
+	}
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		if stringField(message, "receipt_handle") == params["ReceiptHandle"] {
+			h.Messages.Delete(intField(message, "id"))
+			break
+		}
+	}
+	return jsonResponse(http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) purgeQueueJSON(params map[string]string) protocols.ErrorResponse {
+	queue, ok := h.findQueueByURL(params["QueueUrl"])
+	if !ok {
+		return h.queueNotFoundJSON()
+	}
+	for _, message := range h.Messages.FindBy("queue_name", stringField(queue, "queue_name")) {
+		h.Messages.Delete(intField(message, "id"))
+	}
+	return jsonResponse(http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) queueURLResponse(action string, queueURL string, requestID string) protocols.ErrorResponse {
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<` + action + `Response>
+  <` + action + `Result>
+    <QueueUrl>` + xmlEscape(queueURL) + `</QueueUrl>
+  </` + action + `Result>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</` + action + `Response>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) queueNotFound(requestID string) protocols.ErrorResponse {
+	return h.queryError("AWS.SimpleQueueService.NonExistentQueue", "The specified queue does not exist.", http.StatusBadRequest, requestID)
+}
+
+func (h *Handler) queueNotFoundJSON() protocols.ErrorResponse {
+	return jsonResponse(http.StatusBadRequest, map[string]any{"__type": "QueueDoesNotExist", "message": "The specified queue does not exist."})
+}
+
+func (h *Handler) queryError(code string, message string, status int, requestID string) protocols.ErrorResponse {
+	return protocols.SerializeXMLError(protocols.AWSError{
+		Code:       code,
+		Message:    message,
+		RequestID:  requestID,
+		StatusCode: status,
+	})
+}
+
+func (h *Handler) findQueueByName(queueName string) (corestore.Record, bool) {
+	for _, queue := range h.Queues.FindBy("queue_name", queueName) {
+		return queue, true
+	}
+	return nil, false
+}
+
+func (h *Handler) findQueueByURL(queueURL string) (corestore.Record, bool) {
+	for _, queue := range h.Queues.FindBy("queue_url", queueURL) {
+		return queue, true
+	}
+	return nil, false
+}
+
+func (h *Handler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (h *Handler) nowMillis() int64 {
+	return h.now().UnixNano() / int64(time.Millisecond)
+}
+
+func (h *Handler) region() string {
+	if h.Region != "" {
+		return h.Region
+	}
+	return gateway.DefaultRegion
+}
+
+func (h *Handler) accountID() string {
+	if h.AccountID != "" {
+		return h.AccountID
+	}
+	return gateway.DefaultAccountID
+}
+
+func (h *Handler) baseURL(req *http.Request) string {
+	if h.BaseURL != "" {
+		return h.BaseURL
+	}
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + req.Host
+}
+
+func (h *Handler) generateID() string {
+	if h.IDGenerator != nil {
+		return h.IDGenerator()
+	}
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return hex.EncodeToString(bytes[0:4]) + "-" + hex.EncodeToString(bytes[4:6]) + "-" + hex.EncodeToString(bytes[6:8]) + "-" + hex.EncodeToString(bytes[8:10]) + "-" + hex.EncodeToString(bytes[10:16])
+	}
+	return fmt.Sprintf("msg-%d", fallbackIDCounter.Add(1))
+}
+
+func (h *Handler) generateReceiptHandle() string {
+	if h.ReceiptGenerator != nil {
+		return h.ReceiptGenerator()
+	}
+	var bytes [48]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return base64.RawURLEncoding.EncodeToString(bytes[:])
+	}
+	return fmt.Sprintf("receipt-%d", fallbackIDCounter.Add(1))
+}
+
+func xmlResponse(status int, body string) protocols.ErrorResponse {
+	return protocols.ErrorResponse{
+		StatusCode:  status,
+		ContentType: "application/xml",
+		Headers:     map[string]string{"Content-Type": "application/xml"},
+		Body:        []byte(body),
+	}
+}
+
+func jsonResponse(status int, value any) protocols.ErrorResponse {
+	body, _ := json.Marshal(value)
+	return protocols.ErrorResponse{
+		StatusCode:  status,
+		ContentType: "application/x-amz-json-1.0",
+		Headers:     map[string]string{"Content-Type": "application/x-amz-json-1.0"},
+		Body:        body,
+	}
+}
+
+func withRequestID(response protocols.ErrorResponse, requestID string) protocols.ErrorResponse {
+	if requestID == "" {
+		return response
+	}
+	if response.Headers == nil {
+		response.Headers = map[string]string{}
+	}
+	if response.Headers["x-amzn-requestid"] == "" {
+		response.Headers["x-amzn-requestid"] = requestID
+	}
+	return response
+}
+
+func jsonParams(input map[string]any) map[string]string {
+	params := map[string]string{}
+	attributeIndex := 1
+	messageAttributeIndex := 1
+	for key, value := range input {
+		switch key {
+		case "Attributes":
+			if values, ok := value.(map[string]any); ok {
+				for name, attrValue := range values {
+					index := strconv.Itoa(attributeIndex)
+					params["Attribute."+index+".Name"] = name
+					params["Attribute."+index+".Value"] = scalarString(attrValue)
+					attributeIndex++
+				}
+			}
+		case "MessageAttributes":
+			if values, ok := value.(map[string]any); ok {
+				for name, rawAttr := range values {
+					attr, ok := rawAttr.(map[string]any)
+					if !ok {
+						continue
+					}
+					index := strconv.Itoa(messageAttributeIndex)
+					prefix := "MessageAttribute." + index
+					params[prefix+".Name"] = name
+					params[prefix+".Value.DataType"] = scalarString(attr["DataType"])
+					params[prefix+".Value.StringValue"] = scalarString(attr["StringValue"])
+					params[prefix+".Value.BinaryValue"] = scalarString(attr["BinaryValue"])
+					messageAttributeIndex++
+				}
+			}
+		default:
+			params[key] = scalarString(value)
+		}
+	}
+	return params
+}
+
+func scalarString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func indexedAttributes(params map[string]string, prefix string) map[string]string {
+	attrs := map[string]string{}
+	for index := 1; ; index++ {
+		name := params[prefix+"."+strconv.Itoa(index)+".Name"]
+		if name == "" {
+			break
+		}
+		attrs[name] = params[prefix+"."+strconv.Itoa(index)+".Value"]
+	}
+	return attrs
+}
+
+func parseMessageAttributes(params map[string]string) corestore.Record {
+	attrs := corestore.Record{}
+	for index := 1; ; index++ {
+		prefix := "MessageAttribute." + strconv.Itoa(index)
+		name := params[prefix+".Name"]
+		if name == "" {
+			break
+		}
+		value := corestore.Record{
+			"DataType": params[prefix+".Value.DataType"],
+		}
+		if stringValue := params[prefix+".Value.StringValue"]; stringValue != "" {
+			value["StringValue"] = stringValue
+		}
+		if binaryValue := params[prefix+".Value.BinaryValue"]; binaryValue != "" {
+			value["BinaryValue"] = binaryValue
+		}
+		attrs[name] = value
+	}
+	return attrs
+}
+
+func intParam(raw string, fallback int) int {
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	return value
+}
+
+func stringField(record corestore.Record, name string) string {
+	switch value := record[name].(type) {
+	case string:
+		return value
+	default:
+		if value == nil {
+			return ""
+		}
+		return fmt.Sprint(value)
+	}
+}
+
+func intField(record corestore.Record, name string) int {
+	switch value := record[name].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func int64Field(record corestore.Record, name string) int64 {
+	switch value := record[name].(type) {
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	case float64:
+		return int64(value)
+	default:
+		return 0
+	}
+}
+
+func boolField(record corestore.Record, name string) bool {
+	value, _ := record[name].(bool)
+	return value
+}
+
+func md5Hex(value string) string {
+	sum := md5.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+type nameValue struct {
+	Name  string
+	Value string
+}
+
+func xmlEscape(value string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&apos;",
+	)
+	return replacer.Replace(value)
+}

--- a/internal/services/aws/sqs/handler.go
+++ b/internal/services/aws/sqs/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -243,7 +244,7 @@ func (h *Handler) sendMessage(params map[string]string, requestID string) protoc
 			"SenderId":                         h.accountID(),
 		},
 		"message_attributes": parseMessageAttributes(params),
-		"visible_after":      now + int64(intField(queue, "delay_seconds"))*1000,
+		"visible_after":      now + int64(messageDelaySeconds(params, queue))*1000,
 		"sent_timestamp":     now,
 		"receive_count":      0,
 	})
@@ -314,7 +315,9 @@ func (h *Handler) receiveMessage(params map[string]string, requestID string) pro
       <Attribute><Name>ApproximateFirstReceiveTimestamp</Name><Value>`)
 		rows.WriteString(strconv.FormatInt(int64Field(message, "sent_timestamp"), 10))
 		rows.WriteString(`</Value></Attribute>
-    </Message>
+`)
+		writeMessageAttributesXML(&rows, message, params)
+		rows.WriteString(`    </Message>
 `)
 	}
 	body := `<?xml version="1.0" encoding="UTF-8"?>
@@ -474,7 +477,7 @@ func (h *Handler) sendMessageJSON(params map[string]string) protocols.ErrorRespo
 			"SenderId":                         h.accountID(),
 		},
 		"message_attributes": parseMessageAttributes(params),
-		"visible_after":      now + int64(intField(queue, "delay_seconds"))*1000,
+		"visible_after":      now + int64(messageDelaySeconds(params, queue))*1000,
 		"sent_timestamp":     now,
 		"receive_count":      0,
 	})
@@ -510,7 +513,7 @@ func (h *Handler) receiveMessageJSON(params map[string]string) protocols.ErrorRe
 			"visible_after":  now + int64(visibilityTimeout)*1000,
 			"receive_count":  receiveCount,
 		})
-		messages = append(messages, map[string]any{
+		item := map[string]any{
 			"MessageId":     stringField(updated, "message_id"),
 			"ReceiptHandle": stringField(updated, "receipt_handle"),
 			"MD5OfBody":     stringField(updated, "md5_of_body"),
@@ -520,7 +523,11 @@ func (h *Handler) receiveMessageJSON(params map[string]string) protocols.ErrorRe
 				"ApproximateReceiveCount":          strconv.Itoa(intField(updated, "receive_count")),
 				"ApproximateFirstReceiveTimestamp": strconv.FormatInt(int64Field(updated, "sent_timestamp"), 10),
 			},
-		})
+		}
+		if attrs := selectedMessageAttributes(updated, params); len(attrs) > 0 {
+			item["MessageAttributes"] = attrs
+		}
+		messages = append(messages, item)
 		if len(messages) == maxMessages {
 			break
 		}
@@ -716,11 +723,34 @@ func jsonParams(input map[string]any) map[string]string {
 					messageAttributeIndex++
 				}
 			}
+		case "AttributeNames":
+			addJSONListParams(params, "AttributeName", value)
+		case "MessageAttributeNames":
+			addJSONListParams(params, "MessageAttributeName", value)
+		case "MessageSystemAttributeNames":
+			addJSONListParams(params, "MessageSystemAttributeName", value)
 		default:
 			params[key] = scalarString(value)
 		}
 	}
 	return params
+}
+
+func addJSONListParams(params map[string]string, prefix string, value any) {
+	switch values := value.(type) {
+	case []any:
+		for index, item := range values {
+			params[prefix+"."+strconv.Itoa(index+1)] = scalarString(item)
+		}
+	case []string:
+		for index, item := range values {
+			params[prefix+"."+strconv.Itoa(index+1)] = item
+		}
+	default:
+		if raw := scalarString(value); raw != "" {
+			params[prefix+".1"] = raw
+		}
+	}
 }
 
 func scalarString(value any) string {
@@ -772,6 +802,113 @@ func parseMessageAttributes(params map[string]string) corestore.Record {
 		attrs[name] = value
 	}
 	return attrs
+}
+
+func messageDelaySeconds(params map[string]string, queue corestore.Record) int {
+	return intParam(params["DelaySeconds"], intField(queue, "delay_seconds"))
+}
+
+func selectedMessageAttributes(message corestore.Record, params map[string]string) corestore.Record {
+	attrs := recordField(message, "message_attributes")
+	if len(attrs) == 0 {
+		return corestore.Record{}
+	}
+	requested := indexedNames(params, "MessageAttributeName")
+	if len(requested) == 0 {
+		return corestore.Record{}
+	}
+	selected := corestore.Record{}
+	for _, request := range requested {
+		if request == "All" || request == ".*" {
+			for name, value := range attrs {
+				selected[name] = cloneAttributeValue(value)
+			}
+			continue
+		}
+		if strings.HasSuffix(request, ".*") {
+			prefix := strings.TrimSuffix(request, ".*")
+			for name, value := range attrs {
+				if strings.HasPrefix(name, prefix) {
+					selected[name] = cloneAttributeValue(value)
+				}
+			}
+			continue
+		}
+		if value, ok := attrs[request]; ok {
+			selected[request] = cloneAttributeValue(value)
+		}
+	}
+	return selected
+}
+
+func indexedNames(params map[string]string, prefix string) []string {
+	names := []string{}
+	for index := 1; ; index++ {
+		name := params[prefix+"."+strconv.Itoa(index)]
+		if name == "" {
+			break
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func writeMessageAttributesXML(rows *strings.Builder, message corestore.Record, params map[string]string) {
+	attrs := selectedMessageAttributes(message, params)
+	names := sortedRecordKeys(attrs)
+	for _, name := range names {
+		value := recordValue(attrs[name])
+		rows.WriteString(`      <MessageAttribute><Name>`)
+		rows.WriteString(xmlEscape(name))
+		rows.WriteString(`</Name><Value><DataType>`)
+		rows.WriteString(xmlEscape(stringField(value, "DataType")))
+		rows.WriteString(`</DataType>`)
+		if stringValue := stringField(value, "StringValue"); stringValue != "" {
+			rows.WriteString(`<StringValue>`)
+			rows.WriteString(xmlEscape(stringValue))
+			rows.WriteString(`</StringValue>`)
+		}
+		if binaryValue := stringField(value, "BinaryValue"); binaryValue != "" {
+			rows.WriteString(`<BinaryValue>`)
+			rows.WriteString(xmlEscape(binaryValue))
+			rows.WriteString(`</BinaryValue>`)
+		}
+		rows.WriteString(`</Value></MessageAttribute>
+`)
+	}
+}
+
+func sortedRecordKeys(record corestore.Record) []string {
+	keys := make([]string, 0, len(record))
+	for key := range record {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func recordField(record corestore.Record, name string) corestore.Record {
+	return recordValue(record[name])
+}
+
+func recordValue(value any) corestore.Record {
+	switch typed := value.(type) {
+	case corestore.Record:
+		return typed
+	case map[string]any:
+		return corestore.Record(typed)
+	default:
+		return corestore.Record{}
+	}
+}
+
+func cloneAttributeValue(value any) corestore.Record {
+	source := recordValue(value)
+	clone := corestore.Record{}
+	for key, item := range source {
+		clone[key] = item
+	}
+	return clone
 }
 
 func intParam(raw string, fallback int) int {

--- a/internal/services/aws/sqs/handler_test.go
+++ b/internal/services/aws/sqs/handler_test.go
@@ -1,0 +1,52 @@
+package sqs
+
+import (
+	"testing"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func TestReserveVisibleMessageRejectsStaleSnapshot(t *testing.T) {
+	store := corestore.New()
+	messages := store.MustCollection("aws.sqs_messages", "message_id", "queue_name")
+	now := int64(1000)
+	snapshot := messages.Insert(corestore.Record{
+		"queue_name":     "jobs",
+		"message_id":     "m1",
+		"receipt_handle": "old",
+		"visible_after":  now,
+		"receive_count":  0,
+	})
+	handler := Handler{
+		Messages: messages,
+		ReceiptGenerator: func() string {
+			return "receipt"
+		},
+	}
+
+	reserved, ok := handler.reserveVisibleMessage(snapshot, now, 30)
+	if !ok {
+		t.Fatal("first reservation failed")
+	}
+	if got := stringField(reserved, "receipt_handle"); got != "receipt" {
+		t.Fatalf("receipt handle = %q", got)
+	}
+	if got := int64Field(reserved, "visible_after"); got != now+30000 {
+		t.Fatalf("visible_after = %d", got)
+	}
+	if got := intField(reserved, "receive_count"); got != 1 {
+		t.Fatalf("receive_count = %d", got)
+	}
+
+	stale, ok := handler.reserveVisibleMessage(snapshot, now, 30)
+	if ok || stale != nil {
+		t.Fatalf("stale reservation succeeded: %#v %v", stale, ok)
+	}
+	current, ok := messages.Get(intField(snapshot, "id"))
+	if !ok {
+		t.Fatal("message disappeared")
+	}
+	if got := intField(current, "receive_count"); got != 1 {
+		t.Fatalf("receive_count after stale reservation = %d", got)
+	}
+}

--- a/packages/@emulators/aws/README.md
+++ b/packages/@emulators/aws/README.md
@@ -1,6 +1,6 @@
 # @emulators/aws
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. Query and REST XML operations return AWS-compatible XML.
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
@@ -28,7 +28,7 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 - `DELETE /:bucket/:key` — delete object
 
 ### SQS
-Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
+SQS requests use `POST /sqs/` with an `Action` form parameter.
 
 - `CreateQueue`, `ListQueues`, `GetQueueUrl`, `GetQueueAttributes`
 - `SendMessage`, `ReceiveMessage`, `DeleteMessage`

--- a/packages/@emulators/aws/README.md
+++ b/packages/@emulators/aws/README.md
@@ -1,6 +1,6 @@
 # @emulators/aws
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/IAM/STS endpoints. All responses use AWS-compatible XML.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
@@ -28,7 +28,8 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 - `DELETE /:bucket/:key` — delete object
 
 ### SQS
-All operations via `POST /sqs/` with `Action` parameter:
+Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. `@aws-sdk/client-sqs` v3 can use the `/sqs/` endpoint directly; the SDK sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests and receives JSON responses.
+
 - `CreateQueue`, `ListQueues`, `GetQueueUrl`, `GetQueueAttributes`
 - `SendMessage`, `ReceiveMessage`, `DeleteMessage`
 - `PurgeQueue`, `DeleteQueue`

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1031.0",
+    "@aws-sdk/client-sqs": "^3.1049.0",
     "@aws-sdk/s3-presigned-post": "^3.1031.0",
     "tsup": "^8",
     "typescript": "^5.7",

--- a/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
@@ -324,13 +324,21 @@ describeExternalSqsE2E("AWS plugin - real @aws-sdk/client-sqs E2E", () => {
     );
     expect(sent.MessageId).toBeTruthy();
     expect(sent.MD5OfMessageBody).toBeTruthy();
+    expect(sent.MD5OfMessageAttributes).toBeTruthy();
 
     const received = await sqs.send(
-      new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 1, MessageAttributeNames: ["All"] }),
+      new ReceiveMessageCommand({
+        QueueUrl,
+        MaxNumberOfMessages: 1,
+        MessageAttributeNames: ["All"],
+        MessageSystemAttributeNames: ["All"],
+      }),
     );
     expect(received.Messages).toHaveLength(1);
     expect(received.Messages?.[0]?.Body).toBe("hello from sqs sdk");
     expect(received.Messages?.[0]?.ReceiptHandle).toBeTruthy();
+    expect(received.Messages?.[0]?.Attributes?.SenderId).toBe("123456789012");
+    expect(received.Messages?.[0]?.MD5OfMessageAttributes).toBe(sent.MD5OfMessageAttributes);
     expect(received.Messages?.[0]?.MessageAttributes?.color?.StringValue).toBe("blue");
 
     await sqs.send(new DeleteMessageCommand({ QueueUrl, ReceiptHandle: received.Messages?.[0]?.ReceiptHandle }));

--- a/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
@@ -14,6 +14,18 @@ import {
   CopyObjectCommand,
   ListObjectsV2Command,
 } from "@aws-sdk/client-s3";
+import {
+  SQSClient,
+  ListQueuesCommand,
+  CreateQueueCommand as CreateSQSQueueCommand,
+  GetQueueUrlCommand,
+  GetQueueAttributesCommand,
+  SendMessageCommand,
+  ReceiveMessageCommand,
+  DeleteMessageCommand,
+  PurgeQueueCommand,
+  DeleteQueueCommand as DeleteSQSQueueCommand,
+} from "@aws-sdk/client-sqs";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { createTestApp } from "./helpers.js";
 
@@ -48,6 +60,8 @@ async function streamToString(stream: unknown): Promise<string> {
   }
   return Buffer.concat(chunks).toString();
 }
+
+const describeExternalSqsE2E = process.env.AWS_EMULATOR_E2E_URL ? describe : describe.skip;
 
 describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
   let emulator: EmulatorHandle;
@@ -242,5 +256,92 @@ describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
     const res = await fetch(post.url, { method: "POST", body: form });
     expect(res.status).toBe(400);
     expect(await res.text()).toContain("EntityTooLarge");
+  });
+});
+
+describeExternalSqsE2E("AWS plugin - real @aws-sdk/client-sqs E2E", () => {
+  let emulator: EmulatorHandle;
+  let sqs: SQSClient;
+
+  beforeAll(async () => {
+    emulator = await startEmulator();
+    sqs = new SQSClient({
+      endpoint: `${emulator.url.replace(/\/$/, "")}/sqs/`,
+      region: "us-east-1",
+      credentials: { accessKeyId: "AKIA", secretAccessKey: "secret" },
+    });
+  });
+
+  afterAll(async () => {
+    sqs.destroy();
+    await emulator.close();
+  });
+
+  it("ListQueues returns the seeded default queue", async () => {
+    const res = await sqs.send(new ListQueuesCommand({}));
+    expect(res.QueueUrls ?? []).toEqual(expect.arrayContaining([expect.stringContaining("emulate-default-queue")]));
+  });
+
+  it("CreateQueue, GetQueueUrl, GetQueueAttributes, and DeleteQueue roundtrip", async () => {
+    const created = await sqs.send(
+      new CreateSQSQueueCommand({
+        QueueName: "sdk-e2e-queue",
+        Attributes: { VisibilityTimeout: "45" },
+      }),
+    );
+    expect(created.QueueUrl).toContain("sdk-e2e-queue");
+
+    const byName = await sqs.send(new GetQueueUrlCommand({ QueueName: "sdk-e2e-queue" }));
+    expect(byName.QueueUrl).toBe(created.QueueUrl);
+
+    const attrs = await sqs.send(
+      new GetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+    expect(attrs.Attributes?.QueueArn).toContain("sdk-e2e-queue");
+    expect(attrs.Attributes?.VisibilityTimeout).toBe("45");
+
+    const listed = await sqs.send(new ListQueuesCommand({ QueueNamePrefix: "sdk-e2e-" }));
+    expect(listed.QueueUrls ?? []).toContain(created.QueueUrl);
+
+    await sqs.send(new DeleteSQSQueueCommand({ QueueUrl: created.QueueUrl }));
+    const afterDelete = await sqs.send(new ListQueuesCommand({ QueueNamePrefix: "sdk-e2e-queue" }));
+    expect(afterDelete.QueueUrls ?? []).not.toContain(created.QueueUrl);
+  });
+
+  it("SendMessage, ReceiveMessage, and DeleteMessage roundtrip", async () => {
+    const { QueueUrl } = await sqs.send(new CreateSQSQueueCommand({ QueueName: "sdk-e2e-messages" }));
+    expect(QueueUrl).toBeTruthy();
+
+    const sent = await sqs.send(new SendMessageCommand({ QueueUrl, MessageBody: "hello from sqs sdk" }));
+    expect(sent.MessageId).toBeTruthy();
+    expect(sent.MD5OfMessageBody).toBeTruthy();
+
+    const received = await sqs.send(new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 1 }));
+    expect(received.Messages).toHaveLength(1);
+    expect(received.Messages?.[0]?.Body).toBe("hello from sqs sdk");
+    expect(received.Messages?.[0]?.ReceiptHandle).toBeTruthy();
+
+    await sqs.send(new DeleteMessageCommand({ QueueUrl, ReceiptHandle: received.Messages?.[0]?.ReceiptHandle }));
+    const afterDelete = await sqs.send(new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 1 }));
+    expect(afterDelete.Messages ?? []).toHaveLength(0);
+
+    await sqs.send(new DeleteSQSQueueCommand({ QueueUrl }));
+  });
+
+  it("PurgeQueue removes visible messages", async () => {
+    const { QueueUrl } = await sqs.send(new CreateSQSQueueCommand({ QueueName: "sdk-e2e-purge" }));
+    expect(QueueUrl).toBeTruthy();
+
+    await sqs.send(new SendMessageCommand({ QueueUrl, MessageBody: "one" }));
+    await sqs.send(new SendMessageCommand({ QueueUrl, MessageBody: "two" }));
+    await sqs.send(new PurgeQueueCommand({ QueueUrl }));
+
+    const received = await sqs.send(new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 10 }));
+    expect(received.Messages ?? []).toHaveLength(0);
+
+    await sqs.send(new DeleteSQSQueueCommand({ QueueUrl }));
   });
 });

--- a/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
@@ -315,18 +315,39 @@ describeExternalSqsE2E("AWS plugin - real @aws-sdk/client-sqs E2E", () => {
     const { QueueUrl } = await sqs.send(new CreateSQSQueueCommand({ QueueName: "sdk-e2e-messages" }));
     expect(QueueUrl).toBeTruthy();
 
-    const sent = await sqs.send(new SendMessageCommand({ QueueUrl, MessageBody: "hello from sqs sdk" }));
+    const sent = await sqs.send(
+      new SendMessageCommand({
+        QueueUrl,
+        MessageBody: "hello from sqs sdk",
+        MessageAttributes: { color: { DataType: "String", StringValue: "blue" } },
+      }),
+    );
     expect(sent.MessageId).toBeTruthy();
     expect(sent.MD5OfMessageBody).toBeTruthy();
 
-    const received = await sqs.send(new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 1 }));
+    const received = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 1, MessageAttributeNames: ["All"] }),
+    );
     expect(received.Messages).toHaveLength(1);
     expect(received.Messages?.[0]?.Body).toBe("hello from sqs sdk");
     expect(received.Messages?.[0]?.ReceiptHandle).toBeTruthy();
+    expect(received.Messages?.[0]?.MessageAttributes?.color?.StringValue).toBe("blue");
 
     await sqs.send(new DeleteMessageCommand({ QueueUrl, ReceiptHandle: received.Messages?.[0]?.ReceiptHandle }));
     const afterDelete = await sqs.send(new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 1 }));
     expect(afterDelete.Messages ?? []).toHaveLength(0);
+
+    await sqs.send(new DeleteSQSQueueCommand({ QueueUrl }));
+  });
+
+  it("SendMessage DelaySeconds keeps a message hidden initially", async () => {
+    const { QueueUrl } = await sqs.send(new CreateSQSQueueCommand({ QueueName: "sdk-e2e-delay" }));
+    expect(QueueUrl).toBeTruthy();
+
+    await sqs.send(new SendMessageCommand({ QueueUrl, MessageBody: "not yet", DelaySeconds: 5 }));
+
+    const received = await sqs.send(new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 1 }));
+    expect(received.Messages ?? []).toHaveLength(0);
 
     await sqs.send(new DeleteSQSQueueCommand({ QueueUrl }));
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1031.0
         version: 3.1031.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.1049.0
+        version: 3.1049.0
       '@aws-sdk/s3-presigned-post':
         specifier: ^3.1031.0
         version: 3.1031.0
@@ -735,8 +738,16 @@ packages:
     resolution: {integrity: sha512-HflwKSpDl2pwPiH116n9dy1pKW+5yEoiGFor6NO1yADgge+QY5LqluBiHscD7k/o9ib+dgxf6Vg4WsctcRT3OA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sqs@3.1049.0':
+    resolution: {integrity: sha512-AiYaJS3uqH/u6uxxNOuCP9B7pUBDvsrf2LG6HTp7wGFbio3GxcJchUHpSBtbD0j2ZaGyZpOJyuPJ1/4sY5Z20Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.0':
     resolution: {integrity: sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.12':
+    resolution: {integrity: sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.7':
@@ -747,32 +758,64 @@ packages:
     resolution: {integrity: sha512-WBHAMxyPdgeJY6ZGLvq9mJwzZ+GaNUROQbfdVshtMsDVBrZTj5ZuFjKclSjSHvKSHJ4Y4O2yvI/aA/hrJbYfng==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.38':
+    resolution: {integrity: sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.28':
     resolution: {integrity: sha512-+1DwCjjpo1WoiZTN08yGitI3nUwZUSQWVWFrW4C46HqZwACjcUQ7C66tnKPBTVxrEYYDOP11A6Afmu1L6ylt3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    resolution: {integrity: sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.30':
     resolution: {integrity: sha512-Fg1oJcoijwOZjTxdbx+ubqbQl8YEQ4Cwhjw6TWzQjuDEvQYNhnCXW2pN7eKtdTrdE4a6+5TVKGSm2I+i2BKIQg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    resolution: {integrity: sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.30':
     resolution: {integrity: sha512-nchIrrI/7dgjG1bW/DEWOJc00K9n+kkl6B8Mk0KO6d4GfWBOXlVr9uHp7CJR9FIrjmov5SGjHXG2q9XAtkRw6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    resolution: {integrity: sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.31':
     resolution: {integrity: sha512-99OHVQ6eZ5DTxiOWgHdjBMvLqv7xoY4jLK6nZ1NcNSQbAnYZkQNIHi/VqInc9fnmg7of9si/z+waE6YL9OQIlw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.43':
+    resolution: {integrity: sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.26':
     resolution: {integrity: sha512-jibxNld3m+vbmQwn98hcQ+fLIVrx3cQuhZlSs1/hix48SjDS5/pjMLwpmtLD/lFnd6ve1AL4o1bZg3X1WRa2SQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    resolution: {integrity: sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.30':
     resolution: {integrity: sha512-honYIM17F/+QSWJRE84T4u//ofqEi7rLbnwmIpu7fgFX5PML78wbtdSAy5Xwyve3TLpE9/f9zQx0aBVxSjAOPw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    resolution: {integrity: sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.30':
     resolution: {integrity: sha512-CyL4oWUlONQRN2SsYMVrA9Z3i3QfLWTQctI8tuKbjNGCVVDCnJf/yMbSJCOZgpPFRtxh7dgQwvpqwmJm+iytmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    resolution: {integrity: sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
@@ -807,6 +850,10 @@ packages:
     resolution: {integrity: sha512-ayk68penP1WDZmyDZVeUQzq+HI3iDq5xezohUxIQoKFKE0KdCnDcxLCNnLanhBfgQDaKiGHVXhxZMDWJAEEBsQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.24':
+    resolution: {integrity: sha512-ej3vwWFzTP2B0FxlU2JelMaxplEncflFv2ARsoMQ9TXI/yfmsPEZw8zkOdsQp3rMEJ/vN7iKTYDYIcpeMmDRoQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-ssec@3.972.10':
     resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
     engines: {node: '>=20.0.0'}
@@ -817,6 +864,10 @@ packages:
 
   '@aws-sdk/nested-clients@3.996.20':
     resolution: {integrity: sha512-bzPdsNQnCh6TvvUmTHLZlL8qgyME6mNiUErcRMyJPywIl1BEu2VZRShel3mUoSh89bOBEXEWtjocDMolFxd/9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.10':
+    resolution: {integrity: sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.12':
@@ -831,8 +882,16 @@ packages:
     resolution: {integrity: sha512-qDwhXw+SIM5vMAMgflA8LPRa7xP+/wgXYr++llzCOwp7kkM2v7GGGWzoRW8e1CACaO4ljZd/NSQbsRLKm1sMWw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1031.0':
     resolution: {integrity: sha512-zj/PvnbQK/2KJNln5K2QRI9HSsy+B4emz2gbQyUHkk6l7Lidu83P/9tfmC2cJXkcC3vdmyKH2DP3Iw/FDfKQuQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1049.0':
+    resolution: {integrity: sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
@@ -869,6 +928,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.18':
     resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1535,6 +1598,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2525,8 +2591,16 @@ packages:
     resolution: {integrity: sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.3':
+    resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.3':
+    resolution: {integrity: sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.14':
@@ -2551,6 +2625,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.17':
     resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.3':
+    resolution: {integrity: sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -2609,6 +2687,10 @@ packages:
     resolution: {integrity: sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.14':
     resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
@@ -2637,12 +2719,20 @@ packages:
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.3':
+    resolution: {integrity: sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.11':
     resolution: {integrity: sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.14':
@@ -4039,8 +4129,15 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastq@1.20.1:
@@ -5012,6 +5109,10 @@ packages:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -5519,6 +5620,9 @@ packages:
   strnum@2.2.1:
     resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
@@ -5987,6 +6091,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6179,6 +6287,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-sqs@3.1049.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-node': 3.972.43
+      '@aws-sdk/middleware-sdk-sqs': 3.972.24
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.0':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6195,6 +6317,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
       '@smithy/types': 4.14.1
@@ -6205,6 +6338,14 @@ snapshots:
       '@aws-sdk/core': 3.974.0
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -6219,6 +6360,16 @@ snapshots:
       '@smithy/smithy-client': 4.12.11
       '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.5.23
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.30':
@@ -6240,6 +6391,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-login': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.30':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6252,6 +6419,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.31':
     dependencies:
@@ -6270,12 +6446,34 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.43':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-ini': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.26':
     dependencies:
       '@aws-sdk/core': 3.974.0
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -6292,6 +6490,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/token-providers': 3.1049.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.30':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6303,6 +6511,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
     dependencies:
@@ -6382,6 +6599,13 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.24':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-ssec@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6442,6 +6666,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.10':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.12':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6473,6 +6710,14 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1031.0':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6484,6 +6729,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/token-providers@3.1049.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/types@3.973.8':
     dependencies:
@@ -6533,6 +6787,13 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -7142,6 +7403,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.0':
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8120,12 +8383,24 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.14':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.14':
@@ -8164,6 +8439,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -8261,6 +8542,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.14':
     dependencies:
       '@smithy/types': 4.14.1
@@ -8302,6 +8589,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.11':
     dependencies:
       '@smithy/core': 3.23.15
@@ -8313,6 +8606,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -9961,11 +10258,23 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.0
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
   fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
       strnum: 2.2.1
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -11313,6 +11622,8 @@ snapshots:
 
   path-expression-matcher@1.2.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -12054,6 +12365,8 @@ snapshots:
 
   strnum@2.2.1: {}
 
+  strnum@2.3.0: {}
+
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -12568,6 +12881,8 @@ snapshots:
 
   wrappy@1.0.2:
     optional: true
+
+  xml-naming@0.1.0: {}
 
   y18n@5.0.8:
     optional: true

--- a/skills/aws/SKILL.md
+++ b/skills/aws/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
 
 # AWS Emulator
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/IAM/STS endpoints. All state is in-memory, and responses use AWS-compatible XML.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. All state is in-memory. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
 
 ## Start
 
@@ -72,6 +72,8 @@ const sqs = new SQSClient({
   },
 })
 ```
+
+The SQS SDK client sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests to `/sqs` and receives JSON responses. Manual curl calls can use the AWS Query form examples below.
 
 ```typescript
 import { IAMClient } from '@aws-sdk/client-iam'
@@ -170,7 +172,7 @@ curl -X PUT http://localhost:4006/dest-bucket/copy.txt \
 
 ### SQS
 
-All SQS operations use `POST /sqs/` with `Action` as a form-urlencoded parameter.
+Manual SQS calls can use AWS Query over `POST /sqs/` with `Action` as a form-urlencoded parameter. The same operations also work through `@aws-sdk/client-sqs` with endpoint `${AWS_EMULATOR_URL}/sqs`; SDK responses are JSON.
 
 ```bash
 # Create queue

--- a/skills/aws/SKILL.md
+++ b/skills/aws/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
 
 # AWS Emulator
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS Query endpoints for SQS/IAM/STS, and current AWS SDK JSON support for SQS. All state is in-memory. Query and REST XML operations return AWS-compatible XML; SQS JSON requests return AWS-compatible JSON.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime also accepts current AWS SDK JSON requests for SQS and returns JSON responses.
 
 ## Start
 
@@ -73,7 +73,7 @@ const sqs = new SQSClient({
 })
 ```
 
-The SQS SDK client sends `X-Amz-Target: AmazonSQS.<Action>` JSON requests to `/sqs` and receives JSON responses. Manual curl calls can use the AWS Query form examples below.
+The native Go runtime accepts the SQS SDK client's `X-Amz-Target: AmazonSQS.<Action>` JSON requests to `/sqs` and returns JSON responses. Manual curl calls can use the AWS Query form examples below.
 
 ```typescript
 import { IAMClient } from '@aws-sdk/client-iam'
@@ -172,7 +172,7 @@ curl -X PUT http://localhost:4006/dest-bucket/copy.txt \
 
 ### SQS
 
-Manual SQS calls can use AWS Query over `POST /sqs/` with `Action` as a form-urlencoded parameter. The same operations also work through `@aws-sdk/client-sqs` with endpoint `${AWS_EMULATOR_URL}/sqs`; SDK responses are JSON.
+Manual SQS calls can use AWS Query over `POST /sqs/` with `Action` as a form-urlencoded parameter. In the native Go runtime, the same operations also work through `@aws-sdk/client-sqs` with endpoint `${AWS_EMULATOR_URL}/sqs`; SDK responses are JSON.
 
 ```bash
 # Create queue


### PR DESCRIPTION
- Implements native Go SQS queue and message operations for Query and current JSON SDK protocols.

- Seeds the default SQS queue and routes SQS through the AWS service with queue attributes, visibility, purge, and delete behavior.

- Adds Go coverage and JS SDK v3 SQS E2E coverage against the Go runtime.