### PR TITLE
Add native Go IAM and STS current parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - run: go build ./cmd/emulate
 
-      - name: Native SQS SDK E2E
+      - name: Native AWS SDK E2E
         run: |
           go build -o /tmp/emulate-native ./cmd/emulate
           /tmp/emulate-native start --service aws --port 4017 &
@@ -51,7 +51,7 @@ jobs:
             sleep 0.2
           done
           test "${ready:-}" = "1"
-          AWS_EMULATOR_E2E_URL=http://127.0.0.1:4017 pnpm --dir packages/@emulators/aws exec vitest run src/__tests__/aws-sdk.e2e.test.ts -t sqs
+          AWS_EMULATOR_E2E_URL=http://127.0.0.1:4017 pnpm --dir packages/@emulators/aws exec vitest run src/__tests__/aws-sdk.e2e.test.ts -t "sqs|iam|sts"
 
       - run: node scripts/sync-versions.mjs --check
 

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 
 ## AWS
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. Query and REST XML operations return AWS-compatible XML. The native Go runtime also accepts current AWS SDK JSON requests for SQS and returns JSON responses.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. Query and REST XML operations return AWS-compatible XML. The native Go runtime is verified against current AWS SDK v3 clients for SQS, IAM, and STS; SQS uses JSON target requests, while IAM and STS use AWS Query XML.
 
 ### S3
 
@@ -682,13 +682,15 @@ Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. In the
 - `PurgeQueue`, `DeleteQueue`
 
 ### IAM
-All operations via `POST /iam/` with `Action` parameter:
+Manual IAM requests can use `POST /iam/` with an `Action` form parameter. In the native Go runtime, `@aws-sdk/client-iam` v3 can use the `/iam/` endpoint directly.
+
 - `CreateUser`, `GetUser`, `ListUsers`, `DeleteUser`
 - `CreateAccessKey`, `ListAccessKeys`, `DeleteAccessKey`
 - `CreateRole`, `GetRole`, `ListRoles`, `DeleteRole`
 
 ### STS
-All operations via `POST /sts/` with `Action` parameter:
+Manual STS requests can use `POST /sts/` with an `Action` form parameter. In the native Go runtime, `@aws-sdk/client-sts` v3 can use the `/sts/` endpoint directly.
+
 - `GetCallerIdentity`, `AssumeRole`
 
 ## Next.js Integration

--- a/apps/web/app/docs/aws/page.mdx
+++ b/apps/web/app/docs/aws/page.mdx
@@ -1,6 +1,6 @@
 # AWS
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime also accepts current AWS SDK JSON requests for SQS and returns JSON responses.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime is verified against current AWS SDK v3 clients for SQS, IAM, and STS; SQS uses JSON target requests, while IAM and STS use AWS Query XML.
 
 ## S3
 
@@ -34,7 +34,7 @@ Manual SQS requests can use `POST /sqs/` with an `Action` form parameter. In the
 
 ## IAM
 
-All IAM operations use `POST /iam/` with an `Action` form parameter.
+Manual IAM requests can use `POST /iam/` with an `Action` form parameter. In the native Go runtime, `@aws-sdk/client-iam` v3 can use the `/iam/` endpoint directly.
 
 - `CreateUser` / `GetUser` / `ListUsers` / `DeleteUser` - user management
 - `CreateAccessKey` / `ListAccessKeys` / `DeleteAccessKey` - access key management
@@ -42,7 +42,7 @@ All IAM operations use `POST /iam/` with an `Action` form parameter.
 
 ## STS
 
-All STS operations use `POST /sts/` with an `Action` form parameter.
+Manual STS requests can use `POST /sts/` with an `Action` form parameter. In the native Go runtime, `@aws-sdk/client-sts` v3 can use the `/sts/` endpoint directly.
 
 - `GetCallerIdentity` - get caller identity
 - `AssumeRole` - assume a role (returns temporary credentials)

--- a/internal/services/aws/auth/credentials.go
+++ b/internal/services/aws/auth/credentials.go
@@ -1,5 +1,7 @@
 package auth
 
+import "sync"
+
 type Credential struct {
 	AccessKeyID     string
 	SecretAccessKey string
@@ -10,6 +12,7 @@ type Credential struct {
 }
 
 type Store struct {
+	mu          sync.RWMutex
 	credentials map[string]Credential
 }
 
@@ -28,9 +31,34 @@ func (store *Store) Resolve(accessKeyID string) (Credential, bool) {
 	if store == nil || accessKeyID == "" {
 		return Credential{}, false
 	}
+	store.mu.RLock()
+	defer store.mu.RUnlock()
 	credential, ok := store.credentials[accessKeyID]
 	if !ok || credential.Disabled {
 		return Credential{}, false
 	}
 	return credential, true
+}
+
+func (store *Store) Put(credential Credential) bool {
+	if store == nil || credential.AccessKeyID == "" {
+		return false
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.credentials[credential.AccessKeyID] = credential
+	return true
+}
+
+func (store *Store) Delete(accessKeyID string) bool {
+	if store == nil || accessKeyID == "" {
+		return false
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, ok := store.credentials[accessKeyID]; !ok {
+		return false
+	}
+	delete(store.credentials, accessKeyID)
+	return true
 }

--- a/internal/services/aws/defaults.go
+++ b/internal/services/aws/defaults.go
@@ -1,12 +1,19 @@
 package aws
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/services/aws/auth"
 	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
 )
+
+var fallbackAWSIDCounter atomic.Uint64
 
 func seedS3Defaults(store Store, region string) {
 	if len(store.S3Buckets.FindBy("bucket_name", "emulate-default")) > 0 {
@@ -46,4 +53,49 @@ func seedSQSDefaults(store Store, baseURL string, accountID string, region strin
 		"receive_message_wait_time": 0,
 		"fifo":                      false,
 	})
+}
+
+func seedIAMDefaults(store Store, credentialStore *auth.Store, accountID string) {
+	if accountID == "" {
+		accountID = gateway.DefaultAccountID
+	}
+	defaultAccessKeyID := "AKIAIOSFODNN7EXAMPLE"
+	defaultSecretAccessKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	var user corestore.Record
+	if existing := store.IAMUsers.FindBy("user_name", "admin"); len(existing) > 0 {
+		user = existing[0]
+	} else {
+		user = store.IAMUsers.Insert(corestore.Record{
+			"user_name": "admin",
+			"user_id":   generateAWSID("AIDA"),
+			"arn":       "arn:aws:iam::" + accountID + ":user/admin",
+			"path":      "/",
+			"access_keys": []corestore.Record{
+				{
+					"access_key_id":     defaultAccessKeyID,
+					"secret_access_key": defaultSecretAccessKey,
+					"status":            "Active",
+				},
+			},
+		})
+	}
+	credentialStore.Put(auth.Credential{
+		AccessKeyID:     defaultAccessKeyID,
+		SecretAccessKey: defaultSecretAccessKey,
+		AccountID:       accountID,
+		PrincipalARN:    stringRecordField(user, "arn"),
+	})
+}
+
+func generateAWSID(prefix string) string {
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return prefix + strings.ToUpper(hex.EncodeToString(bytes[:]))
+	}
+	return fmt.Sprintf("%s%016X", prefix, fallbackAWSIDCounter.Add(1))
+}
+
+func stringRecordField(record corestore.Record, name string) string {
+	value, _ := record[name].(string)
+	return value
 }

--- a/internal/services/aws/iam/handler.go
+++ b/internal/services/aws/iam/handler.go
@@ -1,0 +1,544 @@
+package iam
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/services/aws/auth"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+)
+
+type Handler struct {
+	Users           *corestore.Collection
+	Roles           *corestore.Collection
+	CredentialStore *auth.Store
+	AccountID       string
+	Now             func() time.Time
+	IDGenerator     func(string) string
+	SecretGenerator func(int) string
+}
+
+var fallbackIDCounter atomic.Uint64
+
+func (h *Handler) Handle(_ *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	requestID := ctx.RequestID
+	if requestID == "" {
+		requestID = h.generateID("req")
+	}
+	var response protocols.ErrorResponse
+	switch ctx.Action {
+	case "CreateUser":
+		response = h.createUser(ctx.Query, requestID)
+	case "GetUser":
+		response = h.getUser(ctx.Query, requestID)
+	case "DeleteUser":
+		response = h.deleteUser(ctx.Query, requestID)
+	case "ListUsers":
+		response = h.listUsers(requestID)
+	case "CreateAccessKey":
+		response = h.createAccessKey(ctx.Query, requestID)
+	case "ListAccessKeys":
+		response = h.listAccessKeys(ctx.Query, requestID)
+	case "DeleteAccessKey":
+		response = h.deleteAccessKey(ctx.Query, requestID)
+	case "CreateRole":
+		response = h.createRole(ctx.Query, requestID)
+	case "GetRole":
+		response = h.getRole(ctx.Query, requestID)
+	case "DeleteRole":
+		response = h.deleteRole(ctx.Query, requestID)
+	case "ListRoles":
+		response = h.listRoles(requestID)
+	default:
+		action := ctx.Action
+		response = h.queryError("InvalidAction", "The action "+action+" is not valid for this endpoint.", http.StatusBadRequest, requestID)
+	}
+	return withRequestID(response, requestID)
+}
+
+func (h *Handler) createUser(params map[string]string, requestID string) protocols.ErrorResponse {
+	userName := params["UserName"]
+	if userName == "" {
+		return h.queryError("ValidationError", "The request must contain the parameter UserName.", http.StatusBadRequest, requestID)
+	}
+	if _, ok := h.findUser(userName); ok {
+		return h.queryError("EntityAlreadyExists", "User with name "+userName+" already exists.", http.StatusConflict, requestID)
+	}
+	path := params["Path"]
+	if path == "" {
+		path = "/"
+	}
+	user := h.Users.Insert(corestore.Record{
+		"user_name":   userName,
+		"user_id":     h.generateID("AIDA"),
+		"arn":         "arn:aws:iam::" + h.accountID() + ":user" + path + userName,
+		"path":        path,
+		"access_keys": []corestore.Record{},
+	})
+	return h.userResponse("CreateUser", user, requestID)
+}
+
+func (h *Handler) getUser(params map[string]string, requestID string) protocols.ErrorResponse {
+	userName := params["UserName"]
+	user, ok := h.findUser(userName)
+	if !ok {
+		return h.noSuchUser(userName, requestID)
+	}
+	return h.userResponse("GetUser", user, requestID)
+}
+
+func (h *Handler) deleteUser(params map[string]string, requestID string) protocols.ErrorResponse {
+	userName := params["UserName"]
+	user, ok := h.findUser(userName)
+	if !ok {
+		return h.noSuchUser(userName, requestID)
+	}
+	for _, key := range accessKeys(user) {
+		h.CredentialStore.Delete(stringField(key, "access_key_id"))
+	}
+	h.Users.Delete(intField(user, "id"))
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<DeleteUserResponse>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</DeleteUserResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) listUsers(requestID string) protocols.ErrorResponse {
+	var rows strings.Builder
+	for _, user := range h.Users.All() {
+		rows.WriteString(`      <member>
+`)
+		writeUserXML(&rows, user)
+		rows.WriteString(`      </member>
+`)
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ListUsersResponse>
+  <ListUsersResult>
+    <IsTruncated>false</IsTruncated>
+    <Users>
+` + strings.TrimRight(rows.String(), "\n") + `
+    </Users>
+  </ListUsersResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</ListUsersResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) createAccessKey(params map[string]string, requestID string) protocols.ErrorResponse {
+	userName := params["UserName"]
+	user, ok := h.findUser(userName)
+	if !ok {
+		return h.noSuchUser(userName, requestID)
+	}
+	accessKeyID := "AKIA" + h.generateID("")[0:16]
+	secretAccessKey := h.generateSecret(30)
+	key := corestore.Record{
+		"access_key_id":     accessKeyID,
+		"secret_access_key": secretAccessKey,
+		"status":            "Active",
+	}
+	keys := append(accessKeys(user), key)
+	updated, _ := h.Users.Update(intField(user, "id"), corestore.Record{"access_keys": keys})
+	h.CredentialStore.Put(auth.Credential{
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: secretAccessKey,
+		AccountID:       h.accountID(),
+		PrincipalARN:    stringField(updated, "arn"),
+	})
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateAccessKeyResponse>
+  <CreateAccessKeyResult>
+    <AccessKey>
+      <UserName>` + xmlEscape(userName) + `</UserName>
+      <AccessKeyId>` + accessKeyID + `</AccessKeyId>
+      <Status>Active</Status>
+      <SecretAccessKey>` + xmlEscape(secretAccessKey) + `</SecretAccessKey>
+      <CreateDate>` + xmlEscape(h.now().Format(time.RFC3339Nano)) + `</CreateDate>
+    </AccessKey>
+  </CreateAccessKeyResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</CreateAccessKeyResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) listAccessKeys(params map[string]string, requestID string) protocols.ErrorResponse {
+	userName := params["UserName"]
+	user, ok := h.findUser(userName)
+	if !ok {
+		return h.noSuchUser(userName, requestID)
+	}
+	var rows strings.Builder
+	for _, key := range accessKeys(user) {
+		rows.WriteString(`      <member>
+        <UserName>`)
+		rows.WriteString(xmlEscape(userName))
+		rows.WriteString(`</UserName>
+        <AccessKeyId>`)
+		rows.WriteString(xmlEscape(stringField(key, "access_key_id")))
+		rows.WriteString(`</AccessKeyId>
+        <Status>`)
+		rows.WriteString(xmlEscape(stringField(key, "status")))
+		rows.WriteString(`</Status>
+      </member>
+`)
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ListAccessKeysResponse>
+  <ListAccessKeysResult>
+    <IsTruncated>false</IsTruncated>
+    <AccessKeyMetadata>
+` + strings.TrimRight(rows.String(), "\n") + `
+    </AccessKeyMetadata>
+  </ListAccessKeysResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</ListAccessKeysResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) deleteAccessKey(params map[string]string, requestID string) protocols.ErrorResponse {
+	userName := params["UserName"]
+	accessKeyID := params["AccessKeyId"]
+	user, ok := h.findUser(userName)
+	if !ok {
+		return h.noSuchUser(userName, requestID)
+	}
+	keys := []corestore.Record{}
+	for _, key := range accessKeys(user) {
+		if stringField(key, "access_key_id") == accessKeyID {
+			h.CredentialStore.Delete(accessKeyID)
+			continue
+		}
+		keys = append(keys, key)
+	}
+	h.Users.Update(intField(user, "id"), corestore.Record{"access_keys": keys})
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<DeleteAccessKeyResponse>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</DeleteAccessKeyResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) createRole(params map[string]string, requestID string) protocols.ErrorResponse {
+	roleName := params["RoleName"]
+	if roleName == "" {
+		return h.queryError("ValidationError", "The request must contain the parameter RoleName.", http.StatusBadRequest, requestID)
+	}
+	if _, ok := h.findRole(roleName); ok {
+		return h.queryError("EntityAlreadyExists", "Role with name "+roleName+" already exists.", http.StatusConflict, requestID)
+	}
+	path := params["Path"]
+	if path == "" {
+		path = "/"
+	}
+	role := h.Roles.Insert(corestore.Record{
+		"role_name":                   roleName,
+		"role_id":                     h.generateID("AROA"),
+		"arn":                         "arn:aws:iam::" + h.accountID() + ":role" + path + roleName,
+		"path":                        path,
+		"assume_role_policy_document": defaultString(params["AssumeRolePolicyDocument"], "{}"),
+		"description":                 params["Description"],
+	})
+	return h.roleResponse("CreateRole", role, requestID)
+}
+
+func (h *Handler) getRole(params map[string]string, requestID string) protocols.ErrorResponse {
+	roleName := params["RoleName"]
+	role, ok := h.findRole(roleName)
+	if !ok {
+		return h.noSuchRole(roleName, requestID)
+	}
+	return h.roleResponse("GetRole", role, requestID)
+}
+
+func (h *Handler) deleteRole(params map[string]string, requestID string) protocols.ErrorResponse {
+	roleName := params["RoleName"]
+	role, ok := h.findRole(roleName)
+	if !ok {
+		return h.noSuchRole(roleName, requestID)
+	}
+	h.Roles.Delete(intField(role, "id"))
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<DeleteRoleResponse>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</DeleteRoleResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) listRoles(requestID string) protocols.ErrorResponse {
+	var rows strings.Builder
+	for _, role := range h.Roles.All() {
+		rows.WriteString(`      <member>
+`)
+		writeRoleXML(&rows, role)
+		rows.WriteString(`      </member>
+`)
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ListRolesResponse>
+  <ListRolesResult>
+    <IsTruncated>false</IsTruncated>
+    <Roles>
+` + strings.TrimRight(rows.String(), "\n") + `
+    </Roles>
+  </ListRolesResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</ListRolesResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) userResponse(action string, user corestore.Record, requestID string) protocols.ErrorResponse {
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<` + action + `Response>
+  <` + action + `Result>
+    <User>
+`
+	var rows strings.Builder
+	writeUserXML(&rows, user)
+	body += strings.TrimRight(rows.String(), "\n") + `
+    </User>
+  </` + action + `Result>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</` + action + `Response>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) roleResponse(action string, role corestore.Record, requestID string) protocols.ErrorResponse {
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<` + action + `Response>
+  <` + action + `Result>
+    <Role>
+`
+	var rows strings.Builder
+	writeRoleXML(&rows, role)
+	body += strings.TrimRight(rows.String(), "\n") + `
+    </Role>
+  </` + action + `Result>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</` + action + `Response>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func writeUserXML(rows *strings.Builder, user corestore.Record) {
+	rows.WriteString(`      <Path>`)
+	rows.WriteString(xmlEscape(stringField(user, "path")))
+	rows.WriteString(`</Path>
+      <UserName>`)
+	rows.WriteString(xmlEscape(stringField(user, "user_name")))
+	rows.WriteString(`</UserName>
+      <UserId>`)
+	rows.WriteString(xmlEscape(stringField(user, "user_id")))
+	rows.WriteString(`</UserId>
+      <Arn>`)
+	rows.WriteString(xmlEscape(stringField(user, "arn")))
+	rows.WriteString(`</Arn>
+      <CreateDate>`)
+	rows.WriteString(xmlEscape(stringField(user, "created_at")))
+	rows.WriteString(`</CreateDate>
+`)
+}
+
+func writeRoleXML(rows *strings.Builder, role corestore.Record) {
+	rows.WriteString(`      <Path>`)
+	rows.WriteString(xmlEscape(stringField(role, "path")))
+	rows.WriteString(`</Path>
+      <RoleName>`)
+	rows.WriteString(xmlEscape(stringField(role, "role_name")))
+	rows.WriteString(`</RoleName>
+      <RoleId>`)
+	rows.WriteString(xmlEscape(stringField(role, "role_id")))
+	rows.WriteString(`</RoleId>
+      <Arn>`)
+	rows.WriteString(xmlEscape(stringField(role, "arn")))
+	rows.WriteString(`</Arn>
+      <CreateDate>`)
+	rows.WriteString(xmlEscape(stringField(role, "created_at")))
+	rows.WriteString(`</CreateDate>
+      <AssumeRolePolicyDocument>`)
+	rows.WriteString(xmlEscape(urlEncode(stringField(role, "assume_role_policy_document"))))
+	rows.WriteString(`</AssumeRolePolicyDocument>
+      <Description>`)
+	rows.WriteString(xmlEscape(stringField(role, "description")))
+	rows.WriteString(`</Description>
+`)
+}
+
+func (h *Handler) noSuchUser(userName string, requestID string) protocols.ErrorResponse {
+	return h.queryError("NoSuchEntity", "The user with name "+userName+" cannot be found.", http.StatusNotFound, requestID)
+}
+
+func (h *Handler) noSuchRole(roleName string, requestID string) protocols.ErrorResponse {
+	return h.queryError("NoSuchEntity", "The role with name "+roleName+" cannot be found.", http.StatusNotFound, requestID)
+}
+
+func (h *Handler) queryError(code string, message string, status int, requestID string) protocols.ErrorResponse {
+	return protocols.SerializeXMLError(protocols.AWSError{
+		Code:       code,
+		Message:    message,
+		RequestID:  requestID,
+		StatusCode: status,
+	})
+}
+
+func (h *Handler) findUser(userName string) (corestore.Record, bool) {
+	for _, user := range h.Users.FindBy("user_name", userName) {
+		return user, true
+	}
+	return nil, false
+}
+
+func (h *Handler) findRole(roleName string) (corestore.Record, bool) {
+	for _, role := range h.Roles.FindBy("role_name", roleName) {
+		return role, true
+	}
+	return nil, false
+}
+
+func (h *Handler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (h *Handler) accountID() string {
+	if h.AccountID != "" {
+		return h.AccountID
+	}
+	return gateway.DefaultAccountID
+}
+
+func (h *Handler) generateID(prefix string) string {
+	if h.IDGenerator != nil {
+		return h.IDGenerator(prefix)
+	}
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return prefix + strings.ToUpper(hex.EncodeToString(bytes[:]))
+	}
+	return fmt.Sprintf("%s%016X", prefix, fallbackIDCounter.Add(1))
+}
+
+func (h *Handler) generateSecret(size int) string {
+	if h.SecretGenerator != nil {
+		return h.SecretGenerator(size)
+	}
+	bytes := make([]byte, size)
+	if _, err := rand.Read(bytes); err == nil {
+		return base64.StdEncoding.EncodeToString(bytes)
+	}
+	return fmt.Sprintf("secret-%d", fallbackIDCounter.Add(1))
+}
+
+func accessKeys(user corestore.Record) []corestore.Record {
+	switch value := user["access_keys"].(type) {
+	case []corestore.Record:
+		return append([]corestore.Record(nil), value...)
+	case []map[string]any:
+		keys := make([]corestore.Record, 0, len(value))
+		for _, item := range value {
+			keys = append(keys, corestore.Record(item))
+		}
+		return keys
+	case []any:
+		keys := make([]corestore.Record, 0, len(value))
+		for _, item := range value {
+			if record := recordValue(item); len(record) > 0 {
+				keys = append(keys, record)
+			}
+		}
+		return keys
+	default:
+		return []corestore.Record{}
+	}
+}
+
+func recordValue(value any) corestore.Record {
+	switch typed := value.(type) {
+	case corestore.Record:
+		return typed
+	case map[string]any:
+		return corestore.Record(typed)
+	default:
+		return corestore.Record{}
+	}
+}
+
+func stringField(record corestore.Record, name string) string {
+	switch value := record[name].(type) {
+	case string:
+		return value
+	default:
+		if value == nil {
+			return ""
+		}
+		return fmt.Sprint(value)
+	}
+}
+
+func intField(record corestore.Record, name string) int {
+	switch value := record[name].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func defaultString(value string, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func urlEncode(value string) string {
+	return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
+}
+
+func xmlResponse(status int, body string) protocols.ErrorResponse {
+	return protocols.ErrorResponse{
+		StatusCode:  status,
+		ContentType: "application/xml",
+		Headers:     map[string]string{"Content-Type": "application/xml"},
+		Body:        []byte(body),
+	}
+}
+
+func withRequestID(response protocols.ErrorResponse, requestID string) protocols.ErrorResponse {
+	if requestID == "" {
+		return response
+	}
+	if response.Headers == nil {
+		response.Headers = map[string]string{}
+	}
+	if response.Headers["x-amzn-requestid"] == "" {
+		response.Headers["x-amzn-requestid"] = requestID
+	}
+	return response
+}
+
+func xmlEscape(value string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&apos;",
+	)
+	return replacer.Replace(value)
+}

--- a/internal/services/aws/inspector.go
+++ b/internal/services/aws/inspector.go
@@ -168,6 +168,8 @@ func yesNo(value bool) string {
 
 func accessKeyCount(record corestore.Record) int {
 	switch value := record["access_keys"].(type) {
+	case []corestore.Record:
+		return len(value)
 	case []any:
 		return len(value)
 	case []map[string]any:

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -9,9 +9,11 @@ import (
 	corestore "github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/services/aws/auth"
 	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+	awsiam "github.com/vercel-labs/emulate/internal/services/aws/iam"
 	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
 	awss3 "github.com/vercel-labs/emulate/internal/services/aws/s3"
 	awssqs "github.com/vercel-labs/emulate/internal/services/aws/sqs"
+	awssts "github.com/vercel-labs/emulate/internal/services/aws/sts"
 )
 
 type Options struct {
@@ -35,6 +37,8 @@ type Service struct {
 	s3PathFallback   bool
 	s3               awss3.Handler
 	sqs              awssqs.Handler
+	iam              awsiam.Handler
+	sts              awssts.Handler
 }
 
 func Register(router *corehttp.Router, options Options) {
@@ -61,15 +65,20 @@ func New(options Options) *Service {
 		assetStore = coreassets.New()
 	}
 	awsStore := NewStore(runtimeStore)
+	credentialStore := options.CredentialStore
+	if credentialStore == nil {
+		credentialStore = auth.NewStore()
+	}
 	seedS3Defaults(awsStore, defaultRegion)
 	seedSQSDefaults(awsStore, options.BaseURL, defaultAccountID, defaultRegion)
+	seedIAMDefaults(awsStore, credentialStore, defaultAccountID)
 	return &Service{
 		store:            awsStore,
 		assets:           assetStore,
 		defaultAccountID: defaultAccountID,
 		defaultRegion:    defaultRegion,
 		authMode:         options.AuthMode,
-		credentialStore:  options.CredentialStore,
+		credentialStore:  credentialStore,
 		s3PathFallback:   options.S3PathFallback,
 		s3: awss3.Handler{
 			Buckets: awsStore.S3Buckets,
@@ -84,6 +93,18 @@ func New(options Options) *Service {
 			BaseURL:   options.BaseURL,
 			AccountID: defaultAccountID,
 			Region:    defaultRegion,
+		},
+		iam: awsiam.Handler{
+			Users:           awsStore.IAMUsers,
+			Roles:           awsStore.IAMRoles,
+			CredentialStore: credentialStore,
+			AccountID:       defaultAccountID,
+		},
+		sts: awssts.Handler{
+			Users:           awsStore.IAMUsers,
+			Roles:           awsStore.IAMRoles,
+			CredentialStore: credentialStore,
+			AccountID:       defaultAccountID,
 		},
 	}
 }
@@ -121,6 +142,14 @@ func (s *Service) handleAWS(c *corehttp.Context) {
 	}
 	if ctx.Service == "sqs" && (ctx.Protocol == protocols.ProtocolQuery || ctx.Protocol == protocols.ProtocolJSONRPC) {
 		writeErrorResponse(c, s.sqs.Handle(c.Request, ctx))
+		return
+	}
+	if ctx.Service == "iam" && ctx.Protocol == protocols.ProtocolQuery {
+		writeErrorResponse(c, s.iam.Handle(c.Request, ctx))
+		return
+	}
+	if ctx.Service == "sts" && ctx.Protocol == protocols.ProtocolQuery {
+		writeErrorResponse(c, s.sts.Handle(c.Request, ctx))
 		return
 	}
 

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -652,6 +652,128 @@ func TestServiceHonorsSQSJSONMessageDelaySeconds(t *testing.T) {
 	}
 }
 
+func TestServiceHandlesIAMLifecycleAndAccessKeys(t *testing.T) {
+	handler := newTestHandler()
+
+	res := executeAWSQueryRequest(handler, "iam", "Action=ListUsers")
+	if res.Code != http.StatusOK {
+		t.Fatalf("list users status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body := res.Body.String(); !strings.Contains(body, "<ListUsersResponse>") || !strings.Contains(body, "admin") {
+		t.Fatalf("unexpected list users body: %s", body)
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=CreateUser&UserName=developer&Path=/team/")
+	if res.Code != http.StatusOK {
+		t.Fatalf("create user status = %d, body = %s", res.Code, res.Body.String())
+	}
+	developerARN := xmlElement(res.Body.String(), "Arn")
+	if !strings.Contains(developerARN, ":user/team/developer") {
+		t.Fatalf("developer arn = %q", developerARN)
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=CreateUser&UserName=developer")
+	if res.Code != http.StatusConflict {
+		t.Fatalf("duplicate create status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=GetUser&UserName=developer")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "<GetUserResponse>") {
+		t.Fatalf("get user status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=CreateAccessKey&UserName=developer")
+	if res.Code != http.StatusOK {
+		t.Fatalf("create key status = %d, body = %s", res.Code, res.Body.String())
+	}
+	accessKeyID := xmlElement(res.Body.String(), "AccessKeyId")
+	if !strings.HasPrefix(accessKeyID, "AKIA") {
+		t.Fatalf("access key id = %q", accessKeyID)
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=ListAccessKeys&UserName=developer")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), accessKeyID) {
+		t.Fatalf("list keys status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequestWithAccessKey(handler, "sts", "Action=GetCallerIdentity", accessKeyID)
+	if res.Code != http.StatusOK {
+		t.Fatalf("caller identity status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if arn := xmlElement(res.Body.String(), "Arn"); arn != developerARN {
+		t.Fatalf("caller arn = %q, want %q", arn, developerARN)
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=DeleteAccessKey&UserName=developer&AccessKeyId="+url.QueryEscape(accessKeyID))
+	if res.Code != http.StatusOK {
+		t.Fatalf("delete key status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=DeleteUser&UserName=developer")
+	if res.Code != http.StatusOK {
+		t.Fatalf("delete user status = %d, body = %s", res.Code, res.Body.String())
+	}
+	res = executeAWSQueryRequest(handler, "iam", "Action=GetUser&UserName=developer")
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("get deleted user status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestServiceHandlesIAMRolesAndSTS(t *testing.T) {
+	handler := newTestHandler()
+	policy := `{"Version":"2012-10-17","Statement":[]}`
+
+	res := executeAWSQueryRequest(handler, "iam", "Action=CreateRole&RoleName=worker&Description=Worker+role&AssumeRolePolicyDocument="+url.QueryEscape(policy))
+	if res.Code != http.StatusOK {
+		t.Fatalf("create role status = %d, body = %s", res.Code, res.Body.String())
+	}
+	roleARN := xmlElement(res.Body.String(), "Arn")
+	if !strings.Contains(roleARN, ":role/worker") {
+		t.Fatalf("role arn = %q", roleARN)
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=GetRole&RoleName=worker")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "Worker role") {
+		t.Fatalf("get role status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=ListRoles")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "worker") {
+		t.Fatalf("list roles status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(handler, "sts", "Action=GetCallerIdentity")
+	if res.Code != http.StatusOK {
+		t.Fatalf("caller identity status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body := res.Body.String(); !strings.Contains(body, "<GetCallerIdentityResponse>") || !strings.Contains(body, "<Account>123456789012</Account>") {
+		t.Fatalf("unexpected caller identity body: %s", body)
+	}
+
+	res = executeAWSQueryRequest(handler, "sts", "Action=AssumeRole&RoleArn="+url.QueryEscape(roleARN)+"&RoleSessionName=test-session")
+	if res.Code != http.StatusOK {
+		t.Fatalf("assume role status = %d, body = %s", res.Code, res.Body.String())
+	}
+	assumedAccessKey := xmlElement(res.Body.String(), "AccessKeyId")
+	sessionToken := xmlElement(res.Body.String(), "SessionToken")
+	if !strings.HasPrefix(assumedAccessKey, "ASIA") || !strings.Contains(res.Body.String(), "<SessionToken>") {
+		t.Fatalf("unexpected assume role body: %s", res.Body.String())
+	}
+
+	res = executeAWSQueryRequestWithAccessKeyAndToken(handler, "sts", "Action=GetCallerIdentity", assumedAccessKey, sessionToken)
+	if res.Code != http.StatusOK {
+		t.Fatalf("assumed caller status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if arn := xmlElement(res.Body.String(), "Arn"); arn != roleARN+"/test-session" {
+		t.Fatalf("assumed arn = %q, want %q", arn, roleARN+"/test-session")
+	}
+
+	res = executeAWSQueryRequest(handler, "iam", "Action=DeleteRole&RoleName=worker")
+	if res.Code != http.StatusOK {
+		t.Fatalf("delete role status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestServiceReturnsJSONRPCNotImplemented(t *testing.T) {
 	handler := newTestHandler()
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", strings.NewReader(`{"TableName":"items"}`))
@@ -799,7 +921,7 @@ func TestServicePassesThroughGenericListQueryParams(t *testing.T) {
 	}
 }
 
-func TestServiceRendersEmptyInspector(t *testing.T) {
+func TestServiceRendersInspectorWithDefaultIAMUser(t *testing.T) {
 	handler := newTestHandler()
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/_inspector?tab=iam", nil))
@@ -808,7 +930,7 @@ func TestServiceRendersEmptyInspector(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	body := res.Body.String()
-	for _, expected := range []string{"AWS Emulator", "S3", "SQS", "IAM", "IAM Users (0)", "IAM Roles (0)", "No users", "No roles"} {
+	for _, expected := range []string{"AWS Emulator", "S3", "SQS", "IAM", "IAM Users (1)", "IAM Roles (0)", "admin", "Access Keys", "No roles"} {
 		if !strings.Contains(body, expected) {
 			t.Fatalf("inspector missing %q in %s", expected, body)
 		}
@@ -861,9 +983,22 @@ func executeAWSRequest(handler http.Handler, method string, target string, body 
 }
 
 func executeAWSQueryRequest(handler http.Handler, service string, body string) *httptest.ResponseRecorder {
-	return executeAWSRequest(handler, http.MethodPost, "http://127.0.0.1/"+service+"/", []byte(body), service, map[string]string{
+	return executeAWSQueryRequestWithAccessKey(handler, service, body, "AKIAEXAMPLE")
+}
+
+func executeAWSQueryRequestWithAccessKey(handler http.Handler, service string, body string, accessKeyID string) *httptest.ResponseRecorder {
+	return executeAWSQueryRequestWithAccessKeyAndToken(handler, service, body, accessKeyID, "")
+}
+
+func executeAWSQueryRequestWithAccessKeyAndToken(handler http.Handler, service string, body string, accessKeyID string, sessionToken string) *httptest.ResponseRecorder {
+	headers := map[string]string{
 		"Content-Type": "application/x-www-form-urlencoded",
-	})
+		"X-Access-Key": accessKeyID,
+	}
+	if sessionToken != "" {
+		headers["X-Amz-Security-Token"] = sessionToken
+	}
+	return executeAWSRequest(handler, http.MethodPost, "http://127.0.0.1/"+service+"/", []byte(body), service, headers)
 }
 
 func executeAWSJSONRequest(t *testing.T, handler http.Handler, action string, payload map[string]any) *httptest.ResponseRecorder {
@@ -933,6 +1068,11 @@ func xmlElement(body string, name string) string {
 }
 
 func signAWSRequest(req *http.Request, service string) {
-	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-east-1/"+service+"/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	accessKeyID := req.Header.Get("X-Access-Key")
+	if accessKeyID == "" {
+		accessKeyID = "AKIAEXAMPLE"
+	}
+	req.Header.Del("X-Access-Key")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+accessKeyID+"/20260519/us-east-1/"+service+"/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
 	req.Header.Set("X-Amz-Date", "20260519T000000Z")
 }

--- a/internal/services/aws/sts/handler.go
+++ b/internal/services/aws/sts/handler.go
@@ -1,0 +1,236 @@
+package sts
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/services/aws/auth"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+	"github.com/vercel-labs/emulate/internal/services/aws/protocols"
+)
+
+type Handler struct {
+	Users           *corestore.Collection
+	Roles           *corestore.Collection
+	CredentialStore *auth.Store
+	AccountID       string
+	Now             func() time.Time
+	IDGenerator     func(string) string
+	SecretGenerator func(int) string
+}
+
+var fallbackIDCounter atomic.Uint64
+
+func (h *Handler) Handle(_ *http.Request, ctx gateway.AwsRequestContext) protocols.ErrorResponse {
+	requestID := ctx.RequestID
+	if requestID == "" {
+		requestID = h.generateID("req")
+	}
+	var response protocols.ErrorResponse
+	switch ctx.Action {
+	case "GetCallerIdentity":
+		response = h.getCallerIdentity(ctx, requestID)
+	case "AssumeRole":
+		response = h.assumeRole(ctx.Query, requestID)
+	default:
+		action := ctx.Action
+		response = h.queryError("InvalidAction", "The action "+action+" is not valid for this endpoint.", http.StatusBadRequest, requestID)
+	}
+	return withRequestID(response, requestID)
+}
+
+func (h *Handler) getCallerIdentity(ctx gateway.AwsRequestContext, requestID string) protocols.ErrorResponse {
+	accountID := ctx.AccountID
+	if accountID == "" {
+		accountID = h.accountID()
+	}
+	arn := ctx.Principal.ARN
+	if arn == "" {
+		arn = "arn:aws:iam::" + accountID + ":user/emulate"
+	}
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<GetCallerIdentityResponse>
+  <GetCallerIdentityResult>
+    <Arn>` + xmlEscape(arn) + `</Arn>
+    <UserId>` + xmlEscape(h.userIDForPrincipal(arn)) + `</UserId>
+    <Account>` + xmlEscape(accountID) + `</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</GetCallerIdentityResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) assumeRole(params map[string]string, requestID string) protocols.ErrorResponse {
+	roleARN := params["RoleArn"]
+	sessionName := params["RoleSessionName"]
+	if sessionName == "" {
+		sessionName = "session"
+	}
+	role, ok := h.findRoleByARN(roleARN)
+	if !ok {
+		return h.queryError("NoSuchEntity", "The role specified cannot be found.", http.StatusNotFound, requestID)
+	}
+	accessKeyID := "ASIA" + h.generateID("")[0:16]
+	secretAccessKey := h.generateSecret(30)
+	sessionToken := h.generateSecret(64)
+	expiration := h.now().Add(time.Hour).Format(time.RFC3339Nano)
+	principalARN := roleARN + "/" + sessionName
+	h.CredentialStore.Put(auth.Credential{
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: secretAccessKey,
+		SessionToken:    sessionToken,
+		AccountID:       h.accountID(),
+		PrincipalARN:    principalARN,
+	})
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleResponse>
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>` + accessKeyID + `</AccessKeyId>
+      <SecretAccessKey>` + xmlEscape(secretAccessKey) + `</SecretAccessKey>
+      <SessionToken>` + xmlEscape(sessionToken) + `</SessionToken>
+      <Expiration>` + xmlEscape(expiration) + `</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>` + xmlEscape(principalARN) + `</Arn>
+      <AssumedRoleId>` + xmlEscape(stringField(role, "role_id")+":"+sessionName) + `</AssumedRoleId>
+    </AssumedRoleUser>
+  </AssumeRoleResult>
+  <ResponseMetadata><RequestId>` + xmlEscape(requestID) + `</RequestId></ResponseMetadata>
+</AssumeRoleResponse>`
+	return xmlResponse(http.StatusOK, body)
+}
+
+func (h *Handler) userIDForPrincipal(arn string) string {
+	for _, user := range h.Users.All() {
+		if stringField(user, "arn") == arn {
+			return stringField(user, "user_id")
+		}
+	}
+	for _, role := range h.Roles.All() {
+		prefix := stringField(role, "arn") + "/"
+		if strings.HasPrefix(arn, prefix) {
+			sessionName := strings.TrimPrefix(arn, prefix)
+			return stringField(role, "role_id") + ":" + sessionName
+		}
+	}
+	if name, ok := strings.CutPrefix(arn, "arn:aws:iam::"+h.accountID()+":user/"); ok {
+		if user := h.userByName(name); user != nil {
+			return stringField(user, "user_id")
+		}
+	}
+	return "AIDAEMULATEUSERID"
+}
+
+func (h *Handler) findRoleByARN(roleARN string) (corestore.Record, bool) {
+	for _, role := range h.Roles.All() {
+		if stringField(role, "arn") == roleARN {
+			return role, true
+		}
+	}
+	return nil, false
+}
+
+func (h *Handler) userByName(userName string) corestore.Record {
+	for _, user := range h.Users.FindBy("user_name", userName) {
+		return user
+	}
+	return nil
+}
+
+func (h *Handler) queryError(code string, message string, status int, requestID string) protocols.ErrorResponse {
+	return protocols.SerializeXMLError(protocols.AWSError{
+		Code:       code,
+		Message:    message,
+		RequestID:  requestID,
+		StatusCode: status,
+	})
+}
+
+func (h *Handler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (h *Handler) accountID() string {
+	if h.AccountID != "" {
+		return h.AccountID
+	}
+	return gateway.DefaultAccountID
+}
+
+func (h *Handler) generateID(prefix string) string {
+	if h.IDGenerator != nil {
+		return h.IDGenerator(prefix)
+	}
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return prefix + strings.ToUpper(hex.EncodeToString(bytes[:]))
+	}
+	return fmt.Sprintf("%s%016X", prefix, fallbackIDCounter.Add(1))
+}
+
+func (h *Handler) generateSecret(size int) string {
+	if h.SecretGenerator != nil {
+		return h.SecretGenerator(size)
+	}
+	bytes := make([]byte, size)
+	if _, err := rand.Read(bytes); err == nil {
+		return base64.StdEncoding.EncodeToString(bytes)
+	}
+	return fmt.Sprintf("secret-%d", fallbackIDCounter.Add(1))
+}
+
+func stringField(record corestore.Record, name string) string {
+	switch value := record[name].(type) {
+	case string:
+		return value
+	default:
+		if value == nil {
+			return ""
+		}
+		return fmt.Sprint(value)
+	}
+}
+
+func xmlResponse(status int, body string) protocols.ErrorResponse {
+	return protocols.ErrorResponse{
+		StatusCode:  status,
+		ContentType: "application/xml",
+		Headers:     map[string]string{"Content-Type": "application/xml"},
+		Body:        []byte(body),
+	}
+}
+
+func withRequestID(response protocols.ErrorResponse, requestID string) protocols.ErrorResponse {
+	if requestID == "" {
+		return response
+	}
+	if response.Headers == nil {
+		response.Headers = map[string]string{}
+	}
+	if response.Headers["x-amzn-requestid"] == "" {
+		response.Headers["x-amzn-requestid"] = requestID
+	}
+	return response
+}
+
+func xmlEscape(value string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&apos;",
+	)
+	return replacer.Replace(value)
+}

--- a/packages/@emulators/aws/README.md
+++ b/packages/@emulators/aws/README.md
@@ -35,13 +35,15 @@ SQS requests use `POST /sqs/` with an `Action` form parameter.
 - `PurgeQueue`, `DeleteQueue`
 
 ### IAM
-All operations via `POST /iam/` with `Action` parameter:
+IAM requests use `POST /iam/` with an `Action` form parameter.
+
 - `CreateUser`, `GetUser`, `ListUsers`, `DeleteUser`
 - `CreateAccessKey`, `ListAccessKeys`, `DeleteAccessKey`
 - `CreateRole`, `GetRole`, `ListRoles`, `DeleteRole`
 
 ### STS
-All operations via `POST /sts/` with `Action` parameter:
+STS requests use `POST /sts/` with an `Action` form parameter.
+
 - `GetCallerIdentity`, `AssumeRole`
 
 ## Auth

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -38,8 +38,10 @@
     "@emulators/core": "workspace:*"
   },
   "devDependencies": {
+    "@aws-sdk/client-iam": "^3.1049.0",
     "@aws-sdk/client-s3": "^3.1031.0",
     "@aws-sdk/client-sqs": "^3.1049.0",
+    "@aws-sdk/client-sts": "^3.1049.0",
     "@aws-sdk/s3-presigned-post": "^3.1031.0",
     "tsup": "^8",
     "typescript": "^5.7",

--- a/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { serve } from "@emulators/core";
 import type { AddressInfo } from "node:net";
 import {
+  IAMClient,
+  ListUsersCommand,
+  GetUserCommand,
+  CreateUserCommand,
+  DeleteUserCommand,
+  CreateAccessKeyCommand,
+  ListAccessKeysCommand,
+  DeleteAccessKeyCommand,
+  CreateRoleCommand,
+  GetRoleCommand,
+  ListRolesCommand,
+  DeleteRoleCommand,
+} from "@aws-sdk/client-iam";
+import {
   S3Client,
   ListBucketsCommand,
   HeadBucketCommand,
@@ -26,6 +40,7 @@ import {
   PurgeQueueCommand,
   DeleteQueueCommand as DeleteSQSQueueCommand,
 } from "@aws-sdk/client-sqs";
+import { STSClient, GetCallerIdentityCommand, AssumeRoleCommand } from "@aws-sdk/client-sts";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { createTestApp } from "./helpers.js";
 
@@ -62,6 +77,7 @@ async function streamToString(stream: unknown): Promise<string> {
 }
 
 const describeExternalSqsE2E = process.env.AWS_EMULATOR_E2E_URL ? describe : describe.skip;
+const describeExternalIamStsE2E = process.env.AWS_EMULATOR_E2E_URL ? describe : describe.skip;
 
 describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
   let emulator: EmulatorHandle;
@@ -372,5 +388,121 @@ describeExternalSqsE2E("AWS plugin - real @aws-sdk/client-sqs E2E", () => {
     expect(received.Messages ?? []).toHaveLength(0);
 
     await sqs.send(new DeleteSQSQueueCommand({ QueueUrl }));
+  });
+});
+
+describeExternalIamStsE2E("AWS plugin - real @aws-sdk/client-iam and @aws-sdk/client-sts E2E", () => {
+  let emulator: EmulatorHandle;
+  let iam: IAMClient;
+  let sts: STSClient;
+
+  beforeAll(async () => {
+    emulator = await startEmulator();
+    iam = new IAMClient({
+      endpoint: `${emulator.url.replace(/\/$/, "")}/iam/`,
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      },
+    });
+    sts = new STSClient({
+      endpoint: `${emulator.url.replace(/\/$/, "")}/sts/`,
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    iam.destroy();
+    sts.destroy();
+    await emulator.close();
+  });
+
+  it("ListUsers and GetUser return the seeded admin user", async () => {
+    const listed = await iam.send(new ListUsersCommand({}));
+    expect((listed.Users ?? []).map((user) => user.UserName)).toContain("admin");
+
+    const admin = await iam.send(new GetUserCommand({ UserName: "admin" }));
+    expect(admin.User?.Arn).toBe("arn:aws:iam::123456789012:user/admin");
+  });
+
+  it("CreateUser, CreateAccessKey, ListAccessKeys, and DeleteUser roundtrip", async () => {
+    const created = await iam.send(new CreateUserCommand({ UserName: "sdk-user", Path: "/team/" }));
+    expect(created.User?.Arn).toBe("arn:aws:iam::123456789012:user/team/sdk-user");
+
+    const key = await iam.send(new CreateAccessKeyCommand({ UserName: "sdk-user" }));
+    expect(key.AccessKey?.AccessKeyId).toMatch(/^AKIA/);
+    expect(key.AccessKey?.SecretAccessKey).toBeTruthy();
+
+    const keys = await iam.send(new ListAccessKeysCommand({ UserName: "sdk-user" }));
+    expect((keys.AccessKeyMetadata ?? []).map((item) => item.AccessKeyId)).toContain(key.AccessKey?.AccessKeyId);
+
+    await iam.send(new DeleteAccessKeyCommand({ UserName: "sdk-user", AccessKeyId: key.AccessKey?.AccessKeyId }));
+    const afterDeleteKey = await iam.send(new ListAccessKeysCommand({ UserName: "sdk-user" }));
+    expect((afterDeleteKey.AccessKeyMetadata ?? []).map((item) => item.AccessKeyId)).not.toContain(
+      key.AccessKey?.AccessKeyId,
+    );
+
+    await iam.send(new DeleteUserCommand({ UserName: "sdk-user" }));
+    const afterDelete = await iam.send(new ListUsersCommand({}));
+    expect((afterDelete.Users ?? []).map((user) => user.UserName)).not.toContain("sdk-user");
+  });
+
+  it("CreateRole, GetRole, ListRoles, AssumeRole, and DeleteRole roundtrip", async () => {
+    const created = await iam.send(
+      new CreateRoleCommand({
+        RoleName: "sdk-role",
+        Description: "SDK role",
+        AssumeRolePolicyDocument: JSON.stringify({ Version: "2012-10-17", Statement: [] }),
+      }),
+    );
+    expect(created.Role?.Arn).toBe("arn:aws:iam::123456789012:role/sdk-role");
+
+    const byName = await iam.send(new GetRoleCommand({ RoleName: "sdk-role" }));
+    expect(byName.Role?.Description).toBe("SDK role");
+
+    const listed = await iam.send(new ListRolesCommand({}));
+    expect((listed.Roles ?? []).map((role) => role.RoleName)).toContain("sdk-role");
+
+    const assumed = await sts.send(
+      new AssumeRoleCommand({
+        RoleArn: created.Role?.Arn,
+        RoleSessionName: "sdk-session",
+      }),
+    );
+    expect(assumed.Credentials?.AccessKeyId).toMatch(/^ASIA/);
+    expect(assumed.Credentials?.SessionToken).toBeTruthy();
+    expect(assumed.AssumedRoleUser?.Arn).toBe(`${created.Role?.Arn}/sdk-session`);
+
+    const assumedSTS = new STSClient({
+      endpoint: `${emulator.url.replace(/\/$/, "")}/sts/`,
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: assumed.Credentials?.AccessKeyId ?? "",
+        secretAccessKey: assumed.Credentials?.SecretAccessKey ?? "",
+        sessionToken: assumed.Credentials?.SessionToken,
+      },
+    });
+    try {
+      const identity = await assumedSTS.send(new GetCallerIdentityCommand({}));
+      expect(identity.Arn).toBe(`${created.Role?.Arn}/sdk-session`);
+    } finally {
+      assumedSTS.destroy();
+    }
+
+    await iam.send(new DeleteRoleCommand({ RoleName: "sdk-role" }));
+    const afterDelete = await iam.send(new ListRolesCommand({}));
+    expect((afterDelete.Roles ?? []).map((role) => role.RoleName)).not.toContain("sdk-role");
+  });
+
+  it("GetCallerIdentity returns the known default admin principal", async () => {
+    const identity = await sts.send(new GetCallerIdentityCommand({}));
+    expect(identity.Account).toBe("123456789012");
+    expect(identity.Arn).toBe("arn:aws:iam::123456789012:user/admin");
+    expect(identity.UserId).toBeTruthy();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,10 +409,16 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@aws-sdk/client-iam':
+        specifier: ^3.1049.0
+        version: 3.1049.0
       '@aws-sdk/client-s3':
         specifier: ^3.1031.0
         version: 3.1031.0
       '@aws-sdk/client-sqs':
+        specifier: ^3.1049.0
+        version: 3.1049.0
+      '@aws-sdk/client-sts':
         specifier: ^3.1049.0
         version: 3.1049.0
       '@aws-sdk/s3-presigned-post':
@@ -734,12 +740,20 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-iam@3.1049.0':
+    resolution: {integrity: sha512-aBPhPLbBQ0jS2ilMFz+2/vIQK1kT/bbSxkEvod6fSOmZYFLUscZVQvMmS9PlR76gJvahdjSIkEFrByJwZTyVkw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1031.0':
     resolution: {integrity: sha512-HflwKSpDl2pwPiH116n9dy1pKW+5yEoiGFor6NO1yADgge+QY5LqluBiHscD7k/o9ib+dgxf6Vg4WsctcRT3OA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sqs@3.1049.0':
     resolution: {integrity: sha512-AiYaJS3uqH/u6uxxNOuCP9B7pUBDvsrf2LG6HTp7wGFbio3GxcJchUHpSBtbD0j2ZaGyZpOJyuPJ1/4sY5Z20Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sts@3.1049.0':
+    resolution: {integrity: sha512-Dq8WJk3oPNQvK7gOYDFnOl6jXh2TiwggATqzs3bbboOu5hleZ50Nt9Zm38jA0zWnWm2nJ5p/qdKJzXeGecHRvA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.0':
@@ -6227,6 +6241,19 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-iam@3.1049.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-node': 3.972.43
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-s3@3.1031.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -6301,6 +6328,20 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-sts@3.1049.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-node': 3.972.43
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.0':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6330,15 +6371,15 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.38':
@@ -6346,19 +6387,19 @@ snapshots:
       '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.28':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.5.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.11
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-stream': 4.5.23
       tslib: 2.8.1
 
@@ -6369,12 +6410,12 @@ snapshots:
       '@smithy/core': 3.24.3
       '@smithy/fetch-http-handler': 5.4.3
       '@smithy/node-http-handler': 4.7.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.30':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/credential-provider-env': 3.972.26
       '@aws-sdk/credential-provider-http': 3.972.28
       '@aws-sdk/credential-provider-login': 3.972.30
@@ -6386,7 +6427,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6404,18 +6445,18 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
       '@smithy/credential-provider-imds': 4.3.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.30':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/nested-clients': 3.996.20
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6426,7 +6467,7 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.10
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.31':
@@ -6462,11 +6503,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.38':
@@ -6474,18 +6515,18 @@ snapshots:
       '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.30':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/nested-clients': 3.996.20
       '@aws-sdk/token-providers': 3.1031.0
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6497,17 +6538,17 @@ snapshots:
       '@aws-sdk/token-providers': 3.1049.0
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.30':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/nested-clients': 3.996.20
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6518,7 +6559,7 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.10
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
@@ -6627,7 +6668,7 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/middleware-host-header': 3.972.10
       '@aws-sdk/middleware-logger': 3.972.10
       '@aws-sdk/middleware-recursion-detection': 3.972.11
@@ -6638,8 +6679,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.972.10
       '@aws-sdk/util-user-agent-node': 3.973.16
       '@smithy/config-resolver': 4.4.16
-      '@smithy/core': 3.23.15
-      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
       '@smithy/hash-node': 4.2.14
       '@smithy/invalid-dependency': 4.2.14
       '@smithy/middleware-content-length': 4.2.14
@@ -6648,10 +6689,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.18
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.5.3
+      '@smithy/node-http-handler': 4.7.3
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.11
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -6676,7 +6717,7 @@ snapshots:
       '@smithy/core': 3.24.3
       '@smithy/fetch-http-handler': 5.4.3
       '@smithy/node-http-handler': 4.7.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.972.12':
@@ -6715,17 +6756,17 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
       '@smithy/signature-v4': 5.4.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1031.0':
     dependencies:
-      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/nested-clients': 3.996.20
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6736,7 +6777,7 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.10
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.8':
@@ -6785,14 +6826,14 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.18':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.24':
     dependencies:
       '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
@@ -8393,7 +8434,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
@@ -8406,7 +8447,7 @@ snapshots:
   '@smithy/eventstream-codec@4.2.14':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
@@ -8430,7 +8471,7 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.2.14':
     dependencies:
       '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.17':
@@ -8550,7 +8591,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.14':
@@ -8560,22 +8601,22 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
 
   '@smithy/shared-ini-file-loader@4.4.9':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.14':

--- a/skills/aws/SKILL.md
+++ b/skills/aws/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
 
 # AWS Emulator
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime also accepts current AWS SDK JSON requests for SQS and returns JSON responses.
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime is verified against current AWS SDK v3 clients for SQS, IAM, and STS; SQS uses JSON target requests, while IAM and STS use AWS Query XML.
 
 ## Start
 
@@ -80,6 +80,19 @@ import { IAMClient } from '@aws-sdk/client-iam'
 
 const iam = new IAMClient({
   endpoint: `${process.env.AWS_EMULATOR_URL}/iam`,
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  },
+})
+```
+
+```typescript
+import { STSClient } from '@aws-sdk/client-sts'
+
+const sts = new STSClient({
+  endpoint: `${process.env.AWS_EMULATOR_URL}/sts`,
   region: 'us-east-1',
   credentials: {
     accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
@@ -240,7 +253,7 @@ curl -X POST http://localhost:4006/sqs/ \
 
 ### IAM
 
-All IAM operations use `POST /iam/` with `Action` as a form-urlencoded parameter.
+Manual IAM calls can use AWS Query over `POST /iam/` with `Action` as a form-urlencoded parameter. In the native Go runtime, the same operations also work through `@aws-sdk/client-iam` with endpoint `${AWS_EMULATOR_URL}/iam`.
 
 ```bash
 # Create user
@@ -301,7 +314,7 @@ curl -X POST http://localhost:4006/iam/ \
 
 ### STS
 
-All STS operations use `POST /sts/` with `Action` as a form-urlencoded parameter.
+Manual STS calls can use AWS Query over `POST /sts/` with `Action` as a form-urlencoded parameter. In the native Go runtime, the same operations also work through `@aws-sdk/client-sts` with endpoint `${AWS_EMULATOR_URL}/sts`.
 
 ```bash
 # Get caller identity


### PR DESCRIPTION
- Implements native IAM users, roles, access keys, and STS caller identity and assume role with credential mapping.

- Seeds default admin IAM credentials and routes IAM and STS Query requests through the Go AWS service.

- Adds JS SDK v3 IAM and STS conformance coverage plus docs for native SDK endpoints.