### PR TITLE
Add native Go Resend current parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,22 @@ jobs:
           test "${ready:-}" = "1"
           AWS_EMULATOR_E2E_URL=http://127.0.0.1:4017 pnpm --dir packages/@emulators/aws exec vitest run src/__tests__/aws-sdk.e2e.test.ts -t "sqs|iam|sts"
 
+      - name: Native Resend SDK E2E
+        run: |
+          go build -o /tmp/emulate-native ./cmd/emulate
+          /tmp/emulate-native start --service resend --port 4018 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+          for attempt in {1..50}; do
+            if curl -fsS http://127.0.0.1:4018/_emulate/health >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 0.2
+          done
+          test "${ready:-}" = "1"
+          RESEND_EMULATOR_E2E_URL=http://127.0.0.1:4018 pnpm --dir packages/@emulators/resend exec vitest run src/__tests__/resend.test.ts -t "real resend SDK E2E"
+
       - run: node scripts/sync-versions.mjs --check
 
       - run: pnpm format:check

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ All services start with sensible defaults. No config file needed:
 - **Slack** on `http://localhost:4003`
 - **Apple** on `http://localhost:4004`
 - **Microsoft** on `http://localhost:4005`
-- **AWS** on `http://localhost:4006`
+- **Okta** on `http://localhost:4006`
+- **AWS** on `http://localhost:4007`
+- **Resend** on `http://localhost:4008`
+- **Stripe** on `http://localhost:4009`
+- **MongoDB Atlas** on `http://localhost:4010`
+- **Clerk** on `http://localhost:4011`
 
 ## CLI
 
@@ -141,7 +146,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, or `'clerk'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -692,6 +697,19 @@ Manual IAM requests can use `POST /iam/` with an `Action` form parameter. In the
 Manual STS requests can use `POST /sts/` with an `Action` form parameter. In the native Go runtime, `@aws-sdk/client-sts` v3 can use the `/sts/` endpoint directly.
 
 - `GetCallerIdentity`, `AssumeRole`
+
+## Resend
+
+Resend email API emulation with local capture for sent emails, domains, API keys, audiences, contacts, and an inbox UI. Set `RESEND_BASE_URL` before importing the official Resend Node.js SDK and the SDK will send to the emulator.
+
+The experimental native Go runtime serves the same current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+
+- `POST /emails`, `POST /emails/batch`, `GET /emails`, `GET /emails/:id`, `POST /emails/:id/cancel`
+- `POST /domains`, `GET /domains`, `GET /domains/:id`, `DELETE /domains/:id`, `POST /domains/:id/verify`
+- `POST /api-keys`, `GET /api-keys`, `DELETE /api-keys/:id`
+- `POST /audiences`, `GET /audiences`, `DELETE /audiences/:id`
+- `POST /audiences/:audience_id/contacts`, `GET /audiences/:audience_id/contacts`, `DELETE /audiences/:audience_id/contacts/:id`
+- `GET /inbox`, `GET /inbox/:id`
 
 ## Next.js Integration
 

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -16,11 +16,12 @@ All services start with sensible defaults. No config file needed:
 - **Slack** on `http://localhost:4003`
 - **Apple** on `http://localhost:4004`
 - **Microsoft** on `http://localhost:4005`
-- **AWS** on `http://localhost:4006`
-- **Okta** on `http://localhost:4007`
-- **MongoDB Atlas** on `http://localhost:4008`
-- **Resend** on `http://localhost:4009`
-- **Stripe** on `http://localhost:4010`
+- **Okta** on `http://localhost:4006`
+- **AWS** on `http://localhost:4007`
+- **Resend** on `http://localhost:4008`
+- **Stripe** on `http://localhost:4009`
+- **MongoDB Atlas** on `http://localhost:4010`
+- **Clerk** on `http://localhost:4011`
 
 ## CLI
 

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -59,7 +59,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>service</code></td>
       <td><em>(required)</em></td>
-      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'aws'</code>, <code>'okta'</code>, <code>'mongoatlas'</code>, <code>'resend'</code>, or <code>'stripe'</code></td>
+      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, or <code>'clerk'</code></td>
     </tr>
     <tr>
       <td><code>port</code></td>

--- a/apps/web/app/docs/resend/page.mdx
+++ b/apps/web/app/docs/resend/page.mdx
@@ -2,6 +2,10 @@
 
 Resend email API emulation with email sending, domain management, API keys, audiences, contacts, and a local inbox for captured messages.
 
+Set `RESEND_BASE_URL` before importing the official `resend` Node.js SDK and the SDK will call the emulator without code changes.
+
+The experimental native Go runtime implements the current Resend routes below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+
 ## Emails
 
 - `POST /emails` — send single email

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 
 	coreconfig "github.com/vercel-labs/emulate/internal/core/config"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
+	"github.com/vercel-labs/emulate/internal/services/resend"
 )
 
 var version = "dev"
@@ -100,14 +102,31 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		fmt.Fprintln(stderr, "The native Go runtime does not support --portless yet.")
 		return 1
 	}
+	var seedServices []string
+	var resendSeed *resend.SeedConfig
 	if *seedValue != "" {
-		fmt.Fprintln(stderr, "The native Go runtime does not support --seed yet.")
-		return 1
+		loaded, err := coreconfig.Load(coreconfig.LoadOptions{Path: *seedValue})
+		if err != nil {
+			fmt.Fprintf(stderr, "Failed to load seed config: %v\n", err)
+			return 1
+		}
+		seedServices = coreconfig.InferServices(loaded.Data, emuruntime.ServiceNames())
+		if raw, ok := loaded.Data["resend"]; ok {
+			var cfg resend.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse resend seed config: %v\n", err)
+				return 1
+			}
+			resendSeed = &cfg
+		}
 	}
 	services, err := parseServices(*serviceValue)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
+	}
+	if *serviceValue == "" && len(seedServices) > 0 {
+		services = seedServices
 	}
 
 	baseURL := *baseURLValue
@@ -115,9 +134,10 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		baseURL = fmt.Sprintf("http://localhost:%d", port)
 	}
 	server := emuruntime.NewServer(emuruntime.ServerOptions{
-		Version:  version,
-		BaseURL:  baseURL,
-		Services: services,
+		Version:    version,
+		BaseURL:    baseURL,
+		Services:   services,
+		ResendSeed: resendSeed,
 	})
 	httpServer := &nethttp.Server{
 		Handler:           server.Handler,
@@ -252,7 +272,7 @@ func printHelp(w io.Writer) {
 	fmt.Fprintln(w, "\nStart options:")
 	fmt.Fprintln(w, "  -p, --port <port>          Base port")
 	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
-	fmt.Fprintln(w, "      --seed <file>          Path to seed config file (not supported in native Go yet)")
+	fmt.Fprintln(w, "      --seed <file>          Path to JSON seed config file (YAML not supported in native Go yet)")
 	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
 	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless (not supported in native Go yet)")
 	fmt.Fprintln(w, "\nThe published TypeScript CLI remains the default user-facing runtime.")
@@ -265,7 +285,7 @@ func printStartHelp(w io.Writer) {
 	fmt.Fprintln(w, "\nOptions:")
 	fmt.Fprintln(w, "  -p, --port <port>          Base port")
 	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
-	fmt.Fprintln(w, "      --seed <file>          Path to seed config file (not supported in native Go yet)")
+	fmt.Fprintln(w, "      --seed <file>          Path to JSON seed config file (YAML not supported in native Go yet)")
 	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
 	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless (not supported in native Go yet)")
 }

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -110,7 +110,11 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			fmt.Fprintf(stderr, "Failed to load seed config: %v\n", err)
 			return 1
 		}
-		seedServices = coreconfig.InferServices(loaded.Data, emuruntime.ServiceNames())
+		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for resend. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			return 1
+		}
+		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
 		if raw, ok := loaded.Data["resend"]; ok {
 			var cfg resend.SeedConfig
 			if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -323,6 +327,28 @@ func parseServices(value string) ([]string, error) {
 		return nil, fmt.Errorf("No services selected")
 	}
 	return services, nil
+}
+
+func nativeSeedServiceNames() []string {
+	return []string{"resend"}
+}
+
+func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {
+	supported := map[string]bool{}
+	for _, service := range nativeSeedServiceNames() {
+		supported[service] = true
+	}
+
+	unsupported := make([]string, 0)
+	for _, service := range emuruntime.ServiceNames() {
+		if supported[service] {
+			continue
+		}
+		if _, ok := data[service]; ok {
+			unsupported = append(unsupported, service)
+		}
+	}
+	return unsupported
 }
 
 func getenv(name string, fallback string) string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -224,6 +224,31 @@ func TestRunStartRejectsYAMLSeedConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"aws":{"s3":{"buckets":[{"name":"example"}]}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"start", "--seed", seedPath},
+		{"start", "--service", "aws", "--seed", seedPath},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code == 0 {
+				t.Fatal("start with unsupported seed service exited successfully")
+			}
+			errText := stderr.String()
+			if !strings.Contains(errText, "only supports --seed for resend") || !strings.Contains(errText, "aws") {
+				t.Fatalf("unexpected stderr: %s", errText)
+			}
+		})
+	}
+}
+
 func TestRunTopLevelHelpIncludesFullStartOptions(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"--help"}, &stdout, &stderr)

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -158,6 +158,72 @@ func TestRunStartServesHealthEndpoint(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsResendFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"resend":{"domains":[{"name":"example.com"}],"contacts":[{"email":"test@example.com","first_name":"Test"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath)
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, healthURL, &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "resend" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	var domains struct {
+		Data []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d/domains", port), &domains)
+	if len(domains.Data) != 1 || domains.Data[0].Name != "example.com" || domains.Data[0].Status != "verified" {
+		t.Fatalf("unexpected seeded domains: %#v", domains)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
+func TestRunStartRejectsYAMLSeedConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.yaml")
+	if err := os.WriteFile(seedPath, []byte("resend:\n  domains:\n    - name: example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"start", "--seed", seedPath}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("start with YAML seed exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "YAML config loading is not implemented") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
 func TestRunTopLevelHelpIncludesFullStartOptions(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"--help"}, &stdout, &stderr)

--- a/internal/core/ui/ui.go
+++ b/internal/core/ui/ui.go
@@ -292,9 +292,13 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,sans-serif;background:
 .inspector-table th,.inspector-table td{text-align:left;padding:8px 12px;border-bottom:1px solid #0a3300;font-size:.8125rem;}
 .inspector-table th{color:#1a8c00;font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.04em;}
 .inspector-table td{color:#33ff00;}
+.inspector-table a{color:#33ff00;text-decoration:none;}
+.inspector-table a:hover{text-decoration:underline;}
 .inspector-table tbody tr{transition:background .1s;}
 .inspector-table tbody tr:hover{background:#0a3300;}
 .inspector-empty{color:#1a8c00;text-align:center;padding:20px 0;font-size:.8125rem;}
+.email-preview-frame{width:100%;min-height:300px;border:1px solid #0a3300;border-radius:8px;background:#fff;}
+.email-preview-text{white-space:pre-wrap;word-break:break-word;color:#33ff00;font:inherit;}
 `
 }
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -7,15 +7,17 @@ import (
 	"github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/core/ui"
 	"github.com/vercel-labs/emulate/internal/services/aws"
+	"github.com/vercel-labs/emulate/internal/services/resend"
 )
 
 const HealthPath = "/_emulate/health"
 
 type ServerOptions struct {
-	Version  string
-	BaseURL  string
-	Services []string
-	Store    *store.Store
+	Version    string
+	BaseURL    string
+	Services   []string
+	Store      *store.Store
+	ResendSeed *resend.SeedConfig
 }
 
 type Server struct {
@@ -67,6 +69,12 @@ func NewServer(options ServerOptions) *Server {
 			Store:          runtimeStore,
 			S3PathFallback: len(services) == 1,
 			BaseURL:        options.BaseURL,
+		})
+	}
+	if serviceEnabled(services, "resend") {
+		resend.Register(router, resend.Options{
+			Store: runtimeStore,
+			Seed:  options.ResendSeed,
 		})
 	}
 	router.NotFound(func(c *corehttp.Context) {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -167,3 +167,33 @@ func TestNewHandlerDoesNotMountAWSWhenDisabled(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }
+
+func TestNewHandlerMountsResendWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/emails", strings.NewReader(`{"from":"a@example.com","to":"b@example.com","subject":"Hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer re_test_token")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"id"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountResendWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"github"}})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/emails", strings.NewReader(`{"from":"a@example.com","to":"b@example.com","subject":"Hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}

--- a/internal/services/resend/service.go
+++ b/internal/services/resend/service.go
@@ -1,0 +1,819 @@
+package resend
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+type Options struct {
+	Store *corestore.Store
+	Seed  *SeedConfig
+}
+
+type SeedConfig struct {
+	Domains  []DomainSeed  `json:"domains"`
+	Contacts []ContactSeed `json:"contacts"`
+}
+
+type DomainSeed struct {
+	Name   string `json:"name"`
+	Region string `json:"region"`
+}
+
+type ContactSeed struct {
+	Email     string `json:"email"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Audience  string `json:"audience"`
+}
+
+type Service struct {
+	store Store
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	service := &Service{
+		store: NewStore(runtimeStore),
+	}
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	router.Post("/emails/batch", s.handleCreateBatchEmails)
+	router.Post("/emails", s.handleCreateEmail)
+	router.Get("/emails", s.handleListEmails)
+	router.Get("/emails/:id", s.handleGetEmail)
+	router.Post("/emails/:id/cancel", s.handleCancelEmail)
+
+	router.Post("/domains", s.handleCreateDomain)
+	router.Get("/domains", s.handleListDomains)
+	router.Get("/domains/:id", s.handleGetDomain)
+	router.Delete("/domains/:id", s.handleDeleteDomain)
+	router.Post("/domains/:id/verify", s.handleVerifyDomain)
+
+	router.Post("/api-keys", s.handleCreateAPIKey)
+	router.Get("/api-keys", s.handleListAPIKeys)
+	router.Delete("/api-keys/:id", s.handleDeleteAPIKey)
+
+	router.Post("/audiences", s.handleCreateAudience)
+	router.Get("/audiences", s.handleListAudiences)
+	router.Delete("/audiences/:id", s.handleDeleteAudience)
+	router.Post("/audiences/:audience_id/contacts", s.handleCreateContact)
+	router.Get("/audiences/:audience_id/contacts", s.handleListContacts)
+	router.Delete("/audiences/:audience_id/contacts/:id", s.handleDeleteContact)
+
+	router.Get("/inbox", s.handleInbox)
+	router.Get("/inbox/:id", s.handleInboxEmail)
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, config SeedConfig) {
+	New(Options{Store: runtimeStore, Seed: &config})
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	for _, domain := range config.Domains {
+		if domain.Name == "" || len(s.store.Domains.FindBy("name", domain.Name)) > 0 {
+			continue
+		}
+		region := domain.Region
+		if region == "" {
+			region = "us-east-1"
+		}
+		s.store.Domains.Insert(corestore.Record{
+			"uuid":    generateUUID(),
+			"name":    domain.Name,
+			"status":  "verified",
+			"region":  region,
+			"records": domainRecords(domain.Name, region, "verified"),
+		})
+	}
+
+	if len(config.Contacts) == 0 {
+		return
+	}
+
+	defaultAudience := s.findAudienceByName("Default")
+	if defaultAudience == nil {
+		defaultAudience = s.store.Audiences.Insert(corestore.Record{
+			"uuid": generateUUID(),
+			"name": "Default",
+		})
+	}
+
+	for _, contact := range config.Contacts {
+		if contact.Email == "" {
+			continue
+		}
+		audienceID := stringField(defaultAudience, "uuid")
+		if contact.Audience != "" {
+			audience := s.findAudienceByName(contact.Audience)
+			if audience == nil {
+				audience = s.store.Audiences.Insert(corestore.Record{
+					"uuid": generateUUID(),
+					"name": contact.Audience,
+				})
+			}
+			audienceID = stringField(audience, "uuid")
+		}
+		s.store.Contacts.Insert(corestore.Record{
+			"uuid":         generateUUID(),
+			"audience_id":  audienceID,
+			"email":        contact.Email,
+			"first_name":   nullableString(contact.FirstName),
+			"last_name":    nullableString(contact.LastName),
+			"unsubscribed": false,
+		})
+	}
+}
+
+func (s *Service) handleCreateBatchEmails(c *corehttp.Context) {
+	var emails []map[string]any
+	if err := decodeJSON(c.Request, &emails); err != nil || emails == nil {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Request body must be an array")
+		return
+	}
+	if len(emails) > 100 {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Batch size cannot exceed 100 emails")
+		return
+	}
+	for _, email := range emails {
+		if stringValue(email["from"]) == "" {
+			writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: from")
+			return
+		}
+		if _, ok := email["to"]; !ok || len(stringSlice(email["to"])) == 0 {
+			writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: to")
+			return
+		}
+		if stringValue(email["subject"]) == "" {
+			writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: subject")
+			return
+		}
+	}
+
+	results := make([]map[string]any, 0, len(emails))
+	for _, email := range emails {
+		record := s.insertEmail(email)
+		results = append(results, map[string]any{"id": stringField(record, "uuid")})
+	}
+	c.JSON(http.StatusOK, map[string]any{"data": results})
+}
+
+func (s *Service) handleCreateEmail(c *corehttp.Context) {
+	body, err := parseResendBody(c.Request)
+	if err != nil {
+		body = map[string]any{}
+	}
+	if stringValue(body["from"]) == "" {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: from")
+		return
+	}
+	if _, ok := body["to"]; !ok || len(stringSlice(body["to"])) == 0 {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: to")
+		return
+	}
+	if stringValue(body["subject"]) == "" {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: subject")
+		return
+	}
+	record := s.insertEmail(body)
+	c.JSON(http.StatusOK, map[string]any{"id": stringField(record, "uuid")})
+}
+
+func (s *Service) handleListEmails(c *corehttp.Context) {
+	emails := s.store.Emails.All()
+	data := make([]map[string]any, 0, len(emails))
+	for _, email := range emails {
+		data = append(data, formatEmail(email))
+	}
+	c.JSON(http.StatusOK, listResponse(data))
+}
+
+func (s *Service) handleGetEmail(c *corehttp.Context) {
+	email := s.findEmail(c.Param("id"))
+	if email == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Email not found")
+		return
+	}
+	c.JSON(http.StatusOK, formatEmail(email))
+}
+
+func (s *Service) handleCancelEmail(c *corehttp.Context) {
+	email := s.findEmail(c.Param("id"))
+	if email == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Email not found")
+		return
+	}
+	if stringField(email, "status") != "scheduled" {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Only scheduled emails can be canceled")
+		return
+	}
+	id := intField(email, "id")
+	updated, _ := s.store.Emails.Update(id, corestore.Record{
+		"status":     "canceled",
+		"last_event": "email.canceled",
+	})
+	c.JSON(http.StatusOK, map[string]any{"id": stringField(updated, "uuid"), "object": "email", "canceled": true})
+}
+
+func (s *Service) handleCreateDomain(c *corehttp.Context) {
+	body, _ := parseResendBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: name")
+		return
+	}
+	region := stringValue(body["region"])
+	if region == "" {
+		region = "us-east-1"
+	}
+	domain := s.store.Domains.Insert(corestore.Record{
+		"uuid":    generateUUID(),
+		"name":    name,
+		"status":  "pending",
+		"region":  region,
+		"records": domainRecords(name, region, "pending"),
+	})
+	c.JSON(http.StatusOK, formatDomain(domain))
+}
+
+func (s *Service) handleListDomains(c *corehttp.Context) {
+	domains := s.store.Domains.All()
+	data := make([]map[string]any, 0, len(domains))
+	for _, domain := range domains {
+		data = append(data, formatDomain(domain))
+	}
+	c.JSON(http.StatusOK, listResponse(data))
+}
+
+func (s *Service) handleGetDomain(c *corehttp.Context) {
+	domain := s.findDomain(c.Param("id"))
+	if domain == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Domain not found")
+		return
+	}
+	c.JSON(http.StatusOK, formatDomain(domain))
+}
+
+func (s *Service) handleDeleteDomain(c *corehttp.Context) {
+	domain := s.findDomain(c.Param("id"))
+	if domain == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Domain not found")
+		return
+	}
+	s.store.Domains.Delete(intField(domain, "id"))
+	c.JSON(http.StatusOK, map[string]any{"object": "domain", "id": stringField(domain, "uuid"), "deleted": true})
+}
+
+func (s *Service) handleVerifyDomain(c *corehttp.Context) {
+	domain := s.findDomain(c.Param("id"))
+	if domain == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Domain not found")
+		return
+	}
+	name := stringField(domain, "name")
+	region := stringField(domain, "region")
+	s.store.Domains.Update(intField(domain, "id"), corestore.Record{
+		"status":  "verified",
+		"records": domainRecords(name, region, "verified"),
+	})
+	c.JSON(http.StatusOK, map[string]any{"object": "domain", "id": stringField(domain, "uuid"), "status": "verified"})
+}
+
+func (s *Service) handleCreateAPIKey(c *corehttp.Context) {
+	body, _ := parseResendBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: name")
+		return
+	}
+	apiKey := s.store.APIKeys.Insert(corestore.Record{
+		"uuid":  generateUUID(),
+		"name":  name,
+		"token": "re_" + randomHex(16),
+	})
+	c.JSON(http.StatusOK, map[string]any{
+		"id":    stringField(apiKey, "uuid"),
+		"token": stringField(apiKey, "token"),
+	})
+}
+
+func (s *Service) handleListAPIKeys(c *corehttp.Context) {
+	keys := s.store.APIKeys.All()
+	data := make([]map[string]any, 0, len(keys))
+	for _, key := range keys {
+		data = append(data, map[string]any{
+			"id":         stringField(key, "uuid"),
+			"name":       stringField(key, "name"),
+			"created_at": key["created_at"],
+		})
+	}
+	c.JSON(http.StatusOK, listResponse(data))
+}
+
+func (s *Service) handleDeleteAPIKey(c *corehttp.Context) {
+	key := findByUUID(s.store.APIKeys, c.Param("id"))
+	if key == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "API key not found")
+		return
+	}
+	s.store.APIKeys.Delete(intField(key, "id"))
+	c.JSON(http.StatusOK, map[string]any{"deleted": true})
+}
+
+func (s *Service) handleCreateAudience(c *corehttp.Context) {
+	body, _ := parseResendBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: name")
+		return
+	}
+	audience := s.store.Audiences.Insert(corestore.Record{"uuid": generateUUID(), "name": name})
+	c.JSON(http.StatusOK, formatAudience(audience))
+}
+
+func (s *Service) handleListAudiences(c *corehttp.Context) {
+	audiences := s.store.Audiences.All()
+	data := make([]map[string]any, 0, len(audiences))
+	for _, audience := range audiences {
+		data = append(data, formatAudience(audience))
+	}
+	c.JSON(http.StatusOK, listResponse(data))
+}
+
+func (s *Service) handleDeleteAudience(c *corehttp.Context) {
+	audience := findByUUID(s.store.Audiences, c.Param("id"))
+	if audience == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Audience not found")
+		return
+	}
+	s.store.Audiences.Delete(intField(audience, "id"))
+	c.JSON(http.StatusOK, map[string]any{"object": "audience", "id": stringField(audience, "uuid"), "deleted": true})
+}
+
+func (s *Service) handleCreateContact(c *corehttp.Context) {
+	audienceID := c.Param("audience_id")
+	audience := findByUUID(s.store.Audiences, audienceID)
+	if audience == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Audience not found")
+		return
+	}
+	body, _ := parseResendBody(c.Request)
+	email := stringValue(body["email"])
+	if email == "" {
+		writeResendError(c, http.StatusUnprocessableEntity, "validation_error", "Missing required field: email")
+		return
+	}
+	contact := s.store.Contacts.Insert(corestore.Record{
+		"uuid":         generateUUID(),
+		"audience_id":  audienceID,
+		"email":        email,
+		"first_name":   nullableAnyString(body["first_name"]),
+		"last_name":    nullableAnyString(body["last_name"]),
+		"unsubscribed": boolValue(body["unsubscribed"]),
+	})
+	c.JSON(http.StatusOK, map[string]any{
+		"id":     stringField(contact, "uuid"),
+		"object": "contact",
+		"email":  stringField(contact, "email"),
+	})
+}
+
+func (s *Service) handleListContacts(c *corehttp.Context) {
+	audienceID := c.Param("audience_id")
+	if findByUUID(s.store.Audiences, audienceID) == nil {
+		writeResendError(c, http.StatusNotFound, "not_found", "Audience not found")
+		return
+	}
+	contacts := s.store.Contacts.FindBy("audience_id", audienceID)
+	data := make([]map[string]any, 0, len(contacts))
+	for _, contact := range contacts {
+		data = append(data, formatContact(contact))
+	}
+	c.JSON(http.StatusOK, listResponse(data))
+}
+
+func (s *Service) handleDeleteContact(c *corehttp.Context) {
+	audienceID := c.Param("audience_id")
+	contact := findByUUID(s.store.Contacts, c.Param("id"))
+	if contact == nil || stringField(contact, "audience_id") != audienceID {
+		writeResendError(c, http.StatusNotFound, "not_found", "Contact not found")
+		return
+	}
+	s.store.Contacts.Delete(intField(contact, "id"))
+	c.JSON(http.StatusOK, map[string]any{"object": "contact", "id": stringField(contact, "uuid"), "deleted": true})
+}
+
+func (s *Service) handleInbox(c *corehttp.Context) {
+	emails := s.store.Emails.All()
+	var rows strings.Builder
+	for i := len(emails) - 1; i >= 0; i-- {
+		email := emails[i]
+		rows.WriteString(`<tr><td><a href="/inbox/`)
+		rows.WriteString(ui.EscapeAttr(stringField(email, "uuid")))
+		rows.WriteString(`">`)
+		rows.WriteString(ui.EscapeHTML(stringField(email, "subject")))
+		rows.WriteString(`</a></td><td>`)
+		rows.WriteString(ui.EscapeHTML(stringField(email, "from")))
+		rows.WriteString(` &rarr; `)
+		rows.WriteString(ui.EscapeHTML(strings.Join(stringSlice(email["to"]), ", ")))
+		rows.WriteString(`</td><td><span class="badge">`)
+		rows.WriteString(ui.EscapeHTML(stringField(email, "status")))
+		rows.WriteString(`</span></td></tr>`)
+	}
+	body := `<div class="inspector-section">
+  <table class="inspector-table">
+    <thead><tr><th>Subject</th><th>Route</th><th>Status</th></tr></thead>
+    <tbody>` + rowsOrEmpty(rows.String(), 3, "No emails sent yet. Use POST /emails to send one.") + `</tbody>
+  </table>
+</div>`
+	subtitle := fmt.Sprintf("%d emails sent", len(emails))
+	if len(emails) == 1 {
+		subtitle = "1 email sent"
+	}
+	c.HTML(http.StatusOK, ui.RenderCardPage("Inbox", subtitle, body, ui.PageOptions{Service: "Resend"}))
+}
+
+func (s *Service) handleInboxEmail(c *corehttp.Context) {
+	email := s.findEmail(c.Param("id"))
+	if email == nil {
+		html := ui.RenderCardPage("Not Found", "The requested email was not found.", `<div class="empty">Email not found</div>`, ui.PageOptions{Service: "Resend"})
+		c.HTML(http.StatusNotFound, html)
+		return
+	}
+
+	var preview string
+	if htmlBody := stringField(email, "html"); htmlBody != "" {
+		preview = `<iframe sandbox="allow-popups allow-popups-to-escape-sandbox" srcdoc="` + ui.EscapeAttr(`<base target="_blank">`+htmlBody) + `" class="email-preview-frame"></iframe>`
+	} else if textBody := stringField(email, "text"); textBody != "" {
+		preview = `<div class="s-card"><pre class="email-preview-text">` + ui.EscapeHTML(textBody) + `</pre></div>`
+	} else {
+		preview = `<div class="empty">No content</div>`
+	}
+
+	body := `<div class="s-card">
+  <div class="section-heading">Recipients <span class="badge">` + ui.EscapeHTML(stringField(email, "status")) + `</span></div>
+  <div class="user-meta"><strong>From:</strong> ` + ui.EscapeHTML(stringField(email, "from")) + `</div>
+  <div class="user-meta"><strong>To:</strong> ` + ui.EscapeHTML(strings.Join(stringSlice(email["to"]), ", ")) + `</div>
+</div>
+<div class="section-heading">Preview</div>
+` + preview + `
+<div class="user-meta"><strong>Last event:</strong> ` + ui.EscapeHTML(stringField(email, "last_event")) + `</div>`
+	c.HTML(http.StatusOK, ui.RenderCardPage(stringField(email, "subject"), "Email "+ui.EscapeHTML(stringField(email, "uuid")), body, ui.PageOptions{Service: "Resend"}))
+}
+
+func (s *Service) insertEmail(body map[string]any) corestore.Record {
+	scheduledAt := stringValue(body["scheduled_at"])
+	status := "delivered"
+	lastEvent := "email.delivered"
+	if scheduledAt != "" {
+		status = "scheduled"
+		lastEvent = "email.scheduled"
+	}
+	return s.store.Emails.Insert(corestore.Record{
+		"uuid":         generateUUID(),
+		"from":         stringValue(body["from"]),
+		"to":           stringSlice(body["to"]),
+		"subject":      stringValue(body["subject"]),
+		"html":         nullableAnyString(body["html"]),
+		"text":         nullableAnyString(body["text"]),
+		"cc":           stringSlice(body["cc"]),
+		"bcc":          stringSlice(body["bcc"]),
+		"reply_to":     stringSlice(body["reply_to"]),
+		"headers":      stringMap(body["headers"]),
+		"tags":         tags(body["tags"]),
+		"status":       status,
+		"scheduled_at": nullableString(scheduledAt),
+		"last_event":   lastEvent,
+	})
+}
+
+func (s *Service) findEmail(uuid string) corestore.Record {
+	return findByUUID(s.store.Emails, uuid)
+}
+
+func (s *Service) findDomain(uuid string) corestore.Record {
+	return findByUUID(s.store.Domains, uuid)
+}
+
+func (s *Service) findAudienceByName(name string) corestore.Record {
+	found := s.store.Audiences.FindBy("name", name)
+	if len(found) == 0 {
+		return nil
+	}
+	return found[0]
+}
+
+func findByUUID(collection *corestore.Collection, uuid string) corestore.Record {
+	found := collection.FindBy("uuid", uuid)
+	if len(found) == 0 {
+		return nil
+	}
+	return found[0]
+}
+
+func parseResendBody(req *http.Request) (map[string]any, error) {
+	contentType := req.Header.Get("Content-Type")
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if strings.Contains(contentType, "application/x-www-form-urlencoded") {
+		values, err := url.ParseQuery(string(raw))
+		if err != nil {
+			return nil, err
+		}
+		out := map[string]any{}
+		for key, values := range values {
+			if len(values) > 0 {
+				out[key] = values[len(values)-1]
+			}
+		}
+		return out, nil
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return map[string]any{}, nil
+	}
+	if body == nil {
+		body = map[string]any{}
+	}
+	return body, nil
+}
+
+func decodeJSON(req *http.Request, out any) error {
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func writeResendError(c *corehttp.Context, status int, name string, message string) {
+	c.JSON(status, map[string]any{"statusCode": status, "name": name, "message": message})
+}
+
+func listResponse(data []map[string]any) map[string]any {
+	return map[string]any{"object": "list", "data": data}
+}
+
+func rowsOrEmpty(rows string, columns int, label string) string {
+	if rows != "" {
+		return rows
+	}
+	return `<tr><td colspan="` + fmt.Sprint(columns) + `"><div class="inspector-empty">` + ui.EscapeHTML(label) + `</div></td></tr>`
+}
+
+func formatEmail(email corestore.Record) map[string]any {
+	return map[string]any{
+		"id":           stringField(email, "uuid"),
+		"object":       "email",
+		"from":         stringField(email, "from"),
+		"to":           stringSlice(email["to"]),
+		"subject":      stringField(email, "subject"),
+		"html":         email["html"],
+		"text":         email["text"],
+		"cc":           stringSlice(email["cc"]),
+		"bcc":          stringSlice(email["bcc"]),
+		"reply_to":     stringSlice(email["reply_to"]),
+		"headers":      stringMap(email["headers"]),
+		"tags":         tags(email["tags"]),
+		"status":       stringField(email, "status"),
+		"scheduled_at": email["scheduled_at"],
+		"last_event":   stringField(email, "last_event"),
+		"created_at":   email["created_at"],
+	}
+}
+
+func formatDomain(domain corestore.Record) map[string]any {
+	return map[string]any{
+		"id":         stringField(domain, "uuid"),
+		"object":     "domain",
+		"name":       stringField(domain, "name"),
+		"status":     stringField(domain, "status"),
+		"region":     stringField(domain, "region"),
+		"records":    domainRecordsFromValue(domain["records"]),
+		"created_at": domain["created_at"],
+	}
+}
+
+func formatAudience(audience corestore.Record) map[string]any {
+	return map[string]any{
+		"id":         stringField(audience, "uuid"),
+		"object":     "audience",
+		"name":       stringField(audience, "name"),
+		"created_at": audience["created_at"],
+	}
+}
+
+func formatContact(contact corestore.Record) map[string]any {
+	return map[string]any{
+		"id":           stringField(contact, "uuid"),
+		"object":       "contact",
+		"email":        stringField(contact, "email"),
+		"first_name":   contact["first_name"],
+		"last_name":    contact["last_name"],
+		"unsubscribed": boolField(contact, "unsubscribed"),
+		"created_at":   contact["created_at"],
+	}
+}
+
+func domainRecords(name string, region string, status string) []map[string]any {
+	return []map[string]any{
+		{
+			"record":   "SPF",
+			"name":     name,
+			"type":     "MX",
+			"ttl":      "Auto",
+			"status":   status,
+			"value":    "feedback-smtp." + region + ".amazonses.com",
+			"priority": 10,
+		},
+		{
+			"record": "SPF",
+			"name":   name,
+			"type":   "TXT",
+			"ttl":    "Auto",
+			"status": status,
+			"value":  "v=spf1 include:amazonses.com ~all",
+		},
+		{
+			"record": "DKIM",
+			"name":   "resend._domainkey." + name,
+			"type":   "CNAME",
+			"ttl":    "Auto",
+			"status": status,
+			"value":  "resend.domainkey." + region + ".amazonses.com",
+		},
+	}
+}
+
+func domainRecordsFromValue(value any) []map[string]any {
+	switch records := value.(type) {
+	case []map[string]any:
+		return records
+	case []any:
+		out := make([]map[string]any, 0, len(records))
+		for _, item := range records {
+			if record, ok := item.(map[string]any); ok {
+				out = append(out, record)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func tags(value any) []map[string]any {
+	switch raw := value.(type) {
+	case []map[string]any:
+		return raw
+	case []any:
+		out := make([]map[string]any, 0, len(raw))
+		for _, item := range raw {
+			if tag, ok := item.(map[string]any); ok {
+				out = append(out, map[string]any{
+					"name":  stringValue(tag["name"]),
+					"value": stringValue(tag["value"]),
+				})
+			}
+		}
+		return out
+	default:
+		return []map[string]any{}
+	}
+}
+
+func stringMap(value any) map[string]any {
+	switch raw := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(raw))
+		for key, value := range raw {
+			out[key] = stringValue(value)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]any, len(raw))
+		for key, value := range raw {
+			out[key] = value
+		}
+		return out
+	default:
+		return map[string]any{}
+	}
+}
+
+func stringSlice(value any) []string {
+	switch raw := value.(type) {
+	case nil:
+		return []string{}
+	case []string:
+		return append([]string(nil), raw...)
+	case []any:
+		out := make([]string, 0, len(raw))
+		for _, item := range raw {
+			out = append(out, stringValue(item))
+		}
+		return out
+	case string:
+		if raw == "" {
+			return []string{}
+		}
+		return []string{raw}
+	default:
+		return []string{fmt.Sprint(raw)}
+	}
+}
+
+func stringValue(value any) string {
+	switch raw := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return raw
+	default:
+		return fmt.Sprint(raw)
+	}
+}
+
+func stringField(record corestore.Record, field string) string {
+	return stringValue(record[field])
+}
+
+func intField(record corestore.Record, field string) int {
+	switch value := record[field].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func boolField(record corestore.Record, field string) bool {
+	return boolValue(record[field])
+}
+
+func boolValue(value any) bool {
+	raw, _ := value.(bool)
+	return raw
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func nullableAnyString(value any) any {
+	text := stringValue(value)
+	if text == "" {
+		return nil
+	}
+	return text
+}
+
+func generateUUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return randomHex(16)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func randomHex(size int) string {
+	buf := make([]byte, size)
+	if _, err := rand.Read(buf); err != nil {
+		return strings.Repeat("0", size*2)
+	}
+	return hex.EncodeToString(buf)
+}

--- a/internal/services/resend/service_test.go
+++ b/internal/services/resend/service_test.go
@@ -1,0 +1,269 @@
+package resend
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func newTestHandler() http.Handler {
+	router := corehttp.NewRouter()
+	Register(router, Options{})
+	router.NotFound(func(c *corehttp.Context) {
+		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+	})
+	return router
+}
+
+func requestJSON(t *testing.T, handler http.Handler, method string, path string, body string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer re_test_token")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	var parsed map[string]any
+	if strings.Contains(res.Header().Get("Content-Type"), "application/json") && res.Body.Len() > 0 {
+		if err := json.Unmarshal(res.Body.Bytes(), &parsed); err != nil {
+			t.Fatalf("failed to parse response JSON: %v\nbody: %s", err, res.Body.String())
+		}
+	}
+	return res, parsed
+}
+
+func TestEmailsLifecycle(t *testing.T) {
+	handler := newTestHandler()
+
+	res, body := requestJSON(t, handler, http.MethodPost, "/emails", `{"from":"a@example.com","to":"b@example.com","subject":"Hello","html":"<h1>Hello</h1>"}`)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	id, _ := body["id"].(string)
+	if id == "" {
+		t.Fatalf("missing id in %#v", body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodGet, "/emails/"+id, "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body["subject"] != "Hello" || body["status"] != "delivered" {
+		t.Fatalf("unexpected email: %#v", body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodGet, "/emails", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	data, _ := body["data"].([]any)
+	if body["object"] != "list" || len(data) != 1 {
+		t.Fatalf("unexpected list: %#v", body)
+	}
+}
+
+func TestEmailValidationAndCancel(t *testing.T) {
+	handler := newTestHandler()
+
+	res, body := requestJSON(t, handler, http.MethodPost, "/emails", `{"from":"a@example.com"}`)
+	if res.Code != http.StatusUnprocessableEntity || body["name"] != "validation_error" {
+		t.Fatalf("unexpected validation response: status=%d body=%#v", res.Code, body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodPost, "/emails", `{"from":"a@example.com","to":"b@example.com","subject":"Later","scheduled_at":"2099-01-01T00:00:00Z"}`)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	id := body["id"].(string)
+
+	res, body = requestJSON(t, handler, http.MethodPost, "/emails/"+id+"/cancel", `{}`)
+	if res.Code != http.StatusOK || body["canceled"] != true {
+		t.Fatalf("unexpected cancel response: status=%d body=%#v", res.Code, body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodGet, "/emails/"+id, "")
+	if res.Code != http.StatusOK || body["status"] != "canceled" {
+		t.Fatalf("unexpected canceled email: status=%d body=%#v", res.Code, body)
+	}
+}
+
+func TestBatchEmailsValidateBeforeInsert(t *testing.T) {
+	handler := newTestHandler()
+
+	res, body := requestJSON(t, handler, http.MethodPost, "/emails/batch", `[{"from":"a@example.com","to":"b@example.com","subject":"One"},{"from":"a@example.com"}]`)
+	if res.Code != http.StatusUnprocessableEntity || body["name"] != "validation_error" {
+		t.Fatalf("unexpected batch validation response: status=%d body=%#v", res.Code, body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodGet, "/emails", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if data := body["data"].([]any); len(data) != 0 {
+		t.Fatalf("batch inserted records after validation failure: %#v", body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodPost, "/emails/batch", `[{"from":"a@example.com","to":"b@example.com","subject":"One"},{"from":"a@example.com","to":"c@example.com","subject":"Two"}]`)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if data := body["data"].([]any); len(data) != 2 {
+		t.Fatalf("unexpected batch response: %#v", body)
+	}
+}
+
+func TestDomainsLifecycle(t *testing.T) {
+	handler := newTestHandler()
+
+	res, body := requestJSON(t, handler, http.MethodPost, "/domains", `{"name":"example.com"}`)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	id := body["id"].(string)
+	if body["status"] != "pending" {
+		t.Fatalf("unexpected domain: %#v", body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodPost, "/domains/"+id+"/verify", `{}`)
+	if res.Code != http.StatusOK || body["status"] != "verified" {
+		t.Fatalf("unexpected verify response: status=%d body=%#v", res.Code, body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodGet, "/domains", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if data := body["data"].([]any); len(data) != 1 {
+		t.Fatalf("unexpected domain list: %#v", body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodDelete, "/domains/"+id, "")
+	if res.Code != http.StatusOK || body["deleted"] != true {
+		t.Fatalf("unexpected delete response: status=%d body=%#v", res.Code, body)
+	}
+}
+
+func TestAPIKeysDoNotExposeTokenInList(t *testing.T) {
+	handler := newTestHandler()
+
+	res, body := requestJSON(t, handler, http.MethodPost, "/api-keys", `{"name":"Production"}`)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	id := body["id"].(string)
+	token := body["token"].(string)
+	if !strings.HasPrefix(token, "re_") {
+		t.Fatalf("unexpected token: %s", token)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodGet, "/api-keys", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	key := body["data"].([]any)[0].(map[string]any)
+	if _, ok := key["token"]; ok {
+		t.Fatalf("list exposed token: %#v", key)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodDelete, "/api-keys/"+id, "")
+	if res.Code != http.StatusOK || body["deleted"] != true {
+		t.Fatalf("unexpected delete response: status=%d body=%#v", res.Code, body)
+	}
+}
+
+func TestAudiencesAndContactsLifecycle(t *testing.T) {
+	handler := newTestHandler()
+
+	res, body := requestJSON(t, handler, http.MethodPost, "/audiences", `{"name":"Newsletter"}`)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	audienceID := body["id"].(string)
+
+	res, body = requestJSON(t, handler, http.MethodPost, "/audiences/"+audienceID+"/contacts", `{"email":"user@example.com","first_name":"Test"}`)
+	if res.Code != http.StatusOK || body["email"] != "user@example.com" {
+		t.Fatalf("unexpected contact response: status=%d body=%#v", res.Code, body)
+	}
+	contactID := body["id"].(string)
+
+	res, body = requestJSON(t, handler, http.MethodGet, "/audiences/"+audienceID+"/contacts", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if data := body["data"].([]any); len(data) != 1 {
+		t.Fatalf("unexpected contacts list: %#v", body)
+	}
+
+	res, body = requestJSON(t, handler, http.MethodDelete, "/audiences/"+audienceID+"/contacts/"+contactID, "")
+	if res.Code != http.StatusOK || body["deleted"] != true {
+		t.Fatalf("unexpected contact delete response: status=%d body=%#v", res.Code, body)
+	}
+}
+
+func TestInboxPages(t *testing.T) {
+	handler := newTestHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/inbox", nil)
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "0 emails sent") {
+		t.Fatalf("unexpected empty inbox: status=%d body=%s", res.Code, res.Body.String())
+	}
+
+	sendRes, body := requestJSON(t, handler, http.MethodPost, "/emails", `{"from":"sender@example.com","to":"recipient@example.com","subject":"Detail Test","html":"<h1>Hello</h1>"}`)
+	if sendRes.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", sendRes.Code, sendRes.Body.String())
+	}
+	id := body["id"].(string)
+
+	res = httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/inbox", nil))
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "Detail Test") || !strings.Contains(res.Body.String(), "1 email sent") {
+		t.Fatalf("unexpected inbox: status=%d body=%s", res.Code, res.Body.String())
+	}
+
+	res = httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/inbox/"+id, nil))
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "Detail Test") || !strings.Contains(res.Body.String(), "email-preview-frame") {
+		t.Fatalf("unexpected inbox detail: status=%d body=%s", res.Code, res.Body.String())
+	}
+}
+
+func TestFormEncodedEmailBody(t *testing.T) {
+	handler := newTestHandler()
+	body := bytes.NewBufferString("from=a%40example.com&to=b%40example.com&subject=Hello")
+	req := httptest.NewRequest(http.MethodPost, "/emails", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestSeedFromConfig(t *testing.T) {
+	runtimeStore := corestore.New()
+	SeedFromConfig(runtimeStore, SeedConfig{
+		Domains:  []DomainSeed{{Name: "example.com"}},
+		Contacts: []ContactSeed{{Email: "user@example.com", FirstName: "Test", LastName: "User"}},
+	})
+
+	rs := NewStore(runtimeStore)
+	domains := rs.Domains.All()
+	if len(domains) != 1 || stringField(domains[0], "status") != "verified" {
+		t.Fatalf("unexpected seeded domains: %#v", domains)
+	}
+	contacts := rs.Contacts.All()
+	if len(contacts) != 1 || stringField(contacts[0], "email") != "user@example.com" {
+		t.Fatalf("unexpected seeded contacts: %#v", contacts)
+	}
+	audiences := rs.Audiences.All()
+	if len(audiences) != 1 || stringField(audiences[0], "name") != "Default" {
+		t.Fatalf("unexpected seeded audiences: %#v", audiences)
+	}
+}

--- a/internal/services/resend/store.go
+++ b/internal/services/resend/store.go
@@ -1,0 +1,21 @@
+package resend
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Emails    *corestore.Collection
+	Domains   *corestore.Collection
+	APIKeys   *corestore.Collection
+	Audiences *corestore.Collection
+	Contacts  *corestore.Collection
+}
+
+func NewStore(runtimeStore *corestore.Store) Store {
+	return Store{
+		Emails:    runtimeStore.MustCollection("resend.emails", "uuid"),
+		Domains:   runtimeStore.MustCollection("resend.domains", "uuid", "name"),
+		APIKeys:   runtimeStore.MustCollection("resend.api_keys", "uuid"),
+		Audiences: runtimeStore.MustCollection("resend.audiences", "uuid", "name"),
+		Contacts:  runtimeStore.MustCollection("resend.contacts", "uuid", "audience_id"),
+	}
+}

--- a/packages/@emulators/resend/README.md
+++ b/packages/@emulators/resend/README.md
@@ -4,6 +4,12 @@ Resend email API emulation with email sending, domain management, API keys, audi
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
+## SDK Support
+
+Set `RESEND_BASE_URL` before importing the official `resend` Node.js SDK and the SDK will call the emulator without code changes.
+
+The experimental native Go runtime implements the current Resend routes listed below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+
 ## Install
 
 ```bash
@@ -49,8 +55,10 @@ npm install @emulators/resend
 resend:
   domains:
     - name: example.com
-  api_keys:
-    - name: default
+  contacts:
+    - email: test@example.com
+      first_name: Test
+      last_name: User
 ```
 
 ## Links

--- a/packages/@emulators/resend/package.json
+++ b/packages/@emulators/resend/package.json
@@ -38,6 +38,7 @@
     "@emulators/core": "workspace:*"
   },
   "devDependencies": {
+    "resend": "^6.10.0",
     "tsup": "^8",
     "typescript": "^5.7",
     "vitest": "^4.1.0"

--- a/packages/@emulators/resend/src/__tests__/resend.test.ts
+++ b/packages/@emulators/resend/src/__tests__/resend.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
 import { Hono } from "@emulators/core";
 import {
   Store,
@@ -33,6 +33,16 @@ function createTestApp() {
 
 function authHeaders(): Record<string, string> {
   return { Authorization: "Bearer re_test_token", "Content-Type": "application/json" };
+}
+
+async function postJSON(url: string, body: Record<string, unknown>) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as Record<string, unknown>;
 }
 
 describe("Resend plugin - Emails", () => {
@@ -456,5 +466,133 @@ describe("Resend plugin - seedFromConfig", () => {
     const contacts = rs.contacts.all();
     expect(contacts.length).toBe(1);
     expect(contacts[0].email).toBe("user@example.com");
+  });
+});
+
+const describeExternalResendSDK = process.env.RESEND_EMULATOR_E2E_URL ? describe : describe.skip;
+
+describeExternalResendSDK("Resend plugin - real resend SDK E2E", () => {
+  let Resend: typeof import("resend").Resend;
+  let previousBaseUrl: string | undefined;
+  const emulatorUrl = process.env.RESEND_EMULATOR_E2E_URL ?? "";
+
+  beforeAll(async () => {
+    previousBaseUrl = process.env.RESEND_BASE_URL;
+    process.env.RESEND_BASE_URL = emulatorUrl;
+    ({ Resend } = await import("resend"));
+  });
+
+  afterAll(() => {
+    if (previousBaseUrl === undefined) {
+      delete process.env.RESEND_BASE_URL;
+    } else {
+      process.env.RESEND_BASE_URL = previousBaseUrl;
+    }
+  });
+
+  it("sends, lists, reads, and cancels emails", async () => {
+    const resend = new Resend("re_test_token");
+
+    const sent = await resend.emails.send({
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      subject: "SDK hello",
+      html: "<p>Hello from the SDK</p>",
+    });
+    expect(sent.error).toBeNull();
+    const id = sent.data?.id;
+    expect(id).toBeTruthy();
+
+    const fetched = await resend.emails.get(id!);
+    expect(fetched.error).toBeNull();
+    expect(fetched.data?.subject).toBe("SDK hello");
+    expect((fetched.data as any)?.status).toBe("delivered");
+
+    const listed = await resend.emails.list();
+    expect(listed.error).toBeNull();
+    expect(listed.data?.data.some((email) => email.id === id)).toBe(true);
+
+    const scheduled = await resend.emails.send({
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      subject: "SDK scheduled",
+      text: "Scheduled body",
+      scheduledAt: "2099-01-01T00:00:00Z",
+    });
+    expect(scheduled.error).toBeNull();
+    const canceled = await resend.emails.cancel(scheduled.data!.id);
+    expect(canceled.error).toBeNull();
+    expect((canceled.data as any)?.canceled).toBe(true);
+  });
+
+  it("batch sends emails", async () => {
+    const resend = new Resend("re_test_token");
+
+    const batch = await resend.batch.send([
+      { from: "sender@example.com", to: "one@example.com", subject: "SDK batch one" },
+      { from: "sender@example.com", to: "two@example.com", subject: "SDK batch two" },
+    ]);
+
+    expect(batch.error).toBeNull();
+    expect(batch.data?.data).toHaveLength(2);
+  });
+
+  it("creates, verifies, lists, and removes domains", async () => {
+    const resend = new Resend("re_test_token");
+    const name = `sdk-${Date.now()}.example.com`;
+
+    const created = await resend.domains.create({ name });
+    expect(created.error).toBeNull();
+    expect(created.data?.name).toBe(name);
+    expect(created.data?.status).toBe("pending");
+
+    const verified = await resend.domains.verify(created.data!.id);
+    expect(verified.error).toBeNull();
+    expect((verified.data as any)?.status).toBe("verified");
+
+    const listed = await resend.domains.list();
+    expect(listed.error).toBeNull();
+    expect(listed.data?.data.some((domain) => domain.id === created.data!.id)).toBe(true);
+
+    const removed = await resend.domains.remove(created.data!.id);
+    expect(removed.error).toBeNull();
+    expect(removed.data?.deleted).toBe(true);
+  });
+
+  it("creates, lists, and removes API keys", async () => {
+    const resend = new Resend("re_test_token");
+
+    const created = await resend.apiKeys.create({ name: "SDK key" });
+    expect(created.error).toBeNull();
+    expect(created.data?.token).toMatch(/^re_/);
+
+    const listed = await resend.apiKeys.list();
+    expect(listed.error).toBeNull();
+    const listedKey = listed.data?.data.find((key) => key.id === created.data!.id);
+    expect(listedKey?.name).toBe("SDK key");
+    expect("token" in (listedKey as Record<string, unknown>)).toBe(false);
+
+    const removed = await resend.apiKeys.remove(created.data!.id);
+    expect(removed.error).toBeNull();
+    expect((removed.data as any)?.deleted).toBe(true);
+  });
+
+  it("creates and removes legacy audience contacts", async () => {
+    const resend = new Resend("re_test_token");
+    const audience = await postJSON(`${emulatorUrl}/audiences`, { name: "SDK audience" });
+    const audienceId = String(audience.id);
+
+    const created = await resend.contacts.create({
+      audienceId,
+      email: "sdk-contact@example.com",
+      firstName: "SDK",
+      lastName: "Contact",
+    });
+    expect(created.error).toBeNull();
+    expect((created.data as any)?.email).toBe("sdk-contact@example.com");
+
+    const removed = await resend.contacts.remove({ audienceId, id: created.data!.id });
+    expect(removed.error).toBeNull();
+    expect(removed.data?.deleted).toBe(true);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      resend:
+        specifier: ^6.10.0
+        version: 6.10.0
       tsup:
         specifier: ^8
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -10,6 +10,8 @@ Fully stateful Resend API emulation. Emails, domains, API keys, audiences, and c
 
 No real emails are sent. Every call to `POST /emails` stores the message locally so you can inspect it programmatically or in the browser.
 
+The experimental native Go runtime implements the current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` Node.js SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+
 ## Start
 
 ```bash


### PR DESCRIPTION
- Implements native Resend emails, domains, API keys, audiences, contacts, inbox UI, and explicit JSON seed handling in the Go runtime.

- Adds official Resend SDK external E2E coverage plus CI wiring for the native Go service.

- Updates Resend docs, skills, and service listings for native runtime support.