### PR TITLE
Add Next proxy adapter foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,7 +772,18 @@ export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulatePro
 
 With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
 
-If a single target handles multiple services, use `target` instead:
+If multiple services share one native runtime URL, keep using `targets` and point each service at that runtime when the runtime expects service-local paths:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4000',
+    aws: 'http://127.0.0.1:4000',
+  },
+})
+```
+
+Use single `target` only when the upstream expects every path segment after the public route prefix:
 
 ```typescript
 export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ The experimental native Go runtime serves the same current Resend routes, suppor
 
 ## Next.js Integration
 
-Embed emulators directly in your Next.js app so they run on the same origin. This solves the Vercel preview deployment problem where OAuth callback URLs change with every deployment.
+Use `@emulators/adapter-next` to run emulator routes on the same origin as your Next.js app. Embedded mode runs JavaScript emulators directly in the app. Proxy mode forwards to a separately running native runtime.
 
 ### Install
 
@@ -723,9 +723,9 @@ npm install @emulators/adapter-next @emulators/github @emulators/google
 
 Only install the emulators you need. Each `@emulators/*` package is published independently.
 
-### Route handler
+### Embedded route handler
 
-Create a catch-all route that serves emulator traffic:
+Create a catch-all route that serves emulator traffic in-process:
 
 ```typescript
 // app/emulate/[...path]/route.ts
@@ -751,6 +751,37 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
   },
 })
 ```
+
+Embedded mode is the current zero-infra path for Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin.
+
+### Native runtime proxy
+
+Use `createEmulateProxy` when a native runtime is running separately and the Next.js route should forward requests to it:
+
+```typescript
+// app/emulate/[...path]/route.ts
+import { createEmulateProxy } from '@emulators/adapter-next'
+
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4018',
+    aws: 'http://127.0.0.1:4020',
+  },
+})
+```
+
+With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
+
+If a single target handles multiple services, use `target` instead:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  routePrefix: '/emulate',
+  target: 'http://127.0.0.1:4020',
+})
+```
+
+Single target mode preserves every path segment. `/emulate/aws/sqs` forwards to `http://127.0.0.1:4020/aws/sqs`. For deployed previews, the target URL must be reachable from the Next.js serverless function.
 
 ### Auth.js / NextAuth configuration
 

--- a/apps/web/app/api/docs-chat/route.ts
+++ b/apps/web/app/api/docs-chat/route.ts
@@ -14,7 +14,7 @@ const DEFAULT_MODEL = "anthropic/claude-haiku-4.5";
 
 const SYSTEM_PROMPT = `You are a helpful documentation assistant for emulate, a local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, MongoDB Atlas, Resend, and Stripe APIs used in CI and no-network sandboxes.
 
-emulate provides fully stateful, production-fidelity API emulation, not mocks. The CLI is installed as the "emulate" npm package and run via "npx emulate". It also supports a programmatic API via createEmulator and a Next.js adapter (@emulators/adapter-next) for embedding emulators in your app.
+emulate provides fully stateful, production-fidelity API emulation, not mocks. The CLI is installed as the "emulate" npm package and run via "npx emulate". It also supports a programmatic API via createEmulator and a Next.js adapter (@emulators/adapter-next) for embedded emulators or native runtime proxy routes in your app.
 
 You have access to the full emulate documentation via the bash and readFile tools. The docs are available as markdown files in the /workspace/ directory.
 

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -64,7 +64,18 @@ export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulatePro
 
 With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
 
-If a single target handles multiple services, use `target` instead:
+If multiple services share one native runtime URL, keep using `targets` and point each service at that runtime when the runtime expects service-local paths:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4000',
+    aws: 'http://127.0.0.1:4000',
+  },
+})
+```
+
+Use single `target` only when the upstream expects every path segment after the public route prefix:
 
 ```typescript
 export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -1,6 +1,6 @@
 # Next.js Integration
 
-The `@emulators/adapter-next` package embeds emulators directly into a Next.js app, running them on the same origin. This is particularly useful for Vercel preview deployments where OAuth callback URLs change with every deployment.
+The `@emulators/adapter-next` package supports two App Router modes. Embedded mode runs JavaScript emulators directly inside the Next.js app. Proxy mode exposes a separately running native runtime on the same origin.
 
 ## Install
 
@@ -10,9 +10,9 @@ npm install @emulators/adapter-next @emulators/github @emulators/google
 
 Only install the emulators you need. Each `@emulators/*` package is published independently, keeping your serverless bundles small.
 
-## Route Handler
+## Embedded Route Handler
 
-Create a catch-all route that serves emulator traffic:
+Create a catch-all route that serves emulator traffic in-process:
 
 ```typescript
 // app/emulate/[...path]/route.ts
@@ -43,6 +43,39 @@ This creates the following routes:
 
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
+
+Embedded mode is the current zero-infra path for Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin.
+
+## Native Runtime Proxy
+
+Use `createEmulateProxy` when a native runtime is running separately and the Next.js route should forward requests to it:
+
+```typescript
+// app/emulate/[...path]/route.ts
+import { createEmulateProxy } from '@emulators/adapter-next'
+
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4018',
+    aws: 'http://127.0.0.1:4020',
+  },
+})
+```
+
+With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
+
+If a single target handles multiple services, use `target` instead:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  routePrefix: '/emulate',
+  target: 'http://127.0.0.1:4020',
+})
+```
+
+Single target mode preserves every path segment. `/emulate/aws/sqs` forwards to `http://127.0.0.1:4020/aws/sqs`.
+
+The proxy adds `x-forwarded-host`, `x-forwarded-proto`, `x-forwarded-port` when known, `x-forwarded-prefix`, `x-emulate-proxy: next`, `x-emulate-original-path`, and `x-emulate-service` for service targets. For deployed previews, the target URL must be reachable from the Next.js serverless function.
 
 ## Auth.js / NextAuth Configuration
 

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -85,4 +85,4 @@ You can also use emulate as a library in your tests. See the [Programmatic API](
 
 ## Next.js Integration
 
-Embed emulators directly in your Next.js app so they run on the same origin. See the [Next.js Integration](/docs/nextjs) page for setup instructions.
+Run emulator routes on the same origin as your Next.js app with embedded mode or native runtime proxy mode. See the [Next.js Integration](/docs/nextjs) page for setup instructions.

--- a/packages/@emulators/adapter-next/README.md
+++ b/packages/@emulators/adapter-next/README.md
@@ -65,7 +65,18 @@ export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulatePro
 
 With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
 
-If a single target handles multiple services, use `target` instead:
+If multiple services share one native runtime URL, keep using `targets` and point each service at that runtime when the runtime expects service-local paths:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4000',
+    aws: 'http://127.0.0.1:4000',
+  },
+})
+```
+
+Use single `target` only when the upstream expects every path segment after the public route prefix:
 
 ```typescript
 export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({

--- a/packages/@emulators/adapter-next/README.md
+++ b/packages/@emulators/adapter-next/README.md
@@ -1,6 +1,6 @@
 # @emulators/adapter-next
 
-Next.js App Router integration for emulate. Embed emulators directly in your Next.js app so they run on the same origin, solving the Vercel preview deployment problem where OAuth callback URLs change with every deployment.
+Next.js App Router integration for emulate. Use embedded mode to run JavaScript emulators directly inside your app, or proxy mode to expose a separately running native runtime on the same origin.
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
@@ -16,9 +16,9 @@ Only install the emulators you need alongside the adapter:
 npm install @emulators/adapter-next @emulators/github @emulators/google
 ```
 
-## Route handler
+## Embedded route handler
 
-Create a catch-all route that serves emulator traffic:
+Create a catch-all route that serves emulator traffic in-process:
 
 ```typescript
 // app/emulate/[...path]/route.ts
@@ -44,6 +44,39 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
   },
 })
 ```
+
+Embedded mode is the current zero-infra path for Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin.
+
+## Native runtime proxy
+
+Use `createEmulateProxy` when a native runtime is running separately and the Next.js route should forward requests to it:
+
+```typescript
+// app/emulate/[...path]/route.ts
+import { createEmulateProxy } from '@emulators/adapter-next'
+
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4018',
+    aws: 'http://127.0.0.1:4020',
+  },
+})
+```
+
+With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
+
+If a single target handles multiple services, use `target` instead:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  routePrefix: '/emulate',
+  target: 'http://127.0.0.1:4020',
+})
+```
+
+Single target mode preserves every path segment. `/emulate/aws/sqs` forwards to `http://127.0.0.1:4020/aws/sqs`.
+
+The proxy adds `x-forwarded-host`, `x-forwarded-proto`, `x-forwarded-port` when known, `x-forwarded-prefix`, `x-emulate-proxy: next`, `x-emulate-original-path`, and `x-emulate-service` for service targets. For deployed previews, the target URL must be reachable from the Next.js serverless function.
 
 ## Auth.js / NextAuth configuration
 

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -41,6 +41,6 @@
   "devDependencies": {
     "tsup": "^8",
     "typescript": "^5.7",
-    "vitest": "^4.1.3"
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -31,6 +31,7 @@
     "build": "tsup --clean",
     "dev": "tsup --watch",
     "clean": "rm -rf dist .turbo",
+    "test": "vitest run",
     "type-check": "tsc --noEmit",
     "lint": "eslint src"
   },
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "tsup": "^8",
-    "typescript": "^5.7"
+    "typescript": "^5.7",
+    "vitest": "^4.1.3"
   }
 }

--- a/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
+++ b/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmulateProxy } from "../index";
+
+const ctx = (path: string[]) => ({ params: Promise.resolve({ path }) });
+
+describe("createEmulateProxy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards service routes to local targets with the service prefix stripped", async () => {
+    let forwardedRequest: Request | null = null;
+    const fetchMock = vi.fn(async (input: unknown) => {
+      forwardedRequest = input as Request;
+      return new Response("ok", {
+        status: 201,
+        headers: { Location: "/emails/email_1" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxy = createEmulateProxy({
+      targets: {
+        resend: "http://127.0.0.1:4018",
+      },
+    });
+
+    const response = await proxy.POST(
+      new Request("https://preview.example.com/emulate/resend/emails?limit=1", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          host: "preview.example.com",
+        },
+        body: JSON.stringify({ to: "test@example.com" }),
+      }),
+      ctx(["resend", "emails"]),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(forwardedRequest).not.toBeNull();
+    const request = forwardedRequest!;
+    expect(request.url).toBe("http://127.0.0.1:4018/emails?limit=1");
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("content-type")).toBe("application/json");
+    expect(request.headers.get("x-forwarded-host")).toBe("preview.example.com");
+    expect(request.headers.get("x-forwarded-proto")).toBe("https");
+    expect(request.headers.get("x-forwarded-prefix")).toBe("/emulate/resend");
+    expect(request.headers.get("x-emulate-proxy")).toBe("next");
+    expect(request.headers.get("x-emulate-service")).toBe("resend");
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Location")).toBe("/emulate/resend/emails/email_1");
+  });
+
+  it("rewrites html returned by proxied service targets", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response('<form action="/emails"><a href="/inbox">Inbox</a></form>', {
+          headers: { "Content-Type": "text/html" },
+        });
+      }),
+    );
+
+    const proxy = createEmulateProxy({
+      targets: {
+        resend: "http://127.0.0.1:4018",
+      },
+    });
+
+    const response = await proxy.GET(
+      new Request("https://preview.example.com/api/emulate/resend/inbox"),
+      ctx(["resend", "inbox"]),
+    );
+
+    await expect(response.text()).resolves.toBe(
+      '<form action="/api/emulate/resend/emails"><a href="/api/emulate/resend/inbox">Inbox</a></form>',
+    );
+  });
+
+  it("does not double prefix public redirect locations", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response("ok", {
+          headers: { Location: "/emulate/resend/inbox" },
+        });
+      }),
+    );
+
+    const proxy = createEmulateProxy({
+      targets: {
+        resend: "http://127.0.0.1:4018",
+      },
+    });
+
+    const response = await proxy.GET(
+      new Request("https://preview.example.com/emulate/resend/login"),
+      ctx(["resend", "login"]),
+    );
+
+    expect(response.headers.get("Location")).toBe("/emulate/resend/inbox");
+  });
+
+  it("forwards every path segment in single target mode", async () => {
+    let forwardedRequest: Request | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        forwardedRequest = input as Request;
+        return new Response("ok", {
+          headers: { Location: "/aws/sqs" },
+        });
+      }),
+    );
+
+    const proxy = createEmulateProxy({
+      routePrefix: "/emulate",
+      target: {
+        target: "http://127.0.0.1:4020/runtime",
+        pathPrefix: "/v1",
+      },
+    });
+
+    const response = await proxy.GET(
+      new Request("https://preview.example.com/emulate/aws/sqs?Action=ListQueues"),
+      ctx(["aws", "sqs"]),
+    );
+
+    expect(forwardedRequest).not.toBeNull();
+    const request = forwardedRequest!;
+    expect(request.url).toBe("http://127.0.0.1:4020/runtime/v1/aws/sqs?Action=ListQueues");
+    expect(request.headers.get("x-forwarded-prefix")).toBe("/emulate");
+    expect(response.headers.get("Location")).toBe("/emulate/aws/sqs");
+  });
+
+  it("allows config and target headers to extend the forwarded header contract", async () => {
+    let forwardedRequest: Request | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        forwardedRequest = input as Request;
+        return new Response("ok");
+      }),
+    );
+
+    const proxy = createEmulateProxy({
+      headers: { "x-emulate-env": "preview" },
+      targets: {
+        resend: {
+          target: "http://127.0.0.1:4018",
+          headers: (_request, context) => ({ "x-emulate-public-prefix": context.publicPrefix }),
+        },
+      },
+    });
+
+    await proxy.GET(new Request("https://preview.example.com/emulate/resend/inbox"), ctx(["resend", "inbox"]));
+
+    expect(forwardedRequest).not.toBeNull();
+    const headers = forwardedRequest!.headers;
+    expect(headers.get("x-emulate-env")).toBe("preview");
+    expect(headers.get("x-emulate-public-prefix")).toBe("/emulate/resend");
+  });
+
+  it("returns 404 for unknown service targets", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxy = createEmulateProxy({
+      targets: {
+        resend: "http://127.0.0.1:4018",
+      },
+    });
+
+    const response = await proxy.GET(new Request("https://preview.example.com/emulate/aws/sqs"), ctx(["aws", "sqs"]));
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Unknown service: aws");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid target configuration", () => {
+    expect(() => createEmulateProxy({})).toThrow("createEmulateProxy requires `target` or `targets`");
+    expect(() =>
+      createEmulateProxy({
+        target: "http://127.0.0.1:4020",
+        targets: {
+          resend: "http://127.0.0.1:4018",
+        },
+      }),
+    ).toThrow("createEmulateProxy accepts either `target` or `targets`, not both");
+  });
+});

--- a/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
+++ b/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
@@ -43,6 +43,7 @@ describe("createEmulateProxy", () => {
     expect(request.url).toBe("http://127.0.0.1:4018/emails?limit=1");
     expect(request.method).toBe("POST");
     expect(request.headers.get("content-type")).toBe("application/json");
+    expect(request.headers.get("accept-encoding")).toBe("identity");
     expect(request.headers.get("x-forwarded-host")).toBe("preview.example.com");
     expect(request.headers.get("x-forwarded-proto")).toBe("https");
     expect(request.headers.get("x-forwarded-prefix")).toBe("/emulate/resend");
@@ -57,7 +58,11 @@ describe("createEmulateProxy", () => {
       "fetch",
       vi.fn(async () => {
         return new Response('<form action="/emails"><a href="/inbox">Inbox</a></form>', {
-          headers: { "Content-Type": "text/html" },
+          headers: {
+            "Content-Encoding": "gzip",
+            "Content-Length": "50",
+            "Content-Type": "text/html",
+          },
         });
       }),
     );
@@ -73,6 +78,8 @@ describe("createEmulateProxy", () => {
       ctx(["resend", "inbox"]),
     );
 
+    expect(response.headers.has("Content-Encoding")).toBe(false);
+    expect(response.headers.has("Content-Length")).toBe(false);
     await expect(response.text()).resolves.toBe(
       '<form action="/api/emulate/resend/emails"><a href="/api/emulate/resend/inbox">Inbox</a></form>',
     );

--- a/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
+++ b/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
@@ -102,6 +102,36 @@ describe("createEmulateProxy", () => {
     expect(response.headers.get("Location")).toBe("/emulate/resend/inbox");
   });
 
+  it("keeps target redirects manual so locations can be rewritten", async () => {
+    let forwardedRequest: Request | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        forwardedRequest = input as Request;
+        return new Response(null, {
+          status: 302,
+          headers: { Location: "/inbox" },
+        });
+      }),
+    );
+
+    const proxy = createEmulateProxy({
+      targets: {
+        resend: "http://127.0.0.1:4018",
+      },
+    });
+
+    const response = await proxy.GET(
+      new Request("https://preview.example.com/emulate/resend/login"),
+      ctx(["resend", "login"]),
+    );
+
+    expect(forwardedRequest).not.toBeNull();
+    expect(forwardedRequest!.redirect).toBe("manual");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/emulate/resend/inbox");
+  });
+
   it("forwards every path segment in single target mode", async () => {
     let forwardedRequest: Request | null = null;
     vi.stubGlobal(

--- a/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
+++ b/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
@@ -164,6 +164,65 @@ describe("createEmulateProxy", () => {
     expect(response.headers.get("Location")).toBe("/emulate/aws/sqs");
   });
 
+  it("strips internal target prefixes from rewritten single target responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          '<form action="/runtime/v1/aws/sqs"><a href="/runtime/v1/aws/sqs">SQS</a><style>.icon{background:url(\'/runtime/v1/_emulate/favicon.ico\')}</style></form>',
+          {
+            headers: {
+              "Content-Type": "text/html",
+              Location: "/runtime/v1/aws/sqs",
+            },
+          },
+        );
+      }),
+    );
+
+    const proxy = createEmulateProxy({
+      routePrefix: "/emulate",
+      target: {
+        target: "http://127.0.0.1:4020/runtime",
+        pathPrefix: "/v1",
+      },
+    });
+
+    const response = await proxy.GET(new Request("https://preview.example.com/emulate/aws/sqs"), ctx(["aws", "sqs"]));
+
+    expect(response.headers.get("Location")).toBe("/emulate/aws/sqs");
+    await expect(response.text()).resolves.toBe(
+      '<form action="/emulate/aws/sqs"><a href="/emulate/aws/sqs">SQS</a><style>.icon{background:url(\'/emulate/_emulate/favicon.ico\')}</style></form>',
+    );
+  });
+
+  it("detects the public prefix when catch-all params contain decoded characters", async () => {
+    let forwardedRequest: Request | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        forwardedRequest = input as Request;
+        return new Response("ok");
+      }),
+    );
+
+    const proxy = createEmulateProxy({
+      targets: {
+        resend: "http://127.0.0.1:4018",
+      },
+    });
+
+    const response = await proxy.GET(
+      new Request("https://preview.example.com/emulate/resend/emails/email%201?expand=html"),
+      ctx(["resend", "emails", "email 1"]),
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwardedRequest).not.toBeNull();
+    expect(forwardedRequest!.url).toBe("http://127.0.0.1:4018/emails/email%201?expand=html");
+    expect(forwardedRequest!.headers.get("x-forwarded-prefix")).toBe("/emulate/resend");
+  });
+
   it("allows config and target headers to extend the forwarded header contract", async () => {
     let forwardedRequest: Request | null = null;
     vi.stubGlobal(

--- a/packages/@emulators/adapter-next/src/index.ts
+++ b/packages/@emulators/adapter-next/src/index.ts
@@ -32,6 +32,36 @@ export interface EmulateHandlerConfig {
   persistence?: PersistenceAdapter;
 }
 
+export type ProxyHeaders = Headers | Array<[string, string]> | Record<string, string>;
+
+export type ProxyHeaderFactory = (
+  request: Request,
+  context: EmulateProxyContext,
+) => ProxyHeaders | Promise<ProxyHeaders>;
+
+export interface EmulateProxyTargetConfig {
+  target: string | URL;
+  pathPrefix?: string;
+  stripServicePrefix?: boolean;
+  headers?: ProxyHeaders | ProxyHeaderFactory;
+}
+
+export interface EmulateProxyConfig {
+  target?: string | URL | EmulateProxyTargetConfig;
+  targets?: Record<string, string | URL | EmulateProxyTargetConfig>;
+  routePrefix?: string;
+  headers?: ProxyHeaders | ProxyHeaderFactory;
+}
+
+export interface EmulateProxyContext {
+  service?: string;
+  mountPath: string;
+  publicPrefix: string;
+  target: URL;
+  pathSegments: string[];
+  forwardedPathSegments: string[];
+}
+
 interface Fetchable {
   fetch(request: Request, ...rest: unknown[]): Response | Promise<Response>;
 }
@@ -54,6 +84,19 @@ type NextResponse = Response;
 type RouteHandler = (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) => Promise<NextResponse>;
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
 
 function resolvePlugin(mod: EmulatorModule): ServicePlugin {
   const plugin = mod.plugin ?? mod.default;
@@ -122,16 +165,138 @@ function detectPrefix(url: string, pathSegments: string[]): string {
   throw new Error(`Could not detect mount path from URL: ${url}`);
 }
 
+function detectProxyPrefix(url: string, pathSegments: string[]): string {
+  if (pathSegments.length === 0) {
+    return normalizeMountPath(new URL(url).pathname);
+  }
+  return detectPrefix(url, pathSegments);
+}
+
+function normalizeMountPath(path: string): string {
+  const trimmed = path.replace(/^\/+|\/+$/g, "");
+  return trimmed ? `/${trimmed}` : "";
+}
+
+function appendPath(prefix: string, segment: string): string {
+  const mountPath = normalizeMountPath(prefix);
+  const cleanedSegment = segment.replace(/^\/+|\/+$/g, "");
+  if (!cleanedSegment) return mountPath || "/";
+  return `${mountPath}/${cleanedSegment}`;
+}
+
+function splitPath(path: string | undefined): string[] {
+  return path ? path.split("/").filter(Boolean) : [];
+}
+
+function encodePathSegments(pathSegments: string[]): string[] {
+  return pathSegments.map((segment) => encodeURIComponent(segment));
+}
+
+function normalizeProxyTarget(input: string | URL | EmulateProxyTargetConfig): EmulateProxyTargetConfig {
+  if (typeof input === "string" || input instanceof URL) {
+    return { target: input };
+  }
+  return input;
+}
+
+function buildProxyUrl(targetConfig: EmulateProxyTargetConfig, forwardedPathSegments: string[], search: string): URL {
+  const target = new URL(targetConfig.target.toString());
+  const parts = [
+    ...splitPath(target.pathname),
+    ...splitPath(targetConfig.pathPrefix),
+    ...encodePathSegments(forwardedPathSegments),
+  ];
+  target.pathname = parts.length > 0 ? `/${parts.join("/")}` : "/";
+  target.search = search;
+  return target;
+}
+
+function copyForwardHeaders(request: Request): Headers {
+  const headers = new Headers(request.headers);
+  const connection = headers.get("connection");
+  if (connection) {
+    for (const token of connection.split(",")) {
+      headers.delete(token.trim());
+    }
+  }
+  for (const header of HOP_BY_HOP_HEADERS) {
+    headers.delete(header);
+  }
+  return headers;
+}
+
+function getForwardedPort(url: URL, request: Request): string | null {
+  const existing = request.headers.get("x-forwarded-port");
+  if (existing) return existing;
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? url.host;
+  const portMatch = host.match(/:(\d+)$/);
+  return portMatch?.[1] ?? (url.port || null);
+}
+
+async function applyProxyHeaders(
+  headers: Headers,
+  input: ProxyHeaders | ProxyHeaderFactory | undefined,
+  request: Request,
+  context: EmulateProxyContext,
+): Promise<void> {
+  if (!input) return;
+  const resolved = typeof input === "function" ? await input(request, context) : input;
+  new Headers(resolved).forEach((value, key) => headers.set(key, value));
+}
+
+async function buildProxyHeaders(
+  request: Request,
+  context: EmulateProxyContext,
+  configHeaders: ProxyHeaders | ProxyHeaderFactory | undefined,
+  targetHeaders: ProxyHeaders | ProxyHeaderFactory | undefined,
+): Promise<Headers> {
+  const headers = copyForwardHeaders(request);
+  const url = new URL(request.url);
+  const forwardedHost = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? url.host;
+  const forwardedProto = request.headers.get("x-forwarded-proto") ?? url.protocol.replace(/:$/, "");
+  const forwardedPort = getForwardedPort(url, request);
+
+  headers.set("x-forwarded-host", forwardedHost);
+  headers.set("x-forwarded-proto", forwardedProto);
+  headers.set("x-forwarded-prefix", context.publicPrefix);
+  headers.set("x-emulate-proxy", "next");
+  headers.set("x-emulate-original-path", url.pathname);
+  if (forwardedPort) {
+    headers.set("x-forwarded-port", forwardedPort);
+  }
+  if (context.service) {
+    headers.set("x-emulate-service", context.service);
+  }
+
+  await applyProxyHeaders(headers, configHeaders, request, context);
+  await applyProxyHeaders(headers, targetHeaders, request, context);
+  return headers;
+}
+
+function buildProxyRequest(request: Request, target: URL, headers: Headers): Request {
+  const init: RequestInit & { duplex?: string } = {
+    method: request.method,
+    headers,
+  };
+  if (!BODYLESS_METHODS.has(request.method)) {
+    init.body = request.body;
+    init.duplex = "half";
+  }
+  return new Request(target.toString(), init);
+}
+
 async function rewriteResponse(response: Response, servicePrefix: string): Promise<Response> {
   const contentType = response.headers.get("Content-Type") ?? "";
   const location = response.headers.get("Location");
   const isHtml = contentType.includes("text/html");
   const locationChanged = location != null && location.startsWith("/");
+  const rewrittenLocation =
+    locationChanged && !location.startsWith(servicePrefix) ? servicePrefix + location : location;
 
   if (!isHtml) {
-    if (!locationChanged) return response;
+    if (!locationChanged || rewrittenLocation === location) return response;
     const headers = new Headers(response.headers);
-    headers.set("Location", servicePrefix + location);
+    headers.set("Location", rewrittenLocation!);
     return new Response(response.body, {
       status: response.status,
       statusText: response.statusText,
@@ -154,8 +319,8 @@ async function rewriteResponse(response: Response, servicePrefix: string): Promi
   });
 
   const headers = new Headers(response.headers);
-  if (locationChanged) {
-    headers.set("Location", servicePrefix + location);
+  if (locationChanged && rewrittenLocation !== location) {
+    headers.set("Location", rewrittenLocation!);
   }
   headers.delete("Content-Length");
 
@@ -300,6 +465,77 @@ export function createEmulateHandler(config: EmulateHandlerConfig) {
     PUT: handler,
     PATCH: handler,
     DELETE: handler,
+  };
+}
+
+export function createEmulateProxy(config: EmulateProxyConfig) {
+  const singleTarget = config.target ? normalizeProxyTarget(config.target) : undefined;
+  const serviceTargets = config.targets
+    ? new Map(Object.entries(config.targets).map(([name, target]) => [name, normalizeProxyTarget(target)]))
+    : undefined;
+
+  if (singleTarget && serviceTargets) {
+    throw new Error("createEmulateProxy accepts either `target` or `targets`, not both");
+  }
+  if (!singleTarget && !serviceTargets) {
+    throw new Error("createEmulateProxy requires `target` or `targets`");
+  }
+
+  async function handleRequest(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }): Promise<NextResponse> {
+    const { path: pathSegments } = await ctx.params;
+    const url = new URL(req.url);
+    const mountPath =
+      config.routePrefix != null ? normalizeMountPath(config.routePrefix) : detectProxyPrefix(req.url, pathSegments);
+
+    let service: string | undefined;
+    let targetConfig: EmulateProxyTargetConfig;
+    let forwardedPathSegments: string[];
+    let publicPrefix: string;
+
+    if (singleTarget) {
+      targetConfig = singleTarget;
+      forwardedPathSegments = pathSegments;
+      publicPrefix = mountPath;
+    } else {
+      if (pathSegments.length === 0) {
+        return new Response("Not found", { status: 404 });
+      }
+      service = pathSegments[0];
+      const target = serviceTargets!.get(service);
+      if (!target) {
+        return new Response(`Unknown service: ${service}`, { status: 404 });
+      }
+      targetConfig = target;
+      const stripServicePrefix = targetConfig.stripServicePrefix ?? true;
+      forwardedPathSegments = stripServicePrefix ? pathSegments.slice(1) : pathSegments;
+      publicPrefix = stripServicePrefix ? appendPath(mountPath, service) : mountPath;
+    }
+
+    const targetUrl = buildProxyUrl(targetConfig, forwardedPathSegments, url.search);
+    const context: EmulateProxyContext = {
+      service,
+      mountPath,
+      publicPrefix,
+      target: targetUrl,
+      pathSegments,
+      forwardedPathSegments,
+    };
+    const headers = await buildProxyHeaders(req, context, config.headers, targetConfig.headers);
+    const proxyRequest = buildProxyRequest(req, targetUrl, headers);
+    const response = await fetch(proxyRequest);
+    return rewriteResponse(response, publicPrefix);
+  }
+
+  const handler: RouteHandler = handleRequest;
+
+  return {
+    GET: handler,
+    HEAD: handler,
+    POST: handler,
+    PUT: handler,
+    PATCH: handler,
+    DELETE: handler,
+    OPTIONS: handler,
   };
 }
 

--- a/packages/@emulators/adapter-next/src/index.ts
+++ b/packages/@emulators/adapter-next/src/index.ts
@@ -277,6 +277,7 @@ function buildProxyRequest(request: Request, target: URL, headers: Headers): Req
   const init: RequestInit & { duplex?: string } = {
     method: request.method,
     headers,
+    redirect: "manual",
   };
   if (!BODYLESS_METHODS.has(request.method)) {
     init.body = request.body;

--- a/packages/@emulators/adapter-next/src/index.ts
+++ b/packages/@emulators/adapter-next/src/index.ts
@@ -241,6 +241,7 @@ function copyForwardHeaders(request: Request): Headers {
   for (const header of HOP_BY_HOP_HEADERS) {
     headers.delete(header);
   }
+  headers.set("accept-encoding", "identity");
   return headers;
 }
 
@@ -367,6 +368,7 @@ async function rewriteResponse(response: Response, options: ResponseRewriteOptio
     headers.set("Location", rewrittenLocation!);
   }
   headers.delete("Content-Length");
+  headers.delete("Content-Encoding");
 
   return new Response(html, {
     status: response.status,

--- a/packages/@emulators/adapter-next/src/index.ts
+++ b/packages/@emulators/adapter-next/src/index.ts
@@ -98,6 +98,11 @@ const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 
+interface ResponseRewriteOptions {
+  publicPrefix: string;
+  upstreamPrefix?: string;
+}
+
 function resolvePlugin(mod: EmulatorModule): ServicePlugin {
   const plugin = mod.plugin ?? mod.default;
   if (!plugin) {
@@ -157,11 +162,17 @@ function restoreFromSnapshot(apps: Map<string, ServiceApp>, snapshot: FullSnapsh
 function detectPrefix(url: string, pathSegments: string[]): string {
   const parsed = new URL(url);
   const fullPath = parsed.pathname;
-  const restPath = "/" + pathSegments.join("/");
-  const idx = fullPath.lastIndexOf(restPath);
-  if (idx > 0) {
-    return fullPath.slice(0, idx);
+  const restPaths = ["/" + encodePathSegments(pathSegments).join("/"), "/" + pathSegments.join("/")];
+
+  for (const restPath of new Set(restPaths)) {
+    if (fullPath === restPath) {
+      return "";
+    }
+    if (fullPath.endsWith(restPath)) {
+      return fullPath.slice(0, fullPath.length - restPath.length);
+    }
   }
+
   throw new Error(`Could not detect mount path from URL: ${url}`);
 }
 
@@ -209,6 +220,14 @@ function buildProxyUrl(targetConfig: EmulateProxyTargetConfig, forwardedPathSegm
   target.pathname = parts.length > 0 ? `/${parts.join("/")}` : "/";
   target.search = search;
   return target;
+}
+
+function buildProxyUpstreamPrefix(targetConfig: EmulateProxyTargetConfig): string {
+  const target = new URL(targetConfig.target.toString());
+  const parts = [...splitPath(target.pathname), ...splitPath(targetConfig.pathPrefix)];
+  if (parts.length === 0) return "";
+  target.pathname = `/${parts.join("/")}`;
+  return normalizeMountPath(target.pathname);
 }
 
 function copyForwardHeaders(request: Request): Headers {
@@ -286,13 +305,41 @@ function buildProxyRequest(request: Request, target: URL, headers: Headers): Req
   return new Request(target.toString(), init);
 }
 
-async function rewriteResponse(response: Response, servicePrefix: string): Promise<Response> {
+function hasPathPrefix(path: string, prefix: string): boolean {
+  return (
+    path === prefix || path.startsWith(`${prefix}/`) || path.startsWith(`${prefix}?`) || path.startsWith(`${prefix}#`)
+  );
+}
+
+function prefixRootPath(prefix: string, path: string): string {
+  const normalizedPrefix = normalizeMountPath(prefix);
+  if (!normalizedPrefix) return path || "/";
+  if (!path || path === "/") return normalizedPrefix;
+  if (path.startsWith("?") || path.startsWith("#")) return `${normalizedPrefix}${path}`;
+  return `${normalizedPrefix}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function rewriteRootPath(path: string, options: ResponseRewriteOptions): string {
+  const publicPrefix = normalizeMountPath(options.publicPrefix);
+  const upstreamPrefix = normalizeMountPath(options.upstreamPrefix ?? "");
+
+  if (publicPrefix && hasPathPrefix(path, publicPrefix)) {
+    return path;
+  }
+
+  if (upstreamPrefix && hasPathPrefix(path, upstreamPrefix)) {
+    return prefixRootPath(publicPrefix, path.slice(upstreamPrefix.length));
+  }
+
+  return prefixRootPath(publicPrefix, path);
+}
+
+async function rewriteResponse(response: Response, options: ResponseRewriteOptions): Promise<Response> {
   const contentType = response.headers.get("Content-Type") ?? "";
   const location = response.headers.get("Location");
   const isHtml = contentType.includes("text/html");
   const locationChanged = location != null && location.startsWith("/");
-  const rewrittenLocation =
-    locationChanged && !location.startsWith(servicePrefix) ? servicePrefix + location : location;
+  const rewrittenLocation = locationChanged ? rewriteRootPath(location, options) : location;
 
   if (!isHtml) {
     if (!locationChanged || rewrittenLocation === location) return response;
@@ -307,16 +354,12 @@ async function rewriteResponse(response: Response, servicePrefix: string): Promi
 
   let html = await response.text();
 
-  // Skip paths already carrying the service prefix to avoid double-prefixing
-  // (e.g., redirects that already went through rewriting).
   html = html.replace(/(action|href)="(\/[^"]*?)"/g, (_match, attr, path) => {
-    if (path.startsWith(servicePrefix)) return `${attr}="${path}"`;
-    return `${attr}="${servicePrefix}${path}"`;
+    return `${attr}="${rewriteRootPath(path, options)}"`;
   });
 
   html = html.replace(/url\('(\/[^']*?)'\)/g, (_match, path) => {
-    if (path.startsWith(servicePrefix)) return `url('${path}')`;
-    return `url('${servicePrefix}${path}')`;
+    return `url('${rewriteRootPath(path, options)}')`;
   });
 
   const headers = new Headers(response.headers);
@@ -449,7 +492,7 @@ export function createEmulateHandler(config: EmulateHandlerConfig) {
     let response = await sa.app.fetch(strippedReq);
 
     const servicePrefix = `${mountPath!}/${serviceName}`;
-    response = await rewriteResponse(response, servicePrefix);
+    response = await rewriteResponse(response, { publicPrefix: servicePrefix });
 
     if (persistence && MUTATING_METHODS.has(req.method)) {
       enqueueSave();
@@ -513,6 +556,7 @@ export function createEmulateProxy(config: EmulateProxyConfig) {
     }
 
     const targetUrl = buildProxyUrl(targetConfig, forwardedPathSegments, url.search);
+    const upstreamPrefix = buildProxyUpstreamPrefix(targetConfig);
     const context: EmulateProxyContext = {
       service,
       mountPath,
@@ -524,7 +568,7 @@ export function createEmulateProxy(config: EmulateProxyConfig) {
     const headers = await buildProxyHeaders(req, context, config.headers, targetConfig.headers);
     const proxyRequest = buildProxyRequest(req, targetUrl, headers);
     const response = await fetch(proxyRequest);
-    return rewriteResponse(response, publicPrefix);
+    return rewriteResponse(response, { publicPrefix, upstreamPrefix });
   }
 
   const handler: RouteHandler = handleRequest;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,8 +384,8 @@ importers:
         specifier: ^5.7
         version: 5.9.3
       vitest:
-        specifier: ^4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/@emulators/apple:
     dependencies:
@@ -3303,8 +3303,22 @@ packages:
   '@vitest/expect@4.1.3':
     resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
 
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
   '@vitest/mocker@4.1.3':
     resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3317,17 +3331,32 @@ packages:
   '@vitest/pretty-format@4.1.3':
     resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
 
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
   '@vitest/runner@4.1.3':
     resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
   '@vitest/snapshot@4.1.3':
     resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
 
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
   '@vitest/spy@4.1.3':
     resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
 
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
   '@vitest/utils@4.1.3':
     resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -6020,6 +6049,47 @@ packages:
       '@vitest/coverage-istanbul': 4.1.3
       '@vitest/coverage-v8': 4.1.3
       '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -9234,6 +9304,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@4.1.3(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.3
@@ -9243,13 +9322,30 @@ snapshots:
       msw: 2.12.13(@types/node@22.19.17)(typescript@5.9.3)
       vite: 8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.6(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
+
   '@vitest/pretty-format@4.1.3':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.0
 
   '@vitest/runner@4.1.3':
     dependencies:
       '@vitest/utils': 4.1.3
+      pathe: 2.0.3
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.3':
@@ -9259,11 +9355,26 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@4.1.3': {}
+
+  '@vitest/spy@4.1.6': {}
 
   '@vitest/utils@4.1.3':
     dependencies:
       '@vitest/pretty-format': 4.1.3
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -12828,6 +12939,34 @@ snapshots:
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       typescript:
         specifier: ^5.7
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/@emulators/apple:
     dependencies:

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -312,9 +312,9 @@ AWS_EMULATOR_URL=http://localhost:4006
 
 Then use these in your app to construct API and OAuth URLs. See each service's skill for SDK-specific override instructions.
 
-## Next.js Integration (Embedded Mode)
+## Next.js Integration
 
-The `@emulators/adapter-next` package embeds emulators directly into a Next.js app on the same origin. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, persistence, and font tracing details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: next
-description: Next.js adapter for embedding emulators directly in a Next.js app via @emulators/adapter-next. Use when the user needs to embed emulators in Next.js, set up same-origin OAuth for Vercel preview deployments, create an emulate catch-all route handler, configure Auth.js/NextAuth with embedded emulators, add persistence to embedded emulators, or wrap next.config with withEmulate. Triggers include "Next.js emulator", "adapter-next", "embedded emulator", "same-origin OAuth", "Vercel preview", "createEmulateHandler", "withEmulate", or any task requiring emulators inside a Next.js app.
+description: Next.js adapter for embedded emulators and native runtime proxying via @emulators/adapter-next. Use when the user needs to embed emulators in Next.js, proxy a native runtime through a Next.js catch-all route, set up same-origin OAuth for Vercel preview deployments, configure Auth.js/NextAuth with emulator routes, add persistence to embedded emulators, or wrap next.config with withEmulate. Triggers include "Next.js emulator", "adapter-next", "embedded emulator", "native runtime proxy", "same-origin OAuth", "Vercel preview", "createEmulateHandler", "createEmulateProxy", "withEmulate", or any task requiring emulators inside a Next.js app.
 allowed-tools: Bash(npx emulate:*), Bash(emulate:*)
 ---
 
 # Next.js Integration
 
-The `@emulators/adapter-next` package embeds emulators directly into a Next.js App Router app, running them on the same origin. This is particularly useful for Vercel preview deployments where OAuth callback URLs change with every deployment.
+The `@emulators/adapter-next` package supports two App Router modes. Embedded mode runs JavaScript emulators directly inside the Next.js app. Proxy mode exposes a separately running native runtime on the same origin.
 
 ## Install
 
@@ -16,9 +16,9 @@ npm install @emulators/adapter-next @emulators/github @emulators/google
 
 Only install the emulators you need. Each `@emulators/*` package is published independently, keeping serverless bundles small.
 
-## Route Handler
+## Embedded Route Handler
 
-Create a catch-all route that serves emulator traffic:
+Create a catch-all route that serves emulator traffic in-process:
 
 ```typescript
 // app/emulate/[...path]/route.ts
@@ -49,6 +49,39 @@ This creates the following routes:
 
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
+
+Embedded mode is the current zero-infra path for Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin.
+
+## Native Runtime Proxy
+
+Use `createEmulateProxy` when a native runtime is running separately and the Next.js route should forward requests to it:
+
+```typescript
+// app/emulate/[...path]/route.ts
+import { createEmulateProxy } from '@emulators/adapter-next'
+
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4018',
+    aws: 'http://127.0.0.1:4020',
+  },
+})
+```
+
+With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
+
+If a single target handles multiple services, use `target` instead:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  routePrefix: '/emulate',
+  target: 'http://127.0.0.1:4020',
+})
+```
+
+Single target mode preserves every path segment. `/emulate/aws/sqs` forwards to `http://127.0.0.1:4020/aws/sqs`.
+
+The proxy adds `x-forwarded-host`, `x-forwarded-proto`, `x-forwarded-port` when known, `x-forwarded-prefix`, `x-emulate-proxy: next`, `x-emulate-original-path`, and `x-emulate-service` for service targets. For deployed previews, the target URL must be reachable from the Next.js serverless function.
 
 ## Auth.js / NextAuth Configuration
 
@@ -157,6 +190,24 @@ Each `EmulatorEntry`:
 |-------|------|-------------|
 | `emulator` | `EmulatorModule` | The emulator package (e.g. `import * as github from '@emulators/github'`) |
 | `seed?` | `Record<string, unknown>` | Seed data matching the service's config schema |
+
+### `createEmulateProxy(config)`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `target?` | `string | URL | EmulateProxyTargetConfig` | Single runtime target. All path segments after the route prefix are preserved. |
+| `targets?` | `Record<string, string | URL | EmulateProxyTargetConfig>` | Service-specific targets. The first path segment selects the target and is stripped by default. |
+| `routePrefix?` | `string` | Explicit public route prefix. If omitted, the adapter derives it from the incoming request and catch-all params. |
+| `headers?` | `ProxyHeaders | ProxyHeaderFactory` | Extra headers added to every proxied request. |
+
+Each `EmulateProxyTargetConfig`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `target` | `string | URL` | Runtime base URL from the Next.js server's perspective. |
+| `pathPrefix?` | `string` | Optional path segment to prepend before the forwarded path. |
+| `stripServicePrefix?` | `boolean` | For `targets`, defaults to `true`. Set to `false` only when the target expects the service segment. |
+| `headers?` | `ProxyHeaders | ProxyHeaderFactory` | Extra headers added for this target. |
 
 ### `withEmulate(nextConfig, options?)`
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -70,7 +70,18 @@ export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulatePro
 
 With `targets`, the first path segment selects the service and is stripped before forwarding. `/emulate/resend/emails` forwards to `http://127.0.0.1:4018/emails`, while response `Location` headers and HTML links are rewritten back to `/emulate/resend/*`.
 
-If a single target handles multiple services, use `target` instead:
+If multiple services share one native runtime URL, keep using `targets` and point each service at that runtime when the runtime expects service-local paths:
+
+```typescript
+export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({
+  targets: {
+    resend: 'http://127.0.0.1:4000',
+    aws: 'http://127.0.0.1:4000',
+  },
+})
+```
+
+Use single `target` only when the upstream expects every path segment after the public route prefix:
 
 ```typescript
 export const { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS } = createEmulateProxy({


### PR DESCRIPTION
- Adds createEmulateProxy with single-target and service-target forwarding, prefix handling, forwarded headers, and response rewriting for native runtimes.

- Keeps embedded Next adapter behavior intact while adding focused proxy tests and adapter test wiring.

- Updates docs and skills to distinguish embedded mode from native runtime proxy mode.