### PR TITLE
Add Vercel Go Function scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ npx emulate init
 # Generate config for a specific service
 npx emulate init --service vercel
 
+# Scaffold a Vercel Go Function preview route
+npx emulate vercel init
+
 # List available services
 npx emulate list
 ```
@@ -664,6 +667,8 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 
 S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. Query and REST XML operations return AWS-compatible XML. The native Go runtime is verified against current AWS SDK v3 clients for SQS, IAM, and STS; SQS uses JSON target requests, while IAM and STS use AWS Query XML.
 
+To expose the native AWS emulator in a Vercel preview without separate infrastructure, run `npx emulate vercel init --service aws`. The generated route serves AWS at `/emulate/aws/*`.
+
 ### S3
 
 S3 routes use root paths matching the real AWS S3 wire format, so the official AWS SDK works out of the box with `forcePathStyle: true`. Legacy `/s3/` prefixed paths are also supported for backward compatibility.
@@ -704,6 +709,8 @@ Resend email API emulation with local capture for sent emails, domains, API keys
 
 The experimental native Go runtime serves the same current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
+To expose the native Resend emulator in a Vercel preview without separate infrastructure, run `npx emulate vercel init --service resend`. The generated route serves Resend at `/emulate/resend/*`.
+
 - `POST /emails`, `POST /emails/batch`, `GET /emails`, `GET /emails/:id`, `POST /emails/:id/cancel`
 - `POST /domains`, `GET /domains`, `GET /domains/:id`, `DELETE /domains/:id`, `POST /domains/:id/verify`
 - `POST /api-keys`, `GET /api-keys`, `DELETE /api-keys/:id`
@@ -714,6 +721,24 @@ The experimental native Go runtime serves the same current Resend routes, suppor
 ## Next.js Integration
 
 Use `@emulators/adapter-next` to run emulator routes on the same origin as your Next.js app. Embedded mode runs JavaScript emulators directly in the app. Proxy mode forwards to a separately running native runtime.
+
+### Vercel Go Function preview
+
+For zero infra Vercel preview deployments with the native Go runtime, scaffold a Go Function and rewrite:
+
+```bash
+npx emulate vercel init
+```
+
+This creates:
+
+- `api/emulate.go`, a Vercel Go Function using `github.com/vercel-labs/emulate/vercel`
+- `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
+- `go.mod`, pinned to the installed `emulate` package version
+
+The scaffold currently enables the native `aws` and `resend` handlers. Use `npx emulate vercel init --service resend` to limit the function to one service.
+
+State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
 ### Install
 
@@ -752,7 +777,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the current zero-infra path for Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws` and `resend` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/docs/aws/page.mdx
+++ b/apps/web/app/docs/aws/page.mdx
@@ -2,6 +2,16 @@
 
 S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime is verified against current AWS SDK v3 clients for SQS, IAM, and STS; SQS uses JSON target requests, while IAM and STS use AWS Query XML.
 
+## Vercel Preview
+
+To expose the native AWS emulator in a Vercel preview without separate infrastructure, scaffold the Go Function route:
+
+```bash
+npx emulate vercel init --service aws
+```
+
+The generated route serves AWS at `/emulate/aws/*`. State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge.
+
 ## S3
 
 S3 routes use root paths matching the real AWS S3 wire format, so the official AWS SDK works out of the box with `forcePathStyle: true`. Legacy `/s3/` prefixed paths are also supported for backward compatibility.

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -2,6 +2,24 @@
 
 The `@emulators/adapter-next` package supports two App Router modes. Embedded mode runs JavaScript emulators directly inside the Next.js app. Proxy mode exposes a separately running native runtime on the same origin.
 
+## Vercel Go Function Preview
+
+For zero infra Vercel preview deployments with the native Go runtime, scaffold a Go Function and rewrite:
+
+```bash
+npx emulate vercel init
+```
+
+This creates:
+
+- `api/emulate.go`, a Vercel Go Function using `github.com/vercel-labs/emulate/vercel`
+- `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
+- `go.mod`, pinned to the installed `emulate` package version
+
+The scaffold currently enables the native `aws` and `resend` handlers. Use `npx emulate vercel init --service resend` to limit the function to one service.
+
+State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
+
 ## Install
 
 ```bash
@@ -44,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the current zero-infra path for Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws` and `resend` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/apps/web/app/docs/resend/page.mdx
+++ b/apps/web/app/docs/resend/page.mdx
@@ -6,6 +6,16 @@ Set `RESEND_BASE_URL` before importing the official `resend` Node.js SDK and the
 
 The experimental native Go runtime implements the current Resend routes below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
+## Vercel Preview
+
+To expose the native Resend emulator in a Vercel preview without separate infrastructure, scaffold the Go Function route:
+
+```bash
+npx emulate vercel init --service resend
+```
+
+The generated route serves Resend at `/emulate/resend/*`. Set `RESEND_BASE_URL` to the preview origin plus `/emulate/resend`. State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge.
+
 ## Emails
 
 - `POST /emails` — send single email

--- a/internal/core/assets/store.go
+++ b/internal/core/assets/store.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -60,6 +61,15 @@ type AssetSnapshot struct {
 
 type StoreSnapshot struct {
 	Assets []AssetSnapshot `json:"assets"`
+}
+
+type FullAssetSnapshot struct {
+	Metadata Metadata `json:"metadata"`
+	Body     []byte   `json:"body"`
+}
+
+type FullStoreSnapshot struct {
+	Assets []FullAssetSnapshot `json:"assets"`
 }
 
 type asset struct {
@@ -204,6 +214,58 @@ func (store *Store) Snapshot() StoreSnapshot {
 	return snapshot
 }
 
+func (store *Store) FullSnapshot() FullStoreSnapshot {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	ids := store.sortedIDsLocked()
+	snapshot := FullStoreSnapshot{Assets: make([]FullAssetSnapshot, 0, len(ids))}
+	for _, id := range ids {
+		asset := store.assets[id]
+		snapshot.Assets = append(snapshot.Assets, FullAssetSnapshot{
+			Metadata: cloneMetadata(asset.metadata),
+			Body:     append([]byte(nil), asset.body...),
+		})
+	}
+	return snapshot
+}
+
+func (store *Store) RestoreFullSnapshot(snapshot FullStoreSnapshot) error {
+	next := make(map[string]asset, len(snapshot.Assets))
+	for _, item := range snapshot.Assets {
+		if item.Metadata.ID == "" {
+			return fmt.Errorf("asset id is required")
+		}
+		if _, ok := next[item.Metadata.ID]; ok {
+			return fmt.Errorf("duplicate asset id %q", item.Metadata.ID)
+		}
+		if err := validateFullAssetSnapshot(item); err != nil {
+			return fmt.Errorf("restore asset %q: %w", item.Metadata.ID, err)
+		}
+		next[item.Metadata.ID] = asset{
+			metadata: cloneMetadata(item.Metadata),
+			body:     append([]byte(nil), item.Body...),
+		}
+	}
+
+	store.mu.Lock()
+	store.assets = next
+	store.mu.Unlock()
+	return nil
+}
+
+func (store *Store) MarshalFullSnapshot() ([]byte, error) {
+	return json.MarshalIndent(store.FullSnapshot(), "", "  ")
+}
+
+func (store *Store) RestoreFullJSON(raw []byte) error {
+	var snapshot FullStoreSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return err
+	}
+	return store.RestoreFullSnapshot(snapshot)
+}
+
 func (store *Store) sortedIDsLocked() []string {
 	ids := make([]string, 0, len(store.assets))
 	for id := range store.assets {
@@ -241,6 +303,29 @@ func buildMetadata(id string, body []byte, options PutOptions, now func() time.T
 		LastModified:   lastModified,
 		UserMetadata:   cloneStringMap(options.UserMetadata),
 	}
+}
+
+func validateFullAssetSnapshot(item FullAssetSnapshot) error {
+	if item.Metadata.ContentLength != int64(len(item.Body)) {
+		return fmt.Errorf("content length %d does not match body length %d", item.Metadata.ContentLength, len(item.Body))
+	}
+	if item.Metadata.ChecksumMD5 != "" && item.Metadata.ChecksumMD5 != checksumMD5Hex(item.Body) {
+		return fmt.Errorf("md5 checksum mismatch")
+	}
+	if item.Metadata.ChecksumSHA256 != "" && item.Metadata.ChecksumSHA256 != checksumSHA256Hex(item.Body) {
+		return fmt.Errorf("sha256 checksum mismatch")
+	}
+	return nil
+}
+
+func checksumMD5Hex(body []byte) string {
+	sum := md5.Sum(body)
+	return hex.EncodeToString(sum[:])
+}
+
+func checksumSHA256Hex(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
 }
 
 func cloneMetadata(metadata Metadata) Metadata {

--- a/internal/core/assets/store_test.go
+++ b/internal/core/assets/store_test.go
@@ -171,6 +171,40 @@ func TestStoreSnapshotUsesStableReferences(t *testing.T) {
 	}
 }
 
+func TestStoreFullSnapshotRoundTripsBodies(t *testing.T) {
+	store := New(WithClock(fixedClock()))
+	if _, err := store.PutBytes("alpha", []byte{0, 1, 255, 'a'}, PutOptions{
+		Purpose:      "aws.s3.object",
+		ContentType:  "application/octet-stream",
+		UserMetadata: map[string]string{"source": "test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := store.MarshalFullSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restored := New()
+	if err := restored.RestoreFullJSON(raw); err != nil {
+		t.Fatal(err)
+	}
+	body, metadata, ok := restored.Bytes("alpha")
+	if !ok {
+		t.Fatal("restored asset missing")
+	}
+	if !bytes.Equal(body, []byte{0, 1, 255, 'a'}) {
+		t.Fatalf("body = %v", body)
+	}
+	if metadata.ContentType != "application/octet-stream" || metadata.Purpose != "aws.s3.object" {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+	if metadata.UserMetadata["source"] != "test" {
+		t.Fatalf("user metadata = %#v", metadata.UserMetadata)
+	}
+}
+
 func TestStoreListDeleteAndReset(t *testing.T) {
 	store := New(WithClock(fixedClock()))
 	if _, err := store.PutBytes("b", []byte("b"), PutOptions{}); err != nil {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"net/http"
 
+	coreassets "github.com/vercel-labs/emulate/internal/core/assets"
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
 	"github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/core/ui"
@@ -17,15 +18,17 @@ type ServerOptions struct {
 	BaseURL    string
 	Services   []string
 	Store      *store.Store
+	AssetStore *coreassets.Store
 	ResendSeed *resend.SeedConfig
 }
 
 type Server struct {
-	Handler  http.Handler
-	Store    *store.Store
-	Version  string
-	BaseURL  string
-	Services []string
+	Handler    http.Handler
+	Store      *store.Store
+	AssetStore *coreassets.Store
+	Version    string
+	BaseURL    string
+	Services   []string
 }
 
 func NewHandler(options ServerOptions) http.Handler {
@@ -45,6 +48,10 @@ func NewServer(options ServerOptions) *Server {
 	runtimeStore := options.Store
 	if runtimeStore == nil {
 		runtimeStore = store.New()
+	}
+	assetStore := options.AssetStore
+	if assetStore == nil {
+		assetStore = coreassets.New()
 	}
 
 	router := corehttp.NewRouter()
@@ -68,6 +75,7 @@ func NewServer(options ServerOptions) *Server {
 		aws.Register(router, aws.Options{
 			Store:          runtimeStore,
 			S3PathFallback: len(services) == 1,
+			AssetStore:     assetStore,
 			BaseURL:        options.BaseURL,
 		})
 	}
@@ -82,11 +90,12 @@ func NewServer(options ServerOptions) *Server {
 	})
 
 	return &Server{
-		Handler:  router,
-		Store:    runtimeStore,
-		Version:  version,
-		BaseURL:  options.BaseURL,
-		Services: services,
+		Handler:    router,
+		Store:      runtimeStore,
+		AssetStore: assetStore,
+		Version:    version,
+		BaseURL:    options.BaseURL,
+		Services:   services,
 	}
 }
 

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,9 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain('Services: []string{"aws", "resend"}');
-    expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain(
-      "require github.com/vercel-labs/emulate v0.5.0",
-    );
+    expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
       rewrites: Array<{ source: string; destination: string }>;
     };
@@ -58,6 +56,70 @@ describe("createVercelScaffold", () => {
       { source: "/docs/:path*", destination: "/docs/:path*" },
       { source: "/emulate/:path*", destination: "/api/emulate?path=:path*" },
     ]);
+  });
+
+  it("inserts the rewrite before a catch-all rewrite", () => {
+    const cwd = tempDir();
+    writeFileSync(
+      join(cwd, "vercel.json"),
+      JSON.stringify({
+        rewrites: [{ source: "/(.*)", destination: "/index.html" }],
+      }),
+    );
+
+    createVercelScaffold({ cwd, version: "0.5.0" });
+
+    const config = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
+      rewrites: Array<{ source: string; destination: string }>;
+    };
+    expect(config.rewrites).toEqual([
+      { source: "/emulate/:path*", destination: "/api/emulate?path=:path*" },
+      { source: "/(.*)", destination: "/index.html" },
+    ]);
+  });
+
+  it("moves an existing rewrite before a catch-all rewrite", () => {
+    const cwd = tempDir();
+    writeFileSync(
+      join(cwd, "vercel.json"),
+      JSON.stringify({
+        rewrites: [
+          { source: "/(.*)", destination: "/index.html" },
+          { source: "/emulate/:path*", destination: "/api/emulate?path=:path*" },
+        ],
+      }),
+    );
+
+    const result = createVercelScaffold({ cwd, version: "0.5.0" });
+
+    expect(result.updated).toContain("vercel.json");
+    const config = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
+      rewrites: Array<{ source: string; destination: string }>;
+    };
+    expect(config.rewrites).toEqual([
+      { source: "/emulate/:path*", destination: "/api/emulate?path=:path*" },
+      { source: "/(.*)", destination: "/index.html" },
+    ]);
+  });
+
+  it("adds the Go dependency to an existing module", () => {
+    const cwd = tempDir();
+    writeFileSync(
+      join(cwd, "go.mod"),
+      `module example.com/app
+
+go 1.24
+
+require (
+\tgithub.com/example/dependency v1.0.0
+)
+`,
+    );
+
+    const result = createVercelScaffold({ cwd, version: "0.5.0" });
+
+    expect(result.updated).toContain("go.mod");
+    expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("github.com/vercel-labs/emulate v0.5.0");
   });
 
   it("is idempotent when generated files already exist", () => {

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVercelScaffold } from "../commands/vercel.js";
+
+const tempDirs: string[] = [];
+
+describe("createVercelScaffold", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the Vercel Go Function scaffold", () => {
+    const cwd = tempDir();
+    const result = createVercelScaffold({ cwd, version: "0.5.0" });
+
+    expect(result.created.sort()).toEqual(["api/emulate.go", "go.mod", "vercel.json"]);
+    expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
+      'emulate "github.com/vercel-labs/emulate/vercel"',
+    );
+    expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain('Services: []string{"aws", "resend"}');
+    expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain(
+      "require github.com/vercel-labs/emulate v0.5.0",
+    );
+    const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
+      rewrites: Array<{ source: string; destination: string }>;
+    };
+    expect(vercelConfig.rewrites).toContainEqual({
+      source: "/emulate/:path*",
+      destination: "/api/emulate?path=:path*",
+    });
+  });
+
+  it("merges the rewrite into an existing vercel.json", () => {
+    const cwd = tempDir();
+    writeFileSync(
+      join(cwd, "vercel.json"),
+      JSON.stringify({
+        cleanUrls: true,
+        rewrites: [{ source: "/docs/:path*", destination: "/docs/:path*" }],
+      }),
+    );
+
+    const result = createVercelScaffold({ cwd, version: "0.5.0", service: "resend" });
+
+    expect(result.updated).toEqual(["vercel.json"]);
+    const handler = readFileSync(join(cwd, "api/emulate.go"), "utf-8");
+    expect(handler).toContain('Services: []string{"resend"}');
+    const config = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
+      cleanUrls: boolean;
+      rewrites: Array<{ source: string; destination: string }>;
+    };
+    expect(config.cleanUrls).toBe(true);
+    expect(config.rewrites).toEqual([
+      { source: "/docs/:path*", destination: "/docs/:path*" },
+      { source: "/emulate/:path*", destination: "/api/emulate?path=:path*" },
+    ]);
+  });
+
+  it("is idempotent when generated files already exist", () => {
+    const cwd = tempDir();
+    createVercelScaffold({ cwd, version: "0.5.0" });
+
+    const result = createVercelScaffold({ cwd, version: "0.5.0" });
+
+    expect(result.created).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.unchanged.sort()).toEqual(["api/emulate.go", "go.mod", "vercel.json"]);
+  });
+
+  it("rejects services not available in the native Vercel scaffold", () => {
+    const cwd = tempDir();
+
+    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "github" })).toThrow(
+      "currently supports native services: aws, resend",
+    );
+  });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "emulate-vercel-"));
+  tempDirs.push(dir);
+  return dir;
+}

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -102,6 +102,30 @@ describe("createVercelScaffold", () => {
     ]);
   });
 
+  it("moves an existing rewrite before a catch-all rewrite when forced", () => {
+    const cwd = tempDir();
+    writeFileSync(
+      join(cwd, "vercel.json"),
+      JSON.stringify({
+        rewrites: [
+          { source: "/(.*)", destination: "/index.html" },
+          { source: "/emulate/:path*", destination: "/api/emulate?path=:path*" },
+        ],
+      }),
+    );
+
+    const result = createVercelScaffold({ cwd, version: "0.5.0", force: true });
+
+    expect(result.updated).toContain("vercel.json");
+    const config = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
+      rewrites: Array<{ source: string; destination: string }>;
+    };
+    expect(config.rewrites).toEqual([
+      { source: "/emulate/:path*", destination: "/api/emulate?path=:path*" },
+      { source: "/(.*)", destination: "/index.html" },
+    ]);
+  });
+
   it("adds the Go dependency to an existing module", () => {
     const cwd = tempDir();
     writeFileSync(
@@ -120,6 +144,28 @@ require (
 
     expect(result.updated).toContain("go.mod");
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("github.com/vercel-labs/emulate v0.5.0");
+  });
+
+  it("updates an existing Go dependency to the current scaffold version", () => {
+    const cwd = tempDir();
+    writeFileSync(
+      join(cwd, "go.mod"),
+      `module example.com/app
+
+go 1.24
+
+require (
+\tgithub.com/vercel-labs/emulate v0.4.0 // indirect
+)
+`,
+    );
+
+    const result = createVercelScaffold({ cwd, version: "0.5.0" });
+
+    expect(result.updated).toContain("go.mod");
+    const content = readFileSync(join(cwd, "go.mod"), "utf-8");
+    expect(content).toContain("github.com/vercel-labs/emulate v0.5.0 // indirect");
+    expect(content).not.toContain("v0.4.0");
   });
 
   it("is idempotent when generated files already exist", () => {

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -1,4 +1,4 @@
-import { createServer, serve, type AppKeyResolver, type Store } from "@emulators/core";
+import { createServer, serve, type AppKeyResolver } from "@emulators/core";
 import { SERVICE_REGISTRY } from "./registry.js";
 export type { ServiceName } from "./registry.js";
 import type { ServiceName } from "./registry.js";

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -1,0 +1,199 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const SUPPORTED_VERCEL_SERVICES = ["aws", "resend"] as const;
+const DEFAULT_REWRITE = {
+  source: "/emulate/:path*",
+  destination: "/api/emulate?path=:path*",
+};
+
+export interface VercelInitOptions {
+  service?: string;
+  force?: boolean;
+  cwd?: string;
+  version: string;
+}
+
+export interface VercelScaffoldResult {
+  created: string[];
+  updated: string[];
+  unchanged: string[];
+  services: string[];
+}
+
+type VercelConfig = Record<string, unknown>;
+
+export function vercelInitCommand(options: VercelInitOptions): void {
+  try {
+    const result = createVercelScaffold(options);
+    for (const file of result.created) {
+      console.log(`Created ${file}`);
+    }
+    for (const file of result.updated) {
+      console.log(`Updated ${file}`);
+    }
+    for (const file of result.unchanged) {
+      console.log(`Skipped existing ${file}`);
+    }
+    console.log(`\nVercel Go Function scaffold ready for: ${result.services.join(", ")}`);
+    console.log("State uses warm in-memory stores by default. Cold starts reset state, and concurrent instances can diverge.");
+    console.log("Add a vercel.Persistence implementation in api/emulate.go when snapshots need to survive cold starts.");
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+export function createVercelScaffold(options: VercelInitOptions): VercelScaffoldResult {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const services = parseServiceList(options.service);
+  const result: VercelScaffoldResult = {
+    created: [],
+    updated: [],
+    unchanged: [],
+    services,
+  };
+
+  mkdirSync(join(cwd, "api"), { recursive: true });
+
+  writeFileIfAllowed(cwd, "api/emulate.go", renderHandler(services), options.force ?? false, result);
+  writeFileIfAllowed(cwd, "go.mod", renderGoMod(options.version), false, result);
+  updateVercelConfig(cwd, options.force ?? false, result);
+
+  return result;
+}
+
+function parseServiceList(input: string | undefined): string[] {
+  if (!input || input.trim() === "" || input.trim().toLowerCase() === "all") {
+    return [...SUPPORTED_VERCEL_SERVICES];
+  }
+  const seen = new Set<string>();
+  const services: string[] = [];
+  for (const raw of input.split(",")) {
+    const name = raw.trim().toLowerCase();
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    if (!SUPPORTED_VERCEL_SERVICES.includes(name as (typeof SUPPORTED_VERCEL_SERVICES)[number])) {
+      throw new Error(
+        `The Vercel Go Function scaffold currently supports native services: ${SUPPORTED_VERCEL_SERVICES.join(", ")}`,
+      );
+    }
+    seen.add(name);
+    services.push(name);
+  }
+  if (services.length === 0) {
+    return [...SUPPORTED_VERCEL_SERVICES];
+  }
+  return services;
+}
+
+function writeFileIfAllowed(
+  cwd: string,
+  relativePath: string,
+  content: string,
+  force: boolean,
+  result: VercelScaffoldResult,
+): void {
+  const target = join(cwd, relativePath);
+  if (existsSync(target) && !force) {
+    result.unchanged.push(relativePath);
+    return;
+  }
+  const existed = existsSync(target);
+  writeFileSync(target, content, "utf-8");
+  if (existed) {
+    result.updated.push(relativePath);
+  } else {
+    result.created.push(relativePath);
+  }
+}
+
+function updateVercelConfig(cwd: string, force: boolean, result: VercelScaffoldResult): void {
+  const relativePath = "vercel.json";
+  const target = join(cwd, relativePath);
+  let config: VercelConfig = {
+    $schema: "https://openapi.vercel.sh/vercel.json",
+  };
+  let existed = false;
+  if (existsSync(target)) {
+    existed = true;
+    try {
+      config = JSON.parse(readFileSync(target, "utf-8")) as VercelConfig;
+    } catch (err) {
+      throw new Error(`Failed to parse ${relativePath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const rewrites = config.rewrites;
+  if (rewrites !== undefined && !Array.isArray(rewrites)) {
+    throw new Error(`${relativePath} rewrites must be an array to add the emulate preview route`);
+  }
+
+  const rewriteList = rewrites ?? [];
+  const sameSource = rewriteList.find((entry) => isRewrite(entry) && entry.source === DEFAULT_REWRITE.source);
+  if (sameSource && isRewrite(sameSource) && sameSource.destination !== DEFAULT_REWRITE.destination) {
+    throw new Error(`${relativePath} already has a rewrite for ${DEFAULT_REWRITE.source}`);
+  }
+
+  const hasRewrite = rewriteList.some(
+    (entry) =>
+      isRewrite(entry) &&
+      entry.source === DEFAULT_REWRITE.source &&
+      entry.destination === DEFAULT_REWRITE.destination,
+  );
+  if (hasRewrite && !force) {
+    result.unchanged.push(relativePath);
+    return;
+  }
+
+  config.rewrites = hasRewrite ? rewriteList : [...rewriteList, DEFAULT_REWRITE];
+  if (!("$schema" in config)) {
+    config.$schema = "https://openapi.vercel.sh/vercel.json";
+  }
+  writeFileSync(target, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+
+  if (existed) {
+    result.updated.push(relativePath);
+  } else {
+    result.created.push(relativePath);
+  }
+}
+
+function isRewrite(value: unknown): value is { source: string; destination: string } {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const maybe = value as Record<string, unknown>;
+  return typeof maybe.source === "string" && typeof maybe.destination === "string";
+}
+
+function renderHandler(services: string[]): string {
+  const serviceList = services.map((service) => `"${service}"`).join(", ");
+  return `package handler
+
+import (
+\t"net/http"
+
+\temulate "github.com/vercel-labs/emulate/vercel"
+)
+
+var emulateHandler = emulate.NewHandler(emulate.Options{
+\tServices: []string{${serviceList}},
+})
+
+func Handler(w http.ResponseWriter, r *http.Request) {
+\temulateHandler.ServeHTTP(w, r)
+}
+`;
+}
+
+function renderGoMod(version: string): string {
+  const moduleVersion = version.startsWith("v") ? version : `v${version}`;
+  return `module emulate-vercel-preview
+
+go 1.24
+
+require github.com/vercel-labs/emulate ${moduleVersion}
+`;
+}

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -36,8 +36,12 @@ export function vercelInitCommand(options: VercelInitOptions): void {
       console.log(`Skipped existing ${file}`);
     }
     console.log(`\nVercel Go Function scaffold ready for: ${result.services.join(", ")}`);
-    console.log("State uses warm in-memory stores by default. Cold starts reset state, and concurrent instances can diverge.");
-    console.log("Add a vercel.Persistence implementation in api/emulate.go when snapshots need to survive cold starts.");
+    console.log(
+      "State uses warm in-memory stores by default. Cold starts reset state, and concurrent instances can diverge.",
+    );
+    console.log(
+      "Add a vercel.Persistence implementation in api/emulate.go when snapshots need to survive cold starts.",
+    );
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
@@ -57,7 +61,7 @@ export function createVercelScaffold(options: VercelInitOptions): VercelScaffold
   mkdirSync(join(cwd, "api"), { recursive: true });
 
   writeFileIfAllowed(cwd, "api/emulate.go", renderHandler(services), options.force ?? false, result);
-  writeFileIfAllowed(cwd, "go.mod", renderGoMod(options.version), false, result);
+  updateGoMod(cwd, options.version, result);
   updateVercelConfig(cwd, options.force ?? false, result);
 
   return result;
@@ -109,6 +113,39 @@ function writeFileIfAllowed(
   }
 }
 
+function updateGoMod(cwd: string, version: string, result: VercelScaffoldResult): void {
+  const relativePath = "go.mod";
+  const target = join(cwd, relativePath);
+  const moduleVersion = normalizeGoModuleVersion(version);
+  if (!existsSync(target)) {
+    writeFileSync(target, renderGoMod(moduleVersion), "utf-8");
+    result.created.push(relativePath);
+    return;
+  }
+
+  const content = readFileSync(target, "utf-8");
+  if (hasEmulateRequirement(content)) {
+    result.unchanged.push(relativePath);
+    return;
+  }
+
+  writeFileSync(target, addEmulateRequirement(content, moduleVersion), "utf-8");
+  result.updated.push(relativePath);
+}
+
+function hasEmulateRequirement(content: string): boolean {
+  return /^\s*(?:require\s+)?github\.com\/vercel-labs\/emulate\s+v\S+/m.test(content);
+}
+
+function addEmulateRequirement(content: string, moduleVersion: string): string {
+  const dependency = `github.com/vercel-labs/emulate ${moduleVersion}`;
+  if (/^require\s*\(/m.test(content)) {
+    return content.replace(/^require\s*\(\s*\n/m, (match) => `${match}\t${dependency}\n`);
+  }
+  const suffix = content.endsWith("\n") ? "" : "\n";
+  return `${content}${suffix}\nrequire ${dependency}\n`;
+}
+
 function updateVercelConfig(cwd: string, force: boolean, result: VercelScaffoldResult): void {
   const relativePath = "vercel.json";
   const target = join(cwd, relativePath);
@@ -136,18 +173,18 @@ function updateVercelConfig(cwd: string, force: boolean, result: VercelScaffoldR
     throw new Error(`${relativePath} already has a rewrite for ${DEFAULT_REWRITE.source}`);
   }
 
-  const hasRewrite = rewriteList.some(
-    (entry) =>
-      isRewrite(entry) &&
-      entry.source === DEFAULT_REWRITE.source &&
-      entry.destination === DEFAULT_REWRITE.destination,
-  );
+  const hasRewrite = rewriteList.some(isDefaultRewrite);
   if (hasRewrite && !force) {
-    result.unchanged.push(relativePath);
-    return;
+    const orderedRewriteList = moveExistingRewriteBeforeCatchAll(rewriteList);
+    if (orderedRewriteList === rewriteList) {
+      result.unchanged.push(relativePath);
+      return;
+    }
+    config.rewrites = orderedRewriteList;
+  } else {
+    config.rewrites = hasRewrite ? rewriteList : insertRewrite(rewriteList);
   }
 
-  config.rewrites = hasRewrite ? rewriteList : [...rewriteList, DEFAULT_REWRITE];
   if (!("$schema" in config)) {
     config.$schema = "https://openapi.vercel.sh/vercel.json";
   }
@@ -158,6 +195,38 @@ function updateVercelConfig(cwd: string, force: boolean, result: VercelScaffoldR
   } else {
     result.created.push(relativePath);
   }
+}
+
+function insertRewrite(rewriteList: unknown[]): unknown[] {
+  const catchAllIndex = rewriteList.findIndex((entry) => isRewrite(entry) && isCatchAllSource(entry.source));
+  if (catchAllIndex < 0) {
+    return [...rewriteList, DEFAULT_REWRITE];
+  }
+  return [...rewriteList.slice(0, catchAllIndex), DEFAULT_REWRITE, ...rewriteList.slice(catchAllIndex)];
+}
+
+function moveExistingRewriteBeforeCatchAll(rewriteList: unknown[]): unknown[] {
+  const rewriteIndex = rewriteList.findIndex(isDefaultRewrite);
+  const catchAllIndex = rewriteList.findIndex((entry) => isRewrite(entry) && isCatchAllSource(entry.source));
+  if (rewriteIndex < 0 || catchAllIndex < 0 || rewriteIndex < catchAllIndex) {
+    return rewriteList;
+  }
+  const ordered = [...rewriteList];
+  const [rewrite] = ordered.splice(rewriteIndex, 1);
+  const updatedCatchAllIndex = ordered.findIndex((entry) => isRewrite(entry) && isCatchAllSource(entry.source));
+  ordered.splice(updatedCatchAllIndex, 0, rewrite);
+  return ordered;
+}
+
+function isCatchAllSource(source: string): boolean {
+  const value = source.trim();
+  return value === "/(.*)" || /^\/:[A-Za-z_][\w-]*\*$/.test(value) || /^\/:[A-Za-z_][\w-]*\(\.\*\)$/.test(value);
+}
+
+function isDefaultRewrite(value: unknown): boolean {
+  return (
+    isRewrite(value) && value.source === DEFAULT_REWRITE.source && value.destination === DEFAULT_REWRITE.destination
+  );
 }
 
 function isRewrite(value: unknown): value is { source: string; destination: string } {
@@ -188,8 +257,12 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 `;
 }
 
-function renderGoMod(version: string): string {
+function normalizeGoModuleVersion(version: string): string {
   const moduleVersion = version.startsWith("v") ? version : `v${version}`;
+  return moduleVersion;
+}
+
+function renderGoMod(moduleVersion: string): string {
   return `module emulate-vercel-preview
 
 go 1.24

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -124,17 +124,28 @@ function updateGoMod(cwd: string, version: string, result: VercelScaffoldResult)
   }
 
   const content = readFileSync(target, "utf-8");
-  if (hasEmulateRequirement(content)) {
+  const existingVersion = getEmulateRequirementVersion(content);
+  if (existingVersion === moduleVersion) {
     result.unchanged.push(relativePath);
     return;
   }
 
-  writeFileSync(target, addEmulateRequirement(content, moduleVersion), "utf-8");
+  const nextContent = existingVersion
+    ? updateEmulateRequirement(content, moduleVersion)
+    : addEmulateRequirement(content, moduleVersion);
+  writeFileSync(target, nextContent, "utf-8");
   result.updated.push(relativePath);
 }
 
-function hasEmulateRequirement(content: string): boolean {
-  return /^\s*(?:require\s+)?github\.com\/vercel-labs\/emulate\s+v\S+/m.test(content);
+function getEmulateRequirementVersion(content: string): string | undefined {
+  return content.match(/^\s*(?:require\s+)?github\.com\/vercel-labs\/emulate\s+(v\S+)/m)?.[1];
+}
+
+function updateEmulateRequirement(content: string, moduleVersion: string): string {
+  return content.replace(
+    /^(\s*(?:require\s+)?github\.com\/vercel-labs\/emulate\s+)v\S+(\s*(?:\/\/.*)?$)/m,
+    `$1${moduleVersion}$2`,
+  );
 }
 
 function addEmulateRequirement(content: string, moduleVersion: string): string {
@@ -174,16 +185,12 @@ function updateVercelConfig(cwd: string, force: boolean, result: VercelScaffoldR
   }
 
   const hasRewrite = rewriteList.some(isDefaultRewrite);
-  if (hasRewrite && !force) {
-    const orderedRewriteList = moveExistingRewriteBeforeCatchAll(rewriteList);
-    if (orderedRewriteList === rewriteList) {
-      result.unchanged.push(relativePath);
-      return;
-    }
-    config.rewrites = orderedRewriteList;
-  } else {
-    config.rewrites = hasRewrite ? rewriteList : insertRewrite(rewriteList);
+  const nextRewriteList = moveExistingRewriteBeforeCatchAll(hasRewrite ? rewriteList : insertRewrite(rewriteList));
+  if (hasRewrite && !force && nextRewriteList === rewriteList) {
+    result.unchanged.push(relativePath);
+    return;
   }
+  config.rewrites = nextRewriteList;
 
   if (!("$schema" in config)) {
     config.$schema = "https://openapi.vercel.sh/vercel.json";

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { startCommand } from "./commands/start.js";
 import { initCommand } from "./commands/init.js";
 import { listCommand } from "./commands/list.js";
+import { vercelInitCommand } from "./commands/vercel.js";
 
 declare const PKG_VERSION: string;
 const pkg = { version: PKG_VERSION };
@@ -52,6 +53,21 @@ program
   .description("List available services")
   .action(() => {
     listCommand();
+  });
+
+const vercel = program.command("vercel").description("Vercel preview helpers");
+
+vercel
+  .command("init")
+  .description("Scaffold an experimental Vercel Go Function")
+  .option("-s, --service <services>", "Comma-separated native services to enable", "aws,resend")
+  .option("--force", "Overwrite generated files")
+  .action((opts) => {
+    vercelInitCommand({
+      service: opts.service,
+      force: opts.force,
+      version: pkg.version,
+    });
   });
 
 program.parse();

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -12,7 +12,7 @@ const defaultPort = process.env.EMULATE_PORT ?? process.env.PORT ?? "4000";
 const program = new Command();
 
 program
-  .name("emulate")
+  .name("npx emulate")
   .description("Local drop-in replacement services for CI and no-network sandboxes")
   .version(pkg.version);
 

--- a/packages/emulate/tsup.config.ts
+++ b/packages/emulate/tsup.config.ts
@@ -14,7 +14,8 @@ const copyFonts = async () => {
 const addShebang = async () => {
   const entry = resolve(__dirname, "dist/index.js");
   const content = readFileSync(entry, "utf-8");
-  writeFileSync(entry, `#!/usr/bin/env node\n${content}`);
+  const shebang = "#!/usr/bin/env node\n";
+  writeFileSync(entry, shebang + content.replace(/^(#!\/usr\/bin\/env node\r?\n)+/, ""));
 };
 
 const shared = {

--- a/skills/apple/SKILL.md
+++ b/skills/apple/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: apple
 description: Emulated Sign in with Apple / Apple OIDC for local development and testing. Use when the user needs to test Apple sign-in locally, emulate Apple OIDC discovery, handle Apple token exchange, configure Apple OAuth clients, or work with Apple userinfo without hitting real Apple APIs. Triggers include "Apple OAuth", "emulate Apple", "mock Apple login", "test Apple sign-in", "Sign in with Apple", "Apple OIDC", "local Apple auth", or any task requiring a local Apple OAuth/OIDC provider.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Apple Sign In Emulator

--- a/skills/aws/SKILL.md
+++ b/skills/aws/SKILL.md
@@ -1,12 +1,22 @@
 ---
 name: aws
-description: Emulated AWS cloud services (S3, SQS, IAM, STS) for local development and testing. Use when the user needs to interact with AWS API endpoints locally, test S3 bucket and object operations, emulate SQS queues and messages, manage IAM users/roles/access keys, test STS assume role, or work without hitting real AWS APIs. Triggers include "AWS emulator", "emulate AWS", "mock S3", "local SQS", "test IAM", "emulate S3", "AWS locally", "STS assume role", or any task requiring local AWS service emulation.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+description: Emulated AWS cloud services (S3, SQS, IAM, STS) for local development, testing, and native Vercel preview functions. Use when the user needs to interact with AWS API endpoints locally, test S3 bucket and object operations, emulate SQS queues and messages, manage IAM users/roles/access keys, test STS assume role, scaffold AWS through npx emulate vercel init, or work without hitting real AWS APIs. Triggers include "AWS emulator", "emulate AWS", "mock S3", "local SQS", "test IAM", "emulate S3", "AWS locally", "STS assume role", or any task requiring local AWS service emulation.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # AWS Emulator
 
 S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and AWS Query endpoints for SQS/IAM/STS. All state is in-memory. Query and REST XML operations return AWS-compatible XML. The native Go runtime is verified against current AWS SDK v3 clients for SQS, IAM, and STS; SQS uses JSON target requests, while IAM and STS use AWS Query XML.
+
+## Vercel Preview
+
+To expose the native AWS emulator in a Vercel preview without separate infrastructure, scaffold the Go Function route:
+
+```bash
+npx emulate vercel init --service aws
+```
+
+The generated route serves AWS at `/emulate/aws/*`. State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge.
 
 ## Start
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: emulate
-description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*)
+description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, scaffold Vercel Go Function previews, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", "npx emulate vercel init", or any task requiring local service emulation.
+allowed-tools: Bash(npx emulate:*)
 ---
 
 # Service Emulation with emulate
@@ -46,6 +46,9 @@ npx emulate init
 
 # Generate config for a specific service
 npx emulate init --service vercel
+
+# Scaffold a Vercel Go Function preview route
+npx emulate vercel init
 
 # List available services
 npx emulate list
@@ -314,7 +317,7 @@ Then use these in your app to construct API and OAuth URLs. See each service's s
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `aws` and `resend` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github
 description: Emulated GitHub REST API for local development and testing. Use when the user needs to interact with GitHub API endpoints locally, test GitHub integrations, emulate repos/issues/PRs, set up GitHub OAuth flows, configure GitHub Apps, test webhooks, or work with actions/checks without hitting the real GitHub API. Triggers include "GitHub API", "emulate GitHub", "mock GitHub", "test GitHub OAuth", "GitHub App JWT", "local GitHub", or any task requiring a local GitHub API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # GitHub API Emulator

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google
 description: Emulated Google OAuth 2.0, OpenID Connect, Gmail, Calendar, and Drive for local development and testing. Use when the user needs to test Google sign-in locally, emulate OIDC discovery, handle Google token exchange, configure Google OAuth clients, work with Gmail messages/drafts/threads/labels, manage Calendar events, upload or list Drive files, or work with Google userinfo without hitting real Google APIs. Triggers include "Google OAuth", "emulate Google", "mock Google login", "test Google sign-in", "OIDC emulator", "Google OIDC", "Gmail API", "Google Calendar", "Google Drive", "local Google auth", or any task requiring a local Google API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Google OAuth 2.0 / OIDC + Gmail, Calendar & Drive Emulator

--- a/skills/microsoft/SKILL.md
+++ b/skills/microsoft/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: microsoft
 description: Emulated Microsoft Entra ID (Azure AD) OAuth 2.0 / OpenID Connect for local development and testing. Use when the user needs to test Microsoft sign-in locally, emulate Entra ID OIDC discovery, handle Microsoft token exchange, configure Azure AD OAuth clients, work with Microsoft Graph /me, or test PKCE/client credentials flows without hitting real Microsoft APIs. Triggers include "Microsoft OAuth", "Entra ID", "Azure AD", "emulate Microsoft", "mock Microsoft login", "test Microsoft sign-in", "Microsoft OIDC", "local Microsoft auth", or any task requiring a local Microsoft OAuth/OIDC provider.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Microsoft Entra ID Emulator

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -1,12 +1,30 @@
 ---
 name: next
-description: Next.js adapter for embedded emulators and native runtime proxying via @emulators/adapter-next. Use when the user needs to embed emulators in Next.js, proxy a native runtime through a Next.js catch-all route, set up same-origin OAuth for Vercel preview deployments, configure Auth.js/NextAuth with emulator routes, add persistence to embedded emulators, or wrap next.config with withEmulate. Triggers include "Next.js emulator", "adapter-next", "embedded emulator", "native runtime proxy", "same-origin OAuth", "Vercel preview", "createEmulateHandler", "createEmulateProxy", "withEmulate", or any task requiring emulators inside a Next.js app.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*)
+description: Next.js adapter for embedded emulators, native runtime proxying via @emulators/adapter-next, and Vercel Go Function preview scaffolding. Use when the user needs to embed emulators in Next.js, proxy a native runtime through a Next.js catch-all route, set up same-origin OAuth for Vercel preview deployments, configure Auth.js/NextAuth with emulator routes, add persistence to embedded emulators, scaffold npx emulate vercel init, or wrap next.config with withEmulate. Triggers include "Next.js emulator", "adapter-next", "embedded emulator", "native runtime proxy", "same-origin OAuth", "Vercel preview", "Vercel Go Function", "npx emulate vercel init", "createEmulateHandler", "createEmulateProxy", "withEmulate", or any task requiring emulators inside a Next.js app.
+allowed-tools: Bash(npx emulate:*)
 ---
 
 # Next.js Integration
 
 The `@emulators/adapter-next` package supports two App Router modes. Embedded mode runs JavaScript emulators directly inside the Next.js app. Proxy mode exposes a separately running native runtime on the same origin.
+
+## Vercel Go Function Preview
+
+For zero infra Vercel preview deployments with the native Go runtime, scaffold a Go Function and rewrite:
+
+```bash
+npx emulate vercel init
+```
+
+This creates:
+
+- `api/emulate.go`, a Vercel Go Function using `github.com/vercel-labs/emulate/vercel`
+- `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
+- `go.mod`, pinned to the installed `emulate` package version
+
+The scaffold currently enables the native `aws` and `resend` handlers. Use `npx emulate vercel init --service resend` to limit the function to one service.
+
+State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
 ## Install
 
@@ -50,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the current zero-infra path for Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws` and `resend` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resend
-description: Emulated Resend email API for local development and testing. Use when the user needs to send emails locally, test transactional email flows, implement magic link or verification code auth, inspect sent emails, manage domains/contacts/API keys, or work with the Resend API without sending real emails. Triggers include "Resend API", "emulate Resend", "send email locally", "test email", "magic link", "verification email", "email inbox", "RESEND_BASE_URL", or any task requiring a local email API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+description: Emulated Resend email API for local development, testing, and native Vercel preview functions. Use when the user needs to send emails locally, test transactional email flows, implement magic link or verification code auth, inspect sent emails, manage domains/contacts/API keys, scaffold Resend through npx emulate vercel init, or work with the Resend API without sending real emails. Triggers include "Resend API", "emulate Resend", "send email locally", "test email", "magic link", "verification email", "email inbox", "RESEND_BASE_URL", or any task requiring a local email API.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Resend Email API Emulator
@@ -11,6 +11,16 @@ Fully stateful Resend API emulation. Emails, domains, API keys, audiences, and c
 No real emails are sent. Every call to `POST /emails` stores the message locally so you can inspect it programmatically or in the browser.
 
 The experimental native Go runtime implements the current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` Node.js SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+
+## Vercel Preview
+
+To expose the native Resend emulator in a Vercel preview without separate infrastructure, scaffold the Go Function route:
+
+```bash
+npx emulate vercel init --service resend
+```
+
+The generated route serves Resend at `/emulate/resend/*`. Set `RESEND_BASE_URL` to the preview origin plus `/emulate/resend`. State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge.
 
 ## Start
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slack
 description: Emulated Slack API for local development and testing. Use when the user needs to interact with Slack API endpoints locally, test Slack integrations, emulate channels/messages/users, set up Slack OAuth flows, test incoming webhooks, or work with the Slack Web API without hitting the real Slack API. Triggers include "Slack API", "emulate Slack", "mock Slack", "test Slack OAuth", "Slack bot", "incoming webhook", "local Slack", or any task requiring a local Slack API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Slack API Emulator

--- a/skills/stripe/SKILL.md
+++ b/skills/stripe/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: stripe
 description: Emulated Stripe API for local development and testing. Use when the user needs to process payments locally, test checkout flows, create customers, manage products and prices, handle payment intents, work with webhooks, or use the Stripe SDK without hitting real Stripe servers. Triggers include "Stripe API", "emulate Stripe", "test payments locally", "checkout flow", "payment intent", "Stripe webhook", "Stripe SDK", "STRIPE_API_KEY", or any task requiring a local Stripe API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Stripe API Emulator

--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vercel
 description: Emulated Vercel REST API for local development and testing. Use when the user needs to interact with Vercel API endpoints locally, test Vercel integrations, emulate projects/deployments/domains, set up Vercel OAuth flows, manage environment variables, create API keys, configure protection bypass, or test without hitting the real Vercel API. Triggers include "Vercel API", "emulate Vercel", "mock Vercel", "test Vercel OAuth", "Vercel integration", "local Vercel", or any task requiring a local Vercel API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Vercel API Emulator

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -1,0 +1,464 @@
+package vercel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
+)
+
+const DefaultRoutePrefix = "/emulate"
+
+var defaultServices = []string{"aws", "resend"}
+
+var mutatingMethods = map[string]struct{}{
+	http.MethodPost:   {},
+	http.MethodPut:    {},
+	http.MethodPatch:  {},
+	http.MethodDelete: {},
+}
+
+var (
+	htmlRootAttrRE = regexp.MustCompile(`(action|href)="(/[^"]*?)"`)
+	htmlRootURLRE  = regexp.MustCompile(`url\('(/[^']*?)'\)`)
+	defaultHandler = NewHandler(Options{})
+)
+
+type Persistence interface {
+	Load(ctx context.Context, service string) ([]byte, error)
+	Save(ctx context.Context, service string, snapshot []byte) error
+}
+
+type Options struct {
+	Version     string
+	RoutePrefix string
+	Services    []string
+	Persistence Persistence
+}
+
+type Runtime struct {
+	version     string
+	routePrefix string
+	services    []string
+	serviceSet  map[string]struct{}
+	persistence Persistence
+
+	mu      sync.Mutex
+	servers map[string]*emuruntime.Server
+}
+
+func SupportedServices() []string {
+	return append([]string(nil), defaultServices...)
+}
+
+func NewHandler(options Options) http.Handler {
+	version := options.Version
+	if version == "" {
+		version = "dev"
+	}
+	services := normalizeServices(options.Services)
+	serviceSet := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		serviceSet[service] = struct{}{}
+	}
+	return &Runtime{
+		version:     version,
+		routePrefix: normalizeMountPath(firstNonEmpty(options.RoutePrefix, DefaultRoutePrefix)),
+		services:    services,
+		serviceSet:  serviceSet,
+		persistence: options.Persistence,
+		servers:     map[string]*emuruntime.Server{},
+	}
+}
+
+func Handler(w http.ResponseWriter, r *http.Request) {
+	defaultHandler.ServeHTTP(w, r)
+}
+
+func (rt *Runtime) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	publicPath, query := rt.publicPathAndQuery(r)
+	if rt.isHealthPath(publicPath) {
+		rt.writeHealth(w)
+		return
+	}
+
+	service, restPath, ok := rt.parseServicePath(publicPath)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "Not Found"})
+		return
+	}
+	if _, ok := rt.serviceSet[service]; !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": fmt.Sprintf("Unknown service: %s", service)})
+		return
+	}
+
+	publicPrefix := appendPath(rt.routePrefix, service)
+	baseURL := originFromRequest(r) + publicPrefix
+	server, err := rt.serverFor(r.Context(), service, baseURL)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+
+	forwarded := cloneForwardedRequest(r, restPath, query, publicPath, publicPrefix, service)
+	recorder := newResponseRecorder()
+	server.Handler.ServeHTTP(recorder, forwarded)
+
+	if rt.persistence != nil && isMutating(r.Method) && recorder.statusOrDefault() < http.StatusInternalServerError {
+		snapshot, err := server.Store.MarshalSnapshot()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+			return
+		}
+		if err := rt.persistence.Save(r.Context(), service, snapshot); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+			return
+		}
+	}
+
+	writeRewrittenResponse(w, r, recorder, publicPrefix)
+}
+
+func (rt *Runtime) publicPathAndQuery(r *http.Request) (string, url.Values) {
+	query := r.URL.Query()
+	rewritePath := query.Get("path")
+	if rewritePath != "" && !hasPathPrefix(r.URL.Path, rt.routePrefix) {
+		query.Del("path")
+		return appendPath(rt.routePrefix, rewritePath), query
+	}
+	return r.URL.Path, query
+}
+
+func (rt *Runtime) isHealthPath(publicPath string) bool {
+	return publicPath == rt.routePrefix ||
+		publicPath == rt.routePrefix+"/" ||
+		publicPath == rt.routePrefix+emuruntime.HealthPath ||
+		publicPath == rt.routePrefix+"/health"
+}
+
+func (rt *Runtime) writeHealth(w http.ResponseWriter) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":           true,
+		"adapter":      "vercel",
+		"runtime":      "go",
+		"version":      rt.version,
+		"route_prefix": rt.routePrefix,
+		"services":     rt.services,
+		"state": map[string]any{
+			"default":     "warm-memory",
+			"persistence": rt.persistence != nil,
+		},
+	})
+}
+
+func (rt *Runtime) parseServicePath(publicPath string) (string, string, bool) {
+	if !hasPathPrefix(publicPath, rt.routePrefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(publicPath, rt.routePrefix)
+	rest = strings.Trim(rest, "/")
+	if rest == "" {
+		return "", "", false
+	}
+	parts := strings.Split(rest, "/")
+	service := parts[0]
+	if service == "" {
+		return "", "", false
+	}
+	if len(parts) == 1 {
+		return service, "/", true
+	}
+	return service, "/" + strings.Join(parts[1:], "/"), true
+}
+
+func (rt *Runtime) serverFor(ctx context.Context, service string, baseURL string) (*emuruntime.Server, error) {
+	key := service + "\x00" + baseURL
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if server, ok := rt.servers[key]; ok {
+		return server, nil
+	}
+
+	runtimeStore := corestore.New()
+	if rt.persistence != nil {
+		raw, err := rt.persistence.Load(ctx, service)
+		if err != nil {
+			return nil, err
+		}
+		if len(bytes.TrimSpace(raw)) > 0 {
+			if err := runtimeStore.RestoreJSON(raw); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	server := emuruntime.NewServer(emuruntime.ServerOptions{
+		Version:  rt.version,
+		BaseURL:  baseURL,
+		Services: []string{service},
+		Store:    runtimeStore,
+	})
+	rt.servers[key] = server
+	return server, nil
+}
+
+func cloneForwardedRequest(r *http.Request, restPath string, query url.Values, publicPath string, publicPrefix string, service string) *http.Request {
+	forwarded := r.Clone(r.Context())
+	forwarded.Header = r.Header.Clone()
+	forwarded.URL = cloneURL(r.URL)
+	forwarded.URL.Path = restPath
+	forwarded.URL.RawPath = ""
+	forwarded.URL.RawQuery = query.Encode()
+	forwarded.RequestURI = ""
+	setForwardHeaders(forwarded, r, publicPath, publicPrefix, service)
+	return forwarded
+}
+
+func cloneURL(input *url.URL) *url.URL {
+	copied := *input
+	return &copied
+}
+
+func setForwardHeaders(forwarded *http.Request, original *http.Request, publicPath string, publicPrefix string, service string) {
+	forwarded.Header.Set("X-Forwarded-Host", firstNonEmpty(firstForwardedValue(original.Header.Get("X-Forwarded-Host")), original.Host, original.URL.Host))
+	forwarded.Header.Set("X-Forwarded-Proto", requestProto(original))
+	forwarded.Header.Set("X-Forwarded-Prefix", publicPrefix)
+	forwarded.Header.Set("X-Emulate-Proxy", "vercel")
+	forwarded.Header.Set("X-Emulate-Original-Path", publicPath)
+	forwarded.Header.Set("X-Emulate-Service", service)
+	if port := forwardedPort(original); port != "" {
+		forwarded.Header.Set("X-Forwarded-Port", port)
+	}
+}
+
+func requestProto(r *http.Request) string {
+	if proto := firstForwardedValue(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		return proto
+	}
+	if r.URL.Scheme != "" {
+		return r.URL.Scheme
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func forwardedPort(r *http.Request) string {
+	if port := firstForwardedValue(r.Header.Get("X-Forwarded-Port")); port != "" {
+		return port
+	}
+	host := firstNonEmpty(firstForwardedValue(r.Header.Get("X-Forwarded-Host")), r.Host, r.URL.Host)
+	if index := strings.LastIndex(host, ":"); index >= 0 {
+		return host[index+1:]
+	}
+	return ""
+}
+
+func originFromRequest(r *http.Request) string {
+	host := firstNonEmpty(firstForwardedValue(r.Header.Get("X-Forwarded-Host")), r.Host, r.URL.Host)
+	return requestProto(r) + "://" + host
+}
+
+func writeRewrittenResponse(w http.ResponseWriter, r *http.Request, recorder *responseRecorder, publicPrefix string) {
+	headers := cloneHeader(recorder.Header())
+	if location := headers.Get("Location"); strings.HasPrefix(location, "/") {
+		headers.Set("Location", rewriteRootPath(publicPrefix, location))
+	}
+
+	body := recorder.body.Bytes()
+	contentType := headers.Get("Content-Type")
+	if strings.Contains(contentType, "text/html") {
+		body = []byte(rewriteHTML(string(body), publicPrefix))
+		headers.Del("Content-Length")
+		headers.Del("Content-Encoding")
+	}
+
+	for name, values := range headers {
+		for _, value := range values {
+			w.Header().Add(name, value)
+		}
+	}
+	w.WriteHeader(recorder.statusOrDefault())
+	if r.Method != http.MethodHead && len(body) > 0 {
+		_, _ = w.Write(body)
+	}
+}
+
+func rewriteHTML(html string, publicPrefix string) string {
+	html = htmlRootAttrRE.ReplaceAllStringFunc(html, func(match string) string {
+		parts := htmlRootAttrRE.FindStringSubmatch(match)
+		if len(parts) != 3 {
+			return match
+		}
+		return parts[1] + `="` + rewriteRootPath(publicPrefix, parts[2]) + `"`
+	})
+	html = htmlRootURLRE.ReplaceAllStringFunc(html, func(match string) string {
+		parts := htmlRootURLRE.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		return `url('` + rewriteRootPath(publicPrefix, parts[1]) + `')`
+	})
+	return html
+}
+
+func rewriteRootPath(publicPrefix string, target string) string {
+	prefix := normalizeMountPath(publicPrefix)
+	if prefix != "" && hasPathPrefix(target, prefix) {
+		return target
+	}
+	if target == "" || target == "/" {
+		if prefix == "" {
+			return "/"
+		}
+		return prefix
+	}
+	if strings.HasPrefix(target, "?") || strings.HasPrefix(target, "#") {
+		return prefix + target
+	}
+	if prefix == "" {
+		return target
+	}
+	return prefix + "/" + strings.TrimLeft(target, "/")
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	body, err := json.Marshal(value)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func normalizeServices(services []string) []string {
+	if len(services) == 0 {
+		return append([]string(nil), defaultServices...)
+	}
+	seen := map[string]struct{}{}
+	normalized := []string{}
+	for _, service := range services {
+		name := strings.ToLower(strings.TrimSpace(service))
+		if name == "" {
+			continue
+		}
+		if name == "all" {
+			return append([]string(nil), defaultServices...)
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		normalized = append(normalized, name)
+	}
+	if len(normalized) == 0 {
+		return append([]string(nil), defaultServices...)
+	}
+	return normalized
+}
+
+func normalizeMountPath(input string) string {
+	trimmed := strings.Trim(input, "/")
+	if trimmed == "" {
+		return ""
+	}
+	return "/" + trimmed
+}
+
+func appendPath(prefix string, segment string) string {
+	mountPath := normalizeMountPath(prefix)
+	cleanedSegment := strings.Trim(segment, "/")
+	if cleanedSegment == "" {
+		if mountPath == "" {
+			return "/"
+		}
+		return mountPath
+	}
+	if mountPath == "" {
+		return "/" + cleanedSegment
+	}
+	return mountPath + "/" + cleanedSegment
+}
+
+func hasPathPrefix(input string, prefix string) bool {
+	normalizedPrefix := normalizeMountPath(prefix)
+	if normalizedPrefix == "" {
+		return true
+	}
+	return input == normalizedPrefix || strings.HasPrefix(input, normalizedPrefix+"/")
+}
+
+func firstForwardedValue(input string) string {
+	if input == "" {
+		return ""
+	}
+	return strings.TrimSpace(strings.Split(input, ",")[0])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func isMutating(method string) bool {
+	_, ok := mutatingMethods[method]
+	return ok
+}
+
+func cloneHeader(input http.Header) http.Header {
+	output := http.Header{}
+	for name, values := range input {
+		output[name] = append([]string(nil), values...)
+	}
+	return output
+}
+
+type responseRecorder struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func newResponseRecorder() *responseRecorder {
+	return &responseRecorder{header: http.Header{}}
+}
+
+func (r *responseRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *responseRecorder) WriteHeader(status int) {
+	if r.status != 0 {
+		return
+	}
+	r.status = status
+}
+
+func (r *responseRecorder) Write(body []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	return r.body.Write(body)
+}
+
+func (r *responseRecorder) statusOrDefault() int {
+	if r.status == 0 {
+		return http.StatusOK
+	}
+	return r.status
+}

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -170,19 +170,18 @@ func (rt *Runtime) parseServicePath(publicPath string) (string, string, bool) {
 		return "", "", false
 	}
 	rest := strings.TrimPrefix(publicPath, rt.routePrefix)
-	rest = strings.Trim(rest, "/")
+	rest = strings.TrimPrefix(rest, "/")
 	if rest == "" {
 		return "", "", false
 	}
-	parts := strings.Split(rest, "/")
-	service := parts[0]
+	service, remainingPath, hasRemainingPath := strings.Cut(rest, "/")
 	if service == "" {
 		return "", "", false
 	}
-	if len(parts) == 1 {
+	if !hasRemainingPath {
 		return service, "/", true
 	}
-	return service, "/" + strings.Join(parts[1:], "/"), true
+	return service, "/" + remainingPath, true
 }
 
 func (rt *Runtime) serverFor(ctx context.Context, service string, baseURL string) (*emuruntime.Server, error) {
@@ -414,7 +413,7 @@ func normalizeMountPath(input string) string {
 
 func appendPath(prefix string, segment string) string {
 	mountPath := normalizeMountPath(prefix)
-	cleanedSegment := strings.Trim(segment, "/")
+	cleanedSegment := strings.TrimLeft(segment, "/")
 	if cleanedSegment == "" {
 		if mountPath == "" {
 			return "/"

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	coreassets "github.com/vercel-labs/emulate/internal/core/assets"
 	corestore "github.com/vercel-labs/emulate/internal/core/store"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 )
@@ -53,6 +54,11 @@ type Runtime struct {
 
 	mu      sync.Mutex
 	servers map[string]*emuruntime.Server
+}
+
+type persistentSnapshot struct {
+	Store  *corestore.StoreSnapshot      `json:"store,omitempty"`
+	Assets *coreassets.FullStoreSnapshot `json:"assets,omitempty"`
 }
 
 func SupportedServices() []string {
@@ -113,7 +119,7 @@ func (rt *Runtime) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	server.Handler.ServeHTTP(recorder, forwarded)
 
 	if rt.persistence != nil && isMutating(r.Method) && recorder.statusOrDefault() < http.StatusInternalServerError {
-		snapshot, err := server.Store.MarshalSnapshot()
+		snapshot, err := marshalPersistentSnapshot(server.Store, server.AssetStore)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
 			return
@@ -188,26 +194,56 @@ func (rt *Runtime) serverFor(ctx context.Context, service string, baseURL string
 	}
 
 	runtimeStore := corestore.New()
+	assetStore := coreassets.New()
 	if rt.persistence != nil {
 		raw, err := rt.persistence.Load(ctx, service)
 		if err != nil {
 			return nil, err
 		}
 		if len(bytes.TrimSpace(raw)) > 0 {
-			if err := runtimeStore.RestoreJSON(raw); err != nil {
+			if err := restorePersistentSnapshot(raw, runtimeStore, assetStore); err != nil {
 				return nil, err
 			}
 		}
 	}
 
 	server := emuruntime.NewServer(emuruntime.ServerOptions{
-		Version:  rt.version,
-		BaseURL:  baseURL,
-		Services: []string{service},
-		Store:    runtimeStore,
+		Version:    rt.version,
+		BaseURL:    baseURL,
+		Services:   []string{service},
+		Store:      runtimeStore,
+		AssetStore: assetStore,
 	})
 	rt.servers[key] = server
 	return server, nil
+}
+
+func marshalPersistentSnapshot(runtimeStore *corestore.Store, assetStore *coreassets.Store) ([]byte, error) {
+	storeSnapshot := runtimeStore.Snapshot()
+	assetSnapshot := assetStore.FullSnapshot()
+	return json.MarshalIndent(persistentSnapshot{
+		Store:  &storeSnapshot,
+		Assets: &assetSnapshot,
+	}, "", "  ")
+}
+
+func restorePersistentSnapshot(raw []byte, runtimeStore *corestore.Store, assetStore *coreassets.Store) error {
+	var snapshot persistentSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return err
+	}
+	if snapshot.Store == nil {
+		return runtimeStore.RestoreJSON(raw)
+	}
+	if err := runtimeStore.Restore(*snapshot.Store); err != nil {
+		return err
+	}
+	if snapshot.Assets != nil {
+		if err := assetStore.RestoreFullSnapshot(*snapshot.Assets); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func cloneForwardedRequest(r *http.Request, restPath string, query url.Values, publicPath string, publicPrefix string, service string) *http.Request {

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -208,6 +208,39 @@ func TestHandlerLoadsAndSavesAWSS3ObjectSnapshots(t *testing.T) {
 	}
 }
 
+func TestHandlerPreservesTrailingSlashInVercelRewritePath(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"aws"}})
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"https://preview.example.com/api/emulate?path=aws/emulate-default/folder/",
+		strings.NewReader("directory marker"),
+	)
+	req.Host = "preview.example.com"
+	req.Header.Set("Content-Type", "text/plain")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("put status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "https://preview.example.com/api/emulate?path=aws/emulate-default&list-type=2", nil)
+	req.Host = "preview.example.com"
+	res = httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", res.Code, res.Body.String())
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "<Key>folder/</Key>") {
+		t.Fatalf("missing trailing slash key in %s", body)
+	}
+	if strings.Contains(body, "<Key>folder</Key>") {
+		t.Fatalf("key lost trailing slash in %s", body)
+	}
+}
+
 func createEmail(t *testing.T, handler http.Handler, subject string) {
 	t.Helper()
 	req := newJSONRequest(

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -1,0 +1,204 @@
+package vercel
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandlerServesPreviewHealth(t *testing.T) {
+	handler := NewHandler(Options{Version: "test"})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/_emulate/health", nil)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		OK          bool     `json:"ok"`
+		Adapter     string   `json:"adapter"`
+		Runtime     string   `json:"runtime"`
+		Version     string   `json:"version"`
+		RoutePrefix string   `json:"route_prefix"`
+		Services    []string `json:"services"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+	if strings.Join(body.Services, ",") != "aws,resend" {
+		t.Fatalf("services = %#v", body.Services)
+	}
+}
+
+func TestHandlerForwardsVercelRewriteQueryToService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"resend"}})
+	req := newJSONRequest(
+		http.MethodPost,
+		"https://preview.example.com/api/emulate?path=resend/emails&limit=1",
+		`{"from":"a@example.com","to":"b@example.com","subject":"Hello"}`,
+	)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"id"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "https://preview.example.com/api/emulate?path=resend/emails", nil)
+	req.Host = "preview.example.com"
+	res = httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "Hello") {
+		t.Fatalf("unexpected list body: %s", res.Body.String())
+	}
+}
+
+func TestHandlerForwardsDirectPublicPathToService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"resend"}})
+	req := newJSONRequest(
+		http.MethodPost,
+		"https://preview.example.com/emulate/resend/emails",
+		`{"from":"a@example.com","to":"b@example.com","subject":"Direct"}`,
+	)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestHandlerRewritesHTMLRootPathsThroughPublicServicePrefix(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"resend"}})
+	createEmail(t, handler, "Rewritten")
+
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/resend/inbox", nil)
+	req.Host = "preview.example.com"
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, `href="/emulate/resend/inbox/`) {
+		t.Fatalf("missing rewritten inbox link: %s", body)
+	}
+	if strings.Contains(body, `href="/inbox/`) || strings.Contains(body, `href="/_emulate/`) {
+		t.Fatalf("contains unrewritten root link: %s", body)
+	}
+	if !strings.Contains(body, `url('/emulate/resend/_emulate/`) {
+		t.Fatalf("missing rewritten asset URL: %s", body)
+	}
+	if res.Header().Get("Content-Length") != "" || res.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("unexpected stale content headers: %#v", res.Header())
+	}
+}
+
+func TestHandlerReturnsUnknownService(t *testing.T) {
+	handler := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/github/user", nil)
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "Unknown service: github") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestHandlerLoadsAndSavesPerServiceSnapshots(t *testing.T) {
+	persistence := &memoryPersistence{snapshots: map[string][]byte{}}
+	handler := NewHandler(Options{
+		Services:    []string{"resend"},
+		Persistence: persistence,
+	})
+	createEmail(t, handler, "Persistent")
+
+	if persistence.saves != 1 {
+		t.Fatalf("saves = %d", persistence.saves)
+	}
+	if len(persistence.snapshots["resend"]) == 0 {
+		t.Fatal("missing resend snapshot")
+	}
+
+	restored := NewHandler(Options{
+		Services:    []string{"resend"},
+		Persistence: persistence,
+	})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/resend/emails", nil)
+	req.Host = "preview.example.com"
+	res := httptest.NewRecorder()
+	restored.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "Persistent") {
+		t.Fatalf("expected restored email, got %s", res.Body.String())
+	}
+	if persistence.loads == 0 {
+		t.Fatal("persistence was not loaded")
+	}
+}
+
+func createEmail(t *testing.T, handler http.Handler, subject string) {
+	t.Helper()
+	req := newJSONRequest(
+		http.MethodPost,
+		"https://preview.example.com/emulate/resend/emails",
+		`{"from":"a@example.com","to":"b@example.com","subject":"`+subject+`"}`,
+	)
+	req.Host = "preview.example.com"
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func newJSONRequest(method string, target string, body string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+type memoryPersistence struct {
+	loads     int
+	saves     int
+	snapshots map[string][]byte
+}
+
+func (p *memoryPersistence) Load(_ context.Context, service string) ([]byte, error) {
+	p.loads++
+	return append([]byte(nil), p.snapshots[service]...), nil
+}
+
+func (p *memoryPersistence) Save(_ context.Context, service string, snapshot []byte) error {
+	p.saves++
+	p.snapshots[service] = append([]byte(nil), snapshot...)
+	return nil
+}

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -165,6 +165,49 @@ func TestHandlerLoadsAndSavesPerServiceSnapshots(t *testing.T) {
 	}
 }
 
+func TestHandlerLoadsAndSavesAWSS3ObjectSnapshots(t *testing.T) {
+	persistence := &memoryPersistence{snapshots: map[string][]byte{}}
+	handler := NewHandler(Options{
+		Services:    []string{"aws"},
+		Persistence: persistence,
+	})
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"https://preview.example.com/emulate/aws/emulate-default/docs/persistent.txt",
+		strings.NewReader("persistent object"),
+	)
+	req.Host = "preview.example.com"
+	req.Header.Set("Content-Type", "text/plain")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("put status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if len(persistence.snapshots["aws"]) == 0 {
+		t.Fatal("missing aws snapshot")
+	}
+
+	restored := NewHandler(Options{
+		Services:    []string{"aws"},
+		Persistence: persistence,
+	})
+	req = httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/aws/emulate-default/docs/persistent.txt", nil)
+	req.Host = "preview.example.com"
+	res = httptest.NewRecorder()
+	restored.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Body.String() != "persistent object" {
+		t.Fatalf("body = %q", res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("content type = %q", got)
+	}
+}
+
 func createEmail(t *testing.T, handler http.Handler, subject string) {
 	t.Helper()
 	req := newJSONRequest(


### PR DESCRIPTION
- Adds a public Go Vercel handler that adapts /emulate/{service} preview routes to native AWS and Resend handlers with warm-memory state and optional snapshot persistence.

- Adds npx emulate vercel init to generate api/emulate.go, vercel.json rewrites, and go.mod for zero infra Vercel previews.

- Documents preview state behavior and covers the scaffold and handler with Go and TypeScript tests.