### PR TITLE
Add Go Vercel API parity foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ microsoft:
 
 ## Vercel API
 
-Every endpoint below is fully stateful with Vercel-style JSON responses and cursor-based pagination.
+Every endpoint below is fully stateful with Vercel-style JSON responses and cursor-based pagination. The native Go runtime implements this same Vercel REST surface for local CLI runs and Vercel Go Function previews.
 
 ### User & Teams
 - `GET /v2/user` - authenticated user
@@ -736,7 +736,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws` and `resend` handlers. Use `npx emulate vercel init --service resend` to limit the function to one service.
+The scaffold currently enables the native `aws`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service vercel` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -777,7 +777,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws` and `resend` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws` and `resend` handlers. Use `npx emulate vercel init --service resend` to limit the function to one service.
+The scaffold currently enables the native `aws`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service vercel` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws` and `resend` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/apps/web/app/docs/vercel/page.mdx
+++ b/apps/web/app/docs/vercel/page.mdx
@@ -1,6 +1,6 @@
 # Vercel API
 
-Every endpoint below is fully stateful with Vercel-style JSON responses and cursor-based pagination.
+Every endpoint below is fully stateful with Vercel-style JSON responses and cursor-based pagination. The native Go runtime implements this same Vercel REST surface for local CLI runs and Vercel Go Function previews.
 
 ## User & Teams
 

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -21,6 +21,7 @@ import (
 	coreconfig "github.com/vercel-labs/emulate/internal/core/config"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 	"github.com/vercel-labs/emulate/internal/services/resend"
+	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
 
 var version = "dev"
@@ -104,6 +105,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 	}
 	var seedServices []string
 	var resendSeed *resend.SeedConfig
+	var vercelSeed *vercel.SeedConfig
 	if *seedValue != "" {
 		loaded, err := coreconfig.Load(coreconfig.LoadOptions{Path: *seedValue})
 		if err != nil {
@@ -111,7 +113,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for resend. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for resend and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
@@ -122,6 +124,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 				return 1
 			}
 			resendSeed = &cfg
+		}
+		if raw, ok := loaded.Data["vercel"]; ok {
+			var cfg vercel.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse vercel seed config: %v\n", err)
+				return 1
+			}
+			vercelSeed = &cfg
 		}
 	}
 	services, err := parseServices(*serviceValue)
@@ -142,6 +152,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		BaseURL:    baseURL,
 		Services:   services,
 		ResendSeed: resendSeed,
+		VercelSeed: vercelSeed,
 	})
 	httpServer := &nethttp.Server{
 		Handler:           server.Handler,
@@ -330,7 +341,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"resend"}
+	return []string{"resend", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/core/ui"
 	"github.com/vercel-labs/emulate/internal/services/aws"
 	"github.com/vercel-labs/emulate/internal/services/resend"
+	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
 
 const HealthPath = "/_emulate/health"
@@ -20,6 +21,7 @@ type ServerOptions struct {
 	Store      *store.Store
 	AssetStore *coreassets.Store
 	ResendSeed *resend.SeedConfig
+	VercelSeed *vercel.SeedConfig
 }
 
 type Server struct {
@@ -83,6 +85,13 @@ func NewServer(options ServerOptions) *Server {
 		resend.Register(router, resend.Options{
 			Store: runtimeStore,
 			Seed:  options.ResendSeed,
+		})
+	}
+	if serviceEnabled(services, "vercel") {
+		vercel.Register(router, vercel.Options{
+			Store:   runtimeStore,
+			BaseURL: options.BaseURL,
+			Seed:    options.VercelSeed,
 		})
 	}
 	router.NotFound(func(c *corehttp.Context) {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -197,3 +197,32 @@ func TestNewHandlerDoesNotMountResendWhenDisabled(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }
+
+func TestNewHandlerMountsVercelWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"vercel"}, BaseURL: "http://localhost:4010"})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v2/user", nil)
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"username":"admin"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountVercelWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v2/user", nil)
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}

--- a/internal/services/vercel/routes_api_keys.go
+++ b/internal/services/vercel/routes_api_keys.go
@@ -1,0 +1,88 @@
+package vercel
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerAPIKeyRoutes(router *corehttp.Router) {
+	router.Post("/v1/api-keys", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		name := stringValue(body["name"])
+		if name == "" {
+			name = "API Key"
+		}
+		teamID := c.Query("teamId")
+		var teamValue any
+		if teamID != "" {
+			teamValue = teamID
+		}
+		tokenString := "vercel_api_" + generateSecret()
+		uid := generateUID("ak")
+		s.store.APIKeys.Insert(corestore.Record{
+			"uid":         uid,
+			"name":        name,
+			"teamId":      teamValue,
+			"userId":      stringField(user, "uid"),
+			"tokenString": tokenString,
+		})
+		c.JSON(http.StatusOK, map[string]any{
+			"apiKeyString": tokenString,
+			"apiKey": map[string]any{
+				"id":        uid,
+				"name":      name,
+				"teamId":    teamValue,
+				"createdAt": nowMillis(),
+			},
+		})
+	})
+
+	router.Get("/v1/api-keys", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		teamID := c.Query("teamId")
+		keys := make([]map[string]any, 0)
+		for _, key := range s.store.APIKeys.FindBy("userId", stringField(user, "uid")) {
+			if teamID != "" && stringField(key, "teamId") != teamID {
+				continue
+			}
+			keys = append(keys, map[string]any{
+				"id":        stringField(key, "uid"),
+				"name":      stringField(key, "name"),
+				"teamId":    key["teamId"],
+				"createdAt": timeMillisField(key, "created_at"),
+			})
+		}
+		c.JSON(http.StatusOK, map[string]any{"keys": keys})
+	})
+
+	router.Delete("/v1/api-keys/:keyId", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		key := firstRecord(s.store.APIKeys.FindBy("uid", c.Param("keyId")))
+		if key == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "API key not found")
+			return
+		}
+		if stringField(key, "userId") != stringField(user, "uid") {
+			writeVercelError(c, http.StatusForbidden, "forbidden", "Not authorized to delete this API key")
+			return
+		}
+		s.store.APIKeys.Delete(intField(key, "id"))
+		c.JSON(http.StatusOK, map[string]any{})
+	})
+}

--- a/internal/services/vercel/routes_deployments.go
+++ b/internal/services/vercel/routes_deployments.go
@@ -1,0 +1,571 @@
+package vercel
+
+import (
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerDeploymentRoutes(router *corehttp.Router) {
+	router.Patch("/v12/deployments/:id/cancel", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		dep := firstRecord(s.store.Deployments.FindBy("uid", c.Param("id")))
+		if dep == nil || !s.assertDeploymentAccess(dep, scoped.AccountID) {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Deployment not found")
+			return
+		}
+		readyState := stringField(dep, "readyState")
+		if readyState != "QUEUED" && readyState != "BUILDING" {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Deployment cannot be canceled in its current state")
+			return
+		}
+		now := nowMillis()
+		updated, ok := s.store.Deployments.Update(intField(dep, "id"), corestore.Record{
+			"readyState": "CANCELED",
+			"state":      "CANCELED",
+			"canceledAt": now,
+		})
+		if !ok {
+			updated = dep
+		}
+		s.store.DeploymentEvents.Insert(corestore.Record{
+			"deploymentId": stringField(updated, "uid"),
+			"type":         "canceled",
+			"payload":      map[string]any{"text": "Deployment canceled"},
+			"date":         now,
+			"serial":       strconv.FormatInt(now, 10),
+		})
+		c.JSON(http.StatusOK, formatDeployment(updated, s.store, s.baseURL))
+	})
+
+	router.Get("/v2/deployments/:id/aliases", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		dep := firstRecord(s.store.Deployments.FindBy("uid", c.Param("id")))
+		if dep == nil || !s.assertDeploymentAccess(dep, scoped.AccountID) {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Deployment not found")
+			return
+		}
+		aliases := s.store.DeploymentAliases.FindBy("deploymentId", stringField(dep, "uid"))
+		out := make([]map[string]any, 0, len(aliases))
+		for _, alias := range aliases {
+			out = append(out, map[string]any{
+				"uid":          stringField(alias, "uid"),
+				"alias":        stringField(alias, "alias"),
+				"deploymentId": stringField(alias, "deploymentId"),
+				"projectId":    stringField(alias, "projectId"),
+			})
+		}
+		c.JSON(http.StatusOK, map[string]any{"aliases": out})
+	})
+
+	router.Get("/v3/deployments/:idOrUrl/events", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		dep := s.findDeploymentByIDOrURL(c.Param("idOrUrl"))
+		if dep == nil || !s.assertDeploymentAccess(dep, scoped.AccountID) {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Deployment not found")
+			return
+		}
+		direction := strings.ToLower(c.Query("direction"))
+		if direction == "" {
+			direction = "backward"
+		}
+		limit := 20
+		if parsed, err := strconv.Atoi(c.Query("limit")); err == nil && parsed > 0 {
+			limit = parsed
+		}
+		if limit > 100 {
+			limit = 100
+		}
+		events := s.store.DeploymentEvents.FindBy("deploymentId", stringField(dep, "uid"))
+		sort.SliceStable(events, func(i int, j int) bool {
+			left := timeMillis(events[i]["date"])
+			right := timeMillis(events[j]["date"])
+			if direction == "backward" {
+				return left > right
+			}
+			return left < right
+		})
+		if len(events) > limit {
+			events = events[:limit]
+		}
+		out := make([]map[string]any, 0, len(events))
+		for _, event := range events {
+			out = append(out, map[string]any{
+				"type":    event["type"],
+				"payload": event["payload"],
+				"date":    event["date"],
+				"serial":  event["serial"],
+			})
+		}
+		c.JSON(http.StatusOK, out)
+	})
+
+	router.Get("/v6/deployments/:id/files", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		dep := firstRecord(s.store.Deployments.FindBy("uid", c.Param("id")))
+		if dep == nil || !s.assertDeploymentAccess(dep, scoped.AccountID) {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Deployment not found")
+			return
+		}
+		files := s.store.DeploymentFiles.FindBy("deploymentId", stringField(dep, "uid"))
+		c.JSON(http.StatusOK, map[string]any{"files": buildFileTree(files)})
+	})
+
+	router.Post("/v13/deployments", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		name := strings.TrimSpace(stringValue(body["name"]))
+		if name == "" {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Missing required field: name")
+			return
+		}
+		project := s.resolveOrCreateProject(scoped.AccountID, name, body["project"])
+		uid := generateUID("dpl")
+		urlValue := deploymentHostname(name, uid, s.baseURL)
+		target := stringValue(body["target"])
+		if target != "production" && target != "preview" && target != "staging" {
+			target = "preview"
+		}
+		meta := stringMapValue(body["meta"])
+		regions := stringSliceValue(body["regions"])
+		if len(regions) == 0 {
+			regions = []string{"iad1"}
+		}
+		now := nowMillis()
+		gitSource := parseGitSource(body["gitSource"])
+		source := "cli"
+		if gitSource != nil {
+			source = "git"
+		}
+		dep := s.store.Deployments.Insert(corestore.Record{
+			"uid":           uid,
+			"name":          name,
+			"url":           urlValue,
+			"projectId":     stringField(project, "uid"),
+			"source":        source,
+			"target":        target,
+			"readyState":    "READY",
+			"readySubstate": nil,
+			"state":         "READY",
+			"creatorId":     stringField(user, "uid"),
+			"inspectorUrl":  s.baseURL + "/deployments/" + uid,
+			"meta":          meta,
+			"gitSource":     gitSource,
+			"buildingAt":    now,
+			"readyAt":       now,
+			"canceledAt":    nil,
+			"errorCode":     nil,
+			"errorMessage":  nil,
+			"regions":       regions,
+			"functions":     nil,
+			"routes":        nil,
+			"plan":          "hobby",
+			"aliasAssigned": true,
+			"aliasError":    nil,
+			"bootedAt":      now,
+		})
+		s.store.DeploymentAliases.Insert(corestore.Record{
+			"uid":          generateUID("als"),
+			"alias":        urlValue,
+			"deploymentId": stringField(dep, "uid"),
+			"projectId":    stringField(project, "uid"),
+		})
+		if target == "production" {
+			s.store.DeploymentAliases.Insert(corestore.Record{
+				"uid":          generateUID("als"),
+				"alias":        productionProjectAlias(stringField(project, "name"), s.baseURL),
+				"deploymentId": stringField(dep, "uid"),
+				"projectId":    stringField(project, "uid"),
+			})
+		}
+		s.upsertProjectDeploymentRefs(project, dep)
+		s.store.Builds.Insert(corestore.Record{
+			"uid":          generateUID("bld"),
+			"deploymentId": stringField(dep, "uid"),
+			"entrypoint":   "api/index.ts",
+			"readyState":   "READY",
+			"output":       []any{},
+			"readyStateAt": now,
+			"fingerprint":  generateUID("fgp"),
+		})
+		s.insertDeploymentEvent(dep, "created", "Deployment created", now, "1")
+		s.insertDeploymentEvent(dep, "building", "Building", now, "2")
+		s.insertDeploymentEvent(dep, "ready", "Deployment ready", now, "3")
+		s.insertDeploymentFilesFromBody(dep, body["files"])
+		c.JSON(http.StatusOK, formatDeployment(dep, s.store, s.baseURL))
+	})
+
+	router.Get("/v6/deployments", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		appName := strings.TrimSpace(c.Query("app"))
+		projectIDFilter := strings.TrimSpace(c.Query("projectId"))
+		targetFilter := c.Query("target")
+		targetFilterValid := targetFilter == "production" || targetFilter == "preview" || targetFilter == "staging"
+		stateFilter := c.Query("state")
+		list := make([]corestore.Record, 0)
+		for _, dep := range s.store.Deployments.All() {
+			project := firstRecord(s.store.Projects.FindBy("uid", stringField(dep, "projectId")))
+			if project == nil || stringField(project, "accountId") != scoped.AccountID {
+				continue
+			}
+			if appName != "" && stringField(project, "name") != appName {
+				continue
+			}
+			if projectIDFilter != "" && stringField(dep, "projectId") != projectIDFilter {
+				continue
+			}
+			if targetFilterValid && stringField(dep, "target") != targetFilter {
+				continue
+			}
+			if stateFilter != "" && stringField(dep, "state") != stateFilter && stringField(dep, "readyState") != stateFilter {
+				continue
+			}
+			list = append(list, dep)
+		}
+		items, page := applyPagination(list, parsePagination(c))
+		out := make([]map[string]any, 0, len(items))
+		for _, dep := range items {
+			out = append(out, formatDeploymentBrief(dep, s.store))
+		}
+		c.JSON(http.StatusOK, map[string]any{"deployments": out, "pagination": page})
+	})
+
+	router.Delete("/v13/deployments/:id", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		dep := firstRecord(s.store.Deployments.FindBy("uid", c.Param("id")))
+		if dep == nil || !s.assertDeploymentAccess(dep, scoped.AccountID) {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Deployment not found")
+			return
+		}
+		uid := stringField(dep, "uid")
+		s.deleteDeploymentCascade(dep)
+		c.JSON(http.StatusOK, map[string]any{"uid": uid, "state": "DELETED"})
+	})
+
+	router.Get("/v13/deployments/:idOrUrl", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		dep := s.findDeploymentByIDOrURL(c.Param("idOrUrl"))
+		if dep == nil || !s.assertDeploymentAccess(dep, scoped.AccountID) {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Deployment not found")
+			return
+		}
+		c.JSON(http.StatusOK, formatDeployment(dep, s.store, s.baseURL))
+	})
+
+	router.Post("/v2/files", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		digest := c.Header("x-vercel-digest")
+		if digest == "" {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Missing x-vercel-digest header")
+			return
+		}
+		size := 0
+		if raw := c.Header("Content-Length"); raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil || parsed < 0 {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid Content-Length")
+				return
+			}
+			size = parsed
+		}
+		_, _ = io.Copy(io.Discard, c.Request.Body)
+		if firstRecord(s.store.Files.FindBy("digest", digest)) == nil {
+			contentType := c.Header("Content-Type")
+			if contentType == "" {
+				contentType = "application/octet-stream"
+			}
+			s.store.Files.Insert(corestore.Record{
+				"digest":      digest,
+				"size":        size,
+				"contentType": contentType,
+			})
+		}
+		c.JSON(http.StatusOK, []any{})
+	})
+}
+
+func (s *Service) assertDeploymentAccess(dep corestore.Record, accountID string) bool {
+	project := firstRecord(s.store.Projects.FindBy("uid", stringField(dep, "projectId")))
+	return project != nil && stringField(project, "accountId") == accountID
+}
+
+func (s *Service) findDeploymentByIDOrURL(idOrURL string) corestore.Record {
+	raw := strings.TrimSpace(idOrURL)
+	if dep := firstRecord(s.store.Deployments.FindBy("uid", raw)); dep != nil {
+		return dep
+	}
+	host := normalizeURLParam(raw)
+	if dep := firstRecord(s.store.Deployments.FindBy("url", host)); dep != nil {
+		return dep
+	}
+	return firstRecord(s.store.Deployments.FindBy("url", raw))
+}
+
+func (s *Service) resolveOrCreateProject(accountID string, name string, rawProject any) corestore.Record {
+	if projectID, ok := rawProject.(string); ok && strings.TrimSpace(projectID) != "" {
+		if project := s.lookupProject(strings.TrimSpace(projectID), accountID); project != nil {
+			return project
+		}
+	}
+	if project := s.lookupProject(name, accountID); project != nil {
+		return project
+	}
+	return s.store.Projects.Insert(defaultProjectRecord(name, accountID))
+}
+
+func parseGitSource(raw any) any {
+	body, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	repoID := stringValue(body["repoId"])
+	if repoID == "" {
+		if number, ok := body["repoId"].(float64); ok {
+			repoID = strconv.FormatInt(int64(number), 10)
+		}
+	}
+	gitType := stringValue(body["type"])
+	if gitType == "" {
+		gitType = "github"
+	}
+	return map[string]any{
+		"type":             gitType,
+		"ref":              stringValue(body["ref"]),
+		"sha":              stringValue(body["sha"]),
+		"repoId":           repoID,
+		"org":              stringValue(body["org"]),
+		"repo":             stringValue(body["repo"]),
+		"message":          stringValue(body["message"]),
+		"authorName":       stringValue(body["authorName"]),
+		"commitAuthorName": stringValue(body["commitAuthorName"]),
+	}
+}
+
+func (s *Service) upsertProjectDeploymentRefs(project corestore.Record, dep corestore.Record) {
+	entry := map[string]any{
+		"id":        stringField(dep, "uid"),
+		"url":       stringField(dep, "url"),
+		"state":     stringField(dep, "state"),
+		"createdAt": timeMillisField(dep, "created_at"),
+	}
+	latest := []any{entry}
+	for _, raw := range anySlice(project["latestDeployments"]) {
+		row, ok := raw.(map[string]any)
+		if !ok || stringValue(row["id"]) == stringField(dep, "uid") {
+			continue
+		}
+		latest = append(latest, row)
+	}
+	targets := map[string]any{}
+	if existing, ok := project["targets"].(map[string]any); ok {
+		for key, value := range existing {
+			targets[key] = value
+		}
+	}
+	targets[targetKey(stringField(dep, "target"))] = entry
+	s.store.Projects.Update(intField(project, "id"), corestore.Record{"latestDeployments": latest, "targets": targets})
+}
+
+func targetKey(target string) string {
+	switch target {
+	case "production", "staging":
+		return target
+	default:
+		return "preview"
+	}
+}
+
+func (s *Service) insertDeploymentEvent(dep corestore.Record, eventType string, text string, date int64, serial string) {
+	s.store.DeploymentEvents.Insert(corestore.Record{
+		"deploymentId": stringField(dep, "uid"),
+		"type":         eventType,
+		"payload":      map[string]any{"text": text},
+		"date":         date,
+		"serial":       serial,
+	})
+}
+
+func (s *Service) insertDeploymentFilesFromBody(dep corestore.Record, raw any) {
+	files, ok := raw.([]any)
+	if !ok {
+		return
+	}
+	for _, item := range files {
+		file, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		filePath := stringValue(file["file"])
+		sha := stringValue(file["sha"])
+		if filePath == "" || sha == "" {
+			continue
+		}
+		size := 0
+		if number, ok := numberToInt(file["size"]); ok {
+			size = number
+		}
+		if firstRecord(s.store.Files.FindBy("digest", sha)) == nil {
+			s.store.Files.Insert(corestore.Record{
+				"digest":      sha,
+				"size":        size,
+				"contentType": "application/octet-stream",
+			})
+		}
+		s.store.DeploymentFiles.Insert(corestore.Record{
+			"deploymentId": stringField(dep, "uid"),
+			"name":         filePath,
+			"type":         "file",
+			"uid":          generateUID("f"),
+			"children":     []string{},
+			"contentType":  "application/octet-stream",
+			"mode":         0o644,
+			"size":         size,
+		})
+	}
+}
+
+func (s *Service) deleteDeploymentCascade(dep corestore.Record) {
+	uid := stringField(dep, "uid")
+	for _, row := range s.store.Builds.FindBy("deploymentId", uid) {
+		s.store.Builds.Delete(intField(row, "id"))
+	}
+	for _, row := range s.store.DeploymentEvents.FindBy("deploymentId", uid) {
+		s.store.DeploymentEvents.Delete(intField(row, "id"))
+	}
+	for _, row := range s.store.DeploymentFiles.FindBy("deploymentId", uid) {
+		s.store.DeploymentFiles.Delete(intField(row, "id"))
+	}
+	for _, row := range s.store.DeploymentAliases.FindBy("deploymentId", uid) {
+		s.store.DeploymentAliases.Delete(intField(row, "id"))
+	}
+	s.store.Deployments.Delete(intField(dep, "id"))
+	project := firstRecord(s.store.Projects.FindBy("uid", stringField(dep, "projectId")))
+	if project == nil {
+		return
+	}
+	latest := []any{}
+	for _, raw := range anySlice(project["latestDeployments"]) {
+		row, ok := raw.(map[string]any)
+		if !ok || stringValue(row["id"]) == uid {
+			continue
+		}
+		latest = append(latest, row)
+	}
+	targets := map[string]any{}
+	if existing, ok := project["targets"].(map[string]any); ok {
+		for key, value := range existing {
+			row, ok := value.(map[string]any)
+			if ok && stringValue(row["id"]) == uid {
+				continue
+			}
+			targets[key] = value
+		}
+	}
+	s.store.Projects.Update(intField(project, "id"), corestore.Record{"latestDeployments": latest, "targets": targets})
+}
+
+func buildFileTree(rows []corestore.Record) []map[string]any {
+	root := map[string]any{
+		"uid":         generateUID("file"),
+		"name":        "/",
+		"type":        "directory",
+		"mode":        0o40755,
+		"size":        0,
+		"contentType": nil,
+		"children":    []any{},
+	}
+	if len(rows) == 0 {
+		return []map[string]any{root}
+	}
+	children := root["children"].([]any)
+	for _, row := range rows {
+		if stringField(row, "type") != "file" {
+			continue
+		}
+		parts := strings.Split(strings.Trim(stringField(row, "name"), "/"), "/")
+		if len(parts) == 0 || parts[0] == "" {
+			continue
+		}
+		children = append(children, map[string]any{
+			"uid":         stringField(row, "uid"),
+			"name":        parts[len(parts)-1],
+			"type":        "file",
+			"mode":        intField(row, "mode"),
+			"size":        intField(row, "size"),
+			"contentType": row["contentType"],
+			"children":    []any{},
+		})
+	}
+	root["children"] = children
+	return []map[string]any{root}
+}
+
+func anySlice(raw any) []any {
+	if raw == nil {
+		return nil
+	}
+	if value, ok := raw.([]any); ok {
+		return value
+	}
+	if values, ok := raw.([]map[string]any); ok {
+		out := make([]any, 0, len(values))
+		for _, value := range values {
+			out = append(out, value)
+		}
+		return out
+	}
+	return nil
+}

--- a/internal/services/vercel/routes_deployments.go
+++ b/internal/services/vercel/routes_deployments.go
@@ -518,19 +518,10 @@ func (s *Service) deleteDeploymentCascade(dep corestore.Record) {
 }
 
 func buildFileTree(rows []corestore.Record) []map[string]any {
-	root := map[string]any{
-		"uid":         generateUID("file"),
-		"name":        "/",
-		"type":        "directory",
-		"mode":        0o40755,
-		"size":        0,
-		"contentType": nil,
-		"children":    []any{},
-	}
+	root := fileTreeDirectory("/")
 	if len(rows) == 0 {
 		return []map[string]any{root}
 	}
-	children := root["children"].([]any)
 	for _, row := range rows {
 		if stringField(row, "type") != "file" {
 			continue
@@ -539,6 +530,11 @@ func buildFileTree(rows []corestore.Record) []map[string]any {
 		if len(parts) == 0 || parts[0] == "" {
 			continue
 		}
+		current := root
+		for _, part := range parts[:len(parts)-1] {
+			current = fileTreeChildDirectory(current, part)
+		}
+		children := current["children"].([]any)
 		children = append(children, map[string]any{
 			"uid":         stringField(row, "uid"),
 			"name":        parts[len(parts)-1],
@@ -548,9 +544,34 @@ func buildFileTree(rows []corestore.Record) []map[string]any {
 			"contentType": row["contentType"],
 			"children":    []any{},
 		})
+		current["children"] = children
 	}
-	root["children"] = children
 	return []map[string]any{root}
+}
+
+func fileTreeDirectory(name string) map[string]any {
+	return map[string]any{
+		"uid":         generateUID("file"),
+		"name":        name,
+		"type":        "directory",
+		"mode":        0o40755,
+		"size":        0,
+		"contentType": nil,
+		"children":    []any{},
+	}
+}
+
+func fileTreeChildDirectory(parent map[string]any, name string) map[string]any {
+	children := parent["children"].([]any)
+	for _, child := range children {
+		node, ok := child.(map[string]any)
+		if ok && stringValue(node["name"]) == name && stringValue(node["type"]) == "directory" {
+			return node
+		}
+	}
+	node := fileTreeDirectory(name)
+	parent["children"] = append(children, node)
+	return node
 }
 
 func anySlice(raw any) []any {

--- a/internal/services/vercel/routes_deployments.go
+++ b/internal/services/vercel/routes_deployments.go
@@ -313,7 +313,14 @@ func (s *Service) registerDeploymentRoutes(router *corehttp.Router) {
 			return
 		}
 		size := 0
-		if raw := c.Header("Content-Length"); raw != "" {
+		maxInt := int(^uint(0) >> 1)
+		if c.Request.ContentLength > 0 {
+			if c.Request.ContentLength > int64(maxInt) {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid Content-Length")
+				return
+			}
+			size = int(c.Request.ContentLength)
+		} else if raw := c.Header("Content-Length"); raw != "" {
 			parsed, err := strconv.Atoi(raw)
 			if err != nil || parsed < 0 {
 				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid Content-Length")

--- a/internal/services/vercel/routes_domains.go
+++ b/internal/services/vercel/routes_domains.go
@@ -1,0 +1,312 @@
+package vercel
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerDomainRoutes(router *corehttp.Router) {
+	router.Post("/v10/projects/:idOrName/domains", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		nameRaw := strings.TrimSpace(stringValue(body["name"]))
+		if nameRaw == "" {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Missing required field: name")
+			return
+		}
+		name := normalizeDomainName(nameRaw)
+		if s.findDomainInProject(stringField(project, "uid"), name) != nil {
+			writeVercelError(c, http.StatusConflict, "domain_already_exists", "A domain with this name already exists on the project")
+			return
+		}
+		redirect := parseNullableTrimmedString(body["redirect"])
+		redirectStatusCode, valid := parseRedirectStatusCode(body["redirectStatusCode"])
+		if !valid {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid redirectStatusCode")
+			return
+		}
+		gitBranch := parseNullableString(body["gitBranch"])
+		customEnvironmentID := parseNullableString(body["customEnvironmentId"])
+		uid := generateUID("")
+		verified := isVercelAppDomain(name)
+		verification := []any{}
+		if !verified {
+			apex := extractApexName(name)
+			verification = append(verification, map[string]any{
+				"type":   "TXT",
+				"domain": "_vercel." + apex,
+				"value":  "vc-domain-verify=" + name + "," + uid,
+				"reason": "Add the TXT record above to verify domain ownership",
+			})
+		}
+		domain := s.store.Domains.Insert(corestore.Record{
+			"uid":                 uid,
+			"projectId":           stringField(project, "uid"),
+			"name":                name,
+			"apexName":            extractApexName(name),
+			"redirect":            redirect,
+			"redirectStatusCode":  redirectStatusCode,
+			"gitBranch":           gitBranch,
+			"customEnvironmentId": customEnvironmentID,
+			"verified":            verified,
+			"verification":        verification,
+		})
+		c.JSON(http.StatusOK, formatDomain(domain))
+	})
+
+	router.Get("/v9/projects/:idOrName/domains", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		list := s.store.Domains.FindBy("projectId", stringField(project, "uid"))
+		items, page := applyPagination(list, parsePagination(c))
+		out := make([]map[string]any, 0, len(items))
+		for _, domain := range items {
+			out = append(out, formatDomain(domain))
+		}
+		c.JSON(http.StatusOK, map[string]any{"domains": out, "pagination": page})
+	})
+
+	router.Get("/v9/projects/:idOrName/domains/:domain", func(c *corehttp.Context) {
+		s.handleGetDomain(c)
+	})
+	router.Post("/v9/projects/:idOrName/domains/:domain/verify", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		existing := s.findDomainInProject(stringField(project, "uid"), decodeDomainParam(c.Param("domain")))
+		if existing == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Domain not found")
+			return
+		}
+		updated, ok := s.store.Domains.Update(intField(existing, "id"), corestore.Record{"verified": true, "verification": []any{}})
+		if !ok {
+			writeVercelError(c, http.StatusInternalServerError, "internal_error", "Failed to update domain")
+			return
+		}
+		c.JSON(http.StatusOK, formatDomain(updated))
+	})
+	router.Patch("/v9/projects/:idOrName/domains/:domain", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		existing := s.findDomainInProject(stringField(project, "uid"), decodeDomainParam(c.Param("domain")))
+		if existing == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Domain not found")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		patch := corestore.Record{}
+		if value, exists := body["gitBranch"]; exists {
+			patch["gitBranch"] = parseNullableString(value)
+		}
+		if value, exists := body["redirect"]; exists {
+			patch["redirect"] = parseNullableTrimmedString(value)
+		}
+		if value, exists := body["redirectStatusCode"]; exists {
+			code, valid := parseRedirectStatusCode(value)
+			if !valid {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid redirectStatusCode")
+				return
+			}
+			patch["redirectStatusCode"] = code
+		}
+		if value, exists := body["customEnvironmentId"]; exists {
+			patch["customEnvironmentId"] = parseNullableString(value)
+		}
+		updated, ok := s.store.Domains.Update(intField(existing, "id"), patch)
+		if !ok {
+			writeVercelError(c, http.StatusInternalServerError, "internal_error", "Failed to update domain")
+			return
+		}
+		c.JSON(http.StatusOK, formatDomain(updated))
+	})
+	router.Delete("/v9/projects/:idOrName/domains/:domain", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		existing := s.findDomainInProject(stringField(project, "uid"), decodeDomainParam(c.Param("domain")))
+		if existing == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Domain not found")
+			return
+		}
+		s.store.Domains.Delete(intField(existing, "id"))
+		c.JSON(http.StatusOK, map[string]any{})
+	})
+}
+
+func (s *Service) handleGetDomain(c *corehttp.Context) {
+	scoped, ok := s.resolveScope(c)
+	if !ok {
+		writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+		return
+	}
+	project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+	if project == nil {
+		writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+		return
+	}
+	existing := s.findDomainInProject(stringField(project, "uid"), decodeDomainParam(c.Param("domain")))
+	if existing == nil {
+		writeVercelError(c, http.StatusNotFound, "not_found", "Domain not found")
+		return
+	}
+	c.JSON(http.StatusOK, formatDomain(existing))
+}
+
+func extractApexName(domain string) string {
+	parts := strings.Split(strings.ToLower(domain), ".")
+	compact := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			compact = append(compact, part)
+		}
+	}
+	if len(compact) == 0 {
+		return domain
+	}
+	if len(compact) == 1 {
+		return compact[0]
+	}
+	return compact[len(compact)-2] + "." + compact[len(compact)-1]
+}
+
+func isVercelAppDomain(domain string) bool {
+	domain = strings.ToLower(domain)
+	return domain == "vercel.app" || strings.HasSuffix(domain, ".vercel.app")
+}
+
+func normalizeDomainName(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func parseRedirectStatusCode(raw any) (any, bool) {
+	if raw == nil {
+		return nil, true
+	}
+	number, ok := numberToInt(raw)
+	if !ok {
+		return nil, false
+	}
+	switch number {
+	case 301, 302, 307, 308:
+		return number, true
+	default:
+		return nil, false
+	}
+}
+
+func numberToInt(raw any) (int, bool) {
+	switch value := raw.(type) {
+	case int:
+		return value, true
+	case float64:
+		next := int(value)
+		return next, float64(next) == value
+	default:
+		return 0, false
+	}
+}
+
+func (s *Service) findDomainInProject(projectID string, domainName string) corestore.Record {
+	normalized := normalizeDomainName(domainName)
+	for _, domain := range s.store.Domains.FindBy("projectId", projectID) {
+		if normalizeDomainName(stringField(domain, "name")) == normalized {
+			return domain
+		}
+	}
+	return nil
+}
+
+func decodeDomainParam(raw string) string {
+	decoded, err := url.QueryUnescape(raw)
+	if err != nil {
+		return raw
+	}
+	return decoded
+}
+
+func parseNullableString(raw any) any {
+	if raw == nil {
+		return nil
+	}
+	if str, ok := raw.(string); ok {
+		return str
+	}
+	return nil
+}
+
+func parseNullableTrimmedString(raw any) any {
+	if raw == nil {
+		return nil
+	}
+	if str, ok := raw.(string); ok {
+		str = strings.TrimSpace(str)
+		if str == "" {
+			return nil
+		}
+		return str
+	}
+	return nil
+}

--- a/internal/services/vercel/routes_domains.go
+++ b/internal/services/vercel/routes_domains.go
@@ -149,10 +149,10 @@ func (s *Service) registerDomainRoutes(router *corehttp.Router) {
 		}
 		patch := corestore.Record{}
 		if value, exists := body["gitBranch"]; exists {
-			patch["gitBranch"] = parseNullableString(value)
+			patch["gitBranch"] = parseNullableStringPatch(value, existing["gitBranch"])
 		}
 		if value, exists := body["redirect"]; exists {
-			patch["redirect"] = parseNullableTrimmedString(value)
+			patch["redirect"] = parseNullableTrimmedStringPatch(value, existing["redirect"])
 		}
 		if value, exists := body["redirectStatusCode"]; exists {
 			code, valid := parseRedirectStatusCode(value)
@@ -163,7 +163,7 @@ func (s *Service) registerDomainRoutes(router *corehttp.Router) {
 			patch["redirectStatusCode"] = code
 		}
 		if value, exists := body["customEnvironmentId"]; exists {
-			patch["customEnvironmentId"] = parseNullableString(value)
+			patch["customEnvironmentId"] = parseNullableStringPatch(value, existing["customEnvironmentId"])
 		}
 		updated, ok := s.store.Domains.Update(intField(existing, "id"), patch)
 		if !ok {
@@ -309,4 +309,28 @@ func parseNullableTrimmedString(raw any) any {
 		return str
 	}
 	return nil
+}
+
+func parseNullableStringPatch(raw any, existing any) any {
+	if raw == nil {
+		return nil
+	}
+	if str, ok := raw.(string); ok {
+		return str
+	}
+	return existing
+}
+
+func parseNullableTrimmedStringPatch(raw any, existing any) any {
+	if raw == nil {
+		return nil
+	}
+	if str, ok := raw.(string); ok {
+		str = strings.TrimSpace(str)
+		if str == "" {
+			return nil
+		}
+		return str
+	}
+	return existing
 }

--- a/internal/services/vercel/routes_env.go
+++ b/internal/services/vercel/routes_env.go
@@ -1,0 +1,419 @@
+package vercel
+
+import (
+	"fmt"
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerEnvRoutes(router *corehttp.Router) {
+	router.Get("/v10/projects/:idOrName/env", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		list := s.store.EnvVars.FindBy("projectId", stringField(project, "uid"))
+		list = filterEnvVarsByQuery(list, c)
+		items, page := applyPagination(list, parsePagination(c))
+		decrypt := parseQueryBool(c.Query("decrypt"))
+		out := make([]map[string]any, 0, len(items))
+		for _, env := range items {
+			out = append(out, formatEnvVar(env, decrypt))
+		}
+		c.JSON(http.StatusOK, map[string]any{"envs": out, "pagination": page})
+	})
+
+	router.Post("/v10/projects/:idOrName/env", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		raw, err := parseAnyJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		rows, ok := envBodyRows(raw)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		upsert := parseQueryBool(c.Query("upsert"))
+		created := make([]corestore.Record, 0, len(rows))
+		pending := make([]corestore.Record, 0)
+		for _, body := range rows {
+			row, message := parseEnvRow(body)
+			if message != "" {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", message)
+				return
+			}
+			existingDB := s.findEnvByKeyAndTargetsOverlap(stringField(project, "uid"), stringField(row, "key"), stringSliceValue(row["target"]), 0)
+			existingPending := findPendingEnvByKeyAndTargets(pending, stringField(row, "key"), stringSliceValue(row["target"]))
+			if upsert {
+				toUpdate := existingDB
+				if toUpdate == nil {
+					toUpdate = existingPending
+				}
+				if toUpdate != nil {
+					updated, ok := s.store.EnvVars.Update(intField(toUpdate, "id"), corestore.Record{
+						"key":                  row["key"],
+						"value":                row["value"],
+						"type":                 row["type"],
+						"target":               row["target"],
+						"gitBranch":            row["gitBranch"],
+						"customEnvironmentIds": row["customEnvironmentIds"],
+						"comment":              row["comment"],
+					})
+					if !ok {
+						writeVercelError(c, http.StatusInternalServerError, "internal_error", "Failed to update environment variable")
+						return
+					}
+					pending = upsertPendingEnv(pending, updated)
+					created = append(created, updated)
+					continue
+				}
+			} else if existingDB != nil || existingPending != nil {
+				writeVercelError(c, http.StatusConflict, "env_already_exists", fmt.Sprintf("An environment variable with key %q and overlapping targets already exists", stringField(row, "key")))
+				return
+			}
+			inserted := s.store.EnvVars.Insert(corestore.Record{
+				"uid":                  generateUID("env"),
+				"projectId":            stringField(project, "uid"),
+				"key":                  row["key"],
+				"value":                row["value"],
+				"type":                 row["type"],
+				"target":               row["target"],
+				"gitBranch":            row["gitBranch"],
+				"customEnvironmentIds": row["customEnvironmentIds"],
+				"comment":              row["comment"],
+				"decrypted":            false,
+			})
+			pending = append(pending, inserted)
+			created = append(created, inserted)
+		}
+		out := make([]map[string]any, 0, len(created))
+		for _, env := range created {
+			out = append(out, formatEnvVar(env, true))
+		}
+		c.JSON(http.StatusOK, map[string]any{"envs": out})
+	})
+
+	router.Get("/v10/projects/:idOrName/env/:id", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		env := s.findEnvByUIDInProject(stringField(project, "uid"), c.Param("id"))
+		if env == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Environment variable not found")
+			return
+		}
+		c.JSON(http.StatusOK, formatEnvVar(env, parseQueryBool(c.Query("decrypt"))))
+	})
+
+	router.Patch("/v9/projects/:idOrName/env/:id", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		existing := s.findEnvByUIDInProject(stringField(project, "uid"), c.Param("id"))
+		if existing == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Environment variable not found")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		patch := corestore.Record{}
+		if value, exists := body["key"]; exists {
+			key, ok := value.(string)
+			if !ok || key == "" {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: key must be a non-empty string")
+				return
+			}
+			patch["key"] = key
+		}
+		if value, exists := body["value"]; exists {
+			str, ok := value.(string)
+			if !ok {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: value must be a string")
+				return
+			}
+			patch["value"] = str
+		}
+		if value, exists := body["type"]; exists {
+			envType := stringValue(value)
+			if !validEnvType(envType) {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: type must be one of system, encrypted, plain, secret, sensitive")
+				return
+			}
+			patch["type"] = envType
+		}
+		if value, exists := body["target"]; exists {
+			target := normalizeTargets(stringSliceValue(value))
+			if len(target) == 0 {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: target must be a non-empty array of production, preview, development")
+				return
+			}
+			patch["target"] = target
+		}
+		if value, exists := body["gitBranch"]; exists {
+			if value == nil {
+				patch["gitBranch"] = nil
+			} else if str, ok := value.(string); ok {
+				patch["gitBranch"] = str
+			} else {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: gitBranch must be a string or null")
+				return
+			}
+		}
+		if value, exists := body["customEnvironmentIds"]; exists {
+			ids := stringSliceValue(value)
+			if value != nil && ids == nil {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: customEnvironmentIds must be an array of strings")
+				return
+			}
+			patch["customEnvironmentIds"] = ids
+		}
+		if value, exists := body["comment"]; exists {
+			if value == nil {
+				patch["comment"] = nil
+			} else if str, ok := value.(string); ok {
+				patch["comment"] = str
+			} else {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: comment must be a string or null")
+				return
+			}
+		}
+		nextKey := stringField(existing, "key")
+		if patch["key"] != nil {
+			nextKey = stringValue(patch["key"])
+		}
+		nextTarget := stringSliceValue(existing["target"])
+		if patch["target"] != nil {
+			nextTarget = stringSliceValue(patch["target"])
+		}
+		if conflict := s.findEnvByKeyAndTargetsOverlap(stringField(project, "uid"), nextKey, nextTarget, intField(existing, "id")); conflict != nil {
+			writeVercelError(c, http.StatusConflict, "env_already_exists", fmt.Sprintf("An environment variable with key %q and overlapping targets already exists", nextKey))
+			return
+		}
+		updated, ok := s.store.EnvVars.Update(intField(existing, "id"), patch)
+		if !ok {
+			writeVercelError(c, http.StatusInternalServerError, "internal_error", "Failed to update environment variable")
+			return
+		}
+		c.JSON(http.StatusOK, formatEnvVar(updated, true))
+	})
+
+	router.Delete("/v9/projects/:idOrName/env/:id", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		existing := s.findEnvByUIDInProject(stringField(project, "uid"), c.Param("id"))
+		if existing == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Environment variable not found")
+			return
+		}
+		snapshot := formatEnvVar(existing, true)
+		s.store.EnvVars.Delete(intField(existing, "id"))
+		c.JSON(http.StatusOK, snapshot)
+	})
+}
+
+func envBodyRows(raw any) ([]map[string]any, bool) {
+	if raw == nil {
+		return nil, false
+	}
+	if row, ok := raw.(map[string]any); ok {
+		return []map[string]any{row}, true
+	}
+	if list, ok := raw.([]any); ok {
+		out := make([]map[string]any, 0, len(list))
+		for _, item := range list {
+			row, ok := item.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, row)
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+func parseEnvRow(body map[string]any) (corestore.Record, string) {
+	key, ok := body["key"].(string)
+	if !ok || key == "" {
+		return nil, "Missing required field: key"
+	}
+	value, ok := body["value"].(string)
+	if !ok {
+		if _, exists := body["value"]; !exists {
+			return nil, "Missing required field: value"
+		}
+		return nil, "Invalid value: value must be a string"
+	}
+	envType := stringValue(body["type"])
+	if !validEnvType(envType) {
+		return nil, "Invalid value: type must be one of system, encrypted, plain, secret, sensitive"
+	}
+	target := normalizeTargets(stringSliceValue(body["target"]))
+	if len(target) == 0 {
+		return nil, "Invalid value: target must be a non-empty array of production, preview, development"
+	}
+	customEnvironmentIDs := []string{}
+	if raw, exists := body["customEnvironmentIds"]; exists && raw != nil {
+		customEnvironmentIDs = stringSliceValue(raw)
+		if customEnvironmentIDs == nil {
+			return nil, "Invalid value: customEnvironmentIds must be an array of strings"
+		}
+	}
+	var gitBranch any
+	if raw, exists := body["gitBranch"]; exists {
+		if raw == nil {
+			gitBranch = nil
+		} else if str, ok := raw.(string); ok {
+			gitBranch = str
+		} else {
+			return nil, "Invalid value: gitBranch must be a string or null"
+		}
+	}
+	var comment any
+	if raw, exists := body["comment"]; exists {
+		if raw == nil {
+			comment = nil
+		} else if str, ok := raw.(string); ok {
+			comment = str
+		} else {
+			return nil, "Invalid value: comment must be a string or null"
+		}
+	}
+	return corestore.Record{
+		"key":                  key,
+		"value":                value,
+		"type":                 envType,
+		"target":               target,
+		"gitBranch":            gitBranch,
+		"customEnvironmentIds": customEnvironmentIDs,
+		"comment":              comment,
+		"decrypted":            false,
+	}, ""
+}
+
+func (s *Service) findEnvByUIDInProject(projectID string, uid string) corestore.Record {
+	for _, env := range s.store.EnvVars.FindBy("projectId", projectID) {
+		if stringField(env, "uid") == uid {
+			return env
+		}
+	}
+	return nil
+}
+
+func (s *Service) findEnvByKeyAndTargetsOverlap(projectID string, key string, targets []string, excludeID int) corestore.Record {
+	for _, env := range s.store.EnvVars.FindBy("projectId", projectID) {
+		if stringField(env, "key") != key {
+			continue
+		}
+		if excludeID != 0 && intField(env, "id") == excludeID {
+			continue
+		}
+		if targetsOverlap(stringSliceValue(env["target"]), targets) {
+			return env
+		}
+	}
+	return nil
+}
+
+func findPendingEnvByKeyAndTargets(pending []corestore.Record, key string, targets []string) corestore.Record {
+	for _, env := range pending {
+		if stringField(env, "key") == key && targetsOverlap(stringSliceValue(env["target"]), targets) {
+			return env
+		}
+	}
+	return nil
+}
+
+func upsertPendingEnv(pending []corestore.Record, env corestore.Record) []corestore.Record {
+	for index, item := range pending {
+		if intField(item, "id") == intField(env, "id") {
+			pending[index] = env
+			return pending
+		}
+	}
+	return append(pending, env)
+}
+
+func filterEnvVarsByQuery(input []corestore.Record, c *corehttp.Context) []corestore.Record {
+	out := input
+	if gitBranch := c.Query("gitBranch"); gitBranch != "" {
+		next := out[:0]
+		for _, env := range out {
+			if stringField(env, "gitBranch") == gitBranch {
+				next = append(next, env)
+			}
+		}
+		out = next
+	}
+	for _, queryName := range []string{"customEnvironmentId", "customEnvironmentSlug"} {
+		value := c.Query(queryName)
+		if value == "" {
+			continue
+		}
+		next := out[:0]
+		for _, env := range out {
+			ids := stringSliceValue(env["customEnvironmentIds"])
+			for _, id := range ids {
+				if id == value {
+					next = append(next, env)
+					break
+				}
+			}
+		}
+		out = next
+	}
+	return out
+}

--- a/internal/services/vercel/routes_env.go
+++ b/internal/services/vercel/routes_env.go
@@ -184,8 +184,8 @@ func (s *Service) registerEnvRoutes(router *corehttp.Router) {
 			patch["type"] = envType
 		}
 		if value, exists := body["target"]; exists {
-			target := normalizeTargets(stringSliceValue(value))
-			if len(target) == 0 {
+			target, ok := parseEnvTargets(value)
+			if !ok {
 				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: target must be a non-empty array of production, preview, development")
 				return
 			}
@@ -202,8 +202,8 @@ func (s *Service) registerEnvRoutes(router *corehttp.Router) {
 			}
 		}
 		if value, exists := body["customEnvironmentIds"]; exists {
-			ids := stringSliceValue(value)
-			if value != nil && ids == nil {
+			ids, ok := parseCustomEnvironmentIDs(value)
+			if !ok {
 				writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid value: customEnvironmentIds must be an array of strings")
 				return
 			}
@@ -301,16 +301,17 @@ func parseEnvRow(body map[string]any) (corestore.Record, string) {
 	if !validEnvType(envType) {
 		return nil, "Invalid value: type must be one of system, encrypted, plain, secret, sensitive"
 	}
-	target := normalizeTargets(stringSliceValue(body["target"]))
-	if len(target) == 0 {
+	target, ok := parseEnvTargets(body["target"])
+	if !ok {
 		return nil, "Invalid value: target must be a non-empty array of production, preview, development"
 	}
 	customEnvironmentIDs := []string{}
 	if raw, exists := body["customEnvironmentIds"]; exists && raw != nil {
-		customEnvironmentIDs = stringSliceValue(raw)
-		if customEnvironmentIDs == nil {
+		ids, ok := parseCustomEnvironmentIDs(raw)
+		if !ok {
 			return nil, "Invalid value: customEnvironmentIds must be an array of strings"
 		}
+		customEnvironmentIDs = ids
 	}
 	var gitBranch any
 	if raw, exists := body["gitBranch"]; exists {
@@ -342,6 +343,26 @@ func parseEnvRow(body map[string]any) (corestore.Record, string) {
 		"comment":              comment,
 		"decrypted":            false,
 	}, ""
+}
+
+func parseEnvTargets(raw any) ([]string, bool) {
+	targets, ok := parseStringSliceStrict(raw)
+	if !ok || len(targets) == 0 {
+		return nil, false
+	}
+	for _, target := range targets {
+		if !validTarget(target) {
+			return nil, false
+		}
+	}
+	return targets, true
+}
+
+func parseCustomEnvironmentIDs(raw any) ([]string, bool) {
+	if raw == nil {
+		return []string{}, true
+	}
+	return parseStringSliceStrict(raw)
 }
 
 func (s *Service) findEnvByUIDInProject(projectID string, uid string) corestore.Record {

--- a/internal/services/vercel/routes_oauth.go
+++ b/internal/services/vercel/routes_oauth.go
@@ -81,7 +81,6 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid form body")
 			return
 		}
-		code := generateHex(20)
 		pending := pendingCode{
 			Username:            c.Request.Form.Get("username"),
 			Scope:               c.Request.Form.Get("scope"),
@@ -91,12 +90,24 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 			CodeChallengeMethod: c.Request.Form.Get("code_challenge_method"),
 			CreatedAt:           time.Now(),
 		}
-		s.storePendingCode(code, pending)
+		if len(s.store.Integrations.All()) > 0 {
+			integration := firstRecord(s.store.Integrations.FindBy("client_id", pending.ClientID))
+			if integration == nil {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Application not found")
+				return
+			}
+			if pending.RedirectURI != "" && !matchesRedirectURI(pending.RedirectURI, stringSliceValue(integration["redirect_uris"])) {
+				writeVercelError(c, http.StatusBadRequest, "bad_request", "Redirect URI mismatch")
+				return
+			}
+		}
 		redirectTarget, err := url.Parse(pending.RedirectURI)
 		if err != nil || redirectTarget == nil {
 			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid redirect_uri")
 			return
 		}
+		code := generateHex(20)
+		s.storePendingCode(code, pending)
 		query := redirectTarget.Query()
 		query.Set("code", code)
 		if state := c.Request.Form.Get("state"); state != "" {
@@ -134,6 +145,11 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 		if time.Since(pending.CreatedAt) > pendingCodeTTL {
 			s.deletePendingCode(code)
 			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The code passed is incorrect or expired."})
+			return
+		}
+		if pending.ClientID != "" && clientID != "" && pending.ClientID != clientID {
+			s.deletePendingCode(code)
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The client_id does not match the one used during authorization."})
 			return
 		}
 		if redirectURI != "" && pending.RedirectURI != "" && redirectURI != pending.RedirectURI {

--- a/internal/services/vercel/routes_oauth.go
+++ b/internal/services/vercel/routes_oauth.go
@@ -1,0 +1,225 @@
+package vercel
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+const pendingCodeTTL = 10 * time.Minute
+
+func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
+	router.Get("/oauth/authorize", func(c *corehttp.Context) {
+		clientID := c.Query("client_id")
+		redirectURI := c.Query("redirect_uri")
+		scope := c.Query("scope")
+		state := c.Query("state")
+		codeChallenge := c.Query("code_challenge")
+		codeChallengeMethod := c.Query("code_challenge_method")
+
+		integrations := s.store.Integrations.All()
+		integrationName := ""
+		if len(integrations) > 0 {
+			integration := firstRecord(s.store.Integrations.FindBy("client_id", clientID))
+			if integration == nil {
+				c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+				return
+			}
+			if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(integration["redirect_uris"])) {
+				c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+				return
+			}
+			integrationName = stringField(integration, "name")
+		}
+
+		subtitle := "Choose a seeded user to continue."
+		if integrationName != "" {
+			subtitle = "Authorize <strong>" + ui.EscapeHTML(integrationName) + "</strong> to access your account."
+		}
+		var body strings.Builder
+		users := s.store.Users.All()
+		if len(users) == 0 {
+			body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+		} else {
+			for _, user := range users {
+				formatted := formatUser(user)
+				username := stringValue(formatted["username"])
+				letter := "?"
+				if username != "" {
+					letter = strings.ToUpper(username[:1])
+				}
+				body.WriteString(ui.RenderUserButton(ui.UserButtonOptions{
+					Letter:     letter,
+					Login:      username,
+					Name:       stringValue(formatted["name"]),
+					Email:      stringValue(formatted["email"]),
+					FormAction: "/oauth/authorize/callback",
+					HiddenFields: map[string]string{
+						"username":              username,
+						"redirect_uri":          redirectURI,
+						"scope":                 scope,
+						"state":                 state,
+						"client_id":             clientID,
+						"code_challenge":        codeChallenge,
+						"code_challenge_method": codeChallengeMethod,
+					},
+				}))
+			}
+		}
+		c.HTML(http.StatusOK, ui.RenderCardPage("Sign in to Vercel", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+	})
+
+	router.Post("/oauth/authorize/callback", func(c *corehttp.Context) {
+		if err := c.Request.ParseForm(); err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid form body")
+			return
+		}
+		code := generateHex(20)
+		pending := pendingCode{
+			Username:            c.Request.Form.Get("username"),
+			Scope:               c.Request.Form.Get("scope"),
+			RedirectURI:         c.Request.Form.Get("redirect_uri"),
+			ClientID:            c.Request.Form.Get("client_id"),
+			CodeChallenge:       c.Request.Form.Get("code_challenge"),
+			CodeChallengeMethod: c.Request.Form.Get("code_challenge_method"),
+			CreatedAt:           time.Now(),
+		}
+		s.mu.Lock()
+		s.codes[code] = pending
+		s.mu.Unlock()
+		redirectTarget, err := url.Parse(pending.RedirectURI)
+		if err != nil || redirectTarget == nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid redirect_uri")
+			return
+		}
+		query := redirectTarget.Query()
+		query.Set("code", code)
+		if state := c.Request.Form.Get("state"); state != "" {
+			query.Set("state", state)
+		}
+		redirectTarget.RawQuery = query.Encode()
+		c.Redirect(http.StatusFound, redirectTarget.String())
+	})
+
+	router.Post("/login/oauth/token", func(c *corehttp.Context) {
+		body, err := parseOAuthTokenBody(c.Request)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_request", "error_description": "Invalid request body."})
+			return
+		}
+		code := stringValue(body["code"])
+		redirectURI := stringValue(body["redirect_uri"])
+		codeVerifier := stringValue(body["code_verifier"])
+		clientID := stringValue(body["client_id"])
+		clientSecret := stringValue(body["client_secret"])
+
+		if len(s.store.Integrations.All()) > 0 {
+			integration := firstRecord(s.store.Integrations.FindBy("client_id", clientID))
+			if integration == nil || !constantTimeEqual(clientSecret, stringField(integration, "client_secret")) {
+				c.JSON(http.StatusUnauthorized, map[string]any{"error": "invalid_client", "error_description": "The client_id and/or client_secret passed are incorrect."})
+				return
+			}
+		}
+
+		s.mu.Lock()
+		pending, ok := s.codes[code]
+		s.mu.Unlock()
+		if !ok {
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The code passed is incorrect or expired."})
+			return
+		}
+		if time.Since(pending.CreatedAt) > pendingCodeTTL {
+			s.mu.Lock()
+			delete(s.codes, code)
+			s.mu.Unlock()
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The code passed is incorrect or expired."})
+			return
+		}
+		if redirectURI != "" && pending.RedirectURI != "" && redirectURI != pending.RedirectURI {
+			s.mu.Lock()
+			delete(s.codes, code)
+			s.mu.Unlock()
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The redirect_uri does not match the one used during authorization."})
+			return
+		}
+		if pending.CodeChallenge != "" && !verifyPKCE(pending, codeVerifier) {
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "PKCE verification failed."})
+			return
+		}
+		user := firstRecord(s.store.Users.FindBy("username", pending.Username))
+		if user == nil {
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The user associated with this code was not found."})
+			return
+		}
+		token := "vercel_" + generateSecret()
+		s.mu.Lock()
+		delete(s.codes, code)
+		s.tokenMap[token] = stringField(user, "username")
+		s.mu.Unlock()
+		c.JSON(http.StatusOK, map[string]any{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"scope":        pending.Scope,
+		})
+	})
+
+	router.Get("/login/oauth/userinfo", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, map[string]any{
+			"sub":                stringField(user, "uid"),
+			"email":              stringField(user, "email"),
+			"name":               user["name"],
+			"preferred_username": stringField(user, "username"),
+			"email_verified":     true,
+			"picture":            user["avatar"],
+		})
+	})
+}
+
+func parseOAuthTokenBody(req *http.Request) (map[string]any, error) {
+	defer req.Body.Close()
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	contentType := req.Header.Get("Content-Type")
+	if strings.Contains(contentType, "application/json") {
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			return map[string]any{}, nil
+		}
+		return body, nil
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return nil, err
+	}
+	body := make(map[string]any, len(values))
+	for key := range values {
+		body[key] = values.Get(key)
+	}
+	return body, nil
+}
+
+func verifyPKCE(pending pendingCode, verifier string) bool {
+	if verifier == "" {
+		return false
+	}
+	method := strings.ToLower(pending.CodeChallengeMethod)
+	if method == "" || method == "plain" {
+		return verifier == pending.CodeChallenge
+	}
+	if method == "s256" {
+		return encodePKCES256(verifier) == pending.CodeChallenge
+	}
+	return false
+}

--- a/internal/services/vercel/routes_oauth.go
+++ b/internal/services/vercel/routes_oauth.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/core/ui"
 )
 
@@ -90,9 +91,7 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 			CodeChallengeMethod: c.Request.Form.Get("code_challenge_method"),
 			CreatedAt:           time.Now(),
 		}
-		s.mu.Lock()
-		s.codes[code] = pending
-		s.mu.Unlock()
+		s.storePendingCode(code, pending)
 		redirectTarget, err := url.Parse(pending.RedirectURI)
 		if err != nil || redirectTarget == nil {
 			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid redirect_uri")
@@ -127,24 +126,18 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 			}
 		}
 
-		s.mu.Lock()
-		pending, ok := s.codes[code]
-		s.mu.Unlock()
+		pending, ok := s.pendingCode(code)
 		if !ok {
 			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The code passed is incorrect or expired."})
 			return
 		}
 		if time.Since(pending.CreatedAt) > pendingCodeTTL {
-			s.mu.Lock()
-			delete(s.codes, code)
-			s.mu.Unlock()
+			s.deletePendingCode(code)
 			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The code passed is incorrect or expired."})
 			return
 		}
 		if redirectURI != "" && pending.RedirectURI != "" && redirectURI != pending.RedirectURI {
-			s.mu.Lock()
-			delete(s.codes, code)
-			s.mu.Unlock()
+			s.deletePendingCode(code)
 			c.JSON(http.StatusBadRequest, map[string]any{"error": "invalid_grant", "error_description": "The redirect_uri does not match the one used during authorization."})
 			return
 		}
@@ -158,10 +151,8 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 			return
 		}
 		token := "vercel_" + generateSecret()
-		s.mu.Lock()
-		delete(s.codes, code)
-		s.tokenMap[token] = stringField(user, "username")
-		s.mu.Unlock()
+		s.deletePendingCode(code)
+		s.storeOAuthToken(token, stringField(user, "username"), pending.Scope)
 		c.JSON(http.StatusOK, map[string]any{
 			"access_token": token,
 			"token_type":   "Bearer",
@@ -182,6 +173,53 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 			"email_verified":     true,
 			"picture":            user["avatar"],
 		})
+	})
+}
+
+func (s *Service) storePendingCode(code string, pending pendingCode) {
+	s.store.OAuthCodes.Insert(corestore.Record{
+		"code":                code,
+		"username":            pending.Username,
+		"scope":               pending.Scope,
+		"redirectURI":         pending.RedirectURI,
+		"clientID":            pending.ClientID,
+		"codeChallenge":       pending.CodeChallenge,
+		"codeChallengeMethod": pending.CodeChallengeMethod,
+		"createdAt":           pending.CreatedAt.UnixMilli(),
+	})
+}
+
+func (s *Service) pendingCode(code string) (pendingCode, bool) {
+	row := firstRecord(s.store.OAuthCodes.FindBy("code", code))
+	if row == nil {
+		return pendingCode{}, false
+	}
+	createdMillis := timeMillis(row["createdAt"])
+	if createdMillis == 0 {
+		createdMillis = timeMillis(row["created_at"])
+	}
+	return pendingCode{
+		Username:            stringField(row, "username"),
+		Scope:               stringField(row, "scope"),
+		RedirectURI:         stringField(row, "redirectURI"),
+		ClientID:            stringField(row, "clientID"),
+		CodeChallenge:       stringField(row, "codeChallenge"),
+		CodeChallengeMethod: stringField(row, "codeChallengeMethod"),
+		CreatedAt:           time.UnixMilli(createdMillis),
+	}, true
+}
+
+func (s *Service) deletePendingCode(code string) {
+	for _, row := range s.store.OAuthCodes.FindBy("code", code) {
+		s.store.OAuthCodes.Delete(intField(row, "id"))
+	}
+}
+
+func (s *Service) storeOAuthToken(token string, username string, scope string) {
+	s.store.OAuthTokens.Insert(corestore.Record{
+		"tokenString": token,
+		"username":    username,
+		"scope":       scope,
 	})
 }
 

--- a/internal/services/vercel/routes_projects.go
+++ b/internal/services/vercel/routes_projects.go
@@ -338,6 +338,10 @@ func (s *Service) insertProjectEnvFromBody(project corestore.Record, raw any) {
 		if len(target) == 0 {
 			target = []string{"production", "preview", "development"}
 		}
+		customEnvironmentIDs := []string{}
+		if ids, ok := parseStringSliceStrict(env["customEnvironmentIds"]); ok {
+			customEnvironmentIDs = ids
+		}
 		s.store.EnvVars.Insert(corestore.Record{
 			"uid":                  generateUID("env"),
 			"projectId":            stringField(project, "uid"),
@@ -346,7 +350,7 @@ func (s *Service) insertProjectEnvFromBody(project corestore.Record, raw any) {
 			"type":                 envType,
 			"target":               target,
 			"gitBranch":            nullableString(stringValue(env["gitBranch"])),
-			"customEnvironmentIds": stringSliceValue(env["customEnvironmentIds"]),
+			"customEnvironmentIds": customEnvironmentIDs,
 			"comment":              nullableString(stringValue(env["comment"])),
 			"decrypted":            false,
 		})

--- a/internal/services/vercel/routes_projects.go
+++ b/internal/services/vercel/routes_projects.go
@@ -1,0 +1,416 @@
+package vercel
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerProjectRoutes(router *corehttp.Router) {
+	router.Post("/v11/projects", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		name := strings.TrimSpace(stringValue(body["name"]))
+		if name == "" {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Missing required field: name")
+			return
+		}
+		if s.lookupProject(name, scoped.AccountID) != nil {
+			writeVercelError(c, http.StatusConflict, "project_already_exists", "A project with this name already exists")
+			return
+		}
+		project := defaultProjectRecord(name, scoped.AccountID)
+		copyStringPatch(body, project, "framework")
+		copyStringPatch(body, project, "buildCommand")
+		copyStringPatch(body, project, "devCommand")
+		copyStringPatch(body, project, "installCommand")
+		copyStringPatch(body, project, "outputDirectory")
+		copyStringPatch(body, project, "rootDirectory")
+		if nodeVersion, ok := body["nodeVersion"].(string); ok {
+			project["nodeVersion"] = nodeVersion
+		}
+		if region, ok := body["serverlessFunctionRegion"].(string); ok {
+			project["serverlessFunctionRegion"] = region
+		}
+		if publicSource, ok := body["publicSource"].(bool); ok {
+			project["publicSource"] = publicSource
+		}
+		project["link"] = parseGitLink(body)
+		inserted := s.store.Projects.Insert(project)
+		s.insertProjectEnvFromBody(inserted, body["environmentVariables"])
+		c.JSON(http.StatusOK, formatProject(inserted, s.baseURL))
+	})
+
+	router.Get("/v10/projects", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		search := strings.ToLower(strings.TrimSpace(c.Query("search")))
+		projects := make([]corestore.Record, 0)
+		for _, project := range s.store.Projects.All() {
+			if stringField(project, "accountId") != scoped.AccountID {
+				continue
+			}
+			if search != "" && !strings.Contains(strings.ToLower(stringField(project, "name")), search) {
+				continue
+			}
+			projects = append(projects, project)
+		}
+		items, page := applyPagination(projects, parsePagination(c))
+		out := make([]map[string]any, 0, len(items))
+		for _, project := range items {
+			out = append(out, formatProject(project, s.baseURL))
+		}
+		c.JSON(http.StatusOK, map[string]any{"projects": out, "pagination": page})
+	})
+
+	router.Get("/v9/projects/:idOrName", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		out := formatProject(project, s.baseURL)
+		envs := s.store.EnvVars.FindBy("projectId", stringField(project, "uid"))
+		formatted := make([]map[string]any, 0, len(envs))
+		for _, env := range envs {
+			formatted = append(formatted, formatEnvVar(env, false))
+		}
+		out["env"] = formatted
+		c.JSON(http.StatusOK, out)
+	})
+
+	router.Patch("/v9/projects/:idOrName", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		patch := corestore.Record{}
+		copyTrimmedNamePatch(body, patch)
+		copyNullableStringPatch(body, patch, project, "buildCommand")
+		copyNullableStringPatch(body, patch, project, "devCommand")
+		copyNullableStringPatch(body, patch, project, "installCommand")
+		copyNullableStringPatch(body, patch, project, "outputDirectory")
+		copyNullableStringPatch(body, patch, project, "framework")
+		copyNullableStringPatch(body, patch, project, "rootDirectory")
+		copyNullableStringPatch(body, patch, project, "serverlessFunctionRegion")
+		copyNullableStringPatch(body, patch, project, "commandForIgnoringBuildStep")
+		for _, key := range []string{"gitForkProtection", "publicSource", "autoAssignCustomDomains"} {
+			if value, ok := body[key].(bool); ok {
+				patch[key] = value
+			}
+		}
+		if nodeVersion, ok := body["nodeVersion"].(string); ok {
+			patch["nodeVersion"] = nodeVersion
+		}
+		updated, ok := s.store.Projects.Update(intField(project, "id"), patch)
+		if !ok {
+			writeVercelError(c, http.StatusInternalServerError, "internal_error", "Failed to update project")
+			return
+		}
+		c.JSON(http.StatusOK, formatProject(updated, s.baseURL))
+	})
+
+	router.Delete("/v9/projects/:idOrName", func(c *corehttp.Context) {
+		if _, ok := s.currentUser(c); !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		s.deleteProjectCascade(project)
+		c.Writer.WriteHeader(http.StatusNoContent)
+	})
+
+	router.Get("/v1/projects/:projectId/promote/aliases", func(c *corehttp.Context) {
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+			return
+		}
+		project := s.lookupProject(c.Param("projectId"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		var production corestore.Record
+		for _, dep := range s.store.Deployments.FindBy("projectId", stringField(project, "uid")) {
+			if stringField(dep, "target") != "production" {
+				continue
+			}
+			if production == nil || timeMillisField(dep, "created_at") > timeMillisField(production, "created_at") {
+				production = dep
+			}
+		}
+		if production == nil {
+			c.JSON(http.StatusOK, map[string]any{"status": "PENDING", "alias": []string{}})
+			return
+		}
+		aliases := s.store.DeploymentAliases.FindBy("deploymentId", stringField(production, "uid"))
+		out := make([]string, 0, len(aliases))
+		for _, alias := range aliases {
+			out = append(out, stringField(alias, "alias"))
+		}
+		status := "PENDING"
+		if stringField(production, "readySubstate") == "PROMOTED" || stringField(production, "readyState") == "READY" {
+			status = "PROMOTED"
+		}
+		c.JSON(http.StatusOK, map[string]any{"status": status, "alias": out})
+	})
+
+	router.Patch("/v1/projects/:idOrName/protection-bypass", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		scoped, ok := s.resolveScope(c)
+		if !ok {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Could not resolve team or account scope")
+			return
+		}
+		project := s.lookupProject(c.Param("idOrName"), scoped.AccountID)
+		if project == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Project not found")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		createdBy := stringField(user, "uid")
+		if generated, ok := body["generate"].(map[string]any); ok {
+			scopeValue := stringValue(generated["scope"])
+			if scopeValue == "" {
+				scopeValue = "deployment"
+			}
+			s.store.ProtectionBypasses.Insert(corestore.Record{
+				"projectId": stringField(project, "uid"),
+				"secret":    generateSecret(),
+				"note":      nullableString(stringValue(generated["note"])),
+				"scope":     scopeValue,
+				"createdBy": createdBy,
+			})
+			project = s.syncProtectionRecord(project)
+		}
+		if revoke, ok := body["revoke"].([]any); ok {
+			for _, rawSecret := range revoke {
+				secret, ok := rawSecret.(string)
+				if !ok {
+					continue
+				}
+				for _, row := range s.store.ProtectionBypasses.FindBy("projectId", stringField(project, "uid")) {
+					if stringField(row, "secret") == secret {
+						s.store.ProtectionBypasses.Delete(intField(row, "id"))
+					}
+				}
+			}
+			project = s.syncProtectionRecord(project)
+		}
+		if regenerate, ok := body["regenerate"].([]any); ok {
+			for _, rawSecret := range regenerate {
+				secret, ok := rawSecret.(string)
+				if !ok {
+					continue
+				}
+				for _, row := range s.store.ProtectionBypasses.FindBy("projectId", stringField(project, "uid")) {
+					if stringField(row, "secret") != secret {
+						continue
+					}
+					note := row["note"]
+					scopeValue := stringField(row, "scope")
+					s.store.ProtectionBypasses.Delete(intField(row, "id"))
+					s.store.ProtectionBypasses.Insert(corestore.Record{
+						"projectId": stringField(project, "uid"),
+						"secret":    generateSecret(),
+						"note":      note,
+						"scope":     scopeValue,
+						"createdBy": createdBy,
+					})
+				}
+			}
+			project = s.syncProtectionRecord(project)
+		}
+		fresh, ok := s.store.Projects.Get(intField(project, "id"))
+		if !ok {
+			fresh = project
+		}
+		c.JSON(http.StatusOK, map[string]any{"protectionBypass": mapOrEmpty(fresh["protectionBypass"])})
+	})
+}
+
+func parseGitLink(body map[string]any) any {
+	raw, ok := body["gitRepository"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	repo := stringValue(raw["repo"])
+	if repo == "" {
+		return nil
+	}
+	repoID := 0
+	if value, ok := raw["repoId"].(float64); ok {
+		repoID = int(value)
+	}
+	now := nowMillis()
+	gitType := stringValue(raw["type"])
+	if gitType == "" {
+		gitType = "github"
+	}
+	branch := stringValue(raw["productionBranch"])
+	if branch == "" {
+		branch = "main"
+	}
+	return map[string]any{
+		"type":             gitType,
+		"repo":             repo,
+		"repoId":           repoID,
+		"org":              stringValue(raw["org"]),
+		"gitCredentialId":  stringValue(raw["gitCredentialId"]),
+		"productionBranch": branch,
+		"createdAt":        now,
+		"updatedAt":        now,
+		"deployHooks":      []any{},
+	}
+}
+
+func (s *Service) insertProjectEnvFromBody(project corestore.Record, raw any) {
+	items, ok := raw.([]any)
+	if !ok {
+		return
+	}
+	for _, item := range items {
+		env, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		key := stringValue(env["key"])
+		if key == "" {
+			continue
+		}
+		envType := stringValue(env["type"])
+		if !validEnvType(envType) {
+			envType = "encrypted"
+		}
+		target := stringSliceValue(env["target"])
+		target = normalizeTargets(target)
+		if len(target) == 0 {
+			target = []string{"production", "preview", "development"}
+		}
+		s.store.EnvVars.Insert(corestore.Record{
+			"uid":                  generateUID("env"),
+			"projectId":            stringField(project, "uid"),
+			"key":                  key,
+			"value":                stringValue(env["value"]),
+			"type":                 envType,
+			"target":               target,
+			"gitBranch":            nullableString(stringValue(env["gitBranch"])),
+			"customEnvironmentIds": stringSliceValue(env["customEnvironmentIds"]),
+			"comment":              nullableString(stringValue(env["comment"])),
+			"decrypted":            false,
+		})
+	}
+}
+
+func (s *Service) deleteProjectCascade(project corestore.Record) {
+	projectID := stringField(project, "uid")
+	for _, dep := range s.store.Deployments.FindBy("projectId", projectID) {
+		s.deleteDeploymentCascade(dep)
+	}
+	for _, row := range s.store.Domains.FindBy("projectId", projectID) {
+		s.store.Domains.Delete(intField(row, "id"))
+	}
+	for _, row := range s.store.EnvVars.FindBy("projectId", projectID) {
+		s.store.EnvVars.Delete(intField(row, "id"))
+	}
+	for _, row := range s.store.ProtectionBypasses.FindBy("projectId", projectID) {
+		s.store.ProtectionBypasses.Delete(intField(row, "id"))
+	}
+	s.store.Projects.Delete(intField(project, "id"))
+}
+
+func (s *Service) syncProtectionRecord(project corestore.Record) corestore.Record {
+	record := map[string]any{}
+	for _, row := range s.store.ProtectionBypasses.FindBy("projectId", stringField(project, "uid")) {
+		record[stringField(row, "secret")] = map[string]any{
+			"createdAt": timeMillisField(row, "created_at"),
+			"createdBy": stringField(row, "createdBy"),
+			"scope":     stringField(row, "scope"),
+		}
+	}
+	updated, ok := s.store.Projects.Update(intField(project, "id"), corestore.Record{"protectionBypass": record})
+	if !ok {
+		project["protectionBypass"] = record
+		return project
+	}
+	return updated
+}
+
+func copyStringPatch(body map[string]any, target corestore.Record, key string) {
+	if value, ok := body[key].(string); ok {
+		target[key] = value
+	}
+}
+
+func copyTrimmedNamePatch(body map[string]any, patch corestore.Record) {
+	if value, ok := body["name"].(string); ok {
+		patch["name"] = strings.TrimSpace(value)
+	}
+}
+
+func copyNullableStringPatch(body map[string]any, patch corestore.Record, existing corestore.Record, key string) {
+	value, ok := body[key]
+	if !ok {
+		return
+	}
+	if value == nil {
+		patch[key] = nil
+		return
+	}
+	if str, ok := value.(string); ok {
+		patch[key] = str
+		return
+	}
+	patch[key] = existing[key]
+}

--- a/internal/services/vercel/routes_user.go
+++ b/internal/services/vercel/routes_user.go
@@ -1,0 +1,331 @@
+package vercel
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerUserRoutes(router *corehttp.Router) {
+	router.Get("/registration", func(c *corehttp.Context) {
+		c.JSON(http.StatusOK, map[string]any{"registration": false})
+	})
+
+	router.Get("/v2/user", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, map[string]any{"user": formatUser(user)})
+	})
+
+	router.Patch("/v2/user", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		patch := corestore.Record{}
+		if value, exists := body["name"]; exists {
+			if value == nil {
+				patch["name"] = nil
+			} else if name, ok := value.(string); ok {
+				patch["name"] = name
+			}
+		}
+		if value, exists := body["email"]; exists {
+			if email, ok := value.(string); ok {
+				patch["email"] = email
+			}
+		}
+		updated, ok := s.store.Users.Update(intField(user, "id"), patch)
+		if !ok {
+			writeVercelError(c, http.StatusInternalServerError, "internal_error", "Failed to update user")
+			return
+		}
+		c.JSON(http.StatusOK, map[string]any{"user": formatUser(updated)})
+	})
+
+	router.Get("/v2/teams", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		memberships := s.store.TeamMembers.FindBy("userId", stringField(user, "uid"))
+		teams := make([]corestore.Record, 0, len(memberships))
+		for _, membership := range memberships {
+			team := firstRecord(s.store.Teams.FindBy("uid", stringField(membership, "teamId")))
+			if team != nil {
+				teams = append(teams, team)
+			}
+		}
+		if c.Query("teamId") != "" || c.Query("slug") != "" {
+			scoped, ok := s.resolveScope(c)
+			if !ok || scoped.Team == nil {
+				writeVercelError(c, http.StatusNotFound, "not_found", "Team not found")
+				return
+			}
+			filtered := teams[:0]
+			for _, team := range teams {
+				if stringField(team, "uid") == stringField(scoped.Team, "uid") {
+					filtered = append(filtered, team)
+				}
+			}
+			teams = filtered
+		}
+		items, page := applyPagination(teams, parsePagination(c))
+		out := make([]map[string]any, 0, len(items))
+		for _, team := range items {
+			member := s.getTeamMember(stringField(team, "uid"), stringField(user, "uid"))
+			out = append(out, formatTeamForViewer(team, member))
+		}
+		c.JSON(http.StatusOK, map[string]any{"teams": out, "pagination": page})
+	})
+
+	router.Post("/v2/teams", func(c *corehttp.Context) {
+		creator, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		slug := strings.TrimSpace(stringValue(body["slug"]))
+		if slug == "" {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Missing required field: slug")
+			return
+		}
+		if firstRecord(s.store.Teams.FindBy("slug", slug)) != nil {
+			writeVercelError(c, http.StatusConflict, "team_slug_already_exists", "A team with this slug already exists")
+			return
+		}
+		name := strings.TrimSpace(stringValue(body["name"]))
+		if name == "" {
+			name = slug
+		}
+		team := s.store.Teams.Insert(defaultTeamRecord(slug, name, nil, stringField(creator, "uid"), "hobby"))
+		s.store.TeamMembers.Insert(corestore.Record{
+			"teamId":     stringField(team, "uid"),
+			"userId":     stringField(creator, "uid"),
+			"role":       "OWNER",
+			"confirmed":  true,
+			"joinedFrom": "cli",
+		})
+		c.JSON(http.StatusOK, map[string]any{"team": formatTeamForViewer(team, s.getTeamMember(stringField(team, "uid"), stringField(creator, "uid")))})
+	})
+
+	router.Get("/v2/teams/:teamId", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		team := s.findTeamByIDOrSlug(c.Param("teamId"))
+		if team == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Team not found")
+			return
+		}
+		c.JSON(http.StatusOK, map[string]any{"team": formatTeamForViewer(team, s.getTeamMember(stringField(team, "uid"), stringField(user, "uid")))})
+	})
+
+	router.Patch("/v2/teams/:teamId", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		team := s.findTeamByIDOrSlug(c.Param("teamId"))
+		if team == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Team not found")
+			return
+		}
+		member := s.getTeamMember(stringField(team, "uid"), stringField(user, "uid"))
+		if member == nil || stringField(member, "role") != "OWNER" {
+			writeVercelError(c, http.StatusForbidden, "forbidden", "Insufficient permissions to update this team")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		patch := corestore.Record{}
+		if name, ok := body["name"].(string); ok {
+			patch["name"] = name
+		}
+		if value, exists := body["description"]; exists {
+			if value == nil {
+				patch["description"] = nil
+			} else if description, ok := value.(string); ok {
+				patch["description"] = description
+			}
+		}
+		if rawSlug, ok := body["slug"].(string); ok {
+			nextSlug := strings.TrimSpace(rawSlug)
+			if nextSlug != "" && nextSlug != stringField(team, "slug") {
+				taken := firstRecord(s.store.Teams.FindBy("slug", nextSlug))
+				if taken != nil && intField(taken, "id") != intField(team, "id") {
+					writeVercelError(c, http.StatusConflict, "team_slug_already_exists", "A team with this slug already exists")
+					return
+				}
+				patch["slug"] = nextSlug
+			}
+		}
+		updated, ok := s.store.Teams.Update(intField(team, "id"), patch)
+		if !ok {
+			writeVercelError(c, http.StatusInternalServerError, "internal_error", "Failed to update team")
+			return
+		}
+		c.JSON(http.StatusOK, map[string]any{"team": formatTeamForViewer(updated, s.getTeamMember(stringField(updated, "uid"), stringField(user, "uid")))})
+	})
+
+	router.Get("/v2/teams/:teamId/members", func(c *corehttp.Context) {
+		user, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		team := s.findTeamByIDOrSlug(c.Param("teamId"))
+		if team == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Team not found")
+			return
+		}
+		if s.getTeamMember(stringField(team, "uid"), stringField(user, "uid")) == nil {
+			writeVercelError(c, http.StatusForbidden, "forbidden", "Not a member of this team")
+			return
+		}
+		members := s.store.TeamMembers.FindBy("teamId", stringField(team, "uid"))
+		items, page := applyPagination(members, parsePagination(c))
+		out := make([]map[string]any, 0, len(items))
+		for _, member := range items {
+			out = append(out, s.formatMemberRow(member))
+		}
+		c.JSON(http.StatusOK, map[string]any{"members": out, "pagination": page})
+	})
+
+	router.Post("/v2/teams/:teamId/members", func(c *corehttp.Context) {
+		actor, ok := s.currentUser(c)
+		if !ok {
+			return
+		}
+		team := s.findTeamByIDOrSlug(c.Param("teamId"))
+		if team == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "Team not found")
+			return
+		}
+		actorMember := s.getTeamMember(stringField(team, "uid"), stringField(actor, "uid"))
+		if actorMember == nil || stringField(actorMember, "role") != "OWNER" {
+			writeVercelError(c, http.StatusForbidden, "forbidden", "Insufficient permissions to add members")
+			return
+		}
+		body, err := parseJSONBody(c.Request)
+		if err != nil {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+			return
+		}
+		email := strings.TrimSpace(stringValue(body["email"]))
+		uid := strings.TrimSpace(stringValue(body["uid"]))
+		var target corestore.Record
+		if uid != "" {
+			target = firstRecord(s.store.Users.FindBy("uid", uid))
+		} else if email != "" {
+			target = firstRecord(s.store.Users.FindBy("email", email))
+		} else {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Provide uid or email")
+			return
+		}
+		if target == nil {
+			writeVercelError(c, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
+		role := parseTeamRole(body["role"], "MEMBER")
+		if role == "" {
+			writeVercelError(c, http.StatusBadRequest, "bad_request", "Invalid role")
+			return
+		}
+		if s.getTeamMember(stringField(team, "uid"), stringField(target, "uid")) != nil {
+			writeVercelError(c, http.StatusConflict, "member_already_exists", "User is already a member of this team")
+			return
+		}
+		joinedFrom := "invite"
+		if email != "" {
+			joinedFrom = "email"
+		}
+		member := s.store.TeamMembers.Insert(corestore.Record{
+			"teamId":     stringField(team, "uid"),
+			"userId":     stringField(target, "uid"),
+			"role":       role,
+			"confirmed":  true,
+			"joinedFrom": joinedFrom,
+		})
+		c.JSON(http.StatusOK, map[string]any{"member": s.formatMemberRow(member)})
+	})
+}
+
+func (s *Service) findTeamByIDOrSlug(idOrSlug string) corestore.Record {
+	if team := firstRecord(s.store.Teams.FindBy("uid", idOrSlug)); team != nil {
+		return team
+	}
+	return firstRecord(s.store.Teams.FindBy("slug", idOrSlug))
+}
+
+func (s *Service) getTeamMember(teamID string, userID string) corestore.Record {
+	for _, member := range s.store.TeamMembers.FindBy("teamId", teamID) {
+		if stringField(member, "userId") == userID {
+			return member
+		}
+	}
+	return nil
+}
+
+func formatTeamForViewer(team corestore.Record, member corestore.Record) map[string]any {
+	out := formatTeam(team)
+	if member != nil {
+		out["membership"] = map[string]any{
+			"confirmed": boolField(member, "confirmed"),
+			"role":      stringField(member, "role"),
+		}
+	} else {
+		out["membership"] = map[string]any{
+			"confirmed": false,
+			"role":      "VIEWER",
+		}
+	}
+	return out
+}
+
+func (s *Service) formatMemberRow(member corestore.Record) map[string]any {
+	user := firstRecord(s.store.Users.FindBy("uid", stringField(member, "userId")))
+	var userOut any
+	if user != nil {
+		userOut = formatUser(user)
+	}
+	return map[string]any{
+		"id":         stringValue(intField(member, "id")),
+		"role":       stringField(member, "role"),
+		"confirmed":  boolField(member, "confirmed"),
+		"joinedFrom": stringField(member, "joinedFrom"),
+		"user":       userOut,
+	}
+}
+
+func parseTeamRole(value any, fallback string) string {
+	if value == nil {
+		return fallback
+	}
+	role, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	switch role {
+	case "OWNER", "MEMBER", "DEVELOPER", "VIEWER":
+		return role
+	default:
+		return ""
+	}
+}

--- a/internal/services/vercel/service.go
+++ b/internal/services/vercel/service.go
@@ -598,7 +598,9 @@ func mapField(record corestore.Record, key string) map[string]any {
 func stringSliceValue(value any) []string {
 	switch v := value.(type) {
 	case []string:
-		return append([]string(nil), v...)
+		out := make([]string, len(v))
+		copy(out, v)
+		return out
 	case []any:
 		out := make([]string, 0, len(v))
 		for _, item := range v {
@@ -609,6 +611,27 @@ func stringSliceValue(value any) []string {
 		return out
 	default:
 		return nil
+	}
+}
+
+func parseStringSliceStrict(value any) ([]string, bool) {
+	switch v := value.(type) {
+	case []string:
+		out := make([]string, len(v))
+		copy(out, v)
+		return out, true
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, s)
+		}
+		return out, true
+	default:
+		return nil, false
 	}
 }
 

--- a/internal/services/vercel/service.go
+++ b/internal/services/vercel/service.go
@@ -1,0 +1,1042 @@
+package vercel
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const serviceLabel = "Vercel"
+
+type Options struct {
+	Store   *corestore.Store
+	BaseURL string
+	Seed    *SeedConfig
+}
+
+type SeedConfig struct {
+	Port         int               `json:"port,omitempty"`
+	Users        []UserSeed        `json:"users"`
+	Teams        []TeamSeed        `json:"teams"`
+	Projects     []ProjectSeed     `json:"projects"`
+	Integrations []IntegrationSeed `json:"integrations"`
+}
+
+type UserSeed struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+}
+
+type TeamSeed struct {
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type ProjectSeed struct {
+	Name            string       `json:"name"`
+	Team            string       `json:"team"`
+	Framework       string       `json:"framework"`
+	BuildCommand    string       `json:"buildCommand"`
+	OutputDirectory string       `json:"outputDirectory"`
+	RootDirectory   string       `json:"rootDirectory"`
+	NodeVersion     string       `json:"nodeVersion"`
+	EnvVars         []EnvVarSeed `json:"envVars"`
+}
+
+type EnvVarSeed struct {
+	Key    string   `json:"key"`
+	Value  string   `json:"value"`
+	Type   string   `json:"type"`
+	Target []string `json:"target"`
+}
+
+type IntegrationSeed struct {
+	ClientID     string   `json:"client_id"`
+	ClientSecret string   `json:"client_secret"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris"`
+}
+
+type Service struct {
+	store    Store
+	baseURL  string
+	mu       sync.Mutex
+	codes    map[string]pendingCode
+	tokenMap map[string]string
+}
+
+type pendingCode struct {
+	Username            string
+	Scope               string
+	RedirectURI         string
+	ClientID            string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	CreatedAt           time.Time
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	baseURL := options.BaseURL
+	if baseURL == "" {
+		baseURL = "http://localhost:4000"
+	}
+	service := &Service{
+		store:    NewStore(runtimeStore),
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		codes:    map[string]pendingCode{},
+		tokenMap: map[string]string{},
+	}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, baseURL string, config SeedConfig) {
+	New(Options{Store: runtimeStore, BaseURL: baseURL, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerOAuthRoutes(router)
+	s.registerUserRoutes(router)
+	s.registerProjectRoutes(router)
+	s.registerDeploymentRoutes(router)
+	s.registerDomainRoutes(router)
+	s.registerEnvRoutes(router)
+	s.registerAPIKeyRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if firstRecord(s.store.Users.FindBy("username", "admin")) != nil {
+		return
+	}
+	s.store.Users.Insert(defaultUserRecord("admin", "admin@localhost", "Admin"))
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	for _, user := range config.Users {
+		username := strings.TrimSpace(user.Username)
+		if username == "" || firstRecord(s.store.Users.FindBy("username", username)) != nil {
+			continue
+		}
+		email := user.Email
+		if email == "" {
+			email = username + "@localhost"
+		}
+		var name any
+		if user.Name != "" {
+			name = user.Name
+		}
+		record := defaultUserRecord(username, email, name)
+		s.store.Users.Insert(record)
+	}
+
+	for _, teamSeed := range config.Teams {
+		slug := strings.TrimSpace(teamSeed.Slug)
+		if slug == "" || firstRecord(s.store.Teams.FindBy("slug", slug)) != nil {
+			continue
+		}
+		creator := firstRecord(s.store.Users.All())
+		creatorID := "unknown"
+		if creator != nil {
+			creatorID = stringField(creator, "uid")
+		}
+		name := teamSeed.Name
+		if name == "" {
+			name = slug
+		}
+		team := s.store.Teams.Insert(defaultTeamRecord(slug, name, nullableString(teamSeed.Description), creatorID, "pro"))
+		for _, user := range s.store.Users.All() {
+			role := "MEMBER"
+			if stringField(user, "uid") == creatorID {
+				role = "OWNER"
+			}
+			s.store.TeamMembers.Insert(corestore.Record{
+				"teamId":     stringField(team, "uid"),
+				"userId":     stringField(user, "uid"),
+				"role":       role,
+				"confirmed":  true,
+				"joinedFrom": "seed",
+			})
+		}
+	}
+
+	for _, projectSeed := range config.Projects {
+		name := strings.TrimSpace(projectSeed.Name)
+		if name == "" {
+			continue
+		}
+		accountID := ""
+		if projectSeed.Team != "" {
+			team := firstRecord(s.store.Teams.FindBy("slug", projectSeed.Team))
+			if team == nil {
+				continue
+			}
+			accountID = stringField(team, "uid")
+		} else if user := firstRecord(s.store.Users.All()); user != nil {
+			accountID = stringField(user, "uid")
+		}
+		if accountID == "" || s.lookupProject(name, accountID) != nil {
+			continue
+		}
+		project := defaultProjectRecord(name, accountID)
+		project["framework"] = nullableString(projectSeed.Framework)
+		project["buildCommand"] = nullableString(projectSeed.BuildCommand)
+		project["outputDirectory"] = nullableString(projectSeed.OutputDirectory)
+		project["rootDirectory"] = nullableString(projectSeed.RootDirectory)
+		if projectSeed.NodeVersion != "" {
+			project["nodeVersion"] = projectSeed.NodeVersion
+		}
+		inserted := s.store.Projects.Insert(project)
+		for _, envSeed := range projectSeed.EnvVars {
+			if envSeed.Key == "" {
+				continue
+			}
+			envType := envSeed.Type
+			if !validEnvType(envType) {
+				envType = "encrypted"
+			}
+			target := normalizeTargets(envSeed.Target)
+			if len(target) == 0 {
+				target = []string{"production", "preview", "development"}
+			}
+			s.store.EnvVars.Insert(corestore.Record{
+				"uid":                  generateUID("env"),
+				"projectId":            stringField(inserted, "uid"),
+				"key":                  envSeed.Key,
+				"value":                envSeed.Value,
+				"type":                 envType,
+				"target":               target,
+				"gitBranch":            nil,
+				"customEnvironmentIds": []string{},
+				"comment":              nil,
+				"decrypted":            false,
+			})
+		}
+	}
+
+	for _, integration := range config.Integrations {
+		if integration.ClientID == "" || firstRecord(s.store.Integrations.FindBy("client_id", integration.ClientID)) != nil {
+			continue
+		}
+		s.store.Integrations.Insert(corestore.Record{
+			"client_id":     integration.ClientID,
+			"client_secret": integration.ClientSecret,
+			"name":          integration.Name,
+			"redirect_uris": integration.RedirectURIs,
+		})
+	}
+}
+
+func defaultUserRecord(username string, email string, name any) corestore.Record {
+	return corestore.Record{
+		"uid":           generateUID("user"),
+		"email":         email,
+		"username":      username,
+		"name":          name,
+		"avatar":        nil,
+		"defaultTeamId": nil,
+		"softBlock":     nil,
+		"billing": map[string]any{
+			"plan":        "hobby",
+			"period":      nil,
+			"trial":       nil,
+			"cancelation": nil,
+			"addons":      nil,
+		},
+		"resourceConfig": map[string]any{
+			"nodeType":         "Edge Functions",
+			"concurrentBuilds": 1,
+		},
+		"stagingPrefix": "staging",
+		"version":       nil,
+	}
+}
+
+func defaultTeamRecord(slug string, name string, description any, creatorID string, plan string) corestore.Record {
+	return corestore.Record{
+		"uid":         generateUID("team"),
+		"slug":        slug,
+		"name":        name,
+		"avatar":      nil,
+		"description": description,
+		"creatorId":   creatorID,
+		"membership": map[string]any{
+			"confirmed": true,
+			"role":      "OWNER",
+		},
+		"billing": map[string]any{
+			"plan":        plan,
+			"period":      nil,
+			"trial":       nil,
+			"cancelation": nil,
+			"addons":      nil,
+		},
+		"resourceConfig": map[string]any{
+			"nodeType":         "Edge Functions",
+			"concurrentBuilds": 1,
+		},
+		"stagingPrefix": "staging",
+	}
+}
+
+func defaultProjectRecord(name string, accountID string) corestore.Record {
+	return corestore.Record{
+		"uid":                              generateUID("prj"),
+		"name":                             name,
+		"accountId":                        accountID,
+		"framework":                        nil,
+		"buildCommand":                     nil,
+		"devCommand":                       nil,
+		"installCommand":                   nil,
+		"outputDirectory":                  nil,
+		"rootDirectory":                    nil,
+		"commandForIgnoringBuildStep":      nil,
+		"nodeVersion":                      "20.x",
+		"serverlessFunctionRegion":         nil,
+		"publicSource":                     false,
+		"autoAssignCustomDomains":          true,
+		"autoAssignCustomDomainsUpdatedBy": nil,
+		"gitForkProtection":                true,
+		"sourceFilesOutsideRootDirectory":  false,
+		"live":                             true,
+		"link":                             nil,
+		"latestDeployments":                []any{},
+		"targets":                          map[string]any{},
+		"protectionBypass":                 map[string]any{},
+		"passwordProtection":               nil,
+		"ssoProtection":                    nil,
+		"trustedIps":                       nil,
+		"connectConfigurationId":           nil,
+		"gitComments": map[string]any{
+			"onPullRequest": true,
+			"onCommit":      false,
+		},
+		"webAnalytics":    nil,
+		"speedInsights":   nil,
+		"oidcTokenConfig": nil,
+		"tier":            "hobby",
+	}
+}
+
+func (s *Service) authLogin(c *corehttp.Context) (string, bool) {
+	token := bearerToken(c.Request)
+	if token == "" {
+		return "", false
+	}
+	s.mu.Lock()
+	login := s.tokenMap[token]
+	s.mu.Unlock()
+	if login != "" {
+		return login, true
+	}
+	if apiKey := firstRecord(s.store.APIKeys.FindBy("tokenString", token)); apiKey != nil {
+		user := firstRecord(s.store.Users.FindBy("uid", stringField(apiKey, "userId")))
+		if user != nil {
+			return stringField(user, "username"), true
+		}
+	}
+	switch token {
+	case "test-token":
+		if firstRecord(s.store.Users.FindBy("username", "testuser")) != nil {
+			return "testuser", true
+		}
+		return "admin", true
+	case "test_token_admin":
+		return "admin", true
+	case "test_token_user1":
+		if firstRecord(s.store.Users.FindBy("username", "octocat")) != nil {
+			return "octocat", true
+		}
+		return "admin", true
+	default:
+		return "", false
+	}
+}
+
+func (s *Service) currentUser(c *corehttp.Context) (corestore.Record, bool) {
+	login, ok := s.authLogin(c)
+	if !ok {
+		writeVercelError(c, http.StatusUnauthorized, "not_authenticated", "Authentication required")
+		return nil, false
+	}
+	user := firstRecord(s.store.Users.FindBy("username", login))
+	if user == nil {
+		writeVercelError(c, http.StatusForbidden, "forbidden", "User not found")
+		return nil, false
+	}
+	return user, true
+}
+
+func bearerToken(req *http.Request) string {
+	header := strings.TrimSpace(req.Header.Get("Authorization"))
+	if header == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if strings.HasPrefix(strings.ToLower(header), strings.ToLower(prefix)) {
+		return strings.TrimSpace(header[len(prefix):])
+	}
+	return ""
+}
+
+type scope struct {
+	AccountID string
+	Team      corestore.Record
+}
+
+func (s *Service) resolveScope(c *corehttp.Context) (*scope, bool) {
+	if teamID := strings.TrimSpace(c.Query("teamId")); teamID != "" {
+		team := firstRecord(s.store.Teams.FindBy("uid", teamID))
+		if team == nil {
+			return nil, false
+		}
+		return &scope{AccountID: stringField(team, "uid"), Team: team}, true
+	}
+	if slug := strings.TrimSpace(c.Query("slug")); slug != "" {
+		team := firstRecord(s.store.Teams.FindBy("slug", slug))
+		if team == nil {
+			return nil, false
+		}
+		return &scope{AccountID: stringField(team, "uid"), Team: team}, true
+	}
+	login, ok := s.authLogin(c)
+	if !ok {
+		return nil, false
+	}
+	user := firstRecord(s.store.Users.FindBy("username", login))
+	if user == nil {
+		return nil, false
+	}
+	return &scope{AccountID: stringField(user, "uid")}, true
+}
+
+func (s *Service) lookupProject(idOrName string, accountID string) corestore.Record {
+	if project := firstRecord(s.store.Projects.FindBy("uid", idOrName)); project != nil && stringField(project, "accountId") == accountID {
+		return project
+	}
+	for _, project := range s.store.Projects.FindBy("name", idOrName) {
+		if stringField(project, "accountId") == accountID {
+			return project
+		}
+	}
+	return nil
+}
+
+func writeVercelError(c *corehttp.Context, status int, code string, message string) {
+	c.JSON(status, map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	})
+}
+
+func parseJSONBody(req *http.Request) (map[string]any, error) {
+	defer req.Body.Close()
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return map[string]any{}, nil
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	if body == nil {
+		body = map[string]any{}
+	}
+	return body, nil
+}
+
+func parseAnyJSONBody(req *http.Request) (any, error) {
+	defer req.Body.Close()
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return nil, nil
+	}
+	var body any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func generateUID(prefix string) string {
+	raw := make([]byte, 12)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	id := base64.RawURLEncoding.EncodeToString(raw)
+	if len(id) > 20 {
+		id = id[:20]
+	}
+	if prefix == "" {
+		return id
+	}
+	return prefix + "_" + id
+}
+
+func generateSecret() string {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func generateHex(size int) string {
+	raw := make([]byte, size)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(raw)
+}
+
+func nowMillis() int64 {
+	return time.Now().UnixMilli()
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func intField(record corestore.Record, key string) int {
+	switch value := record[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		number, _ := value.Int64()
+		return int(number)
+	default:
+		return 0
+	}
+}
+
+func stringField(record corestore.Record, key string) string {
+	return stringValue(record[key])
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func boolField(record corestore.Record, key string) bool {
+	value, _ := record[key].(bool)
+	return value
+}
+
+func mapField(record corestore.Record, key string) map[string]any {
+	if value, ok := record[key].(map[string]any); ok {
+		return value
+	}
+	if value, ok := record[key].(corestore.Record); ok {
+		out := make(map[string]any, len(value))
+		for key, item := range value {
+			out[key] = item
+		}
+		return out
+	}
+	return map[string]any{}
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func stringMapValue(value any) map[string]string {
+	out := map[string]string{}
+	if raw, ok := value.(map[string]any); ok {
+		for key, item := range raw {
+			if str, ok := item.(string); ok {
+				out[key] = str
+			}
+		}
+	}
+	return out
+}
+
+func timeMillisField(record corestore.Record, key string) int64 {
+	return timeMillis(record[key])
+}
+
+func timeMillis(value any) int64 {
+	switch v := value.(type) {
+	case string:
+		t, err := time.Parse(time.RFC3339Nano, v)
+		if err == nil {
+			return t.UnixMilli()
+		}
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return n
+	}
+	return 0
+}
+
+func validEnvType(value string) bool {
+	switch value {
+	case "system", "encrypted", "plain", "secret", "sensitive":
+		return true
+	default:
+		return false
+	}
+}
+
+func validTarget(value string) bool {
+	switch value {
+	case "production", "preview", "development":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeTargets(input []string) []string {
+	targets := make([]string, 0, len(input))
+	seen := map[string]bool{}
+	for _, target := range input {
+		if validTarget(target) && !seen[target] {
+			targets = append(targets, target)
+			seen[target] = true
+		}
+	}
+	return targets
+}
+
+func targetsOverlap(left []string, right []string) bool {
+	seen := map[string]bool{}
+	for _, target := range left {
+		seen[target] = true
+	}
+	for _, target := range right {
+		if seen[target] {
+			return true
+		}
+	}
+	return false
+}
+
+func parseQueryBool(value string) bool {
+	value = strings.ToLower(value)
+	return value == "true" || value == "1" || value == "yes"
+}
+
+type paginationOptions struct {
+	Limit int
+	Since *int64
+	Until *int64
+	From  *int64
+}
+
+func parsePagination(c *corehttp.Context) paginationOptions {
+	limit, err := strconv.Atoi(c.Query("limit"))
+	if err != nil || limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	return paginationOptions{
+		Limit: limit,
+		Since: parseOptionalInt64(c.Query("since")),
+		Until: parseOptionalInt64(c.Query("until")),
+		From:  parseOptionalInt64(c.Query("from")),
+	}
+}
+
+func parseOptionalInt64(value string) *int64 {
+	if value == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func applyPagination(items []corestore.Record, options paginationOptions) ([]corestore.Record, map[string]any) {
+	filtered := append([]corestore.Record(nil), items...)
+	sortRecordsByCreatedAt(filtered)
+	if options.Since != nil {
+		next := filtered[:0]
+		for _, item := range filtered {
+			if timeMillisField(item, "created_at") > *options.Since {
+				next = append(next, item)
+			}
+		}
+		filtered = next
+	}
+	if options.Until != nil {
+		next := filtered[:0]
+		for _, item := range filtered {
+			if timeMillisField(item, "created_at") <= *options.Until {
+				next = append(next, item)
+			}
+		}
+		filtered = next
+	}
+	total := len(filtered)
+	if len(filtered) > options.Limit {
+		filtered = filtered[:options.Limit]
+	}
+	var next any
+	var prev any
+	next = nil
+	prev = nil
+	if total > options.Limit && len(filtered) > 0 {
+		next = timeMillisField(filtered[len(filtered)-1], "created_at")
+	}
+	if len(filtered) > 0 {
+		prev = timeMillisField(filtered[0], "created_at")
+	}
+	return filtered, map[string]any{
+		"count": len(filtered),
+		"next":  next,
+		"prev":  prev,
+	}
+}
+
+func sortRecordsByCreatedAt(items []corestore.Record) {
+	sort.SliceStable(items, func(i int, j int) bool {
+		return timeMillisField(items[i], "created_at") > timeMillisField(items[j], "created_at")
+	})
+}
+
+func formatUser(user corestore.Record) map[string]any {
+	return map[string]any{
+		"id":             stringField(user, "uid"),
+		"email":          stringField(user, "email"),
+		"name":           user["name"],
+		"username":       stringField(user, "username"),
+		"avatar":         user["avatar"],
+		"defaultTeamId":  user["defaultTeamId"],
+		"version":        user["version"],
+		"createdAt":      timeMillisField(user, "created_at"),
+		"softBlock":      user["softBlock"],
+		"billing":        user["billing"],
+		"resourceConfig": user["resourceConfig"],
+		"stagingPrefix":  user["stagingPrefix"],
+	}
+}
+
+func formatTeam(team corestore.Record) map[string]any {
+	return map[string]any{
+		"id":             stringField(team, "uid"),
+		"slug":           stringField(team, "slug"),
+		"name":           stringField(team, "name"),
+		"avatar":         team["avatar"],
+		"description":    team["description"],
+		"creatorId":      stringField(team, "creatorId"),
+		"createdAt":      timeMillisField(team, "created_at"),
+		"updatedAt":      timeMillisField(team, "updated_at"),
+		"membership":     team["membership"],
+		"billing":        team["billing"],
+		"resourceConfig": team["resourceConfig"],
+		"stagingPrefix":  team["stagingPrefix"],
+	}
+}
+
+func formatProject(project corestore.Record, baseURL string) map[string]any {
+	return map[string]any{
+		"accountId":                        stringField(project, "accountId"),
+		"autoAssignCustomDomains":          project["autoAssignCustomDomains"],
+		"autoAssignCustomDomainsUpdatedBy": project["autoAssignCustomDomainsUpdatedBy"],
+		"buildCommand":                     project["buildCommand"],
+		"createdAt":                        timeMillisField(project, "created_at"),
+		"devCommand":                       project["devCommand"],
+		"directoryListing":                 false,
+		"framework":                        project["framework"],
+		"gitForkProtection":                project["gitForkProtection"],
+		"gitComments":                      project["gitComments"],
+		"id":                               stringField(project, "uid"),
+		"installCommand":                   project["installCommand"],
+		"name":                             stringField(project, "name"),
+		"nodeVersion":                      stringField(project, "nodeVersion"),
+		"outputDirectory":                  project["outputDirectory"],
+		"publicSource":                     project["publicSource"],
+		"rootDirectory":                    project["rootDirectory"],
+		"commandForIgnoringBuildStep":      project["commandForIgnoringBuildStep"],
+		"serverlessFunctionRegion":         project["serverlessFunctionRegion"],
+		"sourceFilesOutsideRootDirectory":  project["sourceFilesOutsideRootDirectory"],
+		"updatedAt":                        timeMillisField(project, "updated_at"),
+		"live":                             project["live"],
+		"link":                             project["link"],
+		"latestDeployments":                arrayOrEmpty(project["latestDeployments"]),
+		"targets":                          mapOrEmpty(project["targets"]),
+		"protectionBypass":                 mapOrEmpty(project["protectionBypass"]),
+		"passwordProtection":               project["passwordProtection"],
+		"ssoProtection":                    project["ssoProtection"],
+		"trustedIps":                       project["trustedIps"],
+		"connectConfigurationId":           project["connectConfigurationId"],
+		"webAnalytics":                     project["webAnalytics"],
+		"speedInsights":                    project["speedInsights"],
+		"oidcTokenConfig":                  project["oidcTokenConfig"],
+		"tier":                             project["tier"],
+	}
+}
+
+func formatDeployment(dep corestore.Record, store Store, baseURL string) map[string]any {
+	creator := firstRecord(store.Users.FindBy("uid", stringField(dep, "creatorId")))
+	aliases := store.DeploymentAliases.FindBy("deploymentId", stringField(dep, "uid"))
+	aliasValues := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		aliasValues = append(aliasValues, stringField(alias, "alias"))
+	}
+	var creatorOut any
+	if creator != nil {
+		creatorOut = map[string]any{
+			"uid":      stringField(creator, "uid"),
+			"email":    stringField(creator, "email"),
+			"username": stringField(creator, "username"),
+		}
+	}
+	return map[string]any{
+		"uid":           stringField(dep, "uid"),
+		"id":            stringField(dep, "uid"),
+		"name":          stringField(dep, "name"),
+		"url":           stringField(dep, "url"),
+		"created":       timeMillisField(dep, "created_at"),
+		"createdAt":     timeMillisField(dep, "created_at"),
+		"source":        dep["source"],
+		"state":         dep["state"],
+		"readyState":    dep["readyState"],
+		"readySubstate": dep["readySubstate"],
+		"type":          "LAMBDAS",
+		"creator":       creatorOut,
+		"inspectorUrl":  dep["inspectorUrl"],
+		"meta":          mapOrEmpty(dep["meta"]),
+		"target":        dep["target"],
+		"aliasAssigned": dep["aliasAssigned"],
+		"aliasError":    dep["aliasError"],
+		"buildingAt":    dep["buildingAt"],
+		"readyAt":       dep["readyAt"],
+		"bootedAt":      dep["bootedAt"],
+		"canceledAt":    dep["canceledAt"],
+		"errorCode":     dep["errorCode"],
+		"errorMessage":  dep["errorMessage"],
+		"regions":       arrayOrEmpty(dep["regions"]),
+		"functions":     dep["functions"],
+		"routes":        dep["routes"],
+		"plan":          dep["plan"],
+		"projectId":     dep["projectId"],
+		"gitSource":     dep["gitSource"],
+		"alias":         aliasValues,
+	}
+}
+
+func formatDeploymentBrief(dep corestore.Record, store Store) map[string]any {
+	creator := firstRecord(store.Users.FindBy("uid", stringField(dep, "creatorId")))
+	var creatorOut any
+	if creator != nil {
+		creatorOut = map[string]any{
+			"uid":      stringField(creator, "uid"),
+			"email":    stringField(creator, "email"),
+			"username": stringField(creator, "username"),
+		}
+	}
+	return map[string]any{
+		"uid":           stringField(dep, "uid"),
+		"name":          stringField(dep, "name"),
+		"url":           stringField(dep, "url"),
+		"created":       timeMillisField(dep, "created_at"),
+		"state":         dep["state"],
+		"readyState":    dep["readyState"],
+		"type":          "LAMBDAS",
+		"creator":       creatorOut,
+		"meta":          mapOrEmpty(dep["meta"]),
+		"target":        dep["target"],
+		"aliasAssigned": dep["aliasAssigned"],
+		"projectId":     dep["projectId"],
+	}
+}
+
+func formatDomain(domain corestore.Record) map[string]any {
+	verification := domain["verification"]
+	if boolField(domain, "verified") {
+		verification = []any{}
+	}
+	return map[string]any{
+		"name":                stringField(domain, "name"),
+		"apexName":            stringField(domain, "apexName"),
+		"projectId":           stringField(domain, "projectId"),
+		"redirect":            domain["redirect"],
+		"redirectStatusCode":  domain["redirectStatusCode"],
+		"gitBranch":           domain["gitBranch"],
+		"customEnvironmentId": domain["customEnvironmentId"],
+		"updatedAt":           timeMillisField(domain, "updated_at"),
+		"createdAt":           timeMillisField(domain, "created_at"),
+		"verified":            boolField(domain, "verified"),
+		"verification":        verification,
+	}
+}
+
+func formatEnvVar(env corestore.Record, decrypt bool) map[string]any {
+	value := ""
+	if decrypt || stringField(env, "type") == "plain" {
+		value = stringField(env, "value")
+	}
+	comment := env["comment"]
+	if comment == nil {
+		comment = ""
+	}
+	return map[string]any{
+		"type":                 stringField(env, "type"),
+		"id":                   stringField(env, "uid"),
+		"key":                  stringField(env, "key"),
+		"value":                value,
+		"target":               stringSliceValue(env["target"]),
+		"gitBranch":            env["gitBranch"],
+		"customEnvironmentIds": stringSliceValue(env["customEnvironmentIds"]),
+		"configurationId":      nil,
+		"createdAt":            timeMillisField(env, "created_at"),
+		"updatedAt":            timeMillisField(env, "updated_at"),
+		"createdBy":            nil,
+		"updatedBy":            nil,
+		"comment":              comment,
+	}
+}
+
+func arrayOrEmpty(value any) any {
+	if value == nil {
+		return []any{}
+	}
+	return value
+}
+
+func mapOrEmpty(value any) any {
+	if value == nil {
+		return map[string]any{}
+	}
+	return value
+}
+
+func constantTimeEqual(left string, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+}
+
+func matchesRedirectURI(uri string, registered []string) bool {
+	for _, candidate := range registered {
+		if uri == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func encodePKCES256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func normalizeURLParam(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		parsed, err := url.Parse(raw)
+		if err == nil && parsed.Hostname() != "" {
+			return parsed.Hostname()
+		}
+	}
+	return raw
+}
+
+func primaryHostFromBaseURL(baseURL string) string {
+	parsed, err := url.Parse(baseURL)
+	if err == nil && parsed.Hostname() != "" && parsed.Hostname() != "localhost" && parsed.Hostname() != "127.0.0.1" {
+		return parsed.Hostname()
+	}
+	return "vercel.app"
+}
+
+func deploymentHostname(name string, uid string, baseURL string) string {
+	shortID := uid
+	if strings.HasPrefix(shortID, "dpl_") {
+		shortID = strings.TrimPrefix(shortID, "dpl_")
+	}
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+	return fmt.Sprintf("%s-%s.%s", name, shortID, primaryHostFromBaseURL(baseURL))
+}
+
+func productionProjectAlias(projectName string, baseURL string) string {
+	return projectName + "." + primaryHostFromBaseURL(baseURL)
+}

--- a/internal/services/vercel/service.go
+++ b/internal/services/vercel/service.go
@@ -366,10 +366,7 @@ func (s *Service) authLogin(c *corehttp.Context) (string, bool) {
 	case "test_token_admin":
 		return "admin", true
 	case "test_token_user1":
-		if firstRecord(s.store.Users.FindBy("username", "octocat")) != nil {
-			return "octocat", true
-		}
-		return "admin", true
+		return "octocat", true
 	default:
 		return "", false
 	}

--- a/internal/services/vercel/service.go
+++ b/internal/services/vercel/service.go
@@ -1017,12 +1017,21 @@ func constantTimeEqual(left string, right string) bool {
 }
 
 func matchesRedirectURI(uri string, registered []string) bool {
+	normalized := normalizeRedirectURI(uri)
 	for _, candidate := range registered {
-		if uri == candidate {
+		if normalized == normalizeRedirectURI(candidate) {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeRedirectURI(uri string) string {
+	parsed, err := url.Parse(uri)
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return parsed.Scheme + "://" + parsed.Host + strings.TrimRight(parsed.EscapedPath(), "/")
+	}
+	return strings.TrimRight(strings.Split(uri, "?")[0], "/")
 }
 
 func encodePKCES256(verifier string) string {

--- a/internal/services/vercel/service.go
+++ b/internal/services/vercel/service.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
@@ -75,11 +74,8 @@ type IntegrationSeed struct {
 }
 
 type Service struct {
-	store    Store
-	baseURL  string
-	mu       sync.Mutex
-	codes    map[string]pendingCode
-	tokenMap map[string]string
+	store   Store
+	baseURL string
 }
 
 type pendingCode struct {
@@ -107,10 +103,8 @@ func New(options Options) *Service {
 		baseURL = "http://localhost:4000"
 	}
 	service := &Service{
-		store:    NewStore(runtimeStore),
-		baseURL:  strings.TrimRight(baseURL, "/"),
-		codes:    map[string]pendingCode{},
-		tokenMap: map[string]string{},
+		store:   NewStore(runtimeStore),
+		baseURL: strings.TrimRight(baseURL, "/"),
 	}
 	service.SeedDefaults()
 	if options.Seed != nil {
@@ -351,11 +345,11 @@ func (s *Service) authLogin(c *corehttp.Context) (string, bool) {
 	if token == "" {
 		return "", false
 	}
-	s.mu.Lock()
-	login := s.tokenMap[token]
-	s.mu.Unlock()
-	if login != "" {
-		return login, true
+	if oauthToken := firstRecord(s.store.OAuthTokens.FindBy("tokenString", token)); oauthToken != nil {
+		login := stringField(oauthToken, "username")
+		if login != "" {
+			return login, true
+		}
 	}
 	if apiKey := firstRecord(s.store.APIKeys.FindBy("tokenString", token)); apiKey != nil {
 		user := firstRecord(s.store.Users.FindBy("uid", stringField(apiKey, "userId")))
@@ -413,9 +407,20 @@ type scope struct {
 }
 
 func (s *Service) resolveScope(c *corehttp.Context) (*scope, bool) {
+	login, ok := s.authLogin(c)
+	if !ok {
+		return nil, false
+	}
+	user := firstRecord(s.store.Users.FindBy("username", login))
+	if user == nil {
+		return nil, false
+	}
 	if teamID := strings.TrimSpace(c.Query("teamId")); teamID != "" {
 		team := firstRecord(s.store.Teams.FindBy("uid", teamID))
 		if team == nil {
+			return nil, false
+		}
+		if s.getTeamMember(stringField(team, "uid"), stringField(user, "uid")) == nil {
 			return nil, false
 		}
 		return &scope{AccountID: stringField(team, "uid"), Team: team}, true
@@ -425,15 +430,10 @@ func (s *Service) resolveScope(c *corehttp.Context) (*scope, bool) {
 		if team == nil {
 			return nil, false
 		}
+		if s.getTeamMember(stringField(team, "uid"), stringField(user, "uid")) == nil {
+			return nil, false
+		}
 		return &scope{AccountID: stringField(team, "uid"), Team: team}, true
-	}
-	login, ok := s.authLogin(c)
-	if !ok {
-		return nil, false
-	}
-	user := firstRecord(s.store.Users.FindBy("username", login))
-	if user == nil {
-		return nil, false
 	}
 	return &scope{AccountID: stringField(user, "uid")}, true
 }

--- a/internal/services/vercel/service_test.go
+++ b/internal/services/vercel/service_test.go
@@ -68,6 +68,20 @@ func TestVercelProjectsEnvAndDomains(t *testing.T) {
 		t.Fatalf("unexpected project list: %#v", listed)
 	}
 
+	detail := doVercelJSON(handler, http.MethodGet, "/v9/projects/"+project.ID, "", true)
+	if detail.Code != http.StatusOK {
+		t.Fatalf("detail status = %d, body = %s", detail.Code, detail.Body.String())
+	}
+	var detailBody struct {
+		Env []struct {
+			CustomEnvironmentIDs json.RawMessage `json:"customEnvironmentIds"`
+		} `json:"env"`
+	}
+	decodeVercelBody(t, detail, &detailBody)
+	if len(detailBody.Env) != 1 || string(detailBody.Env[0].CustomEnvironmentIDs) != "[]" {
+		t.Fatalf("unexpected project env customEnvironmentIds: %s", detail.Body.String())
+	}
+
 	envCreate := doVercelJSON(handler, http.MethodPost, "/v10/projects/"+project.ID+"/env?upsert=1", `{
 		"key":"API_URL",
 		"value":"https://override.test",
@@ -130,8 +144,20 @@ func TestVercelDeploymentsFilesAndAliases(t *testing.T) {
 	if files.Code != http.StatusOK {
 		t.Fatalf("files status = %d, body = %s", files.Code, files.Body.String())
 	}
-	if !strings.Contains(files.Body.String(), "index.ts") {
-		t.Fatalf("missing file tree entry: %s", files.Body.String())
+	var fileBody struct {
+		Files []testFileTreeNode `json:"files"`
+	}
+	decodeVercelBody(t, files, &fileBody)
+	if len(fileBody.Files) != 1 {
+		t.Fatalf("unexpected file tree: %#v", fileBody)
+	}
+	apiDir := findTestFileTreeChild(fileBody.Files[0].Children, "api", "directory")
+	if apiDir == nil {
+		t.Fatalf("missing api directory: %s", files.Body.String())
+	}
+	indexFile := findTestFileTreeChild(apiDir.Children, "index.ts", "file")
+	if indexFile == nil {
+		t.Fatalf("missing nested index.ts file: %s", files.Body.String())
 	}
 
 	events := doVercelJSON(handler, http.MethodGet, "/v3/deployments/"+dep.UID+"/events", "", true)
@@ -193,6 +219,65 @@ func TestVercelOAuthIssuesUsableBearerToken(t *testing.T) {
 	}
 }
 
+func TestVercelEnvRejectsMalformedArrays(t *testing.T) {
+	handler := newVercelTestHandler()
+	projectID := createVercelProject(t, handler, "env-validation-app")
+
+	invalidTarget := doVercelJSON(handler, http.MethodPost, "/v10/projects/"+projectID+"/env", `{
+		"key":"BAD_TARGET",
+		"value":"1",
+		"type":"encrypted",
+		"target":["production","bogus"]
+	}`, true)
+	if invalidTarget.Code != http.StatusBadRequest {
+		t.Fatalf("invalid target status = %d, body = %s", invalidTarget.Code, invalidTarget.Body.String())
+	}
+
+	invalidCustomIDs := doVercelJSON(handler, http.MethodPost, "/v10/projects/"+projectID+"/env", `{
+		"key":"BAD_CUSTOM_IDS",
+		"value":"1",
+		"type":"encrypted",
+		"target":["production"],
+		"customEnvironmentIds":["env_a",123]
+	}`, true)
+	if invalidCustomIDs.Code != http.StatusBadRequest {
+		t.Fatalf("invalid custom ids status = %d, body = %s", invalidCustomIDs.Code, invalidCustomIDs.Body.String())
+	}
+
+	valid := doVercelJSON(handler, http.MethodPost, "/v10/projects/"+projectID+"/env", `{
+		"key":"VALID_ENV",
+		"value":"1",
+		"type":"encrypted",
+		"target":["production"]
+	}`, true)
+	if valid.Code != http.StatusOK {
+		t.Fatalf("valid env status = %d, body = %s", valid.Code, valid.Body.String())
+	}
+	var created struct {
+		Envs []struct {
+			ID string `json:"id"`
+		} `json:"envs"`
+	}
+	decodeVercelBody(t, valid, &created)
+	if len(created.Envs) != 1 || created.Envs[0].ID == "" {
+		t.Fatalf("unexpected env create body: %#v", created)
+	}
+
+	patchTarget := doVercelJSON(handler, http.MethodPatch, "/v9/projects/"+projectID+"/env/"+created.Envs[0].ID, `{
+		"target":["preview",false]
+	}`, true)
+	if patchTarget.Code != http.StatusBadRequest {
+		t.Fatalf("patch target status = %d, body = %s", patchTarget.Code, patchTarget.Body.String())
+	}
+
+	patchCustomIDs := doVercelJSON(handler, http.MethodPatch, "/v9/projects/"+projectID+"/env/"+created.Envs[0].ID, `{
+		"customEnvironmentIds":[{}]
+	}`, true)
+	if patchCustomIDs.Code != http.StatusBadRequest {
+		t.Fatalf("patch custom ids status = %d, body = %s", patchCustomIDs.Code, patchCustomIDs.Body.String())
+	}
+}
+
 func TestVercelAPIKeyCanAuthenticateRequests(t *testing.T) {
 	handler := newVercelTestHandler()
 	keyRes := doVercelJSON(handler, http.MethodPost, "/v1/api-keys", `{"name":"SDK Tests"}`, true)
@@ -213,6 +298,21 @@ func TestVercelAPIKeyCanAuthenticateRequests(t *testing.T) {
 	if userRes.Code != http.StatusOK {
 		t.Fatalf("user status = %d, body = %s", userRes.Code, userRes.Body.String())
 	}
+}
+
+type testFileTreeNode struct {
+	Name     string             `json:"name"`
+	Type     string             `json:"type"`
+	Children []testFileTreeNode `json:"children"`
+}
+
+func findTestFileTreeChild(children []testFileTreeNode, name string, nodeType string) *testFileTreeNode {
+	for index := range children {
+		if children[index].Name == name && children[index].Type == nodeType {
+			return &children[index]
+		}
+	}
+	return nil
 }
 
 func newVercelTestHandler() http.Handler {

--- a/internal/services/vercel/service_test.go
+++ b/internal/services/vercel/service_test.go
@@ -1,0 +1,269 @@
+package vercel
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+)
+
+const testBaseURL = "http://localhost:4000"
+
+func TestVercelCurrentUserUsesSeededTokenUser(t *testing.T) {
+	handler := newVercelTestHandler()
+	res := doVercelJSON(handler, http.MethodGet, "/v2/user", "", true)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		User struct {
+			Username string `json:"username"`
+			Email    string `json:"email"`
+		} `json:"user"`
+	}
+	decodeVercelBody(t, res, &body)
+	if body.User.Username != "testuser" || body.User.Email != "testuser@example.com" {
+		t.Fatalf("unexpected user: %#v", body.User)
+	}
+}
+
+func TestVercelProjectsEnvAndDomains(t *testing.T) {
+	handler := newVercelTestHandler()
+	create := doVercelJSON(handler, http.MethodPost, "/v11/projects", `{
+		"name":"docs-app",
+		"framework":"nextjs",
+		"environmentVariables":[{"key":"API_URL","value":"https://example.test","type":"encrypted","target":["production"]}]
+	}`, true)
+	if create.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", create.Code, create.Body.String())
+	}
+	var project struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		Framework string `json:"framework"`
+	}
+	decodeVercelBody(t, create, &project)
+	if project.ID == "" || project.Name != "docs-app" || project.Framework != "nextjs" {
+		t.Fatalf("unexpected project: %#v", project)
+	}
+
+	list := doVercelJSON(handler, http.MethodGet, "/v10/projects?search=docs", "", true)
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", list.Code, list.Body.String())
+	}
+	var listed struct {
+		Projects []struct {
+			ID string `json:"id"`
+		} `json:"projects"`
+		Pagination map[string]any `json:"pagination"`
+	}
+	decodeVercelBody(t, list, &listed)
+	if len(listed.Projects) != 1 || listed.Projects[0].ID != project.ID || listed.Pagination == nil {
+		t.Fatalf("unexpected project list: %#v", listed)
+	}
+
+	envCreate := doVercelJSON(handler, http.MethodPost, "/v10/projects/"+project.ID+"/env?upsert=1", `{
+		"key":"API_URL",
+		"value":"https://override.test",
+		"type":"encrypted",
+		"target":["production"],
+		"comment":"updated"
+	}`, true)
+	if envCreate.Code != http.StatusOK {
+		t.Fatalf("env status = %d, body = %s", envCreate.Code, envCreate.Body.String())
+	}
+	var envBody struct {
+		Envs []struct {
+			ID    string `json:"id"`
+			Value string `json:"value"`
+		} `json:"envs"`
+	}
+	decodeVercelBody(t, envCreate, &envBody)
+	if len(envBody.Envs) != 1 || envBody.Envs[0].Value != "https://override.test" {
+		t.Fatalf("unexpected env body: %#v", envBody)
+	}
+
+	domainCreate := doVercelJSON(handler, http.MethodPost, "/v10/projects/"+project.ID+"/domains", `{"name":"docs-app.vercel.app"}`, true)
+	if domainCreate.Code != http.StatusOK {
+		t.Fatalf("domain status = %d, body = %s", domainCreate.Code, domainCreate.Body.String())
+	}
+	var domain struct {
+		Name     string `json:"name"`
+		Verified bool   `json:"verified"`
+	}
+	decodeVercelBody(t, domainCreate, &domain)
+	if domain.Name != "docs-app.vercel.app" || !domain.Verified {
+		t.Fatalf("unexpected domain: %#v", domain)
+	}
+}
+
+func TestVercelDeploymentsFilesAndAliases(t *testing.T) {
+	handler := newVercelTestHandler()
+	projectID := createVercelProject(t, handler, "deploy-app")
+	deploy := doVercelJSON(handler, http.MethodPost, "/v13/deployments", `{
+		"name":"deploy-app",
+		"project":"`+projectID+`",
+		"target":"production",
+		"meta":{"githubCommitSha":"abc123"},
+		"files":[{"file":"api/index.ts","sha":"sha256-abc","size":123}]
+	}`, true)
+	if deploy.Code != http.StatusOK {
+		t.Fatalf("deploy status = %d, body = %s", deploy.Code, deploy.Body.String())
+	}
+	var dep struct {
+		UID   string   `json:"uid"`
+		State string   `json:"state"`
+		Alias []string `json:"alias"`
+	}
+	decodeVercelBody(t, deploy, &dep)
+	if dep.UID == "" || dep.State != "READY" || len(dep.Alias) != 2 {
+		t.Fatalf("unexpected deployment: %#v", dep)
+	}
+
+	files := doVercelJSON(handler, http.MethodGet, "/v6/deployments/"+dep.UID+"/files", "", true)
+	if files.Code != http.StatusOK {
+		t.Fatalf("files status = %d, body = %s", files.Code, files.Body.String())
+	}
+	if !strings.Contains(files.Body.String(), "index.ts") {
+		t.Fatalf("missing file tree entry: %s", files.Body.String())
+	}
+
+	events := doVercelJSON(handler, http.MethodGet, "/v3/deployments/"+dep.UID+"/events", "", true)
+	if events.Code != http.StatusOK {
+		t.Fatalf("events status = %d, body = %s", events.Code, events.Body.String())
+	}
+	if !strings.Contains(events.Body.String(), "Deployment ready") {
+		t.Fatalf("missing ready event: %s", events.Body.String())
+	}
+}
+
+func TestVercelOAuthIssuesUsableBearerToken(t *testing.T) {
+	handler := newVercelTestHandler()
+	form := url.Values{
+		"username":     {"testuser"},
+		"redirect_uri": {"http://localhost:3000/callback"},
+		"scope":        {"user"},
+		"state":        {"state-1"},
+		"client_id":    {"client-id"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", res.Code, res.Body.String())
+	}
+	location, err := url.Parse(res.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := location.Query().Get("code")
+	if code == "" || location.Query().Get("state") != "state-1" {
+		t.Fatalf("unexpected callback location: %s", location.String())
+	}
+
+	tokenRes := doVercelJSON(handler, http.MethodPost, "/login/oauth/token", `{"code":"`+code+`","redirect_uri":"http://localhost:3000/callback"}`, false)
+	if tokenRes.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	var tokenBody struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+	}
+	decodeVercelBody(t, tokenRes, &tokenBody)
+	if tokenBody.AccessToken == "" || tokenBody.TokenType != "Bearer" {
+		t.Fatalf("unexpected token body: %#v", tokenBody)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/login/oauth/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenBody.AccessToken)
+	userInfo := httptest.NewRecorder()
+	handler.ServeHTTP(userInfo, req)
+	if userInfo.Code != http.StatusOK {
+		t.Fatalf("userinfo status = %d, body = %s", userInfo.Code, userInfo.Body.String())
+	}
+	if !strings.Contains(userInfo.Body.String(), "testuser") {
+		t.Fatalf("unexpected userinfo body: %s", userInfo.Body.String())
+	}
+}
+
+func TestVercelAPIKeyCanAuthenticateRequests(t *testing.T) {
+	handler := newVercelTestHandler()
+	keyRes := doVercelJSON(handler, http.MethodPost, "/v1/api-keys", `{"name":"SDK Tests"}`, true)
+	if keyRes.Code != http.StatusOK {
+		t.Fatalf("key status = %d, body = %s", keyRes.Code, keyRes.Body.String())
+	}
+	var keyBody struct {
+		APIKeyString string `json:"apiKeyString"`
+	}
+	decodeVercelBody(t, keyRes, &keyBody)
+	if keyBody.APIKeyString == "" {
+		t.Fatal("missing API key string")
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v2/user", nil)
+	req.Header.Set("Authorization", "Bearer "+keyBody.APIKeyString)
+	userRes := httptest.NewRecorder()
+	handler.ServeHTTP(userRes, req)
+	if userRes.Code != http.StatusOK {
+		t.Fatalf("user status = %d, body = %s", userRes.Code, userRes.Body.String())
+	}
+}
+
+func newVercelTestHandler() http.Handler {
+	router := corehttp.NewRouter()
+	Register(router, Options{
+		BaseURL: testBaseURL,
+		Seed: &SeedConfig{
+			Users: []UserSeed{{Username: "testuser", Email: "testuser@example.com", Name: "Test User"}},
+		},
+	})
+	return router
+}
+
+func doVercelJSON(handler http.Handler, method string, target string, body string, auth bool) *httptest.ResponseRecorder {
+	var reader *bytes.Reader
+	if body == "" {
+		reader = bytes.NewReader(nil)
+	} else {
+		reader = bytes.NewReader([]byte(body))
+	}
+	req := httptest.NewRequest(method, target, reader)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if auth {
+		req.Header.Set("Authorization", "Bearer test-token")
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
+}
+
+func decodeVercelBody(t *testing.T, res *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	if err := json.Unmarshal(res.Body.Bytes(), target); err != nil {
+		t.Fatalf("decode body: %v: %s", err, res.Body.String())
+	}
+}
+
+func createVercelProject(t *testing.T, handler http.Handler, name string) string {
+	t.Helper()
+	res := doVercelJSON(handler, http.MethodPost, "/v11/projects", `{"name":"`+name+`"}`, true)
+	if res.Code != http.StatusOK {
+		t.Fatalf("project status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var project struct {
+		ID string `json:"id"`
+	}
+	decodeVercelBody(t, res, &project)
+	if project.ID == "" {
+		t.Fatal("missing project id")
+	}
+	return project.ID
+}

--- a/internal/services/vercel/service_test.go
+++ b/internal/services/vercel/service_test.go
@@ -241,6 +241,89 @@ func TestVercelOAuthAuthorizeNormalizesRegisteredRedirectURI(t *testing.T) {
 	}
 }
 
+func TestVercelOAuthCallbackRejectsUnregisteredRedirectURI(t *testing.T) {
+	handler := newVercelTestHandlerWithSeed(&SeedConfig{
+		Users: []UserSeed{{Username: "testuser", Email: "testuser@example.com", Name: "Test User"}},
+		Integrations: []IntegrationSeed{{
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+			Name:         "Test Integration",
+			RedirectURIs: []string{"http://localhost:3000/callback"},
+		}},
+	})
+	form := url.Values{
+		"username":     {"testuser"},
+		"redirect_uri": {"https://evil.example/callback"},
+		"scope":        {"user"},
+		"client_id":    {"client-id"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("callback status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if res.Header().Get("Location") != "" {
+		t.Fatalf("unexpected redirect location: %s", res.Header().Get("Location"))
+	}
+}
+
+func TestVercelOAuthTokenRejectsMismatchedClientID(t *testing.T) {
+	handler := newVercelTestHandlerWithSeed(&SeedConfig{
+		Users: []UserSeed{{Username: "testuser", Email: "testuser@example.com", Name: "Test User"}},
+		Integrations: []IntegrationSeed{
+			{
+				ClientID:     "client-one",
+				ClientSecret: "secret-one",
+				Name:         "Client One",
+				RedirectURIs: []string{"http://localhost:3000/callback"},
+			},
+			{
+				ClientID:     "client-two",
+				ClientSecret: "secret-two",
+				Name:         "Client Two",
+				RedirectURIs: []string{"http://localhost:3000/callback"},
+			},
+		},
+	})
+	form := url.Values{
+		"username":     {"testuser"},
+		"redirect_uri": {"http://localhost:3000/callback"},
+		"scope":        {"user"},
+		"client_id":    {"client-one"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", res.Code, res.Body.String())
+	}
+	location, err := url.Parse(res.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := location.Query().Get("code")
+	if code == "" {
+		t.Fatalf("missing callback code in %s", location.String())
+	}
+
+	tokenRes := doVercelJSON(handler, http.MethodPost, "/login/oauth/token", `{
+		"code":"`+code+`",
+		"redirect_uri":"http://localhost:3000/callback",
+		"client_id":"client-two",
+		"client_secret":"secret-two"
+	}`, false)
+	if tokenRes.Code != http.StatusBadRequest {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	if !strings.Contains(tokenRes.Body.String(), "client_id") {
+		t.Fatalf("unexpected token error: %s", tokenRes.Body.String())
+	}
+}
+
 func TestVercelEnvRejectsMalformedArrays(t *testing.T) {
 	handler := newVercelTestHandler()
 	projectID := createVercelProject(t, handler, "env-validation-app")
@@ -319,6 +402,36 @@ func TestVercelAPIKeyCanAuthenticateRequests(t *testing.T) {
 	handler.ServeHTTP(userRes, req)
 	if userRes.Code != http.StatusOK {
 		t.Fatalf("user status = %d, body = %s", userRes.Code, userRes.Body.String())
+	}
+}
+
+func TestVercelFileUploadRecordsContentLength(t *testing.T) {
+	runtimeStore := corestore.New()
+	router := corehttp.NewRouter()
+	Register(router, Options{
+		Store:   runtimeStore,
+		BaseURL: testBaseURL,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v2/files", strings.NewReader("hello"))
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("x-vercel-digest", "sha256-upload")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("upload status = %d, body = %s", res.Code, res.Body.String())
+	}
+	vercelStore := NewStore(runtimeStore)
+	file := firstRecord(vercelStore.Files.FindBy("digest", "sha256-upload"))
+	if file == nil {
+		t.Fatal("missing uploaded file")
+	}
+	if intField(file, "size") != 5 {
+		t.Fatalf("size = %d, record = %#v", intField(file, "size"), file)
+	}
+	if stringField(file, "contentType") != "text/plain" {
+		t.Fatalf("contentType = %q", stringField(file, "contentType"))
 	}
 }
 

--- a/internal/services/vercel/service_test.go
+++ b/internal/services/vercel/service_test.go
@@ -220,6 +220,27 @@ func TestVercelOAuthIssuesUsableBearerToken(t *testing.T) {
 	}
 }
 
+func TestVercelOAuthAuthorizeNormalizesRegisteredRedirectURI(t *testing.T) {
+	handler := newVercelTestHandlerWithSeed(&SeedConfig{
+		Users: []UserSeed{{Username: "testuser", Email: "testuser@example.com", Name: "Test User"}},
+		Integrations: []IntegrationSeed{{
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+			Name:         "Test Integration",
+			RedirectURIs: []string{"http://localhost:3000/callback"},
+		}},
+	})
+	target := "/oauth/authorize?client_id=client-id&redirect_uri=" + url.QueryEscape("http://localhost:3000/callback/?next=/dashboard")
+	res := doVercelJSON(handler, http.MethodGet, target, "", false)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("authorize status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "Test Integration") {
+		t.Fatalf("authorize page did not render integration name: %s", res.Body.String())
+	}
+}
+
 func TestVercelEnvRejectsMalformedArrays(t *testing.T) {
 	handler := newVercelTestHandler()
 	projectID := createVercelProject(t, handler, "env-validation-app")
@@ -371,12 +392,16 @@ func findTestFileTreeChild(children []testFileTreeNode, name string, nodeType st
 }
 
 func newVercelTestHandler() http.Handler {
+	return newVercelTestHandlerWithSeed(&SeedConfig{
+		Users: []UserSeed{{Username: "testuser", Email: "testuser@example.com", Name: "Test User"}},
+	})
+}
+
+func newVercelTestHandlerWithSeed(seed *SeedConfig) http.Handler {
 	router := corehttp.NewRouter()
 	Register(router, Options{
 		BaseURL: testBaseURL,
-		Seed: &SeedConfig{
-			Users: []UserSeed{{Username: "testuser", Email: "testuser@example.com", Name: "Test User"}},
-		},
+		Seed:    seed,
 	})
 	return router
 }

--- a/internal/services/vercel/service_test.go
+++ b/internal/services/vercel/service_test.go
@@ -34,6 +34,21 @@ func TestVercelCurrentUserUsesSeededTokenUser(t *testing.T) {
 	}
 }
 
+func TestVercelUser1TokenDoesNotFallbackToAdmin(t *testing.T) {
+	handler := newVercelTestHandlerWithSeed(&SeedConfig{})
+	req := httptest.NewRequest(http.MethodGet, "/v2/user", nil)
+	req.Header.Set("Authorization", "Bearer test_token_user1")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code == http.StatusOK {
+		t.Fatalf("test_token_user1 unexpectedly authenticated as admin: %s", res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "User not found") {
+		t.Fatalf("unexpected response: status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestVercelProjectsEnvAndDomains(t *testing.T) {
 	handler := newVercelTestHandler()
 	create := doVercelJSON(handler, http.MethodPost, "/v11/projects", `{
@@ -115,6 +130,45 @@ func TestVercelProjectsEnvAndDomains(t *testing.T) {
 	decodeVercelBody(t, domainCreate, &domain)
 	if domain.Name != "docs-app.vercel.app" || !domain.Verified {
 		t.Fatalf("unexpected domain: %#v", domain)
+	}
+}
+
+func TestVercelDomainPatchMalformedNullableFieldsPreserveExistingValues(t *testing.T) {
+	handler := newVercelTestHandler()
+	projectID := createVercelProject(t, handler, "domain-patch-app")
+	create := doVercelJSON(handler, http.MethodPost, "/v10/projects/"+projectID+"/domains", `{
+		"name":"docs.example.com",
+		"redirect":"https://example.com",
+		"redirectStatusCode":308,
+		"gitBranch":"main",
+		"customEnvironmentId":"env_custom"
+	}`, true)
+	if create.Code != http.StatusOK {
+		t.Fatalf("domain status = %d, body = %s", create.Code, create.Body.String())
+	}
+
+	patch := doVercelJSON(handler, http.MethodPatch, "/v9/projects/"+projectID+"/domains/docs.example.com", `{
+		"redirect":123,
+		"gitBranch":false,
+		"customEnvironmentId":{}
+	}`, true)
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, body = %s", patch.Code, patch.Body.String())
+	}
+	var body struct {
+		Redirect            *string `json:"redirect"`
+		GitBranch           *string `json:"gitBranch"`
+		CustomEnvironmentID *string `json:"customEnvironmentId"`
+	}
+	decodeVercelBody(t, patch, &body)
+	if body.Redirect == nil || *body.Redirect != "https://example.com" {
+		t.Fatalf("redirect was not preserved: %s", patch.Body.String())
+	}
+	if body.GitBranch == nil || *body.GitBranch != "main" {
+		t.Fatalf("gitBranch was not preserved: %s", patch.Body.String())
+	}
+	if body.CustomEnvironmentID == nil || *body.CustomEnvironmentID != "env_custom" {
+		t.Fatalf("customEnvironmentId was not preserved: %s", patch.Body.String())
 	}
 }
 

--- a/internal/services/vercel/service_test.go
+++ b/internal/services/vercel/service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
 )
 
 const testBaseURL = "http://localhost:4000"
@@ -297,6 +298,60 @@ func TestVercelAPIKeyCanAuthenticateRequests(t *testing.T) {
 	handler.ServeHTTP(userRes, req)
 	if userRes.Code != http.StatusOK {
 		t.Fatalf("user status = %d, body = %s", userRes.Code, userRes.Body.String())
+	}
+}
+
+func TestVercelTeamScopeRequiresAuthenticatedMember(t *testing.T) {
+	runtimeStore := corestore.New()
+	service := New(Options{
+		Store:   runtimeStore,
+		BaseURL: testBaseURL,
+		Seed: &SeedConfig{
+			Teams: []TeamSeed{{Slug: "seed-team", Name: "Seed Team"}},
+			Projects: []ProjectSeed{{
+				Name: "team-project",
+				Team: "seed-team",
+			}},
+		},
+	})
+	service.store.Users.Insert(defaultUserRecord("octocat", "octocat@example.com", "Octocat"))
+
+	router := corehttp.NewRouter()
+	service.RegisterRoutes(router)
+
+	unauthenticated := doVercelJSON(router, http.MethodGet, "/v10/projects?slug=seed-team", "", false)
+	if unauthenticated.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, body = %s", unauthenticated.Code, unauthenticated.Body.String())
+	}
+
+	member := doVercelJSON(router, http.MethodGet, "/v10/projects?slug=seed-team", "", true)
+	if member.Code != http.StatusOK {
+		t.Fatalf("member status = %d, body = %s", member.Code, member.Body.String())
+	}
+
+	outsiderReq := httptest.NewRequest(http.MethodPost, "/v11/projects?slug=seed-team", strings.NewReader(`{"name":"intruder"}`))
+	outsiderReq.Header.Set("Content-Type", "application/json")
+	outsiderReq.Header.Set("Authorization", "Bearer test_token_user1")
+	outsider := httptest.NewRecorder()
+	router.ServeHTTP(outsider, outsiderReq)
+	if outsider.Code == http.StatusOK {
+		t.Fatalf("outsider was allowed to mutate team scope: %s", outsider.Body.String())
+	}
+
+	verify := doVercelJSON(router, http.MethodGet, "/v10/projects?slug=seed-team", "", true)
+	if verify.Code != http.StatusOK {
+		t.Fatalf("verify status = %d, body = %s", verify.Code, verify.Body.String())
+	}
+	var body struct {
+		Projects []struct {
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	decodeVercelBody(t, verify, &body)
+	for _, project := range body.Projects {
+		if project.Name == "intruder" {
+			t.Fatal("outsider project was created")
+		}
 	}
 }
 

--- a/internal/services/vercel/store.go
+++ b/internal/services/vercel/store.go
@@ -1,0 +1,41 @@
+package vercel
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Users              *corestore.Collection
+	Teams              *corestore.Collection
+	TeamMembers        *corestore.Collection
+	Projects           *corestore.Collection
+	Deployments        *corestore.Collection
+	DeploymentAliases  *corestore.Collection
+	Builds             *corestore.Collection
+	DeploymentEvents   *corestore.Collection
+	Files              *corestore.Collection
+	DeploymentFiles    *corestore.Collection
+	Domains            *corestore.Collection
+	EnvVars            *corestore.Collection
+	ProtectionBypasses *corestore.Collection
+	APIKeys            *corestore.Collection
+	Integrations       *corestore.Collection
+}
+
+func NewStore(runtimeStore *corestore.Store) Store {
+	return Store{
+		Users:              runtimeStore.MustCollection("vercel.users", "uid", "username", "email"),
+		Teams:              runtimeStore.MustCollection("vercel.teams", "uid", "slug"),
+		TeamMembers:        runtimeStore.MustCollection("vercel.team_members", "teamId", "userId"),
+		Projects:           runtimeStore.MustCollection("vercel.projects", "uid", "name", "accountId"),
+		Deployments:        runtimeStore.MustCollection("vercel.deployments", "uid", "url", "projectId"),
+		DeploymentAliases:  runtimeStore.MustCollection("vercel.deployment_aliases", "uid", "alias", "deploymentId", "projectId"),
+		Builds:             runtimeStore.MustCollection("vercel.builds", "uid", "deploymentId"),
+		DeploymentEvents:   runtimeStore.MustCollection("vercel.deployment_events", "deploymentId"),
+		Files:              runtimeStore.MustCollection("vercel.files", "digest"),
+		DeploymentFiles:    runtimeStore.MustCollection("vercel.deployment_files", "uid", "deploymentId"),
+		Domains:            runtimeStore.MustCollection("vercel.domains", "uid", "projectId", "name"),
+		EnvVars:            runtimeStore.MustCollection("vercel.env_vars", "uid", "projectId", "key"),
+		ProtectionBypasses: runtimeStore.MustCollection("vercel.protection_bypasses", "projectId", "secret"),
+		APIKeys:            runtimeStore.MustCollection("vercel.api_keys", "uid", "userId", "teamId", "tokenString"),
+		Integrations:       runtimeStore.MustCollection("vercel.integrations", "client_id"),
+	}
+}

--- a/internal/services/vercel/store.go
+++ b/internal/services/vercel/store.go
@@ -18,6 +18,8 @@ type Store struct {
 	ProtectionBypasses *corestore.Collection
 	APIKeys            *corestore.Collection
 	Integrations       *corestore.Collection
+	OAuthCodes         *corestore.Collection
+	OAuthTokens        *corestore.Collection
 }
 
 func NewStore(runtimeStore *corestore.Store) Store {
@@ -37,5 +39,7 @@ func NewStore(runtimeStore *corestore.Store) Store {
 		ProtectionBypasses: runtimeStore.MustCollection("vercel.protection_bypasses", "projectId", "secret"),
 		APIKeys:            runtimeStore.MustCollection("vercel.api_keys", "uid", "userId", "teamId", "tokenString"),
 		Integrations:       runtimeStore.MustCollection("vercel.integrations", "client_id"),
+		OAuthCodes:         runtimeStore.MustCollection("vercel.oauth_codes", "code", "username"),
+		OAuthTokens:        runtimeStore.MustCollection("vercel.oauth_tokens", "tokenString", "username"),
 	}
 }

--- a/packages/@emulators/vercel/README.md
+++ b/packages/@emulators/vercel/README.md
@@ -1,6 +1,6 @@
 # @emulators/vercel
 
-Fully stateful Vercel API emulation with Vercel-style JSON responses and cursor-based pagination.
+Fully stateful Vercel API emulation with Vercel-style JSON responses and cursor-based pagination. The package remains published through npm while the native Go runtime implements the service surface for local CLI runs and Vercel Go Function previews.
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -21,7 +21,7 @@ describe("createVercelScaffold", () => {
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
-    expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain('Services: []string{"aws", "resend"}');
+    expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain('Services: []string{"aws", "resend", "vercel"}');
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
       rewrites: Array<{ source: string; destination: string }>;
@@ -223,7 +223,7 @@ require (
     const cwd = tempDir();
 
     expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "github" })).toThrow(
-      "currently supports native services: aws, resend",
+      "currently supports native services: aws, resend, vercel",
     );
   });
 

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -21,7 +21,9 @@ describe("createVercelScaffold", () => {
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
-    expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain('Services: []string{"aws", "resend", "vercel"}');
+    expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
+      'Services: []string{"aws", "resend", "vercel"}',
+    );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
       rewrites: Array<{ source: string; destination: string }>;

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-const SUPPORTED_VERCEL_SERVICES = ["aws", "resend"] as const;
+const SUPPORTED_VERCEL_SERVICES = ["aws", "resend", "vercel"] as const;
 const REQUIRED_GO_VERSION = "1.24";
 const DEFAULT_REWRITE = {
   source: "/emulate/:path*",

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -60,7 +60,7 @@ const vercel = program.command("vercel").description("Vercel preview helpers");
 vercel
   .command("init")
   .description("Scaffold an experimental Vercel Go Function")
-  .option("-s, --service <services>", "Comma-separated native services to enable", "aws,resend")
+  .option("-s, --service <services>", "Comma-separated native services to enable", "aws,resend,vercel")
   .option("--force", "Overwrite generated files")
   .action((opts) => {
     vercelInitCommand({

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -317,7 +317,7 @@ Then use these in your app to construct API and OAuth URLs. See each service's s
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `aws` and `resend` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `aws`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws` and `resend` handlers. Use `npx emulate vercel init --service resend` to limit the function to one service.
+The scaffold currently enables the native `aws`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service vercel` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws` and `resend` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 # Vercel API Emulator
 
-Fully stateful Vercel REST API emulation with Vercel-style JSON responses and cursor-based pagination.
+Fully stateful Vercel REST API emulation with Vercel-style JSON responses and cursor-based pagination. The native Go runtime implements this same Vercel REST surface for local CLI runs and Vercel Go Function previews.
 
 ## Start
 

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"aws", "resend"}
+var defaultServices = []string{"aws", "resend", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -34,7 +34,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "aws,resend" {
+	if strings.Join(body.Services, ",") != "aws,resend,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -85,6 +85,23 @@ func TestHandlerForwardsDirectPublicPathToService(t *testing.T) {
 
 	if res.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestHandlerForwardsVercelService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"vercel"}})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/vercel/v2/user", nil)
+	req.Host = "preview.example.com"
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"username":"admin"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }
 

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -222,6 +223,84 @@ func TestHandlerLoadsAndSavesAWSS3ObjectSnapshots(t *testing.T) {
 	}
 	if got := res.Header().Get("Content-Type"); got != "text/plain" {
 		t.Fatalf("content type = %q", got)
+	}
+}
+
+func TestHandlerPersistsVercelOAuthState(t *testing.T) {
+	persistence := &memoryPersistence{snapshots: map[string][]byte{}}
+	handler := NewHandler(Options{
+		Services:    []string{"vercel"},
+		Persistence: persistence,
+	})
+	form := url.Values{
+		"username":     {"admin"},
+		"redirect_uri": {"https://client.example/callback"},
+		"scope":        {"user"},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"https://preview.example.com/emulate/vercel/oauth/authorize/callback",
+		strings.NewReader(form.Encode()),
+	)
+	req.Host = "preview.example.com"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", res.Code, res.Body.String())
+	}
+	location, err := url.Parse(res.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := location.Query().Get("code")
+	if code == "" {
+		t.Fatalf("missing callback code in %s", location.String())
+	}
+	if len(persistence.snapshots["vercel"]) == 0 {
+		t.Fatal("missing vercel snapshot after callback")
+	}
+
+	restored := NewHandler(Options{
+		Services:    []string{"vercel"},
+		Persistence: persistence,
+	})
+	tokenReq := newJSONRequest(
+		http.MethodPost,
+		"https://preview.example.com/emulate/vercel/login/oauth/token",
+		`{"code":"`+code+`","redirect_uri":"https://client.example/callback"}`,
+	)
+	tokenReq.Host = "preview.example.com"
+	tokenRes := httptest.NewRecorder()
+	restored.ServeHTTP(tokenRes, tokenReq)
+	if tokenRes.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	var tokenBody struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(tokenRes.Body.Bytes(), &tokenBody); err != nil {
+		t.Fatal(err)
+	}
+	if tokenBody.AccessToken == "" {
+		t.Fatal("missing access token")
+	}
+
+	restoredAgain := NewHandler(Options{
+		Services:    []string{"vercel"},
+		Persistence: persistence,
+	})
+	userReq := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/vercel/login/oauth/userinfo", nil)
+	userReq.Host = "preview.example.com"
+	userReq.Header.Set("Authorization", "Bearer "+tokenBody.AccessToken)
+	userRes := httptest.NewRecorder()
+	restoredAgain.ServeHTTP(userRes, userReq)
+	if userRes.Code != http.StatusOK {
+		t.Fatalf("userinfo status = %d, body = %s", userRes.Code, userRes.Body.String())
+	}
+	if !strings.Contains(userRes.Body.String(), `"preferred_username":"admin"`) {
+		t.Fatalf("unexpected userinfo body: %s", userRes.Body.String())
 	}
 }
 


### PR DESCRIPTION
- Ports the current Vercel REST emulator surface to a dependency-free Go service while leaving npm packages and TypeScript tests in place.

- Wires native Vercel seeding, runtime mounting, and Vercel Go Function preview routing.

- Adds Go coverage for user auth, projects, deployments, domains, env vars, API keys, OAuth, and adapter forwarding.