### PR TITLE
Add Go GitHub API parity foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.
 
+The experimental native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
+
 ### Users
 - `GET /user` - authenticated user
 - `PATCH /user` - update profile
@@ -736,7 +738,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service vercel` to limit the function to one service.
+The scaffold currently enables the native `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -777,7 +779,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -2,6 +2,8 @@
 
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.
 
+The experimental native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
+
 ## Users
 
 - `GET /user` - authenticated user

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service vercel` to limit the function to one service.
+The scaffold currently enables the native `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -20,6 +20,7 @@ import (
 
 	coreconfig "github.com/vercel-labs/emulate/internal/core/config"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
+	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
@@ -104,6 +105,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		return 1
 	}
 	var seedServices []string
+	var githubSeed *github.SeedConfig
 	var resendSeed *resend.SeedConfig
 	var vercelSeed *vercel.SeedConfig
 	if *seedValue != "" {
@@ -113,10 +115,34 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for resend and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for github, resend, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
+		if raw, ok := loaded.Data["github"]; ok {
+			var cfg github.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse github seed config: %v\n", err)
+				return 1
+			}
+			githubSeed = &cfg
+		}
+		if raw, ok := loaded.Data["tokens"]; ok {
+			var tokens map[string]github.TokenSeed
+			if err := json.Unmarshal(raw, &tokens); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse token seed config: %v\n", err)
+				return 1
+			}
+			if githubSeed == nil {
+				githubSeed = &github.SeedConfig{}
+			}
+			if githubSeed.Tokens == nil {
+				githubSeed.Tokens = map[string]github.TokenSeed{}
+			}
+			for token, user := range tokens {
+				githubSeed.Tokens[token] = user
+			}
+		}
 		if raw, ok := loaded.Data["resend"]; ok {
 			var cfg resend.SeedConfig
 			if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -151,6 +177,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		Version:    version,
 		BaseURL:    baseURL,
 		Services:   services,
+		GitHubSeed: githubSeed,
 		ResendSeed: resendSeed,
 		VercelSeed: vercelSeed,
 	})
@@ -341,7 +368,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"resend", "vercel"}
+	return []string{"github", "resend", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -207,6 +207,57 @@ func TestRunStartSeedsResendFromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsGitHubFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"tokens":{"dev_token":{"login":"octocat","scopes":["repo","user"]}},"github":{"users":[{"login":"octocat","email":"octocat@github.com"}],"repos":[{"owner":"octocat","name":"hello-world","auto_init":true}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "github" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/repos/octocat/hello-world", port), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer dev_token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("repo status = %d", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartRejectsYAMLSeedConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.yaml")
@@ -242,7 +293,7 @@ func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
 				t.Fatal("start with unsupported seed service exited successfully")
 			}
 			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for resend") || !strings.Contains(errText, "aws") {
+			if !strings.Contains(errText, "only supports --seed for github, resend, and vercel") || !strings.Contains(errText, "aws") {
 				t.Fatalf("unexpected stderr: %s", errText)
 			}
 		})

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/core/ui"
 	"github.com/vercel-labs/emulate/internal/services/aws"
+	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
@@ -20,6 +21,7 @@ type ServerOptions struct {
 	Services   []string
 	Store      *store.Store
 	AssetStore *coreassets.Store
+	GitHubSeed *github.SeedConfig
 	ResendSeed *resend.SeedConfig
 	VercelSeed *vercel.SeedConfig
 }
@@ -92,6 +94,13 @@ func NewServer(options ServerOptions) *Server {
 			Store:   runtimeStore,
 			BaseURL: options.BaseURL,
 			Seed:    options.VercelSeed,
+		})
+	}
+	if serviceEnabled(services, "github") {
+		github.Register(router, github.Options{
+			Store:   runtimeStore,
+			BaseURL: options.BaseURL,
+			Seed:    options.GitHubSeed,
 		})
 	}
 	router.NotFound(func(c *corehttp.Context) {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -226,3 +226,32 @@ func TestNewHandlerDoesNotMountVercelWhenDisabled(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }
+
+func TestNewHandlerMountsGitHubWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"github"}, BaseURL: "http://localhost:4010"})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/user", nil)
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"login":"admin"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountGitHubWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/user", nil)
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}

--- a/internal/services/github/format.go
+++ b/internal/services/github/format.go
@@ -269,7 +269,7 @@ func (s *Service) formatIssue(issue corestore.Record) map[string]any {
 			closedBy = s.formatUser(u)
 		}
 	}
-	return map[string]any{
+	out := map[string]any{
 		"url":                      repoURL + "/issues/" + strconv.Itoa(number),
 		"repository_url":           repoURL,
 		"labels_url":               repoURL + "/issues/" + strconv.Itoa(number) + "/labels{/name}",
@@ -300,6 +300,21 @@ func (s *Service) formatIssue(issue corestore.Record) map[string]any {
 		"performed_via_github_app": nil,
 		"author_association":       s.authorAssociation(intField(issue, "user_id"), intField(issue, "repo_id")),
 	}
+	if boolField(issue, "is_pull_request") {
+		pullURL := repoURL + "/pulls/" + strconv.Itoa(number)
+		htmlURL := s.baseURL + "/" + stringField(repo, "full_name") + "/pull/" + strconv.Itoa(number)
+		pullRequest := map[string]any{
+			"url":       pullURL,
+			"html_url":  htmlURL,
+			"diff_url":  htmlURL + ".diff",
+			"patch_url": htmlURL + ".patch",
+		}
+		if pr := s.findPullByNumber(intField(repo, "id"), number); pr != nil {
+			pullRequest["merged_at"] = pr["merged_at"]
+		}
+		out["pull_request"] = pullRequest
+	}
+	return out
 }
 
 func (s *Service) formatPull(pr corestore.Record) map[string]any {

--- a/internal/services/github/format.go
+++ b/internal/services/github/format.go
@@ -461,6 +461,12 @@ func (s *Service) formatCommit(repo corestore.Record, commit corestore.Record) m
 			"html_url": s.baseURL + "/" + stringField(repo, "full_name") + "/commit/" + sha,
 		})
 	}
+	var author any
+	if userID := intField(commit, "user_id"); userID > 0 {
+		if user, ok := s.store.Users.Get(userID); ok {
+			author = s.formatUser(user)
+		}
+	}
 	return map[string]any{
 		"sha":      stringField(commit, "sha"),
 		"node_id":  stringField(commit, "node_id"),
@@ -483,8 +489,8 @@ func (s *Service) formatCommit(repo corestore.Record, commit corestore.Record) m
 			"comment_count": 0,
 			"verification":  map[string]any{"verified": false, "reason": "unsigned", "signature": nil, "payload": nil, "verified_at": nil},
 		},
-		"author":    nil,
-		"committer": nil,
+		"author":    author,
+		"committer": author,
 		"parents":   parents,
 	}
 }

--- a/internal/services/github/format.go
+++ b/internal/services/github/format.go
@@ -185,7 +185,7 @@ func (s *Service) formatRepo(repo corestore.Record, viewerID int) map[string]any
 		"license":                repo["license"],
 		"allow_forking":          boolField(repo, "allow_forking"),
 		"is_template":            boolField(repo, "is_template"),
-		"topics":                 stringSliceValue(repo["topics"]),
+		"topics":                 stringSliceOrEmpty(repo["topics"]),
 		"visibility":             stringField(repo, "visibility"),
 		"forks":                  intField(repo, "forks_count"),
 		"open_issues":            intField(repo, "open_issues_count"),

--- a/internal/services/github/format.go
+++ b/internal/services/github/format.go
@@ -303,6 +303,12 @@ func (s *Service) formatPull(pr corestore.Record) map[string]any {
 	number := intField(pr, "number")
 	headRepo, _ := s.store.Repos.Get(intField(pr, "head_repo_id"))
 	baseRepo, _ := s.store.Repos.Get(intField(pr, "base_repo_id"))
+	var mergedBy any
+	if mergedByID := nullableIntField(pr, "merged_by_id"); mergedByID != nil && *mergedByID > 0 {
+		if user, ok := s.store.Users.Get(*mergedByID); ok {
+			mergedBy = s.formatUser(user)
+		}
+	}
 	return map[string]any{
 		"url":                   repoURL + "/pulls/" + strconv.Itoa(number),
 		"id":                    intField(pr, "id"),
@@ -343,7 +349,7 @@ func (s *Service) formatPull(pr corestore.Record) map[string]any {
 		"mergeable":             pr["mergeable"],
 		"rebaseable":            true,
 		"mergeable_state":       stringField(pr, "mergeable_state"),
-		"merged_by":             nil,
+		"merged_by":             mergedBy,
 		"comments":              intField(pr, "comments"),
 		"review_comments":       intField(pr, "review_comments"),
 		"maintainer_can_modify": true,

--- a/internal/services/github/format.go
+++ b/internal/services/github/format.go
@@ -1,0 +1,535 @@
+package github
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) userURLs(login string) map[string]any {
+	return map[string]any{
+		"url":                 s.baseURL + "/users/" + login,
+		"html_url":            s.baseURL + "/" + login,
+		"repos_url":           s.baseURL + "/users/" + login + "/repos",
+		"followers_url":       s.baseURL + "/users/" + login + "/followers",
+		"following_url":       s.baseURL + "/users/" + login + "/following{/other_user}",
+		"gists_url":           s.baseURL + "/users/" + login + "/gists{/gist_id}",
+		"starred_url":         s.baseURL + "/users/" + login + "/starred{/owner}{/repo}",
+		"subscriptions_url":   s.baseURL + "/users/" + login + "/subscriptions",
+		"organizations_url":   s.baseURL + "/users/" + login + "/orgs",
+		"events_url":          s.baseURL + "/users/" + login + "/events{/privacy}",
+		"received_events_url": s.baseURL + "/users/" + login + "/received_events",
+		"avatar_url":          s.baseURL + "/avatars/u/" + login,
+	}
+}
+
+func (s *Service) formatUser(user corestore.Record) map[string]any {
+	login := stringField(user, "login")
+	out := map[string]any{
+		"login":          login,
+		"id":             intField(user, "id"),
+		"node_id":        stringField(user, "node_id"),
+		"gravatar_id":    stringField(user, "gravatar_id"),
+		"type":           stringField(user, "type"),
+		"site_admin":     boolField(user, "site_admin"),
+		"user_view_type": "public",
+	}
+	for key, value := range s.userURLs(login) {
+		out[key] = value
+	}
+	return out
+}
+
+func (s *Service) formatUserFull(user corestore.Record) map[string]any {
+	out := s.formatUser(user)
+	for _, key := range []string{"name", "company", "blog", "location", "email", "hireable", "bio", "twitter_username", "public_repos", "public_gists", "followers", "following", "created_at", "updated_at"} {
+		out[key] = user[key]
+	}
+	return out
+}
+
+func (s *Service) formatOrgBrief(org corestore.Record) map[string]any {
+	login := stringField(org, "login")
+	return map[string]any{
+		"login":              login,
+		"id":                 intField(org, "id"),
+		"node_id":            stringField(org, "node_id"),
+		"url":                s.baseURL + "/orgs/" + login,
+		"html_url":           s.baseURL + "/" + login,
+		"repos_url":          s.baseURL + "/orgs/" + login + "/repos",
+		"events_url":         s.baseURL + "/orgs/" + login + "/events",
+		"hooks_url":          s.baseURL + "/orgs/" + login + "/hooks",
+		"issues_url":         s.baseURL + "/orgs/" + login + "/issues",
+		"members_url":        s.baseURL + "/orgs/" + login + "/members{/member}",
+		"public_members_url": s.baseURL + "/orgs/" + login + "/public_members{/member}",
+		"avatar_url":         s.baseURL + "/avatars/o/" + login,
+		"description":        org["description"],
+		"type":               "Organization",
+		"site_admin":         false,
+		"user_view_type":     "public",
+	}
+}
+
+func (s *Service) formatOrgFull(org corestore.Record) map[string]any {
+	out := s.formatOrgBrief(org)
+	for _, key := range []string{"name", "company", "blog", "location", "email", "twitter_username", "is_verified", "has_organization_projects", "has_repository_projects", "public_repos", "public_gists", "followers", "following", "created_at", "updated_at", "members_can_create_repositories", "default_repository_permission", "billing_email"} {
+		out[key] = org[key]
+	}
+	return out
+}
+
+func (s *Service) formatOwner(repo corestore.Record) any {
+	ownerID := intField(repo, "owner_id")
+	if stringField(repo, "owner_type") == "Organization" {
+		if org, ok := s.store.Orgs.Get(ownerID); ok {
+			return s.formatOrgBrief(org)
+		}
+		return nil
+	}
+	if user, ok := s.store.Users.Get(ownerID); ok {
+		return s.formatUser(user)
+	}
+	return nil
+}
+
+func (s *Service) ownerLogin(repo corestore.Record) string {
+	if stringField(repo, "owner_type") == "Organization" {
+		if org, ok := s.store.Orgs.Get(intField(repo, "owner_id")); ok {
+			return stringField(org, "login")
+		}
+		return "unknown"
+	}
+	if user, ok := s.store.Users.Get(intField(repo, "owner_id")); ok {
+		return stringField(user, "login")
+	}
+	return "unknown"
+}
+
+func (s *Service) formatRepo(repo corestore.Record, viewerID int) map[string]any {
+	fullName := stringField(repo, "full_name")
+	repoURL := s.baseURL + "/repos/" + fullName
+	htmlURL := s.baseURL + "/" + fullName
+	hostless := strings.TrimPrefix(strings.TrimPrefix(s.baseURL, "https://"), "http://")
+	out := map[string]any{
+		"id":                     intField(repo, "id"),
+		"node_id":                stringField(repo, "node_id"),
+		"name":                   stringField(repo, "name"),
+		"full_name":              fullName,
+		"private":                boolField(repo, "private"),
+		"owner":                  s.formatOwner(repo),
+		"html_url":               htmlURL,
+		"description":            repo["description"],
+		"fork":                   boolField(repo, "fork"),
+		"url":                    repoURL,
+		"forks_url":              repoURL + "/forks",
+		"keys_url":               repoURL + "/keys{/key_id}",
+		"collaborators_url":      repoURL + "/collaborators{/collaborator}",
+		"teams_url":              repoURL + "/teams",
+		"hooks_url":              repoURL + "/hooks",
+		"issue_events_url":       repoURL + "/issues/events{/number}",
+		"events_url":             repoURL + "/events",
+		"assignees_url":          repoURL + "/assignees{/user}",
+		"branches_url":           repoURL + "/branches{/branch}",
+		"tags_url":               repoURL + "/tags",
+		"blobs_url":              repoURL + "/git/blobs{/sha}",
+		"git_tags_url":           repoURL + "/git/tags{/sha}",
+		"git_refs_url":           repoURL + "/git/ref{/sha}",
+		"trees_url":              repoURL + "/git/trees{/sha}",
+		"statuses_url":           repoURL + "/statuses/{sha}",
+		"languages_url":          repoURL + "/languages",
+		"stargazers_url":         repoURL + "/stargazers",
+		"contributors_url":       repoURL + "/contributors",
+		"subscribers_url":        repoURL + "/subscribers",
+		"subscription_url":       repoURL + "/subscription",
+		"commits_url":            repoURL + "/commits{/sha}",
+		"git_commits_url":        repoURL + "/git/commits{/sha}",
+		"comments_url":           repoURL + "/comments{/number}",
+		"issue_comment_url":      repoURL + "/issues/comments{/number}",
+		"contents_url":           repoURL + "/contents/{+path}",
+		"compare_url":            repoURL + "/compare/{base}...{head}",
+		"merges_url":             repoURL + "/merges",
+		"archive_url":            repoURL + "/{archive_format}{/ref}",
+		"downloads_url":          repoURL + "/downloads",
+		"issues_url":             repoURL + "/issues{/number}",
+		"pulls_url":              repoURL + "/pulls{/number}",
+		"milestones_url":         repoURL + "/milestones{/number}",
+		"notifications_url":      repoURL + "/notifications{?since,all,participating}",
+		"labels_url":             repoURL + "/labels{/name}",
+		"releases_url":           repoURL + "/releases{/id}",
+		"deployments_url":        repoURL + "/deployments",
+		"created_at":             repo["created_at"],
+		"updated_at":             repo["updated_at"],
+		"pushed_at":              repo["pushed_at"],
+		"git_url":                "git://" + hostless + "/" + fullName + ".git",
+		"ssh_url":                "git@" + hostless + ":" + fullName + ".git",
+		"clone_url":              htmlURL + ".git",
+		"svn_url":                htmlURL,
+		"homepage":               repo["homepage"],
+		"size":                   intField(repo, "size"),
+		"stargazers_count":       intField(repo, "stargazers_count"),
+		"watchers_count":         intField(repo, "watchers_count"),
+		"language":               repo["language"],
+		"has_issues":             boolField(repo, "has_issues"),
+		"has_projects":           boolField(repo, "has_projects"),
+		"has_downloads":          boolField(repo, "has_downloads"),
+		"has_wiki":               boolField(repo, "has_wiki"),
+		"has_pages":              boolField(repo, "has_pages"),
+		"has_discussions":        boolField(repo, "has_discussions"),
+		"forks_count":            intField(repo, "forks_count"),
+		"mirror_url":             nil,
+		"archived":               boolField(repo, "archived"),
+		"disabled":               boolField(repo, "disabled"),
+		"open_issues_count":      intField(repo, "open_issues_count"),
+		"license":                repo["license"],
+		"allow_forking":          boolField(repo, "allow_forking"),
+		"is_template":            boolField(repo, "is_template"),
+		"topics":                 stringSliceValue(repo["topics"]),
+		"visibility":             stringField(repo, "visibility"),
+		"forks":                  intField(repo, "forks_count"),
+		"open_issues":            intField(repo, "open_issues_count"),
+		"watchers":               intField(repo, "watchers_count"),
+		"default_branch":         stringField(repo, "default_branch"),
+		"allow_rebase_merge":     boolField(repo, "allow_rebase_merge"),
+		"allow_squash_merge":     boolField(repo, "allow_squash_merge"),
+		"allow_merge_commit":     boolField(repo, "allow_merge_commit"),
+		"allow_auto_merge":       boolField(repo, "allow_auto_merge"),
+		"delete_branch_on_merge": boolField(repo, "delete_branch_on_merge"),
+	}
+	out["permissions"] = s.repoPermissions(repo, viewerID)
+	return out
+}
+
+func (s *Service) repoPermissions(repo corestore.Record, viewerID int) map[string]bool {
+	if viewerID > 0 {
+		if stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == viewerID {
+			return map[string]bool{"admin": true, "maintain": true, "push": true, "triage": true, "pull": true}
+		}
+		for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {
+			if intField(collab, "user_id") != viewerID {
+				continue
+			}
+			return permissionsFromLevel(stringField(collab, "permission"))
+		}
+		if !boolField(repo, "private") {
+			return map[string]bool{"admin": false, "maintain": false, "push": false, "triage": false, "pull": true}
+		}
+	}
+	return map[string]bool{"admin": true, "maintain": true, "push": true, "triage": true, "pull": true}
+}
+
+func permissionsFromLevel(level string) map[string]bool {
+	order := map[string]int{"pull": 0, "triage": 1, "push": 2, "maintain": 3, "admin": 4}
+	idx, ok := order[level]
+	if !ok {
+		idx = -1
+	}
+	return map[string]bool{
+		"admin":    idx >= 4,
+		"maintain": idx >= 3,
+		"push":     idx >= 2,
+		"triage":   idx >= 1,
+		"pull":     idx >= 0,
+	}
+}
+
+func (s *Service) formatIssue(issue corestore.Record) map[string]any {
+	repo, ok := s.store.Repos.Get(intField(issue, "repo_id"))
+	if !ok {
+		return nil
+	}
+	user, _ := s.store.Users.Get(intField(issue, "user_id"))
+	repoURL := s.baseURL + "/repos/" + stringField(repo, "full_name")
+	number := intField(issue, "number")
+	assignees := make([]any, 0)
+	for _, id := range intSliceValue(issue["assignee_ids"]) {
+		if assignee, ok := s.store.Users.Get(id); ok {
+			assignees = append(assignees, s.formatUser(assignee))
+		}
+	}
+	labels := make([]any, 0)
+	for _, id := range intSliceValue(issue["label_ids"]) {
+		if label, ok := s.store.Labels.Get(id); ok {
+			labels = append(labels, s.formatLabel(label, repo))
+		}
+	}
+	var closedBy any
+	if id := nullableIntField(issue, "closed_by_id"); id != nil && *id > 0 {
+		if u, ok := s.store.Users.Get(*id); ok {
+			closedBy = s.formatUser(u)
+		}
+	}
+	return map[string]any{
+		"url":                      repoURL + "/issues/" + strconv.Itoa(number),
+		"repository_url":           repoURL,
+		"labels_url":               repoURL + "/issues/" + strconv.Itoa(number) + "/labels{/name}",
+		"comments_url":             repoURL + "/issues/" + strconv.Itoa(number) + "/comments",
+		"events_url":               repoURL + "/issues/" + strconv.Itoa(number) + "/events",
+		"html_url":                 s.baseURL + "/" + stringField(repo, "full_name") + "/issues/" + strconv.Itoa(number),
+		"id":                       intField(issue, "id"),
+		"node_id":                  stringField(issue, "node_id"),
+		"number":                   number,
+		"title":                    stringField(issue, "title"),
+		"user":                     s.formatNullableUser(user),
+		"labels":                   labels,
+		"state":                    stringField(issue, "state"),
+		"state_reason":             issue["state_reason"],
+		"locked":                   boolField(issue, "locked"),
+		"active_lock_reason":       issue["active_lock_reason"],
+		"assignee":                 firstAny(assignees),
+		"assignees":                assignees,
+		"milestone":                nil,
+		"comments":                 intField(issue, "comments"),
+		"created_at":               issue["created_at"],
+		"updated_at":               issue["updated_at"],
+		"closed_at":                issue["closed_at"],
+		"closed_by":                closedBy,
+		"body":                     issue["body"],
+		"reactions":                defaultReactions(repoURL + "/issues/" + strconv.Itoa(number)),
+		"timeline_url":             repoURL + "/issues/" + strconv.Itoa(number) + "/timeline",
+		"performed_via_github_app": nil,
+		"author_association":       s.authorAssociation(intField(issue, "user_id"), intField(issue, "repo_id")),
+	}
+}
+
+func (s *Service) formatPull(pr corestore.Record) map[string]any {
+	repo, ok := s.store.Repos.Get(intField(pr, "repo_id"))
+	if !ok {
+		return nil
+	}
+	user, _ := s.store.Users.Get(intField(pr, "user_id"))
+	repoURL := s.baseURL + "/repos/" + stringField(repo, "full_name")
+	number := intField(pr, "number")
+	headRepo, _ := s.store.Repos.Get(intField(pr, "head_repo_id"))
+	baseRepo, _ := s.store.Repos.Get(intField(pr, "base_repo_id"))
+	return map[string]any{
+		"url":                   repoURL + "/pulls/" + strconv.Itoa(number),
+		"id":                    intField(pr, "id"),
+		"node_id":               stringField(pr, "node_id"),
+		"html_url":              s.baseURL + "/" + stringField(repo, "full_name") + "/pull/" + strconv.Itoa(number),
+		"diff_url":              s.baseURL + "/" + stringField(repo, "full_name") + "/pull/" + strconv.Itoa(number) + ".diff",
+		"patch_url":             s.baseURL + "/" + stringField(repo, "full_name") + "/pull/" + strconv.Itoa(number) + ".patch",
+		"issue_url":             repoURL + "/issues/" + strconv.Itoa(number),
+		"number":                number,
+		"state":                 stringField(pr, "state"),
+		"locked":                boolField(pr, "locked"),
+		"title":                 stringField(pr, "title"),
+		"user":                  s.formatNullableUser(user),
+		"body":                  pr["body"],
+		"created_at":            pr["created_at"],
+		"updated_at":            pr["updated_at"],
+		"closed_at":             pr["closed_at"],
+		"merged_at":             pr["merged_at"],
+		"merge_commit_sha":      pr["merge_commit_sha"],
+		"assignee":              nil,
+		"assignees":             []any{},
+		"requested_reviewers":   []any{},
+		"requested_teams":       []any{},
+		"labels":                []any{},
+		"milestone":             nil,
+		"draft":                 boolField(pr, "draft"),
+		"commits_url":           repoURL + "/pulls/" + strconv.Itoa(number) + "/commits",
+		"review_comments_url":   repoURL + "/pulls/" + strconv.Itoa(number) + "/comments",
+		"review_comment_url":    repoURL + "/pulls/comments{/number}",
+		"comments_url":          repoURL + "/issues/" + strconv.Itoa(number) + "/comments",
+		"statuses_url":          repoURL + "/statuses/" + stringField(pr, "head_sha"),
+		"head":                  s.formatPullSide(headRepo, stringField(pr, "head_ref"), stringField(pr, "head_sha")),
+		"base":                  s.formatPullSide(baseRepo, stringField(pr, "base_ref"), stringField(pr, "base_sha")),
+		"_links":                s.formatPullLinks(repoURL, number, stringField(pr, "head_sha")),
+		"author_association":    s.authorAssociation(intField(pr, "user_id"), intField(pr, "repo_id")),
+		"auto_merge":            pr["auto_merge"],
+		"merged":                boolField(pr, "merged"),
+		"mergeable":             pr["mergeable"],
+		"rebaseable":            true,
+		"mergeable_state":       stringField(pr, "mergeable_state"),
+		"merged_by":             nil,
+		"comments":              intField(pr, "comments"),
+		"review_comments":       intField(pr, "review_comments"),
+		"maintainer_can_modify": true,
+		"commits":               intField(pr, "commits"),
+		"additions":             intField(pr, "additions"),
+		"deletions":             intField(pr, "deletions"),
+		"changed_files":         intField(pr, "changed_files"),
+	}
+}
+
+func (s *Service) formatPullSide(repo corestore.Record, ref string, sha string) map[string]any {
+	if repo == nil {
+		return map[string]any{"label": "unknown:" + ref, "ref": ref, "sha": sha, "user": nil, "repo": nil}
+	}
+	owner := s.ownerLogin(repo)
+	return map[string]any{
+		"label": owner + ":" + ref,
+		"ref":   ref,
+		"sha":   sha,
+		"user":  s.formatOwner(repo),
+		"repo":  s.formatRepo(repo, 0),
+	}
+}
+
+func (s *Service) formatPullLinks(repoURL string, number int, headSha string) map[string]any {
+	n := strconv.Itoa(number)
+	return map[string]any{
+		"self":            map[string]any{"href": repoURL + "/pulls/" + n},
+		"html":            map[string]any{"href": strings.Replace(repoURL, "/repos/", "/", 1) + "/pull/" + n},
+		"issue":           map[string]any{"href": repoURL + "/issues/" + n},
+		"comments":        map[string]any{"href": repoURL + "/issues/" + n + "/comments"},
+		"review_comments": map[string]any{"href": repoURL + "/pulls/" + n + "/comments"},
+		"review_comment":  map[string]any{"href": repoURL + "/pulls/comments{/number}"},
+		"commits":         map[string]any{"href": repoURL + "/pulls/" + n + "/commits"},
+		"statuses":        map[string]any{"href": repoURL + "/statuses/" + headSha},
+	}
+}
+
+func (s *Service) formatComment(comment corestore.Record) map[string]any {
+	repo, ok := s.store.Repos.Get(intField(comment, "repo_id"))
+	if !ok {
+		return nil
+	}
+	user, _ := s.store.Users.Get(intField(comment, "user_id"))
+	repoURL := s.baseURL + "/repos/" + stringField(repo, "full_name")
+	return map[string]any{
+		"url":                      repoURL + "/issues/comments/" + strconv.Itoa(intField(comment, "id")),
+		"html_url":                 s.baseURL + "/" + stringField(repo, "full_name") + "/issues/" + strconv.Itoa(intField(comment, "issue_number")) + "#issuecomment-" + strconv.Itoa(intField(comment, "id")),
+		"issue_url":                repoURL + "/issues/" + strconv.Itoa(intField(comment, "issue_number")),
+		"id":                       intField(comment, "id"),
+		"node_id":                  stringField(comment, "node_id"),
+		"user":                     s.formatNullableUser(user),
+		"created_at":               comment["created_at"],
+		"updated_at":               comment["updated_at"],
+		"author_association":       s.authorAssociation(intField(comment, "user_id"), intField(comment, "repo_id")),
+		"body":                     stringField(comment, "body"),
+		"reactions":                defaultReactions(repoURL + "/issues/comments/" + strconv.Itoa(intField(comment, "id"))),
+		"performed_via_github_app": nil,
+	}
+}
+
+func (s *Service) formatBranch(branch corestore.Record, repo corestore.Record) map[string]any {
+	sha := stringField(branch, "sha")
+	repoURL := s.baseURL + "/repos/" + stringField(repo, "full_name")
+	return map[string]any{
+		"name": stringField(branch, "name"),
+		"commit": map[string]any{
+			"sha": sha,
+			"url": repoURL + "/commits/" + sha,
+		},
+		"protected":      boolField(branch, "protected"),
+		"protection_url": repoURL + "/branches/" + url.PathEscape(stringField(branch, "name")) + "/protection",
+	}
+}
+
+func (s *Service) formatRef(repo corestore.Record, ref corestore.Record) map[string]any {
+	fullRef := stringField(ref, "ref")
+	shortRef := strings.TrimPrefix(fullRef, "refs/")
+	sha := stringField(ref, "sha")
+	repoURL := s.baseURL + "/repos/" + stringField(repo, "full_name")
+	return map[string]any{
+		"ref":     fullRef,
+		"node_id": stringField(ref, "node_id"),
+		"url":     repoURL + "/git/ref/" + shortRef,
+		"object": map[string]any{
+			"type": "commit",
+			"sha":  sha,
+			"url":  repoURL + "/git/commits/" + sha,
+		},
+	}
+}
+
+func (s *Service) formatCommit(repo corestore.Record, commit corestore.Record) map[string]any {
+	repoURL := s.baseURL + "/repos/" + stringField(repo, "full_name")
+	parents := make([]any, 0)
+	for _, sha := range stringSliceValue(commit["parent_shas"]) {
+		parents = append(parents, map[string]any{
+			"sha":      sha,
+			"url":      repoURL + "/git/commits/" + sha,
+			"html_url": s.baseURL + "/" + stringField(repo, "full_name") + "/commit/" + sha,
+		})
+	}
+	return map[string]any{
+		"sha":      stringField(commit, "sha"),
+		"node_id":  stringField(commit, "node_id"),
+		"url":      repoURL + "/git/commits/" + stringField(commit, "sha"),
+		"html_url": s.baseURL + "/" + stringField(repo, "full_name") + "/commit/" + stringField(commit, "sha"),
+		"commit": map[string]any{
+			"url": repoURL + "/git/commits/" + stringField(commit, "sha"),
+			"author": map[string]any{
+				"name":  stringField(commit, "author_name"),
+				"email": stringField(commit, "author_email"),
+				"date":  stringField(commit, "author_date"),
+			},
+			"committer": map[string]any{
+				"name":  stringField(commit, "committer_name"),
+				"email": stringField(commit, "committer_email"),
+				"date":  stringField(commit, "committer_date"),
+			},
+			"message":       stringField(commit, "message"),
+			"tree":          map[string]any{"sha": stringField(commit, "tree_sha"), "url": repoURL + "/git/trees/" + stringField(commit, "tree_sha")},
+			"comment_count": 0,
+			"verification":  map[string]any{"verified": false, "reason": "unsigned", "signature": nil, "payload": nil, "verified_at": nil},
+		},
+		"author":    nil,
+		"committer": nil,
+		"parents":   parents,
+	}
+}
+
+func (s *Service) formatLabel(label corestore.Record, repo corestore.Record) map[string]any {
+	return map[string]any{
+		"id":          intField(label, "id"),
+		"node_id":     stringField(label, "node_id"),
+		"url":         s.baseURL + "/repos/" + stringField(repo, "full_name") + "/labels/" + url.QueryEscape(stringField(label, "name")),
+		"name":        stringField(label, "name"),
+		"description": label["description"],
+		"color":       stringField(label, "color"),
+		"default":     boolField(label, "default"),
+	}
+}
+
+func (s *Service) formatNullableUser(user corestore.Record) any {
+	if user == nil {
+		return nil
+	}
+	return s.formatUser(user)
+}
+
+func (s *Service) authorAssociation(userID int, repoID int) string {
+	repo, ok := s.store.Repos.Get(repoID)
+	if !ok {
+		return "NONE"
+	}
+	if stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == userID {
+		return "OWNER"
+	}
+	if stringField(repo, "owner_type") == "Organization" && s.isOrgMember(userID, intField(repo, "owner_id")) {
+		return "MEMBER"
+	}
+	for _, collab := range s.store.Collaborators.FindBy("repo_id", repoID) {
+		if intField(collab, "user_id") == userID {
+			return "COLLABORATOR"
+		}
+	}
+	return "NONE"
+}
+
+func defaultReactions(target string) map[string]any {
+	return map[string]any{
+		"url":         target + "/reactions",
+		"total_count": 0,
+		"+1":          0,
+		"-1":          0,
+		"laugh":       0,
+		"hooray":      0,
+		"confused":    0,
+		"heart":       0,
+		"rocket":      0,
+		"eyes":        0,
+	}
+}
+
+func firstAny(values []any) any {
+	if len(values) == 0 {
+		return nil
+	}
+	return values[0]
+}

--- a/internal/services/github/format.go
+++ b/internal/services/github/format.go
@@ -203,7 +203,13 @@ func (s *Service) formatRepo(repo corestore.Record, viewerID int) map[string]any
 
 func (s *Service) repoPermissions(repo corestore.Record, viewerID int) map[string]bool {
 	if viewerID > 0 {
+		if user, ok := s.store.Users.Get(viewerID); ok && boolField(user, "site_admin") {
+			return map[string]bool{"admin": true, "maintain": true, "push": true, "triage": true, "pull": true}
+		}
 		if stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == viewerID {
+			return map[string]bool{"admin": true, "maintain": true, "push": true, "triage": true, "pull": true}
+		}
+		if stringField(repo, "owner_type") == "Organization" && s.isOrgMember(viewerID, intField(repo, "owner_id")) {
 			return map[string]bool{"admin": true, "maintain": true, "push": true, "triage": true, "pull": true}
 		}
 		for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {
@@ -216,7 +222,10 @@ func (s *Service) repoPermissions(repo corestore.Record, viewerID int) map[strin
 			return map[string]bool{"admin": false, "maintain": false, "push": false, "triage": false, "pull": true}
 		}
 	}
-	return map[string]bool{"admin": true, "maintain": true, "push": true, "triage": true, "pull": true}
+	if !boolField(repo, "private") {
+		return map[string]bool{"admin": false, "maintain": false, "push": false, "triage": false, "pull": true}
+	}
+	return map[string]bool{"admin": false, "maintain": false, "push": false, "triage": false, "pull": false}
 }
 
 func permissionsFromLevel(level string) map[string]bool {

--- a/internal/services/github/format.go
+++ b/internal/services/github/format.go
@@ -263,6 +263,12 @@ func (s *Service) formatIssue(issue corestore.Record) map[string]any {
 			labels = append(labels, s.formatLabel(label, repo))
 		}
 	}
+	var milestone any
+	if id := intField(issue, "milestone_id"); id > 0 {
+		if row, ok := s.store.Milestones.Get(id); ok {
+			milestone = s.formatMilestone(row, repo)
+		}
+	}
 	var closedBy any
 	if id := nullableIntField(issue, "closed_by_id"); id != nil && *id > 0 {
 		if u, ok := s.store.Users.Get(*id); ok {
@@ -288,7 +294,7 @@ func (s *Service) formatIssue(issue corestore.Record) map[string]any {
 		"active_lock_reason":       issue["active_lock_reason"],
 		"assignee":                 firstAny(assignees),
 		"assignees":                assignees,
-		"milestone":                nil,
+		"milestone":                milestone,
 		"comments":                 intField(issue, "comments"),
 		"created_at":               issue["created_at"],
 		"updated_at":               issue["updated_at"],
@@ -327,6 +333,24 @@ func (s *Service) formatPull(pr corestore.Record) map[string]any {
 	number := intField(pr, "number")
 	headRepo, _ := s.store.Repos.Get(intField(pr, "head_repo_id"))
 	baseRepo, _ := s.store.Repos.Get(intField(pr, "base_repo_id"))
+	assignees := make([]any, 0)
+	for _, id := range intSliceValue(pr["assignee_ids"]) {
+		if assignee, ok := s.store.Users.Get(id); ok {
+			assignees = append(assignees, s.formatUser(assignee))
+		}
+	}
+	labels := make([]any, 0)
+	for _, id := range intSliceValue(pr["label_ids"]) {
+		if label, ok := s.store.Labels.Get(id); ok {
+			labels = append(labels, s.formatLabel(label, repo))
+		}
+	}
+	var milestone any
+	if id := intField(pr, "milestone_id"); id > 0 {
+		if row, ok := s.store.Milestones.Get(id); ok {
+			milestone = s.formatMilestone(row, repo)
+		}
+	}
 	var mergedBy any
 	if mergedByID := nullableIntField(pr, "merged_by_id"); mergedByID != nil && *mergedByID > 0 {
 		if user, ok := s.store.Users.Get(*mergedByID); ok {
@@ -352,12 +376,12 @@ func (s *Service) formatPull(pr corestore.Record) map[string]any {
 		"closed_at":             pr["closed_at"],
 		"merged_at":             pr["merged_at"],
 		"merge_commit_sha":      pr["merge_commit_sha"],
-		"assignee":              nil,
-		"assignees":             []any{},
+		"assignee":              firstAny(assignees),
+		"assignees":             assignees,
 		"requested_reviewers":   []any{},
 		"requested_teams":       []any{},
-		"labels":                []any{},
-		"milestone":             nil,
+		"labels":                labels,
+		"milestone":             milestone,
 		"draft":                 boolField(pr, "draft"),
 		"commits_url":           repoURL + "/pulls/" + strconv.Itoa(number) + "/commits",
 		"review_comments_url":   repoURL + "/pulls/" + strconv.Itoa(number) + "/comments",
@@ -519,6 +543,35 @@ func (s *Service) formatLabel(label corestore.Record, repo corestore.Record) map
 		"description": label["description"],
 		"color":       stringField(label, "color"),
 		"default":     boolField(label, "default"),
+	}
+}
+
+func (s *Service) formatMilestone(milestone corestore.Record, repo corestore.Record) map[string]any {
+	repoURL := s.baseURL + "/repos/" + stringField(repo, "full_name")
+	number := intField(milestone, "number")
+	var creator any
+	if creatorID := intField(milestone, "creator_id"); creatorID > 0 {
+		if user, ok := s.store.Users.Get(creatorID); ok {
+			creator = s.formatUser(user)
+		}
+	}
+	return map[string]any{
+		"url":           repoURL + "/milestones/" + strconv.Itoa(number),
+		"html_url":      s.baseURL + "/" + stringField(repo, "full_name") + "/milestone/" + strconv.Itoa(number),
+		"labels_url":    repoURL + "/milestones/" + strconv.Itoa(number) + "/labels",
+		"id":            intField(milestone, "id"),
+		"node_id":       stringField(milestone, "node_id"),
+		"number":        number,
+		"title":         stringField(milestone, "title"),
+		"description":   milestone["description"],
+		"creator":       creator,
+		"open_issues":   intField(milestone, "open_issues"),
+		"closed_issues": intField(milestone, "closed_issues"),
+		"state":         stringField(milestone, "state"),
+		"created_at":    milestone["created_at"],
+		"updated_at":    milestone["updated_at"],
+		"due_on":        milestone["due_on"],
+		"closed_at":     milestone["closed_at"],
 	}
 }
 

--- a/internal/services/github/helpers.go
+++ b/internal/services/github/helpers.go
@@ -113,6 +113,17 @@ func boolField(record corestore.Record, key string) bool {
 	return value
 }
 
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func boolOption(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
 func nullableString(value string) any {
 	if value == "" {
 		return nil

--- a/internal/services/github/helpers.go
+++ b/internal/services/github/helpers.go
@@ -139,6 +139,14 @@ func stringSliceValue(value any) []string {
 	}
 }
 
+func stringSliceOrEmpty(value any) []string {
+	out := stringSliceValue(value)
+	if out == nil {
+		return []string{}
+	}
+	return out
+}
+
 func intSliceValue(value any) []int {
 	switch v := value.(type) {
 	case []int:

--- a/internal/services/github/helpers.go
+++ b/internal/services/github/helpers.go
@@ -1,0 +1,394 @@
+package github
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const docsURL = "https://emulate.dev/github"
+
+type authUser struct {
+	Login  string
+	ID     int
+	Scopes []string
+}
+
+type pagination struct {
+	Page    int
+	PerPage int
+}
+
+func generateNodeID(kind string, id int) string {
+	return base64.RawStdEncoding.EncodeToString([]byte(fmt.Sprintf("0:%s%d", kind, id)))
+}
+
+func generateHex(size int) string {
+	raw := make([]byte, size)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(raw)
+}
+
+func generateSha() string {
+	return generateHex(20)
+}
+
+func nowISO() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func intField(record corestore.Record, key string) int {
+	if record == nil {
+		return 0
+	}
+	switch value := record[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		number, _ := value.Int64()
+		return int(number)
+	default:
+		return 0
+	}
+}
+
+func nullableIntField(record corestore.Record, key string) *int {
+	value := intField(record, key)
+	if value == 0 && record[key] == nil {
+		return nil
+	}
+	return &value
+}
+
+func stringField(record corestore.Record, key string) string {
+	if record == nil {
+		return ""
+	}
+	return stringValue(record[key])
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func boolField(record corestore.Record, key string) bool {
+	if record == nil {
+		return false
+	}
+	value, _ := record[key].(bool)
+	return value
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		out := make([]string, len(v))
+		copy(out, v)
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func intSliceValue(value any) []int {
+	switch v := value.(type) {
+	case []int:
+		out := make([]int, len(v))
+		copy(out, v)
+		return out
+	case []any:
+		out := make([]int, 0, len(v))
+		for _, item := range v {
+			switch n := item.(type) {
+			case int:
+				out = append(out, n)
+			case float64:
+				out = append(out, int(n))
+			case json.Number:
+				parsed, _ := n.Int64()
+				out = append(out, int(parsed))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func mapStringIntValue(value any) map[string]int {
+	out := map[string]int{}
+	switch v := value.(type) {
+	case map[string]int:
+		for key, item := range v {
+			out[key] = item
+		}
+	case map[string]any:
+		for key, item := range v {
+			switch n := item.(type) {
+			case int:
+				out[key] = n
+			case float64:
+				out[key] = int(n)
+			case json.Number:
+				parsed, _ := n.Int64()
+				out[key] = int(parsed)
+			}
+		}
+	}
+	return out
+}
+
+func mapStringStringValue(value any) map[string]string {
+	out := map[string]string{}
+	switch v := value.(type) {
+	case map[string]string:
+		for key, item := range v {
+			out[key] = item
+		}
+	case map[string]any:
+		for key, item := range v {
+			if s, ok := item.(string); ok {
+				out[key] = s
+			}
+		}
+	}
+	return out
+}
+
+func parseJSONBody(req *http.Request) (map[string]any, error) {
+	defer req.Body.Close()
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(string(raw)) == "" {
+		return map[string]any{}, nil
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	if body == nil {
+		body = map[string]any{}
+	}
+	return body, nil
+}
+
+func parseOAuthBody(req *http.Request) (map[string]any, error) {
+	defer req.Body.Close()
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if strings.Contains(req.Header.Get("Content-Type"), "application/json") {
+		if strings.TrimSpace(string(raw)) == "" {
+			return map[string]any{}, nil
+		}
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			return map[string]any{}, nil
+		}
+		return body, nil
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return nil, err
+	}
+	body := make(map[string]any, len(values))
+	for key := range values {
+		body[key] = values.Get(key)
+	}
+	return body, nil
+}
+
+func writeGitHubError(c *corehttp.Context, status int, message string) {
+	c.JSON(status, map[string]any{
+		"message":           message,
+		"documentation_url": docsURL,
+	})
+}
+
+func writeNotFound(c *corehttp.Context) {
+	writeGitHubError(c, http.StatusNotFound, "Not Found")
+}
+
+func writeUnauthorized(c *corehttp.Context) {
+	writeGitHubError(c, http.StatusUnauthorized, "Requires authentication")
+}
+
+func writeForbidden(c *corehttp.Context) {
+	writeGitHubError(c, http.StatusForbidden, "Forbidden")
+}
+
+func writeValidation(c *corehttp.Context, message string) {
+	if message == "" {
+		message = "Validation Failed"
+	}
+	writeGitHubError(c, http.StatusUnprocessableEntity, message)
+}
+
+func parsePagination(c *corehttp.Context) pagination {
+	page, err := strconv.Atoi(c.Query("page"))
+	if err != nil || page < 1 {
+		page = 1
+	}
+	perPage, err := strconv.Atoi(c.Query("per_page"))
+	if err != nil || perPage < 1 {
+		perPage = 30
+	}
+	if perPage > 100 {
+		perPage = 100
+	}
+	return pagination{Page: page, PerPage: perPage}
+}
+
+func paginateRecords(c *corehttp.Context, items []corestore.Record, p pagination) []corestore.Record {
+	setLinkHeader(c, len(items), p)
+	start := (p.Page - 1) * p.PerPage
+	if start >= len(items) {
+		return nil
+	}
+	end := start + p.PerPage
+	if end > len(items) {
+		end = len(items)
+	}
+	return items[start:end]
+}
+
+func setLinkHeader(c *corehttp.Context, total int, p pagination) {
+	if p.PerPage <= 0 || total <= p.PerPage {
+		return
+	}
+	last := (total + p.PerPage - 1) / p.PerPage
+	links := make([]string, 0, 4)
+	if p.Page < last {
+		links = append(links, linkForPage(c, p.Page+1, `next`))
+		links = append(links, linkForPage(c, last, `last`))
+	}
+	if p.Page > 1 {
+		links = append(links, linkForPage(c, 1, `first`))
+		links = append(links, linkForPage(c, p.Page-1, `prev`))
+	}
+	if len(links) > 0 {
+		c.Writer.Header().Set("Link", strings.Join(links, ", "))
+	}
+}
+
+func linkForPage(c *corehttp.Context, page int, rel string) string {
+	nextURL := *c.Request.URL
+	query := nextURL.Query()
+	query.Set("page", strconv.Itoa(page))
+	query.Set("per_page", strconv.Itoa(parsePagination(c).PerPage))
+	nextURL.RawQuery = query.Encode()
+	return fmt.Sprintf("<%s>; rel=\"%s\"", nextURL.String(), rel)
+}
+
+func sortRecordsByString(records []corestore.Record, key string, descending bool) {
+	sort.SliceStable(records, func(i, j int) bool {
+		left := stringField(records[i], key)
+		right := stringField(records[j], key)
+		if descending {
+			return left > right
+		}
+		return left < right
+	})
+}
+
+func sortRecordsByInt(records []corestore.Record, key string) {
+	sort.SliceStable(records, func(i, j int) bool {
+		return intField(records[i], key) < intField(records[j], key)
+	})
+}
+
+func tokenFromRequest(req *http.Request) string {
+	header := strings.TrimSpace(req.Header.Get("Authorization"))
+	if header == "" {
+		return ""
+	}
+	lower := strings.ToLower(header)
+	for _, prefix := range []string{"bearer ", "token "} {
+		if strings.HasPrefix(lower, prefix) {
+			return strings.TrimSpace(header[len(prefix):])
+		}
+	}
+	return ""
+}
+
+func uniqueInts(values []int) []int {
+	out := make([]int, 0, len(values))
+	seen := map[int]bool{}
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func containsInt(values []int, target int) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonStringMap(value map[string]int) map[string]any {
+	out := make(map[string]any, len(value))
+	for key, item := range value {
+		out[key] = item
+	}
+	return out
+}

--- a/internal/services/github/routes_comments.go
+++ b/internal/services/github/routes_comments.go
@@ -85,7 +85,7 @@ func (s *Service) handleCreateIssueComment(c *corehttp.Context) {
 	if !ok {
 		return
 	}
-	actor, ok := s.assertRepoWrite(c, repo)
+	actor, ok := s.assertIssueParticipant(c, repo)
 	if !ok {
 		return
 	}

--- a/internal/services/github/routes_comments.go
+++ b/internal/services/github/routes_comments.go
@@ -118,6 +118,9 @@ func (s *Service) handleCreateIssueComment(c *corehttp.Context) {
 	})
 	comment, _ := s.store.Comments.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("IssueComment", intField(row, "id"))})
 	s.store.Issues.Update(intField(issue, "id"), corestore.Record{"comments": intField(issue, "comments") + 1})
+	if boolField(issue, "is_pull_request") {
+		s.adjustPullIssueCommentCount(intField(repo, "id"), intField(issue, "number"), 1)
+	}
 	c.JSON(http.StatusCreated, s.formatComment(comment))
 }
 
@@ -170,9 +173,26 @@ func (s *Service) handleDeleteIssueComment(c *corehttp.Context) {
 				next = 0
 			}
 			s.store.Issues.Update(intField(issue, "id"), corestore.Record{"comments": next})
+			if boolField(issue, "is_pull_request") {
+				s.adjustPullIssueCommentCount(intField(repo, "id"), intField(issue, "number"), -1)
+			}
 		}
 	}
 	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) adjustPullIssueCommentCount(repoID int, number int, delta int) {
+	for _, pr := range s.store.PullRequests.FindBy("repo_id", repoID) {
+		if intField(pr, "number") != number {
+			continue
+		}
+		next := intField(pr, "comments") + delta
+		if next < 0 {
+			next = 0
+		}
+		s.store.PullRequests.Update(intField(pr, "id"), corestore.Record{"comments": next})
+		return
+	}
 }
 
 func (s *Service) issueCommentFromRequest(c *corehttp.Context) (corestore.Record, corestore.Record, bool) {

--- a/internal/services/github/routes_comments.go
+++ b/internal/services/github/routes_comments.go
@@ -1,0 +1,195 @@
+package github
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerCommentRoutes(router *corehttp.Router) {
+	router.Get("/repos/:owner/:repo/issues/comments/:comment_id", s.handleGetIssueComment)
+	router.Patch("/repos/:owner/:repo/issues/comments/:comment_id", s.handlePatchIssueComment)
+	router.Delete("/repos/:owner/:repo/issues/comments/:comment_id", s.handleDeleteIssueComment)
+	router.Get("/repos/:owner/:repo/issues/:issue_number/comments", s.handleListIssueComments)
+	router.Post("/repos/:owner/:repo/issues/:issue_number/comments", s.handleCreateIssueComment)
+	router.Get("/repos/:owner/:repo/issues/comments", s.handleListRepoIssueComments)
+}
+
+func (s *Service) handleListIssueComments(c *corehttp.Context) {
+	repo, issue, ok := s.issueFromRequest(c, true)
+	if !ok {
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	comments := make([]corestore.Record, 0)
+	for _, comment := range s.store.Comments.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(comment, "comment_type") == "issue" && intField(comment, "issue_number") == intField(issue, "number") {
+			comments = append(comments, comment)
+		}
+	}
+	s.respondCommentList(c, comments)
+}
+
+func (s *Service) handleListRepoIssueComments(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	comments := make([]corestore.Record, 0)
+	for _, comment := range s.store.Comments.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(comment, "comment_type") == "issue" {
+			comments = append(comments, comment)
+		}
+	}
+	s.respondCommentList(c, comments)
+}
+
+func (s *Service) respondCommentList(c *corehttp.Context, comments []corestore.Record) {
+	direction := c.Query("direction")
+	if direction != "desc" {
+		direction = "asc"
+	}
+	sortKey := c.Query("sort")
+	if sortKey != "updated" {
+		sortKey = "created"
+	}
+	sort.SliceStable(comments, func(i, j int) bool {
+		field := "created_at"
+		if sortKey == "updated" {
+			field = "updated_at"
+		}
+		if direction == "desc" {
+			return stringField(comments[i], field) > stringField(comments[j], field)
+		}
+		return stringField(comments[i], field) < stringField(comments[j], field)
+	})
+	page := paginateRecords(c, comments, parsePagination(c))
+	out := make([]any, 0, len(page))
+	for _, comment := range page {
+		out = append(out, s.formatComment(comment))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleCreateIssueComment(c *corehttp.Context) {
+	repo, issue, ok := s.issueFromRequest(c, true)
+	if !ok {
+		return
+	}
+	actor, ok := s.assertRepoWrite(c, repo)
+	if !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	text := stringValue(body["body"])
+	if text == "" {
+		writeValidation(c, "Validation failed")
+		return
+	}
+	row := s.store.Comments.Insert(corestore.Record{
+		"node_id":        "",
+		"repo_id":        intField(repo, "id"),
+		"issue_number":   intField(issue, "number"),
+		"pull_number":    nil,
+		"commit_sha":     nil,
+		"body":           text,
+		"user_id":        intField(actor, "id"),
+		"in_reply_to_id": nil,
+		"path":           nil,
+		"position":       nil,
+		"line":           nil,
+		"side":           nil,
+		"subject_type":   nil,
+		"comment_type":   "issue",
+		"review_id":      nil,
+	})
+	comment, _ := s.store.Comments.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("IssueComment", intField(row, "id"))})
+	s.store.Issues.Update(intField(issue, "id"), corestore.Record{"comments": intField(issue, "comments") + 1})
+	c.JSON(http.StatusCreated, s.formatComment(comment))
+}
+
+func (s *Service) handleGetIssueComment(c *corehttp.Context) {
+	repo, comment, ok := s.issueCommentFromRequest(c)
+	if !ok {
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	c.JSON(http.StatusOK, s.formatComment(comment))
+}
+
+func (s *Service) handlePatchIssueComment(c *corehttp.Context) {
+	repo, comment, ok := s.issueCommentFromRequest(c)
+	if !ok {
+		return
+	}
+	if _, ok := s.assertRepoWrite(c, repo); !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	text, ok := body["body"].(string)
+	if !ok {
+		writeValidation(c, "Validation failed")
+		return
+	}
+	updated, _ := s.store.Comments.Update(intField(comment, "id"), corestore.Record{"body": text})
+	c.JSON(http.StatusOK, s.formatComment(updated))
+}
+
+func (s *Service) handleDeleteIssueComment(c *corehttp.Context) {
+	repo, comment, ok := s.issueCommentFromRequest(c)
+	if !ok {
+		return
+	}
+	if _, ok := s.assertRepoWrite(c, repo); !ok {
+		return
+	}
+	s.store.Comments.Delete(intField(comment, "id"))
+	for _, issue := range s.store.Issues.FindBy("repo_id", intField(repo, "id")) {
+		if intField(issue, "number") == intField(comment, "issue_number") {
+			next := intField(issue, "comments") - 1
+			if next < 0 {
+				next = 0
+			}
+			s.store.Issues.Update(intField(issue, "id"), corestore.Record{"comments": next})
+		}
+	}
+	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) issueCommentFromRequest(c *corehttp.Context) (corestore.Record, corestore.Record, bool) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	id, err := strconv.Atoi(c.Param("comment_id"))
+	if err != nil {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	comment, ok := s.store.Comments.Get(id)
+	if !ok || intField(comment, "repo_id") != intField(repo, "id") || stringField(comment, "comment_type") != "issue" {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	return repo, comment, true
+}

--- a/internal/services/github/routes_git.go
+++ b/internal/services/github/routes_git.go
@@ -126,8 +126,16 @@ func (s *Service) handleCreateRef(c *corehttp.Context) {
 	}
 	fullRef := stringValue(body["ref"])
 	sha := stringValue(body["sha"])
-	if !strings.HasPrefix(fullRef, "refs/") || sha == "" {
+	if !strings.HasPrefix(fullRef, "refs/") {
 		writeValidation(c, "Invalid ref")
+		return
+	}
+	if sha == "" {
+		writeValidation(c, "sha is required")
+		return
+	}
+	if s.findCommitExact(repo, sha) == nil {
+		writeValidation(c, "Invalid sha")
 		return
 	}
 	if s.findRef(repo, fullRef) != nil {
@@ -167,6 +175,10 @@ func (s *Service) handlePatchRef(c *corehttp.Context) {
 	sha := stringValue(body["sha"])
 	if sha == "" {
 		writeValidation(c, "sha is required")
+		return
+	}
+	if s.findCommitExact(repo, sha) == nil {
+		writeValidation(c, "Invalid sha")
 		return
 	}
 	updated, _ := s.store.Refs.Update(intField(ref, "id"), corestore.Record{"sha": sha})
@@ -247,7 +259,7 @@ func (s *Service) getOrCreateBranch(repo corestore.Record, branchName string) co
 		sha = stringField(defaultBranch, "sha")
 	}
 	if sha == "" {
-		sha = generateSha()
+		return nil
 	}
 	return s.createBranch(repo, branchName, sha)
 }
@@ -314,6 +326,15 @@ func (s *Service) findCommit(repo corestore.Record, sha string) corestore.Record
 	for _, commit := range s.store.Commits.FindBy("repo_id", intField(repo, "id")) {
 		full := stringField(commit, "sha")
 		if full == sha || strings.HasPrefix(full, sha) {
+			return commit
+		}
+	}
+	return nil
+}
+
+func (s *Service) findCommitExact(repo corestore.Record, sha string) corestore.Record {
+	for _, commit := range s.store.Commits.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(commit, "sha") == sha {
 			return commit
 		}
 	}

--- a/internal/services/github/routes_git.go
+++ b/internal/services/github/routes_git.go
@@ -250,20 +250,6 @@ func (s *Service) handleGetTree(c *corehttp.Context) {
 	writeNotFound(c)
 }
 
-func (s *Service) getOrCreateBranch(repo corestore.Record, branchName string) corestore.Record {
-	if branch := s.findBranch(repo, branchName); branch != nil {
-		return branch
-	}
-	sha := ""
-	if defaultBranch := s.findBranch(repo, stringField(repo, "default_branch")); defaultBranch != nil {
-		sha = stringField(defaultBranch, "sha")
-	}
-	if sha == "" {
-		return nil
-	}
-	return s.createBranch(repo, branchName, sha)
-}
-
 func (s *Service) createBranch(repo corestore.Record, branchName string, sha string) corestore.Record {
 	branch := s.store.Branches.Insert(corestore.Record{
 		"repo_id":   intField(repo, "id"),

--- a/internal/services/github/routes_git.go
+++ b/internal/services/github/routes_git.go
@@ -181,6 +181,23 @@ func (s *Service) handlePatchRef(c *corehttp.Context) {
 		writeValidation(c, "Invalid sha")
 		return
 	}
+	force := false
+	if value, ok := body["force"].(bool); ok {
+		force = value
+	}
+	if !force {
+		oldSha := stringField(ref, "sha")
+		oldCommit := s.findCommitExact(repo, oldSha)
+		newCommit := s.findCommitExact(repo, sha)
+		if oldCommit == nil || newCommit == nil {
+			writeValidation(c, "Fast-forward update requires commit objects")
+			return
+		}
+		if !s.isDescendantOf(repo, oldSha, sha) {
+			writeValidation(c, "Update is not a fast-forward")
+			return
+		}
+	}
 	updated, _ := s.store.Refs.Update(intField(ref, "id"), corestore.Record{"sha": sha})
 	s.syncBranchFromRef(repo, stringField(updated, "ref"), sha)
 	c.JSON(http.StatusOK, s.formatRef(repo, updated))
@@ -278,6 +295,15 @@ func (s *Service) updateBranchSha(repo corestore.Record, branchName string, sha 
 	}
 }
 
+func (s *Service) deleteBranchByName(repo corestore.Record, branchName string) {
+	if branch := s.findBranch(repo, branchName); branch != nil {
+		s.store.Branches.Delete(intField(branch, "id"))
+	}
+	if ref := s.findRef(repo, "refs/heads/"+branchName); ref != nil {
+		s.store.Refs.Delete(intField(ref, "id"))
+	}
+}
+
 func (s *Service) syncBranchFromRef(repo corestore.Record, fullRef string, sha string) {
 	if !strings.HasPrefix(fullRef, "refs/heads/") {
 		return
@@ -325,6 +351,28 @@ func (s *Service) findCommitExact(repo corestore.Record, sha string) corestore.R
 		}
 	}
 	return nil
+}
+
+func (s *Service) isDescendantOf(repo corestore.Record, ancestorSha string, descendantSha string) bool {
+	seen := map[string]bool{}
+	stack := []string{descendantSha}
+	for len(stack) > 0 {
+		sha := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if sha == ancestorSha {
+			return true
+		}
+		if seen[sha] {
+			continue
+		}
+		seen[sha] = true
+		commit := s.findCommitExact(repo, sha)
+		if commit == nil {
+			continue
+		}
+		stack = append(stack, stringSliceValue(commit["parent_shas"])...)
+	}
+	return false
 }
 
 func fullRefFromParam(ref string) string {

--- a/internal/services/github/routes_git.go
+++ b/internal/services/github/routes_git.go
@@ -353,6 +353,41 @@ func (s *Service) findCommitExact(repo corestore.Record, sha string) corestore.R
 	return nil
 }
 
+func (s *Service) findTreeExact(repo corestore.Record, sha string) corestore.Record {
+	for _, tree := range s.store.Trees.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(tree, "sha") == sha {
+			return tree
+		}
+	}
+	return nil
+}
+
+func (s *Service) findBlobExact(repo corestore.Record, sha string) corestore.Record {
+	for _, blob := range s.store.Blobs.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(blob, "sha") == sha {
+			return blob
+		}
+	}
+	return nil
+}
+
+func treeEntries(value any) []map[string]any {
+	switch entries := value.(type) {
+	case []map[string]any:
+		return entries
+	case []any:
+		out := make([]map[string]any, 0, len(entries))
+		for _, entry := range entries {
+			if row, ok := entry.(map[string]any); ok {
+				out = append(out, row)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
 func (s *Service) isDescendantOf(repo corestore.Record, ancestorSha string, descendantSha string) bool {
 	seen := map[string]bool{}
 	stack := []string{descendantSha}

--- a/internal/services/github/routes_git.go
+++ b/internal/services/github/routes_git.go
@@ -1,0 +1,339 @@
+package github
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerBranchAndGitRoutes(router *corehttp.Router) {
+	router.Get("/repos/:owner/:repo/branches/:branch{.+}", s.handleGetBranch)
+	router.Get("/repos/:owner/:repo/branches", s.handleListBranches)
+	router.Get("/repos/:owner/:repo/git/ref/:ref{.+}", s.handleGetRef)
+	router.Get("/repos/:owner/:repo/git/matching-refs/:ref{.+}", s.handleMatchingRefs)
+	router.Post("/repos/:owner/:repo/git/refs", s.handleCreateRef)
+	router.Patch("/repos/:owner/:repo/git/refs/:ref{.+}", s.handlePatchRef)
+	router.Delete("/repos/:owner/:repo/git/refs/:ref{.+}", s.handleDeleteRef)
+	router.Get("/repos/:owner/:repo/git/commits/:commit_sha", s.handleGetCommit)
+	router.Get("/repos/:owner/:repo/commits/:commit_sha", s.handleGetCommit)
+	router.Get("/repos/:owner/:repo/git/trees/:tree_sha", s.handleGetTree)
+}
+
+func (s *Service) handleListBranches(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	branches := s.store.Branches.FindBy("repo_id", intField(repo, "id"))
+	if protected := c.Query("protected"); protected == "true" || protected == "false" {
+		want := protected == "true"
+		filtered := branches[:0]
+		for _, branch := range branches {
+			if boolField(branch, "protected") == want {
+				filtered = append(filtered, branch)
+			}
+		}
+		branches = filtered
+	}
+	sortRecordsByString(branches, "name", false)
+	page := paginateRecords(c, branches, parsePagination(c))
+	out := make([]any, 0, len(page))
+	for _, branch := range page {
+		out = append(out, s.formatBranch(branch, repo))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleGetBranch(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	branch := s.findBranch(repo, c.Param("branch"))
+	if branch == nil {
+		writeNotFound(c)
+		return
+	}
+	c.JSON(http.StatusOK, s.formatBranch(branch, repo))
+}
+
+func (s *Service) handleGetRef(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	ref := s.findRef(repo, fullRefFromParam(c.Param("ref")))
+	if ref == nil {
+		writeNotFound(c)
+		return
+	}
+	c.JSON(http.StatusOK, s.formatRef(repo, ref))
+}
+
+func (s *Service) handleMatchingRefs(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	prefix := fullRefFromParam(c.Param("ref"))
+	refs := make([]corestore.Record, 0)
+	for _, ref := range s.store.Refs.FindBy("repo_id", intField(repo, "id")) {
+		if strings.HasPrefix(stringField(ref, "ref"), prefix) {
+			refs = append(refs, ref)
+		}
+	}
+	sortRecordsByString(refs, "ref", false)
+	out := make([]any, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, s.formatRef(repo, ref))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleCreateRef(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if _, ok := s.assertRepoWrite(c, repo); !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	fullRef := stringValue(body["ref"])
+	sha := stringValue(body["sha"])
+	if !strings.HasPrefix(fullRef, "refs/") || sha == "" {
+		writeValidation(c, "Invalid ref")
+		return
+	}
+	if s.findRef(repo, fullRef) != nil {
+		writeValidation(c, "Reference already exists")
+		return
+	}
+	row := s.store.Refs.Insert(corestore.Record{
+		"repo_id": intField(repo, "id"),
+		"ref":     fullRef,
+		"sha":     sha,
+		"node_id": "",
+	})
+	ref, _ := s.store.Refs.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("Ref", intField(row, "id"))})
+	s.syncBranchFromRef(repo, fullRef, sha)
+	c.JSON(http.StatusCreated, s.formatRef(repo, ref))
+}
+
+func (s *Service) handlePatchRef(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if _, ok := s.assertRepoWrite(c, repo); !ok {
+		return
+	}
+	ref := s.findRef(repo, fullRefFromParam(c.Param("ref")))
+	if ref == nil {
+		writeNotFound(c)
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	sha := stringValue(body["sha"])
+	if sha == "" {
+		writeValidation(c, "sha is required")
+		return
+	}
+	updated, _ := s.store.Refs.Update(intField(ref, "id"), corestore.Record{"sha": sha})
+	s.syncBranchFromRef(repo, stringField(updated, "ref"), sha)
+	c.JSON(http.StatusOK, s.formatRef(repo, updated))
+}
+
+func (s *Service) handleDeleteRef(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if _, ok := s.assertRepoWrite(c, repo); !ok {
+		return
+	}
+	ref := s.findRef(repo, fullRefFromParam(c.Param("ref")))
+	if ref == nil {
+		writeNotFound(c)
+		return
+	}
+	s.store.Refs.Delete(intField(ref, "id"))
+	if strings.HasPrefix(stringField(ref, "ref"), "refs/heads/") {
+		if branch := s.findBranch(repo, strings.TrimPrefix(stringField(ref, "ref"), "refs/heads/")); branch != nil {
+			s.store.Branches.Delete(intField(branch, "id"))
+		}
+	}
+	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) handleGetCommit(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	commit := s.findCommit(repo, c.Param("commit_sha"))
+	if commit == nil {
+		writeNotFound(c)
+		return
+	}
+	c.JSON(http.StatusOK, s.formatCommit(repo, commit))
+}
+
+func (s *Service) handleGetTree(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	for _, tree := range s.store.Trees.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(tree, "sha") == c.Param("tree_sha") {
+			c.JSON(http.StatusOK, map[string]any{
+				"sha":       stringField(tree, "sha"),
+				"node_id":   stringField(tree, "node_id"),
+				"url":       s.baseURL + "/repos/" + stringField(repo, "full_name") + "/git/trees/" + stringField(tree, "sha"),
+				"tree":      tree["tree"],
+				"truncated": boolField(tree, "truncated"),
+			})
+			return
+		}
+	}
+	writeNotFound(c)
+}
+
+func (s *Service) getOrCreateBranch(repo corestore.Record, branchName string) corestore.Record {
+	if branch := s.findBranch(repo, branchName); branch != nil {
+		return branch
+	}
+	sha := ""
+	if defaultBranch := s.findBranch(repo, stringField(repo, "default_branch")); defaultBranch != nil {
+		sha = stringField(defaultBranch, "sha")
+	}
+	if sha == "" {
+		sha = generateSha()
+	}
+	return s.createBranch(repo, branchName, sha)
+}
+
+func (s *Service) createBranch(repo corestore.Record, branchName string, sha string) corestore.Record {
+	branch := s.store.Branches.Insert(corestore.Record{
+		"repo_id":   intField(repo, "id"),
+		"name":      branchName,
+		"sha":       sha,
+		"protected": false,
+	})
+	if s.findRef(repo, "refs/heads/"+branchName) == nil {
+		ref := s.store.Refs.Insert(corestore.Record{
+			"repo_id": intField(repo, "id"),
+			"ref":     "refs/heads/" + branchName,
+			"sha":     sha,
+			"node_id": "",
+		})
+		s.store.Refs.Update(intField(ref, "id"), corestore.Record{"node_id": generateNodeID("Ref", intField(ref, "id"))})
+	}
+	return branch
+}
+
+func (s *Service) updateBranchSha(repo corestore.Record, branchName string, sha string) {
+	if branch := s.findBranch(repo, branchName); branch != nil {
+		s.store.Branches.Update(intField(branch, "id"), corestore.Record{"sha": sha})
+	}
+	if ref := s.findRef(repo, "refs/heads/"+branchName); ref != nil {
+		s.store.Refs.Update(intField(ref, "id"), corestore.Record{"sha": sha})
+	}
+}
+
+func (s *Service) syncBranchFromRef(repo corestore.Record, fullRef string, sha string) {
+	if !strings.HasPrefix(fullRef, "refs/heads/") {
+		return
+	}
+	branchName := strings.TrimPrefix(fullRef, "refs/heads/")
+	if branch := s.findBranch(repo, branchName); branch != nil {
+		s.store.Branches.Update(intField(branch, "id"), corestore.Record{"sha": sha})
+	} else {
+		s.createBranch(repo, branchName, sha)
+	}
+}
+
+func (s *Service) findBranch(repo corestore.Record, branchName string) corestore.Record {
+	for _, branch := range s.store.Branches.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(branch, "name") == branchName {
+			return branch
+		}
+	}
+	return nil
+}
+
+func (s *Service) findRef(repo corestore.Record, fullRef string) corestore.Record {
+	for _, ref := range s.store.Refs.FindBy("repo_id", intField(repo, "id")) {
+		if stringField(ref, "ref") == fullRef {
+			return ref
+		}
+	}
+	return nil
+}
+
+func (s *Service) findCommit(repo corestore.Record, sha string) corestore.Record {
+	for _, commit := range s.store.Commits.FindBy("repo_id", intField(repo, "id")) {
+		full := stringField(commit, "sha")
+		if full == sha || strings.HasPrefix(full, sha) {
+			return commit
+		}
+	}
+	return nil
+}
+
+func fullRefFromParam(ref string) string {
+	if strings.HasPrefix(ref, "refs/") {
+		return ref
+	}
+	return "refs/" + ref
+}
+
+func sortedRefs(refs []corestore.Record) {
+	sort.SliceStable(refs, func(i, j int) bool {
+		return stringField(refs[i], "ref") < stringField(refs[j], "ref")
+	})
+}
+
+func parseIntParam(value string) (int, bool) {
+	n, err := strconv.Atoi(value)
+	return n, err == nil
+}

--- a/internal/services/github/routes_issues.go
+++ b/internal/services/github/routes_issues.go
@@ -36,9 +36,6 @@ func (s *Service) handleListIssues(c *corehttp.Context) {
 	}
 	list := make([]corestore.Record, 0)
 	for _, issue := range s.store.Issues.FindBy("repo_id", intField(repo, "id")) {
-		if boolField(issue, "is_pull_request") {
-			continue
-		}
 		if state == "open" || state == "closed" {
 			if stringField(issue, "state") != state {
 				continue
@@ -135,7 +132,7 @@ func (s *Service) handleCreateIssue(c *corehttp.Context) {
 }
 
 func (s *Service) handleGetIssue(c *corehttp.Context) {
-	repo, issue, ok := s.issueFromRequest(c, false)
+	repo, issue, ok := s.issueFromRequest(c, true)
 	if !ok {
 		return
 	}
@@ -146,7 +143,7 @@ func (s *Service) handleGetIssue(c *corehttp.Context) {
 }
 
 func (s *Service) handlePatchIssue(c *corehttp.Context) {
-	repo, issue, ok := s.issueFromRequest(c, false)
+	repo, issue, ok := s.issueFromRequest(c, true)
 	if !ok {
 		return
 	}
@@ -209,6 +206,9 @@ func (s *Service) handlePatchIssue(c *corehttp.Context) {
 		patch["label_ids"] = labelIDs
 	}
 	updated, _ := s.store.Issues.Update(intField(issue, "id"), patch)
+	if boolField(issue, "is_pull_request") {
+		s.syncPullFromIssuePatch(intField(repo, "id"), intField(issue, "number"), patch)
+	}
 	if openIssuesDelta != 0 {
 		s.adjustOpenIssues(intField(repo, "id"), openIssuesDelta)
 	}
@@ -237,6 +237,27 @@ func (s *Service) issueFromRequest(c *corehttp.Context, allowPull bool) (coresto
 	}
 	writeNotFound(c)
 	return nil, nil, false
+}
+
+func (s *Service) syncPullFromIssuePatch(repoID int, number int, issuePatch corestore.Record) {
+	if len(issuePatch) == 0 {
+		return
+	}
+	patch := corestore.Record{}
+	for _, key := range []string{"title", "body", "state", "closed_at", "assignee_ids", "label_ids", "milestone_id"} {
+		if value, exists := issuePatch[key]; exists {
+			patch[key] = value
+		}
+	}
+	if len(patch) == 0 {
+		return
+	}
+	for _, pr := range s.store.PullRequests.FindBy("repo_id", repoID) {
+		if intField(pr, "number") == number {
+			s.store.PullRequests.Update(intField(pr, "id"), patch)
+			return
+		}
+	}
 }
 
 func (s *Service) nextIssueNumber(repoID int) int {

--- a/internal/services/github/routes_issues.go
+++ b/internal/services/github/routes_issues.go
@@ -88,7 +88,7 @@ func (s *Service) handleCreateIssue(c *corehttp.Context) {
 		writeNotFound(c)
 		return
 	}
-	actor, ok := s.assertRepoWrite(c, repo)
+	actor, ok := s.assertIssueParticipant(c, repo)
 	if !ok {
 		return
 	}

--- a/internal/services/github/routes_issues.go
+++ b/internal/services/github/routes_issues.go
@@ -166,6 +166,12 @@ func (s *Service) handlePatchIssue(c *corehttp.Context) {
 	oldState := stringField(issue, "state")
 	openIssuesDelta := 0
 	if state := stringValue(body["state"]); state == "open" || state == "closed" {
+		if state == "open" && boolField(issue, "is_pull_request") {
+			if pr := s.findPullByNumber(intField(repo, "id"), intField(issue, "number")); pr != nil && boolField(pr, "merged") {
+				writeValidation(c, "Validation failed")
+				return
+			}
+		}
 		patch["state"] = state
 		if state == "closed" && oldState == "open" {
 			patch["closed_at"] = nowISO()

--- a/internal/services/github/routes_issues.go
+++ b/internal/services/github/routes_issues.go
@@ -167,6 +167,7 @@ func (s *Service) handlePatchIssue(c *corehttp.Context) {
 		patch["body"] = nullableIssueBody(value)
 	}
 	oldState := stringField(issue, "state")
+	openIssuesDelta := 0
 	if state := stringValue(body["state"]); state == "open" || state == "closed" {
 		patch["state"] = state
 		if state == "closed" && oldState == "open" {
@@ -175,7 +176,7 @@ func (s *Service) handlePatchIssue(c *corehttp.Context) {
 			if _, exists := body["state_reason"]; !exists {
 				patch["state_reason"] = "completed"
 			}
-			s.adjustOpenIssues(intField(repo, "id"), -1)
+			openIssuesDelta = -1
 		}
 		if state == "open" && oldState == "closed" {
 			patch["closed_at"] = nil
@@ -183,7 +184,7 @@ func (s *Service) handlePatchIssue(c *corehttp.Context) {
 			if _, exists := body["state_reason"]; !exists {
 				patch["state_reason"] = "reopened"
 			}
-			s.adjustOpenIssues(intField(repo, "id"), 1)
+			openIssuesDelta = 1
 		}
 	}
 	if reason, exists := body["state_reason"]; exists {
@@ -208,6 +209,9 @@ func (s *Service) handlePatchIssue(c *corehttp.Context) {
 		patch["label_ids"] = labelIDs
 	}
 	updated, _ := s.store.Issues.Update(intField(issue, "id"), patch)
+	if openIssuesDelta != 0 {
+		s.adjustOpenIssues(intField(repo, "id"), openIssuesDelta)
+	}
 	c.JSON(http.StatusOK, s.formatIssue(updated))
 }
 

--- a/internal/services/github/routes_issues.go
+++ b/internal/services/github/routes_issues.go
@@ -1,0 +1,342 @@
+package github
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerIssueRoutes(router *corehttp.Router) {
+	router.Get("/repos/:owner/:repo/issues", s.handleListIssues)
+	router.Post("/repos/:owner/:repo/issues", s.handleCreateIssue)
+	router.Get("/repos/:owner/:repo/issues/:issue_number", s.handleGetIssue)
+	router.Patch("/repos/:owner/:repo/issues/:issue_number", s.handlePatchIssue)
+}
+
+func (s *Service) handleListIssues(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	if !boolField(repo, "has_issues") {
+		writeNotFound(c)
+		return
+	}
+	state := c.Query("state")
+	if state == "" {
+		state = "open"
+	}
+	list := make([]corestore.Record, 0)
+	for _, issue := range s.store.Issues.FindBy("repo_id", intField(repo, "id")) {
+		if boolField(issue, "is_pull_request") {
+			continue
+		}
+		if state == "open" || state == "closed" {
+			if stringField(issue, "state") != state {
+				continue
+			}
+		}
+		list = append(list, issue)
+	}
+	sortKey := c.Query("sort")
+	if sortKey == "" {
+		sortKey = "created"
+	}
+	direction := c.Query("direction")
+	if direction != "asc" {
+		direction = "desc"
+	}
+	sort.SliceStable(list, func(i, j int) bool {
+		if sortKey == "comments" {
+			if direction == "asc" {
+				return intField(list[i], "comments") < intField(list[j], "comments")
+			}
+			return intField(list[i], "comments") > intField(list[j], "comments")
+		}
+		field := "created_at"
+		if sortKey == "updated" {
+			field = "updated_at"
+		}
+		if direction == "asc" {
+			return stringField(list[i], field) < stringField(list[j], field)
+		}
+		return stringField(list[i], field) > stringField(list[j], field)
+	})
+	page := paginateRecords(c, list, parsePagination(c))
+	out := make([]any, 0, len(page))
+	for _, issue := range page {
+		out = append(out, s.formatIssue(issue))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleCreateIssue(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !boolField(repo, "has_issues") {
+		writeNotFound(c)
+		return
+	}
+	actor, ok := s.assertRepoWrite(c, repo)
+	if !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	title := strings.TrimSpace(stringValue(body["title"]))
+	if title == "" {
+		writeValidation(c, "Validation failed")
+		return
+	}
+	assigneeIDs, ok := s.resolveAssignees(c, body["assignees"])
+	if !ok {
+		return
+	}
+	labelIDs, ok := s.resolveLabelIDs(c, repo, body["labels"], true)
+	if !ok {
+		return
+	}
+	row := s.store.Issues.Insert(corestore.Record{
+		"node_id":            "",
+		"number":             s.nextIssueNumber(intField(repo, "id")),
+		"repo_id":            intField(repo, "id"),
+		"title":              title,
+		"body":               nullableIssueBody(body["body"]),
+		"state":              "open",
+		"state_reason":       nil,
+		"locked":             false,
+		"active_lock_reason": nil,
+		"user_id":            intField(actor, "id"),
+		"assignee_ids":       assigneeIDs,
+		"label_ids":          labelIDs,
+		"milestone_id":       nil,
+		"comments":           0,
+		"closed_at":          nil,
+		"closed_by_id":       nil,
+		"is_pull_request":    false,
+	})
+	issue, _ := s.store.Issues.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("Issue", intField(row, "id"))})
+	s.adjustOpenIssues(intField(repo, "id"), 1)
+	c.JSON(http.StatusCreated, s.formatIssue(issue))
+}
+
+func (s *Service) handleGetIssue(c *corehttp.Context) {
+	repo, issue, ok := s.issueFromRequest(c, false)
+	if !ok {
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	c.JSON(http.StatusOK, s.formatIssue(issue))
+}
+
+func (s *Service) handlePatchIssue(c *corehttp.Context) {
+	repo, issue, ok := s.issueFromRequest(c, false)
+	if !ok {
+		return
+	}
+	actor, ok := s.assertRepoWrite(c, repo)
+	if !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	patch := corestore.Record{}
+	if title, ok := body["title"].(string); ok {
+		patch["title"] = title
+	}
+	if value, exists := body["body"]; exists {
+		patch["body"] = nullableIssueBody(value)
+	}
+	oldState := stringField(issue, "state")
+	if state := stringValue(body["state"]); state == "open" || state == "closed" {
+		patch["state"] = state
+		if state == "closed" && oldState == "open" {
+			patch["closed_at"] = nowISO()
+			patch["closed_by_id"] = intField(actor, "id")
+			if _, exists := body["state_reason"]; !exists {
+				patch["state_reason"] = "completed"
+			}
+			s.adjustOpenIssues(intField(repo, "id"), -1)
+		}
+		if state == "open" && oldState == "closed" {
+			patch["closed_at"] = nil
+			patch["closed_by_id"] = nil
+			if _, exists := body["state_reason"]; !exists {
+				patch["state_reason"] = "reopened"
+			}
+			s.adjustOpenIssues(intField(repo, "id"), 1)
+		}
+	}
+	if reason, exists := body["state_reason"]; exists {
+		if reason == nil {
+			patch["state_reason"] = nil
+		} else if value := stringValue(reason); value == "completed" || value == "not_planned" || value == "reopened" {
+			patch["state_reason"] = value
+		}
+	}
+	if _, exists := body["assignees"]; exists {
+		assigneeIDs, ok := s.resolveAssignees(c, body["assignees"])
+		if !ok {
+			return
+		}
+		patch["assignee_ids"] = assigneeIDs
+	}
+	if _, exists := body["labels"]; exists {
+		labelIDs, ok := s.resolveLabelIDs(c, repo, body["labels"], true)
+		if !ok {
+			return
+		}
+		patch["label_ids"] = labelIDs
+	}
+	updated, _ := s.store.Issues.Update(intField(issue, "id"), patch)
+	c.JSON(http.StatusOK, s.formatIssue(updated))
+}
+
+func (s *Service) issueFromRequest(c *corehttp.Context, allowPull bool) (corestore.Record, corestore.Record, bool) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	if !boolField(repo, "has_issues") {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	number, err := strconv.Atoi(c.Param("issue_number"))
+	if err != nil {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	for _, issue := range s.store.Issues.FindBy("repo_id", intField(repo, "id")) {
+		if intField(issue, "number") == number && (allowPull || !boolField(issue, "is_pull_request")) {
+			return repo, issue, true
+		}
+	}
+	writeNotFound(c)
+	return nil, nil, false
+}
+
+func (s *Service) nextIssueNumber(repoID int) int {
+	maxNumber := 0
+	for _, issue := range s.store.Issues.FindBy("repo_id", repoID) {
+		if n := intField(issue, "number"); n > maxNumber {
+			maxNumber = n
+		}
+	}
+	for _, pr := range s.store.PullRequests.FindBy("repo_id", repoID) {
+		if n := intField(pr, "number"); n > maxNumber {
+			maxNumber = n
+		}
+	}
+	return maxNumber + 1
+}
+
+func (s *Service) adjustOpenIssues(repoID int, delta int) {
+	repo, ok := s.store.Repos.Get(repoID)
+	if !ok {
+		return
+	}
+	next := intField(repo, "open_issues_count") + delta
+	if next < 0 {
+		next = 0
+	}
+	s.store.Repos.Update(repoID, corestore.Record{"open_issues_count": next})
+}
+
+func (s *Service) resolveAssignees(c *corehttp.Context, raw any) ([]int, bool) {
+	if raw == nil {
+		return []int{}, true
+	}
+	logins := stringSliceValue(raw)
+	ids := make([]int, 0, len(logins))
+	for _, login := range logins {
+		user := firstRecord(s.store.Users.FindBy("login", login))
+		if user == nil {
+			writeValidation(c, "Validation failed")
+			return nil, false
+		}
+		ids = append(ids, intField(user, "id"))
+	}
+	return uniqueInts(ids), true
+}
+
+func (s *Service) resolveLabelIDs(c *corehttp.Context, repo corestore.Record, raw any, createMissing bool) ([]int, bool) {
+	if raw == nil {
+		return []int{}, true
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		writeValidation(c, "Validation failed")
+		return nil, false
+	}
+	ids := make([]int, 0, len(values))
+	for _, item := range values {
+		switch value := item.(type) {
+		case string:
+			label := firstRecord(s.store.Labels.FindBy("repo_id", intField(repo, "id")))
+			for _, candidate := range s.store.Labels.FindBy("repo_id", intField(repo, "id")) {
+				if stringField(candidate, "name") == value {
+					label = candidate
+					break
+				}
+			}
+			if label == nil || stringField(label, "name") != value {
+				if !createMissing {
+					writeValidation(c, "Validation failed")
+					return nil, false
+				}
+				inserted := s.store.Labels.Insert(corestore.Record{
+					"node_id":     "",
+					"repo_id":     intField(repo, "id"),
+					"name":        value,
+					"description": nil,
+					"color":       "ededed",
+					"default":     false,
+				})
+				label, _ = s.store.Labels.Update(intField(inserted, "id"), corestore.Record{"node_id": generateNodeID("Label", intField(inserted, "id"))})
+			}
+			ids = append(ids, intField(label, "id"))
+		case float64:
+			id := int(value)
+			label, ok := s.store.Labels.Get(id)
+			if !ok || intField(label, "repo_id") != intField(repo, "id") {
+				writeValidation(c, "Validation failed")
+				return nil, false
+			}
+			ids = append(ids, id)
+		default:
+			writeValidation(c, "Validation failed")
+			return nil, false
+		}
+	}
+	return uniqueInts(ids), true
+}
+
+func nullableIssueBody(value any) any {
+	if value == nil {
+		return nil
+	}
+	if body, ok := value.(string); ok {
+		return body
+	}
+	return nil
+}

--- a/internal/services/github/routes_issues.go
+++ b/internal/services/github/routes_issues.go
@@ -43,6 +43,143 @@ func (s *Service) handleListIssues(c *corehttp.Context) {
 		}
 		list = append(list, issue)
 	}
+	labelNames := issueLabelFilters(c.Query("labels"))
+	if len(labelNames) > 0 {
+		labelIDs := make([]int, 0, len(labelNames))
+		for _, name := range labelNames {
+			var labelID int
+			for _, label := range s.store.Labels.FindBy("repo_id", intField(repo, "id")) {
+				if stringField(label, "name") == name {
+					labelID = intField(label, "id")
+					break
+				}
+			}
+			if labelID == 0 {
+				list = nil
+				break
+			}
+			labelIDs = append(labelIDs, labelID)
+		}
+		if len(list) > 0 {
+			filtered := list[:0]
+			for _, issue := range list {
+				issueLabelIDs := intSliceValue(issue["label_ids"])
+				matches := true
+				for _, labelID := range labelIDs {
+					if !containsInt(issueLabelIDs, labelID) {
+						matches = false
+						break
+					}
+				}
+				if matches {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		}
+	}
+	if milestone := c.Query("milestone"); milestone != "" {
+		switch milestone {
+		case "none":
+			filtered := list[:0]
+			for _, issue := range list {
+				if intField(issue, "milestone_id") == 0 {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		case "*":
+			filtered := list[:0]
+			for _, issue := range list {
+				if intField(issue, "milestone_id") > 0 {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		default:
+			number, err := strconv.Atoi(milestone)
+			if err != nil {
+				list = nil
+				break
+			}
+			var milestoneID int
+			for _, row := range s.store.Milestones.FindBy("repo_id", intField(repo, "id")) {
+				if intField(row, "number") == number {
+					milestoneID = intField(row, "id")
+					break
+				}
+			}
+			if milestoneID == 0 {
+				list = nil
+				break
+			}
+			filtered := list[:0]
+			for _, issue := range list {
+				if intField(issue, "milestone_id") == milestoneID {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		}
+	}
+	if assignee := c.Query("assignee"); assignee != "" {
+		switch assignee {
+		case "none":
+			filtered := list[:0]
+			for _, issue := range list {
+				if len(intSliceValue(issue["assignee_ids"])) == 0 {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		case "*":
+			filtered := list[:0]
+			for _, issue := range list {
+				if len(intSliceValue(issue["assignee_ids"])) > 0 {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		default:
+			user := firstRecord(s.store.Users.FindBy("login", assignee))
+			if user == nil {
+				list = nil
+				break
+			}
+			userID := intField(user, "id")
+			filtered := list[:0]
+			for _, issue := range list {
+				if containsInt(intSliceValue(issue["assignee_ids"]), userID) {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		}
+	}
+	if creator := c.Query("creator"); creator != "" {
+		user := firstRecord(s.store.Users.FindBy("login", creator))
+		if user == nil {
+			list = nil
+		} else {
+			userID := intField(user, "id")
+			filtered := list[:0]
+			for _, issue := range list {
+				if intField(issue, "user_id") == userID {
+					filtered = append(filtered, issue)
+				}
+			}
+			list = filtered
+		}
+	}
+	if since := c.Query("since"); since != "" {
+		filtered := list[:0]
+		for _, issue := range list {
+			if stringField(issue, "updated_at") >= since {
+				filtered = append(filtered, issue)
+			}
+		}
+		list = filtered
+	}
 	sortKey := c.Query("sort")
 	if sortKey == "" {
 		sortKey = "created"
@@ -370,4 +507,18 @@ func nullableIssueBody(value any) any {
 		return body
 	}
 	return nil
+}
+
+func issueLabelFilters(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if label := strings.TrimSpace(part); label != "" {
+			out = append(out, label)
+		}
+	}
+	return out
 }

--- a/internal/services/github/routes_meta.go
+++ b/internal/services/github/routes_meta.go
@@ -1,0 +1,105 @@
+package github
+
+import (
+	"math/rand"
+	"net/http"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+)
+
+func (s *Service) registerMetaRoutes(router *corehttp.Router) {
+	router.Get("/rate_limit", s.handleRateLimit)
+	router.Get("/meta", s.handleMeta)
+	router.Get("/emojis", s.handleEmojis)
+	router.Get("/zen", s.handleZen)
+	router.Get("/versions", s.handleVersions)
+}
+
+func (s *Service) handleRateLimit(c *corehttp.Context) {
+	now := time.Now().Unix()
+	reset := now + 3600
+	core := map[string]any{"limit": 5000, "remaining": 4999, "reset": reset, "used": 1, "resource": "core"}
+	c.JSON(http.StatusOK, map[string]any{
+		"resources": map[string]any{
+			"core":                 core,
+			"search":               map[string]any{"limit": 30, "remaining": 29, "reset": reset, "used": 1, "resource": "search"},
+			"graphql":              map[string]any{"limit": 5000, "remaining": 4999, "reset": reset, "used": 1, "resource": "graphql"},
+			"integration_manifest": map[string]any{"limit": 5000, "remaining": 4999, "reset": reset, "used": 1, "resource": "integration_manifest"},
+			"source_import":        map[string]any{"limit": 100, "remaining": 99, "reset": reset, "used": 1, "resource": "source_import"},
+			"code_scanning_upload": map[string]any{"limit": 500, "remaining": 499, "reset": reset, "used": 1, "resource": "code_scanning_upload"},
+		},
+		"rate": core,
+	})
+}
+
+func (s *Service) handleMeta(c *corehttp.Context) {
+	c.JSON(http.StatusOK, map[string]any{
+		"verifiable_password_authentication": true,
+		"ssh_key_fingerprints": map[string]any{
+			"SHA256_RSA":     "placeholder",
+			"SHA256_DSA":     "placeholder",
+			"SHA256_ECDSA":   "placeholder",
+			"SHA256_ED25519": "placeholder",
+		},
+		"ssh_keys":                   []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPlaceholder"},
+		"hooks":                      []string{"127.0.0.1/32"},
+		"web":                        []string{"127.0.0.1/32"},
+		"api":                        []string{"127.0.0.1/32"},
+		"git":                        []string{"127.0.0.1/32"},
+		"github_enterprise_importer": []string{"127.0.0.1/32"},
+		"packages":                   []string{"127.0.0.1/32"},
+		"pages":                      []string{"127.0.0.1/32"},
+		"importer":                   []string{"127.0.0.1/32"},
+		"actions":                    []string{"127.0.0.1/32"},
+		"actions_macos":              []string{"127.0.0.1/32"},
+		"dependabot":                 []string{"127.0.0.1/32"},
+		"copilot":                    []string{"127.0.0.1/32"},
+		"domains": map[string]any{
+			"website":               []string{"localhost"},
+			"codespaces":            []string{"localhost"},
+			"copilot":               []string{"localhost"},
+			"packages":              []string{"localhost"},
+			"actions":               []string{"localhost"},
+			"artifact_attestations": map[string]any{"trust_domain": "localhost"},
+		},
+	})
+}
+
+func (s *Service) handleEmojis(c *corehttp.Context) {
+	c.JSON(http.StatusOK, map[string]any{
+		"+1":         s.baseURL + "/emojis/+1.png",
+		"-1":         s.baseURL + "/emojis/-1.png",
+		"100":        s.baseURL + "/emojis/100.png",
+		"tada":       s.baseURL + "/emojis/tada.png",
+		"rocket":     s.baseURL + "/emojis/rocket.png",
+		"heart":      s.baseURL + "/emojis/heart.png",
+		"eyes":       s.baseURL + "/emojis/eyes.png",
+		"thinking":   s.baseURL + "/emojis/thinking.png",
+		"thumbsup":   s.baseURL + "/emojis/thumbsup.png",
+		"thumbsdown": s.baseURL + "/emojis/thumbsdown.png",
+	})
+}
+
+func (s *Service) handleZen(c *corehttp.Context) {
+	phrases := []string{
+		"Non-blocking is better than blocking.",
+		"Design for failure.",
+		"Half measures are as bad as nothing at all.",
+		"Encourage flow.",
+		"Anything added dilutes everything else.",
+		"Approachable is better than simple.",
+		"Mind your words, they are important.",
+		"Speak like a human.",
+		"It is not fully shipped until it is fast.",
+		"Responsive is better than fast.",
+		"Keep it logically awesome.",
+		"Favor focus over features.",
+		"Avoid administrative distraction.",
+	}
+	c.Text(http.StatusOK, phrases[rand.Intn(len(phrases))])
+}
+
+func (s *Service) handleVersions(c *corehttp.Context) {
+	c.JSON(http.StatusOK, []string{"2022-11-28", "2022-08-09"})
+}

--- a/internal/services/github/routes_oauth.go
+++ b/internal/services/github/routes_oauth.go
@@ -127,15 +127,13 @@ func (s *Service) handleOAuthCallback(c *corehttp.Context) {
 func (s *Service) handleOAuthToken(c *corehttp.Context) {
 	body, err := parseOAuthBody(c.Request)
 	if err != nil {
-		c.JSON(http.StatusOK, map[string]any{
-			"error":             "bad_verification_code",
-			"error_description": "The code passed is incorrect or expired.",
-		})
+		writeBadVerificationCode(c)
 		return
 	}
 	code := stringValue(body["code"])
 	clientID := stringValue(body["client_id"])
 	clientSecret := stringValue(body["client_secret"])
+	redirectURI := stringValue(body["redirect_uri"])
 	if len(s.store.OAuthApps.All()) > 0 {
 		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
 		if app == nil || subtle.ConstantTimeCompare([]byte(clientSecret), []byte(stringField(app, "client_secret"))) != 1 {
@@ -148,19 +146,23 @@ func (s *Service) handleOAuthToken(c *corehttp.Context) {
 	}
 	pending := firstRecord(s.store.OAuthCodes.FindBy("code", code))
 	if pending == nil || time.Since(pendingCodeCreatedAt(pending)) > pendingCodeTTL {
-		c.JSON(http.StatusOK, map[string]any{
-			"error":             "bad_verification_code",
-			"error_description": "The code passed is incorrect or expired.",
-		})
+		writeBadVerificationCode(c)
+		return
+	}
+	pendingClientID := stringField(pending, "client_id")
+	if pendingClientID != "" && clientID != "" && clientID != pendingClientID {
+		writeBadVerificationCode(c)
+		return
+	}
+	pendingRedirectURI := stringField(pending, "redirectURI")
+	if redirectURI != "" && pendingRedirectURI != "" && redirectURI != pendingRedirectURI {
+		writeBadVerificationCode(c)
 		return
 	}
 	s.deleteOAuthCode(code)
 	user := firstRecord(s.store.Users.FindBy("login", stringField(pending, "login")))
 	if user == nil {
-		c.JSON(http.StatusOK, map[string]any{
-			"error":             "bad_verification_code",
-			"error_description": "The code passed is incorrect or expired.",
-		})
+		writeBadVerificationCode(c)
 		return
 	}
 	scope := stringField(pending, "scope")
@@ -184,6 +186,13 @@ func (s *Service) handleOAuthToken(c *corehttp.Context) {
 		"access_token": token,
 		"token_type":   "bearer",
 		"scope":        scope,
+	})
+}
+
+func writeBadVerificationCode(c *corehttp.Context) {
+	c.JSON(http.StatusOK, map[string]any{
+		"error":             "bad_verification_code",
+		"error_description": "The code passed is incorrect or expired.",
 	})
 }
 

--- a/internal/services/github/routes_oauth.go
+++ b/internal/services/github/routes_oauth.go
@@ -20,7 +20,6 @@ func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
 	router.Get("/login/oauth/authorize", s.handleOAuthAuthorize)
 	router.Post("/login/oauth/callback", s.handleOAuthCallback)
 	router.Post("/login/oauth/access_token", s.handleOAuthToken)
-	router.Get("/login/oauth/userinfo", s.handleOAuthUserinfo)
 	router.Get("/userinfo", s.handleOAuthUserinfo)
 	router.Get("/user/emails", s.handleUserEmails)
 }

--- a/internal/services/github/routes_oauth.go
+++ b/internal/services/github/routes_oauth.go
@@ -1,0 +1,227 @@
+package github
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+const pendingCodeTTL = 10 * time.Minute
+
+func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
+	router.Get("/login/oauth/authorize", s.handleOAuthAuthorize)
+	router.Post("/login/oauth/callback", s.handleOAuthCallback)
+	router.Post("/login/oauth/access_token", s.handleOAuthToken)
+	router.Get("/login/oauth/userinfo", s.handleOAuthUserinfo)
+	router.Get("/userinfo", s.handleOAuthUserinfo)
+	router.Get("/user/emails", s.handleUserEmails)
+}
+
+func (s *Service) handleOAuthAuthorize(c *corehttp.Context) {
+	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
+	scope := c.Query("scope")
+	state := c.Query("state")
+	appName := ""
+	if len(s.store.OAuthApps.All()) > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(app["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		appName = stringField(app, "name")
+	}
+	users := s.store.Users.All()
+	sortRecordsByString(users, "login", false)
+	subtitle := "Choose a seeded user to authorize this application."
+	if appName != "" {
+		subtitle = "Authorize <strong>" + ui.EscapeHTML(appName) + "</strong> to access your account."
+	}
+	var body strings.Builder
+	if len(users) == 0 {
+		body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+	} else {
+		for _, user := range users {
+			login := stringField(user, "login")
+			letter := "?"
+			if login != "" {
+				letter = strings.ToUpper(login[:1])
+			}
+			body.WriteString(ui.RenderUserButton(ui.UserButtonOptions{
+				Letter:     letter,
+				Login:      login,
+				Name:       stringField(user, "name"),
+				Email:      stringField(user, "email"),
+				FormAction: "/login/oauth/callback",
+				HiddenFields: map[string]string{
+					"login":        login,
+					"redirect_uri": redirectURI,
+					"scope":        scope,
+					"state":        state,
+					"client_id":    clientID,
+				},
+			}))
+		}
+	}
+	c.HTML(http.StatusOK, ui.RenderCardPage("Sign in to GitHub", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+}
+
+func (s *Service) handleOAuthCallback(c *corehttp.Context) {
+	if err := c.Request.ParseForm(); err != nil {
+		writeGitHubError(c, http.StatusBadRequest, "Invalid form body")
+		return
+	}
+	login := c.Request.Form.Get("login")
+	redirectURI := c.Request.Form.Get("redirect_uri")
+	clientID := c.Request.Form.Get("client_id")
+	scope := c.Request.Form.Get("scope")
+	state := c.Request.Form.Get("state")
+	if firstRecord(s.store.Users.FindBy("login", login)) == nil {
+		writeGitHubError(c, http.StatusBadRequest, "User not found")
+		return
+	}
+	if len(s.store.OAuthApps.All()) > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil {
+			writeGitHubError(c, http.StatusBadRequest, "Application not found")
+			return
+		}
+		if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(app["redirect_uris"])) {
+			writeGitHubError(c, http.StatusBadRequest, "Redirect URI mismatch")
+			return
+		}
+	}
+	target, err := url.Parse(redirectURI)
+	if err != nil || target == nil || target.Scheme == "" {
+		writeGitHubError(c, http.StatusBadRequest, "Invalid redirect_uri")
+		return
+	}
+	code := generateHex(20)
+	s.store.OAuthCodes.Insert(corestore.Record{
+		"code":        code,
+		"login":       login,
+		"scope":       scope,
+		"redirectURI": redirectURI,
+		"client_id":   clientID,
+		"createdAt":   time.Now().UnixMilli(),
+	})
+	query := target.Query()
+	query.Set("code", code)
+	query.Set("state", state)
+	target.RawQuery = query.Encode()
+	c.Redirect(http.StatusFound, target.String())
+}
+
+func (s *Service) handleOAuthToken(c *corehttp.Context) {
+	body, err := parseOAuthBody(c.Request)
+	if err != nil {
+		c.JSON(http.StatusOK, map[string]any{
+			"error":             "bad_verification_code",
+			"error_description": "The code passed is incorrect or expired.",
+		})
+		return
+	}
+	code := stringValue(body["code"])
+	clientID := stringValue(body["client_id"])
+	clientSecret := stringValue(body["client_secret"])
+	if len(s.store.OAuthApps.All()) > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil || subtle.ConstantTimeCompare([]byte(clientSecret), []byte(stringField(app, "client_secret"))) != 1 {
+			c.JSON(http.StatusOK, map[string]any{
+				"error":             "incorrect_client_credentials",
+				"error_description": "The client_id and/or client_secret passed are incorrect.",
+			})
+			return
+		}
+	}
+	pending := firstRecord(s.store.OAuthCodes.FindBy("code", code))
+	if pending == nil || time.Since(pendingCodeCreatedAt(pending)) > pendingCodeTTL {
+		c.JSON(http.StatusOK, map[string]any{
+			"error":             "bad_verification_code",
+			"error_description": "The code passed is incorrect or expired.",
+		})
+		return
+	}
+	s.deleteOAuthCode(code)
+	user := firstRecord(s.store.Users.FindBy("login", stringField(pending, "login")))
+	if user == nil {
+		c.JSON(http.StatusOK, map[string]any{
+			"error":             "bad_verification_code",
+			"error_description": "The code passed is incorrect or expired.",
+		})
+		return
+	}
+	scope := stringField(pending, "scope")
+	scopes := []string{"repo", "user"}
+	if scope != "" {
+		scopes = strings.FieldsFunc(scope, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' || r == '\n' })
+	}
+	token := "gho_" + base64URLSecret(20)
+	s.store.OAuthTokens.Insert(corestore.Record{
+		"tokenString": token,
+		"login":       stringField(user, "login"),
+		"scopes":      scopes,
+		"client_id":   stringField(pending, "client_id"),
+	})
+	if strings.Contains(c.Request.Header.Get("Accept"), "application/x-www-form-urlencoded") {
+		c.Writer.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+		c.Text(http.StatusOK, "access_token="+url.QueryEscape(token)+"&token_type=bearer&scope="+url.QueryEscape(scope))
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"access_token": token,
+		"token_type":   "bearer",
+		"scope":        scope,
+	})
+}
+
+func (s *Service) handleOAuthUserinfo(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"sub":                strconv.Itoa(intField(user, "id")),
+		"email":              user["email"],
+		"name":               user["name"],
+		"preferred_username": stringField(user, "login"),
+		"email_verified":     true,
+		"picture":            s.baseURL + "/avatars/u/" + stringField(user, "login"),
+	})
+}
+
+func (s *Service) handleUserEmails(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	email := stringField(user, "email")
+	if email == "" {
+		email = stringField(user, "login") + "@users.noreply.localhost"
+	}
+	c.JSON(http.StatusOK, []any{
+		map[string]any{"email": email, "primary": true, "verified": true, "visibility": "public"},
+	})
+}
+
+func (s *Service) deleteOAuthCode(code string) {
+	for _, row := range s.store.OAuthCodes.FindBy("code", code) {
+		s.store.OAuthCodes.Delete(intField(row, "id"))
+	}
+}
+
+func base64URLSecret(size int) string {
+	return strings.TrimRight(base64.RawURLEncoding.EncodeToString([]byte(generateHex(size))), "=")
+}

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -96,6 +96,10 @@ func (s *Service) handleCreatePull(c *corehttp.Context) {
 	}
 	headBranch := s.getOrCreateBranch(headRepo, headRef)
 	baseBranch := s.getOrCreateBranch(repo, base)
+	if headBranch == nil || baseBranch == nil {
+		writeValidation(c, "The repository is empty.")
+		return
+	}
 	number := s.nextIssueNumber(intField(repo, "id"))
 	prBody := nullableIssueBody(body["body"])
 	issue := s.store.Issues.Insert(corestore.Record{
@@ -216,6 +220,10 @@ func (s *Service) handlePatchPull(c *corehttp.Context) {
 	}
 	if base := strings.TrimSpace(stringValue(body["base"])); base != "" {
 		branch := s.getOrCreateBranch(repo, base)
+		if branch == nil {
+			writeValidation(c, "The repository is empty.")
+			return
+		}
 		patch["base_ref"] = base
 		patch["base_sha"] = stringField(branch, "sha")
 	}
@@ -239,7 +247,24 @@ func (s *Service) handleMergePull(c *corehttp.Context) {
 		writeValidation(c, "Pull Request is not mergeable")
 		return
 	}
-	mergeSha := generateSha()
+	baseRepo, ok := s.store.Repos.Get(intField(pr, "base_repo_id"))
+	if !ok {
+		writeValidation(c, "Base repository not found")
+		return
+	}
+	headRepo, ok := s.store.Repos.Get(intField(pr, "head_repo_id"))
+	if !ok {
+		writeValidation(c, "Head repository not found")
+		return
+	}
+	baseCommit := s.findCommitExact(baseRepo, stringField(pr, "base_sha"))
+	headCommit := s.findCommitExact(headRepo, stringField(pr, "head_sha"))
+	if baseCommit == nil || headCommit == nil {
+		writeValidation(c, "Could not resolve commits to merge.")
+		return
+	}
+	mergeCommit := s.insertCommit(baseRepo, stringField(headCommit, "tree_sha"), []string{stringField(baseCommit, "sha"), stringField(headCommit, "sha")}, mergeCommitMessage(pr), actor)
+	mergeSha := stringField(mergeCommit, "sha")
 	now := nowISO()
 	s.store.PullRequests.Update(intField(pr, "id"), corestore.Record{
 		"merged":           true,
@@ -295,7 +320,11 @@ func (s *Service) handlePullCommits(c *corehttp.Context) {
 }
 
 func (s *Service) handlePullFiles(c *corehttp.Context) {
-	if _, _, ok := s.pullFromRequest(c); !ok {
+	repo, _, ok := s.pullFromRequest(c)
+	if !ok {
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
 		return
 	}
 	c.JSON(http.StatusOK, []any{})
@@ -328,4 +357,37 @@ func (s *Service) findPullIssue(repoID int, number int) corestore.Record {
 		}
 	}
 	return nil
+}
+
+func (s *Service) insertCommit(repo corestore.Record, treeSha string, parentShas []string, message string, actor corestore.Record) corestore.Record {
+	authorName := stringField(actor, "name")
+	if authorName == "" {
+		authorName = stringField(actor, "login")
+	}
+	authorEmail := stringField(actor, "email")
+	if authorEmail == "" {
+		authorEmail = stringField(actor, "login") + "@localhost"
+	}
+	now := nowISO()
+	row := s.store.Commits.Insert(corestore.Record{
+		"repo_id":         intField(repo, "id"),
+		"sha":             generateSha(),
+		"node_id":         "",
+		"message":         message,
+		"author_name":     authorName,
+		"author_email":    authorEmail,
+		"author_date":     now,
+		"committer_name":  authorName,
+		"committer_email": authorEmail,
+		"committer_date":  now,
+		"tree_sha":        treeSha,
+		"parent_shas":     parentShas,
+		"user_id":         intField(actor, "id"),
+	})
+	commit, _ := s.store.Commits.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("Commit", intField(row, "id"))})
+	return commit
+}
+
+func mergeCommitMessage(pr corestore.Record) string {
+	return "Merge pull request #" + strconv.Itoa(intField(pr, "number")) + " from " + stringField(pr, "head_ref")
 }

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -43,7 +43,7 @@ func (s *Service) handleListPulls(c *corehttp.Context) {
 		if base := strings.TrimSpace(c.Query("base")); base != "" && stringField(pr, "base_ref") != base {
 			continue
 		}
-		if head := strings.TrimSpace(c.Query("head")); head != "" && stringField(pr, "head_ref") != strings.TrimPrefix(head, s.ownerLogin(repo)+":") {
+		if head := strings.TrimSpace(c.Query("head")); head != "" && !s.matchesPullHeadFilter(pr, head) {
 			continue
 		}
 		pulls = append(pulls, pr)
@@ -374,6 +374,21 @@ func (s *Service) resolvePullHead(baseRepo corestore.Record, head string) (cores
 		return nil, "", false
 	}
 	return headRepo, ref, true
+}
+
+func (s *Service) matchesPullHeadFilter(pr corestore.Record, head string) bool {
+	head = strings.TrimSpace(head)
+	if head == "" {
+		return true
+	}
+	if !strings.Contains(head, ":") {
+		return stringField(pr, "head_ref") == head
+	}
+	headRepo, ok := s.store.Repos.Get(intField(pr, "head_repo_id"))
+	if !ok {
+		return false
+	}
+	return s.ownerLogin(headRepo)+":"+stringField(pr, "head_ref") == head
 }
 
 func (s *Service) insertCommit(repo corestore.Record, treeSha string, parentShas []string, message string, actor corestore.Record) corestore.Record {

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -65,8 +65,11 @@ func (s *Service) handleCreatePull(c *corehttp.Context) {
 		writeNotFound(c)
 		return
 	}
-	actor, ok := s.assertRepoWrite(c, repo)
+	actor, auth, ok := s.currentAuthUser(c)
 	if !ok {
+		return
+	}
+	if !s.assertPullBaseAccess(c, auth, repo) {
 		return
 	}
 	body, err := parseJSONBody(c.Request)
@@ -84,6 +87,9 @@ func (s *Service) handleCreatePull(c *corehttp.Context) {
 	headRepo, headRef, ok := s.resolvePullHead(repo, head)
 	if !ok {
 		writeValidation(c, "Validation failed")
+		return
+	}
+	if !s.assertPullHeadAccess(c, auth, headRepo) {
 		return
 	}
 	if headRef == base && intField(headRepo, "id") == intField(repo, "id") {

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -81,23 +81,19 @@ func (s *Service) handleCreatePull(c *corehttp.Context) {
 		writeValidation(c, "Validation failed")
 		return
 	}
-	headRepo := repo
-	headRef := head
-	if strings.Contains(head, ":") {
-		parts := strings.SplitN(head, ":", 2)
-		headRef = parts[1]
-		if other := s.lookupRepo(parts[0], stringField(repo, "name")); other != nil {
-			headRepo = other
-		}
+	headRepo, headRef, ok := s.resolvePullHead(repo, head)
+	if !ok {
+		writeValidation(c, "Validation failed")
+		return
 	}
 	if headRef == base && intField(headRepo, "id") == intField(repo, "id") {
 		writeValidation(c, "Validation failed")
 		return
 	}
-	headBranch := s.getOrCreateBranch(headRepo, headRef)
-	baseBranch := s.getOrCreateBranch(repo, base)
+	headBranch := s.findBranch(headRepo, headRef)
+	baseBranch := s.findBranch(repo, base)
 	if headBranch == nil || baseBranch == nil {
-		writeValidation(c, "The repository is empty.")
+		writeValidation(c, "Validation failed")
 		return
 	}
 	number := s.nextIssueNumber(intField(repo, "id"))
@@ -219,9 +215,9 @@ func (s *Service) handlePatchPull(c *corehttp.Context) {
 		patch["draft"] = draft
 	}
 	if base := strings.TrimSpace(stringValue(body["base"])); base != "" {
-		branch := s.getOrCreateBranch(repo, base)
+		branch := s.findBranch(repo, base)
 		if branch == nil {
-			writeValidation(c, "The repository is empty.")
+			writeValidation(c, "Validation failed")
 			return
 		}
 		patch["base_ref"] = base
@@ -357,6 +353,23 @@ func (s *Service) findPullIssue(repoID int, number int) corestore.Record {
 		}
 	}
 	return nil
+}
+
+func (s *Service) resolvePullHead(baseRepo corestore.Record, head string) (corestore.Record, string, bool) {
+	if !strings.Contains(head, ":") {
+		return baseRepo, head, true
+	}
+	parts := strings.SplitN(head, ":", 2)
+	owner := strings.TrimSpace(parts[0])
+	ref := strings.TrimSpace(parts[1])
+	if owner == "" || ref == "" {
+		return nil, "", false
+	}
+	headRepo := s.lookupRepo(owner, stringField(baseRepo, "name"))
+	if headRepo == nil {
+		return nil, "", false
+	}
+	return headRepo, ref, true
 }
 
 func (s *Service) insertCommit(repo corestore.Record, treeSha string, parentShas []string, message string, actor corestore.Record) corestore.Record {

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -202,6 +202,10 @@ func (s *Service) handlePatchPull(c *corehttp.Context) {
 		issuePatch["body"] = nullableIssueBody(value)
 	}
 	if state := stringValue(body["state"]); state == "open" || state == "closed" {
+		if state == "open" && boolField(pr, "merged") {
+			writeValidation(c, "Validation failed")
+			return
+		}
 		patch["state"] = state
 		issuePatch["state"] = state
 		if state == "closed" && stringField(pr, "state") == "open" {
@@ -297,6 +301,9 @@ func (s *Service) handleMergePull(c *corehttp.Context) {
 	if baseCommit == nil || headCommit == nil {
 		writeValidation(c, "Could not resolve commits to merge.")
 		return
+	}
+	if intField(baseRepo, "id") != intField(headRepo, "id") {
+		s.materializeCommitGraph(baseRepo, headRepo, stringField(headCommit, "sha"), map[string]bool{}, map[string]bool{})
 	}
 	parentShas := []string{stringField(baseCommit, "sha"), stringField(headCommit, "sha")}
 	if mergeMethod != "merge" {
@@ -469,6 +476,84 @@ func (s *Service) insertCommit(repo corestore.Record, treeSha string, parentShas
 	})
 	commit, _ := s.store.Commits.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("Commit", intField(row, "id"))})
 	return commit
+}
+
+func (s *Service) materializeCommitGraph(targetRepo corestore.Record, sourceRepo corestore.Record, sha string, seenCommits map[string]bool, seenTrees map[string]bool) {
+	if sha == "" || seenCommits[sha] || s.findCommitExact(targetRepo, sha) != nil {
+		return
+	}
+	seenCommits[sha] = true
+	source := s.findCommitExact(sourceRepo, sha)
+	if source == nil {
+		return
+	}
+	for _, parent := range stringSliceValue(source["parent_shas"]) {
+		s.materializeCommitGraph(targetRepo, sourceRepo, parent, seenCommits, seenTrees)
+	}
+	s.materializeTree(targetRepo, sourceRepo, stringField(source, "tree_sha"), seenTrees)
+	row := s.store.Commits.Insert(corestore.Record{
+		"repo_id":         intField(targetRepo, "id"),
+		"sha":             stringField(source, "sha"),
+		"node_id":         "",
+		"message":         stringField(source, "message"),
+		"author_name":     stringField(source, "author_name"),
+		"author_email":    stringField(source, "author_email"),
+		"author_date":     stringField(source, "author_date"),
+		"committer_name":  stringField(source, "committer_name"),
+		"committer_email": stringField(source, "committer_email"),
+		"committer_date":  stringField(source, "committer_date"),
+		"tree_sha":        stringField(source, "tree_sha"),
+		"parent_shas":     stringSliceValue(source["parent_shas"]),
+		"user_id":         source["user_id"],
+	})
+	s.store.Commits.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("Commit", intField(row, "id"))})
+}
+
+func (s *Service) materializeTree(targetRepo corestore.Record, sourceRepo corestore.Record, sha string, seen map[string]bool) {
+	if sha == "" || seen[sha] || s.findTreeExact(targetRepo, sha) != nil {
+		return
+	}
+	seen[sha] = true
+	source := s.findTreeExact(sourceRepo, sha)
+	if source == nil {
+		return
+	}
+	for _, item := range treeEntries(source["tree"]) {
+		itemSha := stringValue(item["sha"])
+		switch stringValue(item["type"]) {
+		case "blob":
+			s.materializeBlob(targetRepo, sourceRepo, itemSha)
+		case "tree":
+			s.materializeTree(targetRepo, sourceRepo, itemSha, seen)
+		}
+	}
+	row := s.store.Trees.Insert(corestore.Record{
+		"repo_id":   intField(targetRepo, "id"),
+		"sha":       stringField(source, "sha"),
+		"node_id":   "",
+		"tree":      source["tree"],
+		"truncated": boolField(source, "truncated"),
+	})
+	s.store.Trees.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("Tree", intField(row, "id"))})
+}
+
+func (s *Service) materializeBlob(targetRepo corestore.Record, sourceRepo corestore.Record, sha string) {
+	if sha == "" || s.findBlobExact(targetRepo, sha) != nil {
+		return
+	}
+	source := s.findBlobExact(sourceRepo, sha)
+	if source == nil {
+		return
+	}
+	row := s.store.Blobs.Insert(corestore.Record{
+		"repo_id":  intField(targetRepo, "id"),
+		"sha":      stringField(source, "sha"),
+		"node_id":  "",
+		"content":  source["content"],
+		"encoding": stringField(source, "encoding"),
+		"size":     intField(source, "size"),
+	})
+	s.store.Blobs.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("Blob", intField(row, "id"))})
 }
 
 func (s *Service) mergeCommitMessage(pr corestore.Record, body map[string]any) string {

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -365,6 +365,15 @@ func (s *Service) findPullIssue(repoID int, number int) corestore.Record {
 	return nil
 }
 
+func (s *Service) findPullByNumber(repoID int, number int) corestore.Record {
+	for _, pr := range s.store.PullRequests.FindBy("repo_id", repoID) {
+		if intField(pr, "number") == number {
+			return pr
+		}
+	}
+	return nil
+}
+
 func (s *Service) resolvePullHead(baseRepo corestore.Record, head string) (corestore.Record, string, bool) {
 	if !strings.Contains(head, ":") {
 		return baseRepo, head, true

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -266,6 +266,22 @@ func (s *Service) handleMergePull(c *corehttp.Context) {
 		writeValidation(c, "Head sha is out of date")
 		return
 	}
+	mergeMethod := "merge"
+	if value, ok := body["merge_method"].(string); ok && (value == "squash" || value == "rebase") {
+		mergeMethod = value
+	}
+	if mergeMethod == "merge" && !boolField(repo, "allow_merge_commit") {
+		writeValidation(c, "Merge commits are not allowed on this repository.")
+		return
+	}
+	if mergeMethod == "squash" && !boolField(repo, "allow_squash_merge") {
+		writeValidation(c, "Squash merges are not allowed on this repository.")
+		return
+	}
+	if mergeMethod == "rebase" && !boolField(repo, "allow_rebase_merge") {
+		writeValidation(c, "Rebase merges are not allowed on this repository.")
+		return
+	}
 	baseRepo, ok := s.store.Repos.Get(intField(pr, "base_repo_id"))
 	if !ok {
 		writeValidation(c, "Base repository not found")
@@ -282,7 +298,11 @@ func (s *Service) handleMergePull(c *corehttp.Context) {
 		writeValidation(c, "Could not resolve commits to merge.")
 		return
 	}
-	mergeCommit := s.insertCommit(baseRepo, stringField(headCommit, "tree_sha"), []string{stringField(baseCommit, "sha"), stringField(headCommit, "sha")}, mergeCommitMessage(pr), actor)
+	parentShas := []string{stringField(baseCommit, "sha"), stringField(headCommit, "sha")}
+	if mergeMethod != "merge" {
+		parentShas = []string{stringField(baseCommit, "sha")}
+	}
+	mergeCommit := s.insertCommit(baseRepo, stringField(headCommit, "tree_sha"), parentShas, s.mergeCommitMessage(pr, body), actor)
 	mergeSha := stringField(mergeCommit, "sha")
 	now := nowISO()
 	s.store.PullRequests.Update(intField(pr, "id"), corestore.Record{
@@ -302,7 +322,10 @@ func (s *Service) handleMergePull(c *corehttp.Context) {
 			"closed_by_id": intField(actor, "id"),
 		})
 	}
-	s.updateBranchSha(repo, stringField(pr, "base_ref"), mergeSha)
+	s.updateBranchSha(baseRepo, stringField(pr, "base_ref"), mergeSha)
+	if boolField(repo, "delete_branch_on_merge") && stringField(pr, "head_ref") != stringField(pr, "base_ref") {
+		s.deleteBranchByName(headRepo, stringField(pr, "head_ref"))
+	}
 	s.adjustOpenIssues(intField(repo, "id"), -1)
 	c.JSON(http.StatusOK, map[string]any{
 		"sha":     mergeSha,
@@ -448,6 +471,29 @@ func (s *Service) insertCommit(repo corestore.Record, treeSha string, parentShas
 	return commit
 }
 
-func mergeCommitMessage(pr corestore.Record) string {
-	return "Merge pull request #" + strconv.Itoa(intField(pr, "number")) + " from " + stringField(pr, "head_ref")
+func (s *Service) mergeCommitMessage(pr corestore.Record, body map[string]any) string {
+	title := ""
+	if value, ok := body["commit_title"].(string); ok {
+		title = strings.TrimSpace(value)
+	}
+	if title == "" {
+		title = "Merge pull request #" + strconv.Itoa(intField(pr, "number")) + " from " + s.pullHeadLabel(pr)
+	}
+	message := ""
+	if value, ok := body["commit_message"].(string); ok {
+		message = strings.TrimSpace(value)
+	}
+	if message == "" {
+		return title
+	}
+	return title + "\n\n" + message
+}
+
+func (s *Service) pullHeadLabel(pr corestore.Record) string {
+	headRepo, ok := s.store.Repos.Get(intField(pr, "head_repo_id"))
+	owner := "unknown"
+	if ok {
+		owner = s.ownerLogin(headRepo)
+	}
+	return owner + ":" + stringField(pr, "head_ref")
 }

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -186,6 +186,7 @@ func (s *Service) handlePatchPull(c *corehttp.Context) {
 	}
 	patch := corestore.Record{}
 	issuePatch := corestore.Record{}
+	openIssuesDelta := 0
 	if title, ok := body["title"].(string); ok {
 		patch["title"] = title
 		issuePatch["title"] = title
@@ -202,13 +203,13 @@ func (s *Service) handlePatchPull(c *corehttp.Context) {
 			patch["closed_at"] = now
 			issuePatch["closed_at"] = now
 			issuePatch["closed_by_id"] = intField(actor, "id")
-			s.adjustOpenIssues(intField(repo, "id"), -1)
+			openIssuesDelta = -1
 		}
 		if state == "open" && stringField(pr, "state") == "closed" {
 			patch["closed_at"] = nil
 			issuePatch["closed_at"] = nil
 			issuePatch["closed_by_id"] = nil
-			s.adjustOpenIssues(intField(repo, "id"), 1)
+			openIssuesDelta = 1
 		}
 	}
 	if draft, ok := body["draft"].(bool); ok {
@@ -226,6 +227,9 @@ func (s *Service) handlePatchPull(c *corehttp.Context) {
 	updated, _ := s.store.PullRequests.Update(intField(pr, "id"), patch)
 	if issue := s.findPullIssue(intField(repo, "id"), intField(pr, "number")); issue != nil {
 		s.store.Issues.Update(intField(issue, "id"), issuePatch)
+	}
+	if openIssuesDelta != 0 {
+		s.adjustOpenIssues(intField(repo, "id"), openIssuesDelta)
 	}
 	c.JSON(http.StatusOK, s.formatPull(updated))
 }

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -253,6 +253,19 @@ func (s *Service) handleMergePull(c *corehttp.Context) {
 		writeValidation(c, "Pull Request is not mergeable")
 		return
 	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	if boolField(pr, "draft") {
+		writeValidation(c, "Draft pull requests cannot be merged.")
+		return
+	}
+	if sha := strings.TrimSpace(stringValue(body["sha"])); sha != "" && sha != stringField(pr, "head_sha") {
+		writeValidation(c, "Head sha is out of date")
+		return
+	}
 	baseRepo, ok := s.store.Repos.Get(intField(pr, "base_repo_id"))
 	if !ok {
 		writeValidation(c, "Base repository not found")

--- a/internal/services/github/routes_pulls.go
+++ b/internal/services/github/routes_pulls.go
@@ -1,0 +1,331 @@
+package github
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerPullRoutes(router *corehttp.Router) {
+	router.Get("/repos/:owner/:repo/pulls", s.handleListPulls)
+	router.Post("/repos/:owner/:repo/pulls", s.handleCreatePull)
+	router.Get("/repos/:owner/:repo/pulls/:pull_number", s.handleGetPull)
+	router.Patch("/repos/:owner/:repo/pulls/:pull_number", s.handlePatchPull)
+	router.Put("/repos/:owner/:repo/pulls/:pull_number/merge", s.handleMergePull)
+	router.Get("/repos/:owner/:repo/pulls/:pull_number/commits", s.handlePullCommits)
+	router.Get("/repos/:owner/:repo/pulls/:pull_number/files", s.handlePullFiles)
+}
+
+func (s *Service) handleListPulls(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	state := c.Query("state")
+	if state == "" {
+		state = "open"
+	}
+	pulls := make([]corestore.Record, 0)
+	for _, pr := range s.store.PullRequests.FindBy("repo_id", intField(repo, "id")) {
+		if state == "open" || state == "closed" {
+			if stringField(pr, "state") != state {
+				continue
+			}
+		}
+		if base := strings.TrimSpace(c.Query("base")); base != "" && stringField(pr, "base_ref") != base {
+			continue
+		}
+		if head := strings.TrimSpace(c.Query("head")); head != "" && stringField(pr, "head_ref") != strings.TrimPrefix(head, s.ownerLogin(repo)+":") {
+			continue
+		}
+		pulls = append(pulls, pr)
+	}
+	sort.SliceStable(pulls, func(i, j int) bool {
+		return stringField(pulls[i], "created_at") > stringField(pulls[j], "created_at")
+	})
+	page := paginateRecords(c, pulls, parsePagination(c))
+	out := make([]any, 0, len(page))
+	for _, pr := range page {
+		out = append(out, s.formatPull(pr))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleCreatePull(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	actor, ok := s.assertRepoWrite(c, repo)
+	if !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	title := strings.TrimSpace(stringValue(body["title"]))
+	head := strings.TrimSpace(stringValue(body["head"]))
+	base := strings.TrimSpace(stringValue(body["base"]))
+	if title == "" || head == "" || base == "" {
+		writeValidation(c, "Validation failed")
+		return
+	}
+	headRepo := repo
+	headRef := head
+	if strings.Contains(head, ":") {
+		parts := strings.SplitN(head, ":", 2)
+		headRef = parts[1]
+		if other := s.lookupRepo(parts[0], stringField(repo, "name")); other != nil {
+			headRepo = other
+		}
+	}
+	if headRef == base && intField(headRepo, "id") == intField(repo, "id") {
+		writeValidation(c, "Validation failed")
+		return
+	}
+	headBranch := s.getOrCreateBranch(headRepo, headRef)
+	baseBranch := s.getOrCreateBranch(repo, base)
+	number := s.nextIssueNumber(intField(repo, "id"))
+	prBody := nullableIssueBody(body["body"])
+	issue := s.store.Issues.Insert(corestore.Record{
+		"node_id":            "",
+		"number":             number,
+		"repo_id":            intField(repo, "id"),
+		"title":              title,
+		"body":               prBody,
+		"state":              "open",
+		"state_reason":       nil,
+		"locked":             false,
+		"active_lock_reason": nil,
+		"user_id":            intField(actor, "id"),
+		"assignee_ids":       []int{},
+		"label_ids":          []int{},
+		"milestone_id":       nil,
+		"comments":           0,
+		"closed_at":          nil,
+		"closed_by_id":       nil,
+		"is_pull_request":    true,
+	})
+	s.store.Issues.Update(intField(issue, "id"), corestore.Record{"node_id": generateNodeID("Issue", intField(issue, "id"))})
+	row := s.store.PullRequests.Insert(corestore.Record{
+		"node_id":                "",
+		"number":                 number,
+		"repo_id":                intField(repo, "id"),
+		"title":                  title,
+		"body":                   prBody,
+		"state":                  "open",
+		"locked":                 false,
+		"user_id":                intField(actor, "id"),
+		"assignee_ids":           []int{},
+		"label_ids":              []int{},
+		"milestone_id":           nil,
+		"head_ref":               headRef,
+		"head_sha":               stringField(headBranch, "sha"),
+		"head_repo_id":           intField(headRepo, "id"),
+		"base_ref":               base,
+		"base_sha":               stringField(baseBranch, "sha"),
+		"base_repo_id":           intField(repo, "id"),
+		"merged":                 false,
+		"merged_at":              nil,
+		"merged_by_id":           nil,
+		"merge_commit_sha":       nil,
+		"mergeable":              true,
+		"mergeable_state":        "clean",
+		"comments":               0,
+		"review_comments":        0,
+		"commits":                1,
+		"additions":              0,
+		"deletions":              0,
+		"changed_files":          0,
+		"draft":                  boolField(corestore.Record{"draft": body["draft"]}, "draft"),
+		"requested_reviewer_ids": []int{},
+		"requested_team_ids":     []int{},
+		"closed_at":              nil,
+		"auto_merge":             nil,
+	})
+	pr, _ := s.store.PullRequests.Update(intField(row, "id"), corestore.Record{"node_id": generateNodeID("PullRequest", intField(row, "id"))})
+	s.adjustOpenIssues(intField(repo, "id"), 1)
+	c.JSON(http.StatusCreated, s.formatPull(pr))
+}
+
+func (s *Service) handleGetPull(c *corehttp.Context) {
+	repo, pr, ok := s.pullFromRequest(c)
+	if !ok {
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	c.JSON(http.StatusOK, s.formatPull(pr))
+}
+
+func (s *Service) handlePatchPull(c *corehttp.Context) {
+	repo, pr, ok := s.pullFromRequest(c)
+	if !ok {
+		return
+	}
+	actor, ok := s.assertRepoWrite(c, repo)
+	if !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	patch := corestore.Record{}
+	issuePatch := corestore.Record{}
+	if title, ok := body["title"].(string); ok {
+		patch["title"] = title
+		issuePatch["title"] = title
+	}
+	if value, exists := body["body"]; exists {
+		patch["body"] = nullableIssueBody(value)
+		issuePatch["body"] = nullableIssueBody(value)
+	}
+	if state := stringValue(body["state"]); state == "open" || state == "closed" {
+		patch["state"] = state
+		issuePatch["state"] = state
+		if state == "closed" && stringField(pr, "state") == "open" {
+			now := nowISO()
+			patch["closed_at"] = now
+			issuePatch["closed_at"] = now
+			issuePatch["closed_by_id"] = intField(actor, "id")
+			s.adjustOpenIssues(intField(repo, "id"), -1)
+		}
+		if state == "open" && stringField(pr, "state") == "closed" {
+			patch["closed_at"] = nil
+			issuePatch["closed_at"] = nil
+			issuePatch["closed_by_id"] = nil
+			s.adjustOpenIssues(intField(repo, "id"), 1)
+		}
+	}
+	if draft, ok := body["draft"].(bool); ok {
+		patch["draft"] = draft
+	}
+	if base := strings.TrimSpace(stringValue(body["base"])); base != "" {
+		branch := s.getOrCreateBranch(repo, base)
+		patch["base_ref"] = base
+		patch["base_sha"] = stringField(branch, "sha")
+	}
+	updated, _ := s.store.PullRequests.Update(intField(pr, "id"), patch)
+	if issue := s.findPullIssue(intField(repo, "id"), intField(pr, "number")); issue != nil {
+		s.store.Issues.Update(intField(issue, "id"), issuePatch)
+	}
+	c.JSON(http.StatusOK, s.formatPull(updated))
+}
+
+func (s *Service) handleMergePull(c *corehttp.Context) {
+	repo, pr, ok := s.pullFromRequest(c)
+	if !ok {
+		return
+	}
+	actor, ok := s.assertRepoWrite(c, repo)
+	if !ok {
+		return
+	}
+	if boolField(pr, "merged") || stringField(pr, "state") == "closed" {
+		writeValidation(c, "Pull Request is not mergeable")
+		return
+	}
+	mergeSha := generateSha()
+	now := nowISO()
+	s.store.PullRequests.Update(intField(pr, "id"), corestore.Record{
+		"merged":           true,
+		"merged_at":        now,
+		"merged_by_id":     intField(actor, "id"),
+		"merge_commit_sha": mergeSha,
+		"state":            "closed",
+		"closed_at":        now,
+		"mergeable":        false,
+		"mergeable_state":  "unknown",
+	})
+	if issue := s.findPullIssue(intField(repo, "id"), intField(pr, "number")); issue != nil {
+		s.store.Issues.Update(intField(issue, "id"), corestore.Record{
+			"state":        "closed",
+			"closed_at":    now,
+			"closed_by_id": intField(actor, "id"),
+		})
+	}
+	s.updateBranchSha(repo, stringField(pr, "base_ref"), mergeSha)
+	s.adjustOpenIssues(intField(repo, "id"), -1)
+	c.JSON(http.StatusOK, map[string]any{
+		"sha":     mergeSha,
+		"merged":  true,
+		"message": "Pull Request successfully merged",
+	})
+}
+
+func (s *Service) handlePullCommits(c *corehttp.Context) {
+	repo, pr, ok := s.pullFromRequest(c)
+	if !ok {
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	headRepo, ok := s.store.Repos.Get(intField(pr, "head_repo_id"))
+	if !ok {
+		writeNotFound(c)
+		return
+	}
+	commits := make([]corestore.Record, 0)
+	for _, commit := range s.store.Commits.FindBy("repo_id", intField(headRepo, "id")) {
+		if stringField(commit, "sha") == stringField(pr, "head_sha") {
+			commits = append(commits, commit)
+			break
+		}
+	}
+	out := make([]any, 0, len(commits))
+	for _, commit := range commits {
+		out = append(out, s.formatCommit(headRepo, commit))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handlePullFiles(c *corehttp.Context) {
+	if _, _, ok := s.pullFromRequest(c); !ok {
+		return
+	}
+	c.JSON(http.StatusOK, []any{})
+}
+
+func (s *Service) pullFromRequest(c *corehttp.Context) (corestore.Record, corestore.Record, bool) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	number, err := strconv.Atoi(c.Param("pull_number"))
+	if err != nil {
+		writeNotFound(c)
+		return nil, nil, false
+	}
+	for _, pr := range s.store.PullRequests.FindBy("repo_id", intField(repo, "id")) {
+		if intField(pr, "number") == number {
+			return repo, pr, true
+		}
+	}
+	writeNotFound(c)
+	return nil, nil, false
+}
+
+func (s *Service) findPullIssue(repoID int, number int) corestore.Record {
+	for _, issue := range s.store.Issues.FindBy("repo_id", repoID) {
+		if intField(issue, "number") == number && boolField(issue, "is_pull_request") {
+			return issue
+		}
+	}
+	return nil
+}

--- a/internal/services/github/routes_repos.go
+++ b/internal/services/github/routes_repos.go
@@ -10,16 +10,23 @@ import (
 )
 
 type createRepoOptions struct {
-	Name          string
-	Description   any
-	Private       bool
-	Homepage      any
-	OwnerID       int
-	OwnerType     string
-	OwnerLogin    string
-	DefaultBranch string
-	Language      any
-	Topics        []string
+	Name                string
+	Description         any
+	Private             bool
+	Homepage            any
+	OwnerID             int
+	OwnerType           string
+	OwnerLogin          string
+	DefaultBranch       string
+	Language            any
+	Topics              []string
+	HasIssues           *bool
+	HasProjects         *bool
+	HasWiki             *bool
+	AllowRebaseMerge    *bool
+	AllowSquashMerge    *bool
+	AllowMergeCommit    *bool
+	DeleteBranchOnMerge *bool
 }
 
 func (s *Service) registerRepoRoutes(router *corehttp.Router) {
@@ -139,6 +146,27 @@ func (s *Service) createRepoFromBody(c *corehttp.Context, body map[string]any, o
 			}
 		}
 	}
+	if value, ok := body["has_issues"].(bool); ok {
+		options.HasIssues = boolPtr(value)
+	}
+	if value, ok := body["has_projects"].(bool); ok {
+		options.HasProjects = boolPtr(value)
+	}
+	if value, ok := body["has_wiki"].(bool); ok {
+		options.HasWiki = boolPtr(value)
+	}
+	if value, ok := body["allow_rebase_merge"].(bool); ok {
+		options.AllowRebaseMerge = boolPtr(value)
+	}
+	if value, ok := body["allow_squash_merge"].(bool); ok {
+		options.AllowSquashMerge = boolPtr(value)
+	}
+	if value, ok := body["allow_merge_commit"].(bool); ok {
+		options.AllowMergeCommit = boolPtr(value)
+	}
+	if value, ok := body["delete_branch_on_merge"].(bool); ok {
+		options.DeleteBranchOnMerge = boolPtr(value)
+	}
 	repo := s.createRepoRecord(options)
 	if repo == nil {
 		writeValidation(c, "Repository already exists")
@@ -172,6 +200,13 @@ func (s *Service) createRepoRecord(options createRepoOptions) corestore.Record {
 	if topics == nil {
 		topics = []string{}
 	}
+	hasIssues := boolOption(options.HasIssues, true)
+	hasProjects := boolOption(options.HasProjects, true)
+	hasWiki := boolOption(options.HasWiki, true)
+	allowRebaseMerge := boolOption(options.AllowRebaseMerge, true)
+	allowSquashMerge := boolOption(options.AllowSquashMerge, true)
+	allowMergeCommit := boolOption(options.AllowMergeCommit, true)
+	deleteBranchOnMerge := boolOption(options.DeleteBranchOnMerge, false)
 	repo := s.store.Repos.Insert(corestore.Record{
 		"node_id":                "",
 		"name":                   name,
@@ -192,9 +227,9 @@ func (s *Service) createRepoRecord(options createRepoOptions) corestore.Record {
 		"default_branch":         options.DefaultBranch,
 		"open_issues_count":      0,
 		"topics":                 topics,
-		"has_issues":             true,
-		"has_projects":           true,
-		"has_wiki":               true,
+		"has_issues":             hasIssues,
+		"has_projects":           hasProjects,
+		"has_wiki":               hasWiki,
 		"has_pages":              false,
 		"has_downloads":          true,
 		"has_discussions":        false,
@@ -202,11 +237,11 @@ func (s *Service) createRepoRecord(options createRepoOptions) corestore.Record {
 		"disabled":               false,
 		"visibility":             visibility,
 		"pushed_at":              nil,
-		"allow_rebase_merge":     true,
-		"allow_squash_merge":     true,
-		"allow_merge_commit":     true,
+		"allow_rebase_merge":     allowRebaseMerge,
+		"allow_squash_merge":     allowSquashMerge,
+		"allow_merge_commit":     allowMergeCommit,
 		"allow_auto_merge":       false,
-		"delete_branch_on_merge": false,
+		"delete_branch_on_merge": deleteBranchOnMerge,
 		"allow_forking":          true,
 		"is_template":            false,
 		"license":                nil,

--- a/internal/services/github/routes_repos.go
+++ b/internal/services/github/routes_repos.go
@@ -168,6 +168,10 @@ func (s *Service) createRepoRecord(options createRepoOptions) corestore.Record {
 	if language, ok := options.Language.(string); ok && language != "" {
 		languages[language] = 10000
 	}
+	topics := append([]string(nil), options.Topics...)
+	if topics == nil {
+		topics = []string{}
+	}
 	repo := s.store.Repos.Insert(corestore.Record{
 		"node_id":                "",
 		"name":                   name,
@@ -187,7 +191,7 @@ func (s *Service) createRepoRecord(options createRepoOptions) corestore.Record {
 		"size":                   0,
 		"default_branch":         options.DefaultBranch,
 		"open_issues_count":      0,
-		"topics":                 options.Topics,
+		"topics":                 topics,
 		"has_issues":             true,
 		"has_projects":           true,
 		"has_wiki":               true,
@@ -394,7 +398,7 @@ func (s *Service) handleGetRepoTopics(c *corehttp.Context) {
 	if !s.assertRepoRead(c, repo) {
 		return
 	}
-	c.JSON(http.StatusOK, map[string]any{"names": stringSliceValue(repo["topics"])})
+	c.JSON(http.StatusOK, map[string]any{"names": stringSliceOrEmpty(repo["topics"])})
 }
 
 func (s *Service) handlePutRepoTopics(c *corehttp.Context) {
@@ -411,9 +415,9 @@ func (s *Service) handlePutRepoTopics(c *corehttp.Context) {
 		writeValidation(c, "Invalid JSON body")
 		return
 	}
-	topics := stringSliceValue(body["names"])
+	topics := stringSliceOrEmpty(body["names"])
 	updated, _ := s.store.Repos.Update(intField(repo, "id"), corestore.Record{"topics": topics})
-	c.JSON(http.StatusOK, map[string]any{"names": stringSliceValue(updated["topics"])})
+	c.JSON(http.StatusOK, map[string]any{"names": stringSliceOrEmpty(updated["topics"])})
 }
 
 func (s *Service) handleGetRepoLanguages(c *corehttp.Context) {

--- a/internal/services/github/routes_repos.go
+++ b/internal/services/github/routes_repos.go
@@ -52,13 +52,17 @@ func (s *Service) handleGetRepo(c *corehttp.Context) {
 }
 
 func (s *Service) handleCreateUserRepo(c *corehttp.Context) {
-	user, ok := s.currentUser(c)
+	user, auth, ok := s.currentAuthUser(c)
 	if !ok {
 		return
 	}
 	body, err := parseJSONBody(c.Request)
 	if err != nil {
 		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	if !hasRepoCreationScope(auth, body) {
+		writeForbidden(c)
 		return
 	}
 	repo, ok := s.createRepoFromBody(c, body, user, "User")
@@ -69,7 +73,7 @@ func (s *Service) handleCreateUserRepo(c *corehttp.Context) {
 }
 
 func (s *Service) handleCreateOrgRepo(c *corehttp.Context) {
-	user, ok := s.currentUser(c)
+	user, auth, ok := s.currentAuthUser(c)
 	if !ok {
 		return
 	}
@@ -85,6 +89,10 @@ func (s *Service) handleCreateOrgRepo(c *corehttp.Context) {
 	body, err := parseJSONBody(c.Request)
 	if err != nil {
 		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	if !hasRepoCreationScope(auth, body) {
+		writeForbidden(c)
 		return
 	}
 	repo, ok := s.createRepoFromBody(c, body, org, "Organization")
@@ -505,4 +513,15 @@ func sortedRepos(repos []corestore.Record, sortKey string, direction string) []c
 		})
 	}
 	return out
+}
+
+func hasRepoCreationScope(user *authUser, body map[string]any) bool {
+	private := false
+	if value, ok := body["private"].(bool); ok {
+		private = value
+	}
+	if private {
+		return hasScope(user, "repo")
+	}
+	return hasScope(user, "repo") || hasScope(user, "public_repo")
 }

--- a/internal/services/github/routes_repos.go
+++ b/internal/services/github/routes_repos.go
@@ -310,7 +310,15 @@ func (s *Service) handlePatchRepo(c *corehttp.Context) {
 			}
 		}
 	}
-	for _, key := range []string{"private", "has_issues", "has_projects", "has_wiki", "has_pages", "has_downloads", "has_discussions", "archived", "disabled", "allow_rebase_merge", "allow_squash_merge", "allow_merge_commit", "allow_auto_merge", "delete_branch_on_merge", "allow_forking", "is_template"} {
+	if value, ok := body["private"].(bool); ok {
+		patch["private"] = value
+		if value {
+			patch["visibility"] = "private"
+		} else {
+			patch["visibility"] = "public"
+		}
+	}
+	for _, key := range []string{"has_issues", "has_projects", "has_wiki", "has_pages", "has_downloads", "has_discussions", "archived", "disabled", "allow_rebase_merge", "allow_squash_merge", "allow_merge_commit", "allow_auto_merge", "delete_branch_on_merge", "allow_forking", "is_template"} {
 		if value, ok := body[key].(bool); ok {
 			patch[key] = value
 		}

--- a/internal/services/github/routes_repos.go
+++ b/internal/services/github/routes_repos.go
@@ -65,7 +65,7 @@ func (s *Service) handleCreateUserRepo(c *corehttp.Context) {
 		writeForbidden(c)
 		return
 	}
-	repo, ok := s.createRepoFromBody(c, body, user, "User")
+	repo, ok := s.createRepoFromBody(c, body, user, "User", user)
 	if !ok {
 		return
 	}
@@ -95,14 +95,14 @@ func (s *Service) handleCreateOrgRepo(c *corehttp.Context) {
 		writeForbidden(c)
 		return
 	}
-	repo, ok := s.createRepoFromBody(c, body, org, "Organization")
+	repo, ok := s.createRepoFromBody(c, body, org, "Organization", user)
 	if !ok {
 		return
 	}
 	c.JSON(http.StatusCreated, s.formatRepo(repo, intField(user, "id")))
 }
 
-func (s *Service) createRepoFromBody(c *corehttp.Context, body map[string]any, owner corestore.Record, ownerKind string) (corestore.Record, bool) {
+func (s *Service) createRepoFromBody(c *corehttp.Context, body map[string]any, owner corestore.Record, ownerKind string, actor corestore.Record) (corestore.Record, bool) {
 	name := strings.TrimSpace(stringValue(body["name"]))
 	if !validateRepoName(name) {
 		writeValidation(c, "Invalid repository name")
@@ -145,7 +145,7 @@ func (s *Service) createRepoFromBody(c *corehttp.Context, body map[string]any, o
 		return nil, false
 	}
 	if autoInit, ok := body["auto_init"].(bool); ok && autoInit {
-		s.seedInitialGit(repo, owner)
+		s.seedInitialGit(repo, actor)
 		repo, _ = s.store.Repos.Get(intField(repo, "id"))
 	}
 	return repo, true
@@ -240,12 +240,20 @@ func (s *Service) seedInitialGit(repo corestore.Record, actor corestore.Record) 
 	})
 	s.store.Trees.Update(intField(tree, "id"), corestore.Record{"node_id": generateNodeID("Tree", intField(tree, "id"))})
 	authorName := stringField(actor, "name")
+	authorLogin := stringField(actor, "login")
+	if authorLogin == "" {
+		authorLogin = s.ownerLogin(repo)
+	}
 	if authorName == "" {
-		authorName = stringField(actor, "login")
+		authorName = authorLogin
 	}
 	authorEmail := stringField(actor, "email")
 	if authorEmail == "" {
-		authorEmail = stringField(actor, "login") + "@localhost"
+		authorEmail = authorLogin + "@localhost"
+	}
+	var userID any
+	if intField(actor, "id") > 0 && stringField(actor, "type") == "User" {
+		userID = intField(actor, "id")
 	}
 	now := nowISO()
 	commit := s.store.Commits.Insert(corestore.Record{
@@ -261,7 +269,7 @@ func (s *Service) seedInitialGit(repo corestore.Record, actor corestore.Record) 
 		"committer_date":  now,
 		"tree_sha":        stringField(tree, "sha"),
 		"parent_shas":     []string{},
-		"user_id":         intField(actor, "id"),
+		"user_id":         userID,
 	})
 	s.store.Commits.Update(intField(commit, "id"), corestore.Record{"node_id": generateNodeID("Commit", intField(commit, "id"))})
 	s.store.Branches.Insert(corestore.Record{

--- a/internal/services/github/routes_repos.go
+++ b/internal/services/github/routes_repos.go
@@ -1,0 +1,500 @@
+package github
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+type createRepoOptions struct {
+	Name          string
+	Description   any
+	Private       bool
+	Homepage      any
+	OwnerID       int
+	OwnerType     string
+	OwnerLogin    string
+	DefaultBranch string
+	Language      any
+	Topics        []string
+}
+
+func (s *Service) registerRepoRoutes(router *corehttp.Router) {
+	router.Get("/repos/:owner/:repo", s.handleGetRepo)
+	router.Post("/user/repos", s.handleCreateUserRepo)
+	router.Post("/orgs/:org/repos", s.handleCreateOrgRepo)
+	router.Patch("/repos/:owner/:repo", s.handlePatchRepo)
+	router.Delete("/repos/:owner/:repo", s.handleDeleteRepo)
+	router.Get("/repos/:owner/:repo/topics", s.handleGetRepoTopics)
+	router.Put("/repos/:owner/:repo/topics", s.handlePutRepoTopics)
+	router.Get("/repos/:owner/:repo/languages", s.handleGetRepoLanguages)
+	router.Get("/repos/:owner/:repo/contributors", s.handleListContributors)
+	router.Get("/repos/:owner/:repo/tags", s.handleListTags)
+}
+
+func (s *Service) handleGetRepo(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	viewerID := 0
+	if auth, ok := s.authUser(c); ok {
+		viewerID = auth.ID
+	}
+	c.JSON(http.StatusOK, s.formatRepo(repo, viewerID))
+}
+
+func (s *Service) handleCreateUserRepo(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	repo, ok := s.createRepoFromBody(c, body, user, "User")
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusCreated, s.formatRepo(repo, intField(user, "id")))
+}
+
+func (s *Service) handleCreateOrgRepo(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	org := firstRecord(s.store.Orgs.FindBy("login", c.Param("org")))
+	if org == nil {
+		writeNotFound(c)
+		return
+	}
+	if !boolField(user, "site_admin") && !s.isOrgMember(intField(user, "id"), intField(org, "id")) {
+		writeForbidden(c)
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	repo, ok := s.createRepoFromBody(c, body, org, "Organization")
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusCreated, s.formatRepo(repo, intField(user, "id")))
+}
+
+func (s *Service) createRepoFromBody(c *corehttp.Context, body map[string]any, owner corestore.Record, ownerKind string) (corestore.Record, bool) {
+	name := strings.TrimSpace(stringValue(body["name"]))
+	if !validateRepoName(name) {
+		writeValidation(c, "Invalid repository name")
+		return nil, false
+	}
+	defaultBranch := "main"
+	if v := strings.TrimSpace(stringValue(body["default_branch"])); v != "" {
+		defaultBranch = v
+	}
+	options := createRepoOptions{
+		Name:          name,
+		Description:   nil,
+		Private:       false,
+		Homepage:      nil,
+		OwnerID:       intField(owner, "id"),
+		OwnerType:     ownerKind,
+		OwnerLogin:    stringField(owner, "login"),
+		DefaultBranch: defaultBranch,
+		Topics:        nil,
+	}
+	if value, ok := body["description"].(string); ok {
+		options.Description = value
+	}
+	if value, ok := body["private"].(bool); ok {
+		options.Private = value
+	}
+	if value, ok := body["homepage"].(string); ok {
+		options.Homepage = value
+	}
+	if names, ok := body["topics"].([]any); ok {
+		for _, item := range names {
+			if topic, ok := item.(string); ok {
+				options.Topics = append(options.Topics, topic)
+			}
+		}
+	}
+	repo := s.createRepoRecord(options)
+	if repo == nil {
+		writeValidation(c, "Repository already exists")
+		return nil, false
+	}
+	if autoInit, ok := body["auto_init"].(bool); ok && autoInit {
+		s.seedInitialGit(repo, owner)
+		repo, _ = s.store.Repos.Get(intField(repo, "id"))
+	}
+	return repo, true
+}
+
+func (s *Service) createRepoRecord(options createRepoOptions) corestore.Record {
+	name := strings.TrimSpace(options.Name)
+	fullName := options.OwnerLogin + "/" + name
+	if firstRecord(s.store.Repos.FindBy("full_name", fullName)) != nil {
+		return nil
+	}
+	visibility := "public"
+	if options.Private {
+		visibility = "private"
+	}
+	if options.DefaultBranch == "" {
+		options.DefaultBranch = "main"
+	}
+	languages := map[string]int{}
+	if language, ok := options.Language.(string); ok && language != "" {
+		languages[language] = 10000
+	}
+	repo := s.store.Repos.Insert(corestore.Record{
+		"node_id":                "",
+		"name":                   name,
+		"full_name":              fullName,
+		"owner_id":               options.OwnerID,
+		"owner_type":             options.OwnerType,
+		"private":                options.Private,
+		"description":            options.Description,
+		"fork":                   false,
+		"forked_from_id":         nil,
+		"homepage":               options.Homepage,
+		"language":               options.Language,
+		"languages":              languages,
+		"forks_count":            0,
+		"stargazers_count":       0,
+		"watchers_count":         0,
+		"size":                   0,
+		"default_branch":         options.DefaultBranch,
+		"open_issues_count":      0,
+		"topics":                 options.Topics,
+		"has_issues":             true,
+		"has_projects":           true,
+		"has_wiki":               true,
+		"has_pages":              false,
+		"has_downloads":          true,
+		"has_discussions":        false,
+		"archived":               false,
+		"disabled":               false,
+		"visibility":             visibility,
+		"pushed_at":              nil,
+		"allow_rebase_merge":     true,
+		"allow_squash_merge":     true,
+		"allow_merge_commit":     true,
+		"allow_auto_merge":       false,
+		"delete_branch_on_merge": false,
+		"allow_forking":          true,
+		"is_template":            false,
+		"license":                nil,
+	})
+	repo, _ = s.store.Repos.Update(intField(repo, "id"), corestore.Record{"node_id": generateNodeID("Repository", intField(repo, "id"))})
+	if !options.Private {
+		s.bumpPublicRepos(options.OwnerID, options.OwnerType, 1)
+	}
+	return repo
+}
+
+func (s *Service) seedInitialGit(repo corestore.Record, actor corestore.Record) {
+	readme := "# " + stringField(repo, "name") + "\n"
+	blob := s.store.Blobs.Insert(corestore.Record{
+		"repo_id":  intField(repo, "id"),
+		"sha":      generateSha(),
+		"node_id":  "",
+		"content":  readme,
+		"encoding": "utf-8",
+		"size":     len([]byte(readme)),
+	})
+	s.store.Blobs.Update(intField(blob, "id"), corestore.Record{"node_id": generateNodeID("Blob", intField(blob, "id"))})
+	tree := s.store.Trees.Insert(corestore.Record{
+		"repo_id": intField(repo, "id"),
+		"sha":     generateSha(),
+		"node_id": "",
+		"tree": []any{
+			map[string]any{"path": "README.md", "mode": "100644", "type": "blob", "sha": stringField(blob, "sha"), "size": len([]byte(readme))},
+		},
+		"truncated": false,
+	})
+	s.store.Trees.Update(intField(tree, "id"), corestore.Record{"node_id": generateNodeID("Tree", intField(tree, "id"))})
+	authorName := stringField(actor, "name")
+	if authorName == "" {
+		authorName = stringField(actor, "login")
+	}
+	authorEmail := stringField(actor, "email")
+	if authorEmail == "" {
+		authorEmail = stringField(actor, "login") + "@localhost"
+	}
+	now := nowISO()
+	commit := s.store.Commits.Insert(corestore.Record{
+		"repo_id":         intField(repo, "id"),
+		"sha":             generateSha(),
+		"node_id":         "",
+		"message":         "Initial commit",
+		"author_name":     authorName,
+		"author_email":    authorEmail,
+		"author_date":     now,
+		"committer_name":  authorName,
+		"committer_email": authorEmail,
+		"committer_date":  now,
+		"tree_sha":        stringField(tree, "sha"),
+		"parent_shas":     []string{},
+		"user_id":         intField(actor, "id"),
+	})
+	s.store.Commits.Update(intField(commit, "id"), corestore.Record{"node_id": generateNodeID("Commit", intField(commit, "id"))})
+	s.store.Branches.Insert(corestore.Record{
+		"repo_id":   intField(repo, "id"),
+		"name":      stringField(repo, "default_branch"),
+		"sha":       stringField(commit, "sha"),
+		"protected": false,
+	})
+	ref := s.store.Refs.Insert(corestore.Record{
+		"repo_id": intField(repo, "id"),
+		"ref":     "refs/heads/" + stringField(repo, "default_branch"),
+		"sha":     stringField(commit, "sha"),
+		"node_id": "",
+	})
+	s.store.Refs.Update(intField(ref, "id"), corestore.Record{"node_id": generateNodeID("Ref", intField(ref, "id"))})
+	s.store.Repos.Update(intField(repo, "id"), corestore.Record{
+		"size":      len([]byte(readme)),
+		"pushed_at": now,
+		"language":  "Markdown",
+		"languages": map[string]int{"Markdown": len([]byte(readme))},
+	})
+}
+
+func (s *Service) handlePatchRepo(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if _, ok := s.assertRepoAdmin(c, repo); !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	patch := corestore.Record{}
+	if name := strings.TrimSpace(stringValue(body["name"])); name != "" {
+		if !validateRepoName(name) {
+			writeValidation(c, "Invalid repository name")
+			return
+		}
+		newFullName := s.ownerLogin(repo) + "/" + name
+		if existing := firstRecord(s.store.Repos.FindBy("full_name", newFullName)); existing != nil && intField(existing, "id") != intField(repo, "id") {
+			writeValidation(c, "Repository already exists")
+			return
+		}
+		patch["name"] = name
+		patch["full_name"] = newFullName
+	}
+	for _, key := range []string{"description", "homepage"} {
+		if value, exists := body[key]; exists {
+			if value == nil {
+				patch[key] = nil
+			} else if s, ok := value.(string); ok {
+				patch[key] = s
+			}
+		}
+	}
+	for _, key := range []string{"private", "has_issues", "has_projects", "has_wiki", "has_pages", "has_downloads", "has_discussions", "archived", "disabled", "allow_rebase_merge", "allow_squash_merge", "allow_merge_commit", "allow_auto_merge", "delete_branch_on_merge", "allow_forking", "is_template"} {
+		if value, ok := body[key].(bool); ok {
+			patch[key] = value
+		}
+	}
+	if value, ok := body["visibility"].(string); ok && (value == "public" || value == "private" || value == "internal") {
+		patch["visibility"] = value
+		patch["private"] = value != "public"
+	}
+	if value, ok := body["default_branch"].(string); ok && value != "" {
+		patch["default_branch"] = value
+	}
+	if raw, ok := body["topics"].([]any); ok {
+		topics := make([]string, 0, len(raw))
+		for _, item := range raw {
+			if topic, ok := item.(string); ok {
+				topics = append(topics, topic)
+			}
+		}
+		patch["topics"] = topics
+	}
+	oldPrivate := boolField(repo, "private")
+	updated, _ := s.store.Repos.Update(intField(repo, "id"), patch)
+	if newPrivate := boolField(updated, "private"); newPrivate != oldPrivate {
+		if newPrivate {
+			s.bumpPublicRepos(intField(updated, "owner_id"), stringField(updated, "owner_type"), -1)
+		} else {
+			s.bumpPublicRepos(intField(updated, "owner_id"), stringField(updated, "owner_type"), 1)
+		}
+	}
+	viewerID := 0
+	if auth, ok := s.authUser(c); ok {
+		viewerID = auth.ID
+	}
+	c.JSON(http.StatusOK, s.formatRepo(updated, viewerID))
+}
+
+func (s *Service) handleDeleteRepo(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if _, ok := s.assertRepoAdmin(c, repo); !ok {
+		return
+	}
+	repoID := intField(repo, "id")
+	for _, collection := range []*corestore.Collection{s.store.Collaborators, s.store.Issues, s.store.PullRequests, s.store.Labels, s.store.Milestones, s.store.Comments, s.store.Branches, s.store.Refs, s.store.Commits, s.store.Trees, s.store.Blobs, s.store.Webhooks} {
+		for _, row := range collection.FindBy("repo_id", repoID) {
+			collection.Delete(intField(row, "id"))
+		}
+	}
+	s.store.Repos.Delete(repoID)
+	if !boolField(repo, "private") {
+		s.bumpPublicRepos(intField(repo, "owner_id"), stringField(repo, "owner_type"), -1)
+	}
+	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) handleGetRepoTopics(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{"names": stringSliceValue(repo["topics"])})
+}
+
+func (s *Service) handlePutRepoTopics(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if _, ok := s.assertRepoAdmin(c, repo); !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	topics := stringSliceValue(body["names"])
+	updated, _ := s.store.Repos.Update(intField(repo, "id"), corestore.Record{"topics": topics})
+	c.JSON(http.StatusOK, map[string]any{"names": stringSliceValue(updated["topics"])})
+}
+
+func (s *Service) handleGetRepoLanguages(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	c.JSON(http.StatusOK, jsonStringMap(mapStringIntValue(repo["languages"])))
+}
+
+func (s *Service) handleListContributors(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	byID := map[int]corestore.Record{}
+	if stringField(repo, "owner_type") == "User" {
+		if owner, ok := s.store.Users.Get(intField(repo, "owner_id")); ok {
+			byID[intField(owner, "id")] = owner
+		}
+	}
+	for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {
+		if user, ok := s.store.Users.Get(intField(collab, "user_id")); ok {
+			byID[intField(user, "id")] = user
+		}
+	}
+	users := make([]corestore.Record, 0, len(byID))
+	for _, user := range byID {
+		users = append(users, user)
+	}
+	sortRecordsByString(users, "login", false)
+	page := paginateRecords(c, users, parsePagination(c))
+	out := make([]any, 0, len(page))
+	for _, user := range page {
+		row := s.formatUser(user)
+		row["contributions"] = 1
+		out = append(out, row)
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleListTags(c *corehttp.Context) {
+	repo := s.lookupRepo(c.Param("owner"), c.Param("repo"))
+	if repo == nil {
+		writeNotFound(c)
+		return
+	}
+	if !s.assertRepoRead(c, repo) {
+		return
+	}
+	c.JSON(http.StatusOK, []any{})
+}
+
+func (s *Service) bumpPublicRepos(ownerID int, ownerKind string, delta int) {
+	if delta == 0 {
+		return
+	}
+	collection := s.store.Users
+	if ownerKind == "Organization" {
+		collection = s.store.Orgs
+	}
+	owner, ok := collection.Get(ownerID)
+	if !ok {
+		return
+	}
+	next := intField(owner, "public_repos") + delta
+	if next < 0 {
+		next = 0
+	}
+	collection.Update(ownerID, corestore.Record{"public_repos": next})
+}
+
+func sortedRepos(repos []corestore.Record, sortKey string, direction string) []corestore.Record {
+	out := append([]corestore.Record(nil), repos...)
+	desc := direction == "desc"
+	switch sortKey {
+	case "created":
+		sortRecordsByString(out, "created_at", desc)
+	case "updated":
+		sortRecordsByString(out, "updated_at", desc)
+	case "pushed":
+		sortRecordsByString(out, "pushed_at", desc)
+	default:
+		sort.SliceStable(out, func(i, j int) bool {
+			if desc {
+				return stringField(out[i], "full_name") > stringField(out[j], "full_name")
+			}
+			return stringField(out[i], "full_name") < stringField(out[j], "full_name")
+		})
+	}
+	return out
+}

--- a/internal/services/github/routes_users.go
+++ b/internal/services/github/routes_users.go
@@ -78,7 +78,7 @@ func (s *Service) handleListCurrentUserRepos(c *corehttp.Context) {
 		return
 	}
 	repos := s.reposForUser(user, listType)
-	s.respondRepoList(c, repos, intField(user, "id"))
+	s.respondRepoList(c, s.filterReadableRepos(c, repos), intField(user, "id"))
 }
 
 func (s *Service) handleListUserRepos(c *corehttp.Context) {

--- a/internal/services/github/routes_users.go
+++ b/internal/services/github/routes_users.go
@@ -92,7 +92,7 @@ func (s *Service) handleListUserRepos(c *corehttp.Context) {
 		return
 	}
 	repos := s.reposForUser(user, listType)
-	s.respondRepoList(c, repos, 0)
+	s.respondRepoList(c, s.filterReadableRepos(c, repos), s.viewerID(c))
 }
 
 func (s *Service) handleListOrgRepos(c *corehttp.Context) {
@@ -107,7 +107,7 @@ func (s *Service) handleListOrgRepos(c *corehttp.Context) {
 			repos = append(repos, repo)
 		}
 	}
-	s.respondRepoList(c, repos, 0)
+	s.respondRepoList(c, s.filterReadableRepos(c, repos), s.viewerID(c))
 }
 
 func (s *Service) respondRepoList(c *corehttp.Context, repos []corestore.Record, viewerID int) {

--- a/internal/services/github/routes_users.go
+++ b/internal/services/github/routes_users.go
@@ -1,0 +1,307 @@
+package github
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerUserAndOrgRoutes(router *corehttp.Router) {
+	router.Get("/user", s.handleCurrentUser)
+	router.Patch("/user", s.handlePatchCurrentUser)
+	router.Get("/user/repos", s.handleListCurrentUserRepos)
+	router.Get("/user/orgs", s.handleListCurrentUserOrgs)
+	router.Get("/users", s.handleListUsers)
+	router.Get("/users/:username/repos", s.handleListUserRepos)
+	router.Get("/users/:username/orgs", s.handleListUserOrgs)
+	router.Get("/users/:username/followers", s.handleEmptyUserList)
+	router.Get("/users/:username/following", s.handleEmptyUserList)
+	router.Get("/users/:username/hovercard", s.handleHovercard)
+	router.Get("/users/:username", s.handleGetUser)
+	router.Get("/organizations", s.handleListOrganizations)
+	router.Get("/orgs/:org/repos", s.handleListOrgRepos)
+	router.Get("/orgs/:org", s.handleGetOrg)
+}
+
+func (s *Service) handleCurrentUser(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusOK, s.formatUserFull(user))
+}
+
+func (s *Service) handlePatchCurrentUser(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	body, err := parseJSONBody(c.Request)
+	if err != nil {
+		writeValidation(c, "Invalid JSON body")
+		return
+	}
+	patch := corestore.Record{}
+	for _, key := range []string{"name", "email", "company", "location", "bio", "twitter_username"} {
+		if value, exists := body[key]; exists {
+			if value == nil {
+				patch[key] = nil
+			} else if s, ok := value.(string); ok {
+				patch[key] = s
+			}
+		}
+	}
+	if value, ok := body["blog"].(string); ok {
+		patch["blog"] = value
+	}
+	if value, exists := body["hireable"]; exists {
+		if value == nil {
+			patch["hireable"] = nil
+		} else if b, ok := value.(bool); ok {
+			patch["hireable"] = b
+		}
+	}
+	updated, _ := s.store.Users.Update(intField(user, "id"), patch)
+	c.JSON(http.StatusOK, s.formatUserFull(updated))
+}
+
+func (s *Service) handleListCurrentUserRepos(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	listType, ok := repoListType(c, "all")
+	if !ok {
+		return
+	}
+	repos := s.reposForUser(user, listType)
+	s.respondRepoList(c, repos, intField(user, "id"))
+}
+
+func (s *Service) handleListUserRepos(c *corehttp.Context) {
+	user := firstRecord(s.store.Users.FindBy("login", c.Param("username")))
+	if user == nil {
+		writeNotFound(c)
+		return
+	}
+	listType, ok := repoListType(c, "owner")
+	if !ok {
+		return
+	}
+	repos := s.reposForUser(user, listType)
+	s.respondRepoList(c, repos, 0)
+}
+
+func (s *Service) handleListOrgRepos(c *corehttp.Context) {
+	org := firstRecord(s.store.Orgs.FindBy("login", c.Param("org")))
+	if org == nil {
+		writeNotFound(c)
+		return
+	}
+	repos := make([]corestore.Record, 0)
+	for _, repo := range s.store.Repos.FindBy("owner_id", intField(org, "id")) {
+		if stringField(repo, "owner_type") == "Organization" {
+			repos = append(repos, repo)
+		}
+	}
+	s.respondRepoList(c, repos, 0)
+}
+
+func (s *Service) respondRepoList(c *corehttp.Context, repos []corestore.Record, viewerID int) {
+	sortKey := strings.ToLower(defaultString(c.Query("sort"), "full_name"))
+	if sortKey != "created" && sortKey != "updated" && sortKey != "pushed" && sortKey != "full_name" {
+		writeValidation(c, "Invalid sort parameter")
+		return
+	}
+	direction := strings.ToLower(c.Query("direction"))
+	if direction == "" {
+		if sortKey == "full_name" {
+			direction = "asc"
+		} else {
+			direction = "desc"
+		}
+	}
+	if direction != "asc" && direction != "desc" {
+		writeValidation(c, "Invalid direction parameter")
+		return
+	}
+	repos = sortedRepos(repos, sortKey, direction)
+	page := paginateRecords(c, repos, parsePagination(c))
+	out := make([]any, 0, len(page))
+	for _, repo := range page {
+		out = append(out, s.formatRepo(repo, viewerID))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) reposForUser(user corestore.Record, listType string) []corestore.Record {
+	if listType != "all" && listType != "owner" && listType != "member" {
+		listType = "all"
+	}
+	owned := make([]corestore.Record, 0)
+	for _, repo := range s.store.Repos.FindBy("owner_id", intField(user, "id")) {
+		if stringField(repo, "owner_type") == "User" {
+			owned = append(owned, repo)
+		}
+	}
+	member := make([]corestore.Record, 0)
+	for _, collab := range s.store.Collaborators.FindBy("user_id", intField(user, "id")) {
+		if repo, ok := s.store.Repos.Get(intField(collab, "repo_id")); ok {
+			if !(stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == intField(user, "id")) {
+				member = append(member, repo)
+			}
+		}
+	}
+	if listType == "owner" {
+		return owned
+	}
+	if listType == "member" {
+		return member
+	}
+	byID := map[int]corestore.Record{}
+	for _, repo := range owned {
+		byID[intField(repo, "id")] = repo
+	}
+	for _, repo := range member {
+		byID[intField(repo, "id")] = repo
+	}
+	out := make([]corestore.Record, 0, len(byID))
+	for _, repo := range byID {
+		out = append(out, repo)
+	}
+	return out
+}
+
+func (s *Service) handleListCurrentUserOrgs(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return
+	}
+	s.respondOrgList(c, s.orgsForUser(intField(user, "id")))
+}
+
+func (s *Service) handleListUserOrgs(c *corehttp.Context) {
+	user := firstRecord(s.store.Users.FindBy("login", c.Param("username")))
+	if user == nil {
+		writeNotFound(c)
+		return
+	}
+	s.respondOrgList(c, s.orgsForUser(intField(user, "id")))
+}
+
+func (s *Service) respondOrgList(c *corehttp.Context, orgs []corestore.Record) {
+	sortRecordsByString(orgs, "login", false)
+	out := make([]any, 0, len(orgs))
+	for _, org := range orgs {
+		out = append(out, s.formatOrgBrief(org))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) orgsForUser(userID int) []corestore.Record {
+	byID := map[int]corestore.Record{}
+	for _, member := range s.store.TeamMembers.FindBy("user_id", userID) {
+		team, ok := s.store.Teams.Get(intField(member, "team_id"))
+		if !ok {
+			continue
+		}
+		if org, ok := s.store.Orgs.Get(intField(team, "org_id")); ok {
+			byID[intField(org, "id")] = org
+		}
+	}
+	out := make([]corestore.Record, 0, len(byID))
+	for _, org := range byID {
+		out = append(out, org)
+	}
+	return out
+}
+
+func (s *Service) handleListUsers(c *corehttp.Context) {
+	since, _ := strconv.Atoi(c.Query("since"))
+	perPage, _ := strconv.Atoi(c.Query("per_page"))
+	if perPage < 1 {
+		perPage = 30
+	}
+	if perPage > 100 {
+		perPage = 100
+	}
+	users := make([]corestore.Record, 0)
+	for _, user := range s.store.Users.All() {
+		if intField(user, "id") > since {
+			users = append(users, user)
+		}
+	}
+	sortRecordsByInt(users, "id")
+	if len(users) > perPage {
+		users = users[:perPage]
+	}
+	out := make([]any, 0, len(users))
+	for _, user := range users {
+		out = append(out, s.formatUser(user))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleGetUser(c *corehttp.Context) {
+	user := firstRecord(s.store.Users.FindBy("login", c.Param("username")))
+	if user == nil {
+		writeNotFound(c)
+		return
+	}
+	c.JSON(http.StatusOK, s.formatUserFull(user))
+}
+
+func (s *Service) handleEmptyUserList(c *corehttp.Context) {
+	if firstRecord(s.store.Users.FindBy("login", c.Param("username"))) == nil {
+		writeNotFound(c)
+		return
+	}
+	c.JSON(http.StatusOK, []any{})
+}
+
+func (s *Service) handleHovercard(c *corehttp.Context) {
+	if firstRecord(s.store.Users.FindBy("login", c.Param("username"))) == nil {
+		writeNotFound(c)
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{"contexts": []any{}})
+}
+
+func (s *Service) handleListOrganizations(c *corehttp.Context) {
+	orgs := s.store.Orgs.All()
+	sortRecordsByInt(orgs, "id")
+	page := paginateRecords(c, orgs, parsePagination(c))
+	out := make([]any, 0, len(page))
+	for _, org := range page {
+		out = append(out, s.formatOrgBrief(org))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Service) handleGetOrg(c *corehttp.Context) {
+	org := firstRecord(s.store.Orgs.FindBy("login", c.Param("org")))
+	if org == nil {
+		writeNotFound(c)
+		return
+	}
+	c.JSON(http.StatusOK, s.formatOrgFull(org))
+}
+
+func defaultString(value string, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func repoListType(c *corehttp.Context, fallback string) (string, bool) {
+	listType := strings.ToLower(defaultString(c.Query("type"), fallback))
+	if listType != "all" && listType != "owner" && listType != "member" {
+		writeValidation(c, "Invalid type parameter")
+		return "", false
+	}
+	return listType, true
+}

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -380,7 +380,7 @@ func (s *Service) assertRepoWrite(c *corehttp.Context, repo corestore.Record) (c
 	if !ok {
 		return nil, false
 	}
-	if !boolField(repo, "private") || s.hasRepoAdmin(user, repo) || s.canAccessRepo(&authUser{Login: stringField(user, "login"), ID: intField(user, "id")}, repo) {
+	if s.hasRepoAdmin(user, repo) || s.canAccessRepo(&authUser{Login: stringField(user, "login"), ID: intField(user, "id")}, repo) {
 		return user, true
 	}
 	writeForbidden(c)

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -93,6 +93,9 @@ func New(options Options) *Service {
 		baseURL: baseURL,
 	}
 	service.SeedDefaults()
+	if options.Seed == nil || options.Seed.Tokens == nil {
+		service.SeedDefaultTokens()
+	}
 	if options.Seed != nil {
 		service.SeedFromConfig(*options.Seed)
 	}
@@ -126,6 +129,9 @@ func (s *Service) SeedDefaults() {
 			"bio":     "Default admin user",
 		})
 	}
+}
+
+func (s *Service) SeedDefaultTokens() {
 	if firstRecord(s.store.Tokens.FindBy("tokenString", "test_token_admin")) == nil {
 		s.store.Tokens.Insert(corestore.Record{
 			"tokenString": "test_token_admin",

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -330,18 +330,23 @@ func (s *Service) authUserFromLogin(login string, scopes []string) (*authUser, b
 	return &authUser{Login: login, ID: intField(user, "id"), Scopes: scopes}, true
 }
 
-func (s *Service) currentUser(c *corehttp.Context) (corestore.Record, bool) {
+func (s *Service) currentAuthUser(c *corehttp.Context) (corestore.Record, *authUser, bool) {
 	auth, ok := s.authUser(c)
 	if !ok {
 		writeUnauthorized(c)
-		return nil, false
+		return nil, nil, false
 	}
 	user := firstRecord(s.store.Users.FindBy("login", auth.Login))
 	if user == nil {
 		writeUnauthorized(c)
-		return nil, false
+		return nil, nil, false
 	}
-	return user, true
+	return user, auth, true
+}
+
+func (s *Service) currentUser(c *corehttp.Context) (corestore.Record, bool) {
+	user, _, ok := s.currentAuthUser(c)
+	return user, ok
 }
 
 func (s *Service) lookupOwner(login string) corestore.Record {
@@ -368,6 +373,10 @@ func (s *Service) assertRepoRead(c *corehttp.Context, repo corestore.Record) boo
 		writeUnauthorized(c)
 		return false
 	}
+	if !hasScope(user, "repo") {
+		writeForbidden(c)
+		return false
+	}
 	if s.canAccessRepo(user, repo) {
 		return true
 	}
@@ -391,7 +400,7 @@ func (s *Service) filterReadableRepos(c *corehttp.Context, repos []corestore.Rec
 			out = append(out, repo)
 			continue
 		}
-		if authenticated && s.canAccessRepo(auth, repo) {
+		if authenticated && hasScope(auth, "repo") && s.canAccessRepo(auth, repo) {
 			out = append(out, repo)
 		}
 	}
@@ -399,11 +408,15 @@ func (s *Service) filterReadableRepos(c *corehttp.Context, repos []corestore.Rec
 }
 
 func (s *Service) assertRepoWrite(c *corehttp.Context, repo corestore.Record) (corestore.Record, bool) {
-	user, ok := s.currentUser(c)
+	user, auth, ok := s.currentAuthUser(c)
 	if !ok {
 		return nil, false
 	}
-	if s.hasRepoAdmin(user, repo) || s.canAccessRepo(&authUser{Login: stringField(user, "login"), ID: intField(user, "id")}, repo) {
+	if !hasRepoMutationScope(auth, repo) {
+		writeForbidden(c)
+		return nil, false
+	}
+	if s.hasRepoAdmin(user, repo) || s.canAccessRepo(auth, repo) {
 		return user, true
 	}
 	writeForbidden(c)
@@ -411,8 +424,12 @@ func (s *Service) assertRepoWrite(c *corehttp.Context, repo corestore.Record) (c
 }
 
 func (s *Service) assertRepoAdmin(c *corehttp.Context, repo corestore.Record) (corestore.Record, bool) {
-	user, ok := s.currentUser(c)
+	user, auth, ok := s.currentAuthUser(c)
 	if !ok {
+		return nil, false
+	}
+	if !hasRepoMutationScope(auth, repo) {
+		writeForbidden(c)
 		return nil, false
 	}
 	if s.hasRepoAdmin(user, repo) {
@@ -420,6 +437,39 @@ func (s *Service) assertRepoAdmin(c *corehttp.Context, repo corestore.Record) (c
 	}
 	writeForbidden(c)
 	return nil, false
+}
+
+func (s *Service) assertIssueParticipant(c *corehttp.Context, repo corestore.Record) (corestore.Record, bool) {
+	user, auth, ok := s.currentAuthUser(c)
+	if !ok {
+		return nil, false
+	}
+	if boolField(repo, "private") {
+		if !hasScope(auth, "repo") || !s.canAccessRepo(auth, repo) {
+			writeForbidden(c)
+			return nil, false
+		}
+	}
+	return user, true
+}
+
+func hasRepoMutationScope(user *authUser, repo corestore.Record) bool {
+	if boolField(repo, "private") {
+		return hasScope(user, "repo")
+	}
+	return hasScope(user, "repo") || hasScope(user, "public_repo")
+}
+
+func hasScope(user *authUser, scope string) bool {
+	if user == nil {
+		return false
+	}
+	for _, candidate := range user.Scopes {
+		if candidate == scope {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Service) canAccessRepo(user *authUser, repo corestore.Record) bool {

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -459,6 +459,33 @@ func (s *Service) assertIssueParticipant(c *corehttp.Context, repo corestore.Rec
 	return user, true
 }
 
+func (s *Service) assertPullBaseAccess(c *corehttp.Context, user *authUser, repo corestore.Record) bool {
+	if boolField(repo, "private") {
+		if !hasScope(user, "repo") || !s.canAccessRepo(user, repo) {
+			writeForbidden(c)
+			return false
+		}
+		return true
+	}
+	if !hasRepoMutationScope(user, repo) {
+		writeForbidden(c)
+		return false
+	}
+	return true
+}
+
+func (s *Service) assertPullHeadAccess(c *corehttp.Context, user *authUser, repo corestore.Record) bool {
+	if boolField(repo, "private") && !hasScope(user, "repo") {
+		writeForbidden(c)
+		return false
+	}
+	if !s.canAccessRepo(user, repo) {
+		writeForbidden(c)
+		return false
+	}
+	return true
+}
+
 func hasRepoMutationScope(user *authUser, repo corestore.Record) bool {
 	if boolField(repo, "private") {
 		return hasScope(user, "repo")

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -93,11 +93,11 @@ func New(options Options) *Service {
 		baseURL: baseURL,
 	}
 	service.SeedDefaults()
-	if options.Seed == nil || options.Seed.Tokens == nil {
-		service.SeedDefaultTokens()
-	}
 	if options.Seed != nil {
 		service.SeedFromConfig(*options.Seed)
+	}
+	if options.Seed == nil || options.Seed.Tokens == nil {
+		service.SeedDefaultTokens()
 	}
 	return service
 }
@@ -140,6 +140,10 @@ func (s *Service) SeedDefaultTokens() {
 		})
 	}
 	if firstRecord(s.store.Tokens.FindBy("tokenString", "test_token_user1")) == nil {
+		if firstRecord(s.store.Users.FindBy("login", "octocat")) == nil {
+			octocat := s.store.Users.Insert(defaultUserRecord("octocat", "The Octocat", "octocat@github.com", false))
+			s.store.Users.Update(intField(octocat, "id"), corestore.Record{"node_id": generateNodeID("User", intField(octocat, "id"))})
+		}
 		s.store.Tokens.Insert(corestore.Record{
 			"tokenString": "test_token_user1",
 			"login":       "octocat",

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -375,6 +375,29 @@ func (s *Service) assertRepoRead(c *corehttp.Context, repo corestore.Record) boo
 	return false
 }
 
+func (s *Service) viewerID(c *corehttp.Context) int {
+	auth, ok := s.authUser(c)
+	if !ok {
+		return 0
+	}
+	return auth.ID
+}
+
+func (s *Service) filterReadableRepos(c *corehttp.Context, repos []corestore.Record) []corestore.Record {
+	auth, authenticated := s.authUser(c)
+	out := make([]corestore.Record, 0, len(repos))
+	for _, repo := range repos {
+		if !boolField(repo, "private") {
+			out = append(out, repo)
+			continue
+		}
+		if authenticated && s.canAccessRepo(auth, repo) {
+			out = append(out, repo)
+		}
+	}
+	return out
+}
+
 func (s *Service) assertRepoWrite(c *corehttp.Context, repo corestore.Record) (corestore.Record, bool) {
 	user, ok := s.currentUser(c)
 	if !ok {

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -481,10 +481,13 @@ func (s *Service) canAccessRepo(user *authUser, repo corestore.Record) bool {
 		return false
 	}
 	userID := intField(userRecord, "id")
+	if boolField(userRecord, "site_admin") {
+		return true
+	}
 	if stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == userID {
 		return true
 	}
-	if s.isOrgMember(userID, intField(repo, "owner_id")) {
+	if stringField(repo, "owner_type") == "Organization" && s.isOrgMember(userID, intField(repo, "owner_id")) {
 		return true
 	}
 	for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -1,0 +1,496 @@
+package github
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const serviceLabel = "GitHub"
+
+type Options struct {
+	Store   *corestore.Store
+	BaseURL string
+	Seed    *SeedConfig
+}
+
+type SeedConfig struct {
+	Port      int                  `json:"port,omitempty"`
+	Users     []UserSeed           `json:"users"`
+	Orgs      []OrgSeed            `json:"orgs"`
+	Tokens    map[string]TokenSeed `json:"tokens"`
+	Repos     []RepoSeed           `json:"repos"`
+	OAuthApps []OAuthAppSeed       `json:"oauth_apps"`
+}
+
+type UserSeed struct {
+	Login           string `json:"login"`
+	Name            string `json:"name"`
+	Email           string `json:"email"`
+	Bio             string `json:"bio"`
+	Company         string `json:"company"`
+	Location        string `json:"location"`
+	Blog            string `json:"blog"`
+	TwitterUsername string `json:"twitter_username"`
+	SiteAdmin       bool   `json:"site_admin"`
+}
+
+type OrgSeed struct {
+	Login       string `json:"login"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Email       string `json:"email"`
+}
+
+type TokenSeed struct {
+	Login  string   `json:"login"`
+	Scopes []string `json:"scopes"`
+}
+
+type RepoSeed struct {
+	Owner         string   `json:"owner"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description"`
+	Private       bool     `json:"private"`
+	Language      string   `json:"language"`
+	Topics        []string `json:"topics"`
+	DefaultBranch string   `json:"default_branch"`
+	AutoInit      *bool    `json:"auto_init"`
+}
+
+type OAuthAppSeed struct {
+	ClientID     string   `json:"client_id"`
+	ClientSecret string   `json:"client_secret"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris"`
+}
+
+type Service struct {
+	store   Store
+	baseURL string
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	baseURL := strings.TrimRight(options.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:4000"
+	}
+	service := &Service{
+		store:   NewStore(runtimeStore),
+		baseURL: baseURL,
+	}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, baseURL string, config SeedConfig) {
+	New(Options{Store: runtimeStore, BaseURL: baseURL, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerOAuthRoutes(router)
+	s.registerUserAndOrgRoutes(router)
+	s.registerCommentRoutes(router)
+	s.registerIssueRoutes(router)
+	s.registerPullRoutes(router)
+	s.registerBranchAndGitRoutes(router)
+	s.registerRepoRoutes(router)
+	s.registerMetaRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if firstRecord(s.store.Users.FindBy("login", "ghost")) == nil {
+		ghost := s.store.Users.Insert(defaultUserRecord("ghost", "Ghost", "", false))
+		s.store.Users.Update(intField(ghost, "id"), corestore.Record{"node_id": generateNodeID("User", intField(ghost, "id"))})
+	}
+	if firstRecord(s.store.Users.FindBy("login", "admin")) == nil {
+		admin := s.store.Users.Insert(defaultUserRecord("admin", "Admin", "admin@localhost", true))
+		s.store.Users.Update(intField(admin, "id"), corestore.Record{
+			"node_id": generateNodeID("User", intField(admin, "id")),
+			"bio":     "Default admin user",
+		})
+	}
+	if firstRecord(s.store.Tokens.FindBy("tokenString", "test_token_admin")) == nil {
+		s.store.Tokens.Insert(corestore.Record{
+			"tokenString": "test_token_admin",
+			"login":       "admin",
+			"scopes":      []string{"repo", "user", "admin:org", "admin:repo_hook"},
+		})
+	}
+	if firstRecord(s.store.Tokens.FindBy("tokenString", "test_token_user1")) == nil {
+		s.store.Tokens.Insert(corestore.Record{
+			"tokenString": "test_token_user1",
+			"login":       "octocat",
+			"scopes":      []string{"repo", "user"},
+		})
+	}
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	for _, seed := range config.Users {
+		login := strings.TrimSpace(seed.Login)
+		if login == "" || firstRecord(s.store.Users.FindBy("login", login)) != nil {
+			continue
+		}
+		user := s.store.Users.Insert(defaultUserRecord(login, seed.Name, seed.Email, seed.SiteAdmin))
+		patch := corestore.Record{"node_id": generateNodeID("User", intField(user, "id"))}
+		if seed.Bio != "" {
+			patch["bio"] = seed.Bio
+		}
+		if seed.Company != "" {
+			patch["company"] = seed.Company
+		}
+		if seed.Location != "" {
+			patch["location"] = seed.Location
+		}
+		if seed.Blog != "" {
+			patch["blog"] = seed.Blog
+		}
+		if seed.TwitterUsername != "" {
+			patch["twitter_username"] = seed.TwitterUsername
+		}
+		s.store.Users.Update(intField(user, "id"), patch)
+	}
+
+	for _, seed := range config.Orgs {
+		login := strings.TrimSpace(seed.Login)
+		if login == "" || firstRecord(s.store.Orgs.FindBy("login", login)) != nil {
+			continue
+		}
+		org := s.store.Orgs.Insert(defaultOrgRecord(login, seed.Name, seed.Description, seed.Email))
+		s.store.Orgs.Update(intField(org, "id"), corestore.Record{"node_id": generateNodeID("Organization", intField(org, "id"))})
+	}
+
+	for token, seed := range config.Tokens {
+		if strings.TrimSpace(token) == "" || strings.TrimSpace(seed.Login) == "" {
+			continue
+		}
+		if firstRecord(s.store.Tokens.FindBy("tokenString", token)) != nil {
+			continue
+		}
+		scopes := seed.Scopes
+		if len(scopes) == 0 {
+			scopes = []string{"repo", "user", "admin:org", "admin:repo_hook"}
+		}
+		s.store.Tokens.Insert(corestore.Record{
+			"tokenString": token,
+			"login":       seed.Login,
+			"scopes":      scopes,
+		})
+	}
+
+	for _, seed := range config.Repos {
+		if strings.TrimSpace(seed.Owner) == "" || strings.TrimSpace(seed.Name) == "" {
+			continue
+		}
+		owner := s.lookupOwner(seed.Owner)
+		if owner == nil {
+			continue
+		}
+		if s.lookupRepo(seed.Owner, seed.Name) != nil {
+			continue
+		}
+		defaultBranch := seed.DefaultBranch
+		if defaultBranch == "" {
+			defaultBranch = "main"
+		}
+		repo := s.createRepoRecord(createRepoOptions{
+			Name:          seed.Name,
+			Description:   nullableString(seed.Description),
+			Private:       seed.Private,
+			OwnerID:       intField(owner, "id"),
+			OwnerType:     ownerType(owner),
+			OwnerLogin:    seed.Owner,
+			DefaultBranch: defaultBranch,
+			Language:      nullableString(seed.Language),
+			Topics:        seed.Topics,
+		})
+		autoInit := true
+		if seed.AutoInit != nil {
+			autoInit = *seed.AutoInit
+		}
+		if autoInit {
+			s.seedInitialGit(repo, owner)
+		}
+		if seed.Language != "" {
+			s.store.Repos.Update(intField(repo, "id"), corestore.Record{
+				"language":  seed.Language,
+				"languages": map[string]int{seed.Language: 10000},
+			})
+		}
+	}
+
+	for _, seed := range config.OAuthApps {
+		if seed.ClientID == "" || firstRecord(s.store.OAuthApps.FindBy("client_id", seed.ClientID)) != nil {
+			continue
+		}
+		s.store.OAuthApps.Insert(corestore.Record{
+			"client_id":     seed.ClientID,
+			"client_secret": seed.ClientSecret,
+			"name":          seed.Name,
+			"redirect_uris": seed.RedirectURIs,
+		})
+	}
+}
+
+func defaultUserRecord(login string, name string, email string, siteAdmin bool) corestore.Record {
+	if name == "" {
+		name = login
+	}
+	return corestore.Record{
+		"login":            login,
+		"node_id":          "",
+		"avatar_url":       "",
+		"gravatar_id":      "",
+		"type":             "User",
+		"site_admin":       siteAdmin,
+		"name":             nullableString(name),
+		"company":          nil,
+		"blog":             "",
+		"location":         nil,
+		"email":            nullableString(email),
+		"hireable":         nil,
+		"bio":              nil,
+		"twitter_username": nil,
+		"public_repos":     0,
+		"public_gists":     0,
+		"followers":        0,
+		"following":        0,
+	}
+}
+
+func defaultOrgRecord(login string, name string, description string, email string) corestore.Record {
+	return corestore.Record{
+		"login":                           login,
+		"node_id":                         "",
+		"description":                     nullableString(description),
+		"name":                            nullableString(name),
+		"company":                         nil,
+		"blog":                            "",
+		"location":                        nil,
+		"email":                           nullableString(email),
+		"twitter_username":                nil,
+		"is_verified":                     false,
+		"has_organization_projects":       true,
+		"has_repository_projects":         true,
+		"public_repos":                    0,
+		"public_gists":                    0,
+		"followers":                       0,
+		"following":                       0,
+		"members_can_create_repositories": true,
+		"default_repository_permission":   "read",
+		"billing_email":                   nil,
+	}
+}
+
+func (s *Service) authUser(c *corehttp.Context) (*authUser, bool) {
+	token := tokenFromRequest(c.Request)
+	if token == "" {
+		return nil, false
+	}
+	if row := firstRecord(s.store.OAuthTokens.FindBy("tokenString", token)); row != nil {
+		return s.authUserFromLogin(stringField(row, "login"), stringSliceValue(row["scopes"]))
+	}
+	if row := firstRecord(s.store.Tokens.FindBy("tokenString", token)); row != nil {
+		return s.authUserFromLogin(stringField(row, "login"), stringSliceValue(row["scopes"]))
+	}
+	if token == "test-token" {
+		if firstRecord(s.store.Users.FindBy("login", "octocat")) != nil {
+			return s.authUserFromLogin("octocat", []string{"repo", "user", "admin:org"})
+		}
+		return s.authUserFromLogin("admin", []string{"repo", "user", "admin:org", "admin:repo_hook"})
+	}
+	return nil, false
+}
+
+func (s *Service) authUserFromLogin(login string, scopes []string) (*authUser, bool) {
+	user := firstRecord(s.store.Users.FindBy("login", login))
+	if user == nil {
+		return &authUser{Login: login, Scopes: scopes}, true
+	}
+	if len(scopes) == 0 {
+		scopes = []string{"repo", "user"}
+	}
+	return &authUser{Login: login, ID: intField(user, "id"), Scopes: scopes}, true
+}
+
+func (s *Service) currentUser(c *corehttp.Context) (corestore.Record, bool) {
+	auth, ok := s.authUser(c)
+	if !ok {
+		writeUnauthorized(c)
+		return nil, false
+	}
+	user := firstRecord(s.store.Users.FindBy("login", auth.Login))
+	if user == nil {
+		writeUnauthorized(c)
+		return nil, false
+	}
+	return user, true
+}
+
+func (s *Service) lookupOwner(login string) corestore.Record {
+	if user := firstRecord(s.store.Users.FindBy("login", login)); user != nil {
+		return user
+	}
+	return firstRecord(s.store.Orgs.FindBy("login", login))
+}
+
+func (s *Service) lookupRepo(owner string, name string) corestore.Record {
+	return firstRecord(s.store.Repos.FindBy("full_name", owner+"/"+name))
+}
+
+func (s *Service) assertRepoRead(c *corehttp.Context, repo corestore.Record) bool {
+	if repo == nil {
+		writeNotFound(c)
+		return false
+	}
+	if !boolField(repo, "private") {
+		return true
+	}
+	user, ok := s.authUser(c)
+	if !ok {
+		writeUnauthorized(c)
+		return false
+	}
+	if s.canAccessRepo(user, repo) {
+		return true
+	}
+	writeForbidden(c)
+	return false
+}
+
+func (s *Service) assertRepoWrite(c *corehttp.Context, repo corestore.Record) (corestore.Record, bool) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return nil, false
+	}
+	if !boolField(repo, "private") || s.hasRepoAdmin(user, repo) || s.canAccessRepo(&authUser{Login: stringField(user, "login"), ID: intField(user, "id")}, repo) {
+		return user, true
+	}
+	writeForbidden(c)
+	return nil, false
+}
+
+func (s *Service) assertRepoAdmin(c *corehttp.Context, repo corestore.Record) (corestore.Record, bool) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		return nil, false
+	}
+	if s.hasRepoAdmin(user, repo) {
+		return user, true
+	}
+	writeForbidden(c)
+	return nil, false
+}
+
+func (s *Service) canAccessRepo(user *authUser, repo corestore.Record) bool {
+	if user == nil {
+		return false
+	}
+	userRecord := firstRecord(s.store.Users.FindBy("login", user.Login))
+	if userRecord == nil {
+		return false
+	}
+	userID := intField(userRecord, "id")
+	if stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == userID {
+		return true
+	}
+	if s.isOrgMember(userID, intField(repo, "owner_id")) {
+		return true
+	}
+	for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {
+		if intField(collab, "user_id") == userID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) hasRepoAdmin(user corestore.Record, repo corestore.Record) bool {
+	userID := intField(user, "id")
+	if boolField(user, "site_admin") {
+		return true
+	}
+	if stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == userID {
+		return true
+	}
+	if stringField(repo, "owner_type") == "Organization" && s.isOrgMember(userID, intField(repo, "owner_id")) {
+		return true
+	}
+	for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {
+		if intField(collab, "user_id") == userID {
+			permission := stringField(collab, "permission")
+			return permission == "admin" || permission == "maintain"
+		}
+	}
+	return false
+}
+
+func (s *Service) isOrgMember(userID int, orgID int) bool {
+	for _, team := range s.store.Teams.FindBy("org_id", orgID) {
+		for _, member := range s.store.TeamMembers.FindBy("team_id", intField(team, "id")) {
+			if intField(member, "user_id") == userID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ownerType(owner corestore.Record) string {
+	if stringField(owner, "type") == "User" {
+		return "User"
+	}
+	return "Organization"
+}
+
+func validateRepoName(name string) bool {
+	if strings.TrimSpace(name) == "" || len(name) > 100 {
+		return false
+	}
+	return regexp.MustCompile(`^[a-zA-Z0-9._-]+$`).MatchString(name)
+}
+
+func matchesRedirectURI(candidate string, allowed []string) bool {
+	if candidate == "" {
+		return true
+	}
+	candidateURL, err := url.Parse(candidate)
+	if err != nil {
+		return false
+	}
+	for _, registered := range allowed {
+		registeredURL, err := url.Parse(registered)
+		if err != nil {
+			continue
+		}
+		if candidateURL.Scheme == registeredURL.Scheme && candidateURL.Host == registeredURL.Host && strings.TrimRight(candidateURL.Path, "/") == strings.TrimRight(registeredURL.Path, "/") {
+			return true
+		}
+	}
+	return false
+}
+
+func pendingCodeCreatedAt(row corestore.Record) time.Time {
+	millis := intField(row, "createdAt")
+	if millis == 0 {
+		return time.Now()
+	}
+	return time.UnixMilli(int64(millis))
+}

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -426,7 +426,7 @@ func (s *Service) assertRepoWrite(c *corehttp.Context, repo corestore.Record) (c
 		writeForbidden(c)
 		return nil, false
 	}
-	if s.hasRepoAdmin(user, repo) || s.canAccessRepo(auth, repo) {
+	if s.hasRepoWrite(user, repo) {
 		return user, true
 	}
 	writeForbidden(c)
@@ -548,11 +548,46 @@ func (s *Service) hasRepoAdmin(user corestore.Record, repo corestore.Record) boo
 	}
 	for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {
 		if intField(collab, "user_id") == userID {
-			permission := stringField(collab, "permission")
-			return permission == "admin" || permission == "maintain"
+			return repoPermissionLevel(stringField(collab, "permission")) >= repoPermissionLevel("maintain")
 		}
 	}
 	return false
+}
+
+func (s *Service) hasRepoWrite(user corestore.Record, repo corestore.Record) bool {
+	userID := intField(user, "id")
+	if boolField(user, "site_admin") {
+		return true
+	}
+	if stringField(repo, "owner_type") == "User" && intField(repo, "owner_id") == userID {
+		return true
+	}
+	if stringField(repo, "owner_type") == "Organization" && s.isOrgMember(userID, intField(repo, "owner_id")) {
+		return true
+	}
+	for _, collab := range s.store.Collaborators.FindBy("repo_id", intField(repo, "id")) {
+		if intField(collab, "user_id") == userID {
+			return repoPermissionLevel(stringField(collab, "permission")) >= repoPermissionLevel("push")
+		}
+	}
+	return false
+}
+
+func repoPermissionLevel(permission string) int {
+	switch permission {
+	case "pull":
+		return 0
+	case "triage":
+		return 1
+	case "push":
+		return 2
+	case "maintain":
+		return 3
+	case "admin":
+		return 4
+	default:
+		return -1
+	}
 }
 
 func (s *Service) isOrgMember(userID int, orgID int) bool {

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -116,6 +116,37 @@ func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
 	}
 }
 
+func TestGitHubRepoWithoutTopicsReturnsEmptyArrays(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	repo := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world", "", "Bearer test_token_user1")
+	if repo.Code != http.StatusOK {
+		t.Fatalf("repo status = %d, body = %s", repo.Code, repo.Body.String())
+	}
+	var repoBody struct {
+		Topics []string `json:"topics"`
+	}
+	decodeGitHubBody(t, repo, &repoBody)
+	if repoBody.Topics == nil || len(repoBody.Topics) != 0 {
+		t.Fatalf("topics should be an empty array: %#v, body = %s", repoBody.Topics, repo.Body.String())
+	}
+
+	topics := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/topics", "", "Bearer test_token_user1")
+	if topics.Code != http.StatusOK {
+		t.Fatalf("topics status = %d, body = %s", topics.Code, topics.Body.String())
+	}
+	var topicsBody struct {
+		Names []string `json:"names"`
+	}
+	decodeGitHubBody(t, topics, &topicsBody)
+	if topicsBody.Names == nil || len(topicsBody.Names) != 0 {
+		t.Fatalf("topic names should be an empty array: %#v, body = %s", topicsBody.Names, topics.Body.String())
+	}
+}
+
 func TestGitHubListPullsFiltersForkHeadByOwnerAndBranch(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{
@@ -156,6 +187,49 @@ func TestGitHubListPullsFiltersForkHeadByOwnerAndBranch(t *testing.T) {
 	decodeGitHubBody(t, list, &body)
 	if len(body) != 1 || body[0].Head.Label != "forker:feature" {
 		t.Fatalf("unexpected filtered pulls: %#v, body = %s", body, list.Body.String())
+	}
+}
+
+func TestGitHubPublicForkOwnerCanCreatePullAgainstBaseRepo(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "forker", Email: "forker@example.com"},
+		},
+		Tokens: map[string]TokenSeed{
+			"forker_token": {Login: "forker", Scopes: []string{"repo", "user"}},
+		},
+		Repos: []RepoSeed{
+			{Owner: "octocat", Name: "hello-world"},
+			{Owner: "forker", Name: "hello-world"},
+		},
+	})
+
+	forkBranches := doGitHubJSON(handler, http.MethodGet, "/repos/forker/hello-world/branches", "", "Bearer forker_token")
+	if forkBranches.Code != http.StatusOK {
+		t.Fatalf("fork branches status = %d, body = %s", forkBranches.Code, forkBranches.Body.String())
+	}
+	forkMainSha := defaultBranchSha(t, forkBranches, "main")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/forker/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+forkMainSha+`"}`, "Bearer forker_token")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Fork feature","head":"forker:feature","base":"main"}`, "Bearer forker_token")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+	var body struct {
+		Head struct {
+			Label string `json:"label"`
+		} `json:"head"`
+		Base struct {
+			Label string `json:"label"`
+		} `json:"base"`
+	}
+	decodeGitHubBody(t, pr, &body)
+	if body.Head.Label != "forker:feature" || body.Base.Label != "octocat:main" {
+		t.Fatalf("unexpected pull sides: %#v, body = %s", body, pr.Body.String())
 	}
 }
 

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -116,6 +116,72 @@ func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
 	}
 }
 
+func TestGitHubPullRequestIsVisibleThroughIssuesAPI(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	issue := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/issues/1", "", "Bearer test_token_user1")
+	if issue.Code != http.StatusOK {
+		t.Fatalf("issue status = %d, body = %s", issue.Code, issue.Body.String())
+	}
+	var issueBody struct {
+		Number      int `json:"number"`
+		PullRequest *struct {
+			URL string `json:"url"`
+		} `json:"pull_request"`
+	}
+	decodeGitHubBody(t, issue, &issueBody)
+	if issueBody.Number != 1 || issueBody.PullRequest == nil || issueBody.PullRequest.URL == "" {
+		t.Fatalf("unexpected pull issue: %#v, body = %s", issueBody, issue.Body.String())
+	}
+
+	list := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/issues", "", "Bearer test_token_user1")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", list.Code, list.Body.String())
+	}
+	var listBody []struct {
+		Number      int            `json:"number"`
+		PullRequest map[string]any `json:"pull_request"`
+	}
+	decodeGitHubBody(t, list, &listBody)
+	if len(listBody) != 1 || listBody[0].Number != 1 || listBody[0].PullRequest == nil {
+		t.Fatalf("unexpected issue list: %#v, body = %s", listBody, list.Body.String())
+	}
+
+	patch := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/issues/1", `{"title":"Retitled","state":"closed"}`, "Bearer test_token_user1")
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, body = %s", patch.Code, patch.Body.String())
+	}
+	pull := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")
+	if pull.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body = %s", pull.Code, pull.Body.String())
+	}
+	var pullBody struct {
+		Title string `json:"title"`
+		State string `json:"state"`
+	}
+	decodeGitHubBody(t, pull, &pullBody)
+	if pullBody.Title != "Retitled" || pullBody.State != "closed" {
+		t.Fatalf("issue patch did not sync pull: %#v, body = %s", pullBody, pull.Body.String())
+	}
+}
+
 func TestGitHubRepoWithoutTopicsReturnsEmptyArrays(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
@@ -144,6 +210,40 @@ func TestGitHubRepoWithoutTopicsReturnsEmptyArrays(t *testing.T) {
 	decodeGitHubBody(t, topics, &topicsBody)
 	if topicsBody.Names == nil || len(topicsBody.Names) != 0 {
 		t.Fatalf("topic names should be an empty array: %#v, body = %s", topicsBody.Names, topics.Body.String())
+	}
+}
+
+func TestGitHubOrgRepoSeedCommitDoesNotResolveToCollidingUser(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Orgs:  []OrgSeed{{Login: "my-org", Name: "My Org"}},
+		Repos: []RepoSeed{{Owner: "my-org", Name: "org-repo"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/my-org/org-repo/branches", "", "Bearer test_token_admin")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+	commit := doGitHubJSON(handler, http.MethodGet, "/repos/my-org/org-repo/git/commits/"+mainSha, "", "Bearer test_token_admin")
+	if commit.Code != http.StatusOK {
+		t.Fatalf("commit status = %d, body = %s", commit.Code, commit.Body.String())
+	}
+	var body struct {
+		Author *struct {
+			Login string `json:"login"`
+		} `json:"author"`
+		Commit struct {
+			Author struct {
+				Name string `json:"name"`
+			} `json:"author"`
+		} `json:"commit"`
+	}
+	decodeGitHubBody(t, commit, &body)
+	if body.Author != nil {
+		t.Fatalf("org seed commit resolved to user author: %#v, body = %s", body.Author, commit.Body.String())
+	}
+	if body.Commit.Author.Name != "My Org" {
+		t.Fatalf("unexpected commit author name: %#v, body = %s", body.Commit.Author, commit.Body.String())
 	}
 }
 

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -105,6 +105,49 @@ func TestGitHubRejectsRefsToMissingCommits(t *testing.T) {
 	}
 }
 
+func TestGitHubCreatePullRejectsMissingBranches(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	res := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Missing","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if res.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	if strings.Contains(branches.Body.String(), `"name":"feature"`) {
+		t.Fatalf("missing head branch was created: %s", branches.Body.String())
+	}
+}
+
+func TestGitHubPatchPullRejectsMissingBaseBranch(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	mainSha := defaultBranchSha(t, branches, "main")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	patch := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/pulls/1", `{"base":"missing"}`, "Bearer test_token_user1")
+	if patch.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("patch status = %d, body = %s", patch.Code, patch.Body.String())
+	}
+}
+
 func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
@@ -229,6 +272,28 @@ func TestGitHubPublicRepoListsHidePrivateRepos(t *testing.T) {
 	}
 }
 
+func TestGitHubPublicRepoIssuesAllowAuthenticatedNonCollaborator(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "intruder", Email: "intruder@example.com"},
+		},
+		Tokens: map[string]TokenSeed{
+			"intruder_token": {Login: "intruder", Scopes: []string{"repo", "user"}},
+		},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	issue := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues", `{"title":"Bug"}`, "Bearer intruder_token")
+	if issue.Code != http.StatusCreated {
+		t.Fatalf("issue status = %d, body = %s", issue.Code, issue.Body.String())
+	}
+	comment := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues/1/comments", `{"body":"confirmed"}`, "Bearer intruder_token")
+	if comment.Code != http.StatusCreated {
+		t.Fatalf("comment status = %d, body = %s", comment.Code, comment.Body.String())
+	}
+}
+
 func TestGitHubPatchRepoPrivateSyncsVisibility(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
@@ -246,6 +311,41 @@ func TestGitHubPatchRepoPrivateSyncsVisibility(t *testing.T) {
 	decodeGitHubBody(t, res, &body)
 	if !body.Private || body.Visibility != "private" {
 		t.Fatalf("unexpected repo visibility: %#v", body)
+	}
+}
+
+func TestGitHubRepoScopeRequiredForPrivateReadAndRepoMutation(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Tokens: map[string]TokenSeed{
+			"user_only_token": {Login: "octocat", Scopes: []string{"user"}},
+		},
+		Repos: []RepoSeed{
+			{Owner: "octocat", Name: "hello-world"},
+			{Owner: "octocat", Name: "private-repo", Private: true},
+		},
+	})
+
+	privateRepo := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/private-repo", "", "Bearer user_only_token")
+	if privateRepo.Code != http.StatusForbidden {
+		t.Fatalf("private repo status = %d, body = %s", privateRepo.Code, privateRepo.Body.String())
+	}
+	userRepos := doGitHubJSON(handler, http.MethodGet, "/user/repos", "", "Bearer user_only_token")
+	if userRepos.Code != http.StatusOK {
+		t.Fatalf("user repos status = %d, body = %s", userRepos.Code, userRepos.Body.String())
+	}
+	if strings.Contains(userRepos.Body.String(), "private-repo") {
+		t.Fatalf("user-only token listed private repo: %s", userRepos.Body.String())
+	}
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer user_only_token")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/user-only","sha":"`+mainSha+`"}`, "Bearer user_only_token")
+	if ref.Code != http.StatusForbidden {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
 	}
 }
 

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -365,6 +365,45 @@ func TestGitHubRejectsRefsToMissingCommits(t *testing.T) {
 	}
 }
 
+func TestGitHubPatchRefRequiresFastForwardUnlessForced(t *testing.T) {
+	service, handler := newGitHubTestServiceHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+	repo := service.lookupRepo("octocat", "hello-world")
+	actor := firstRecord(service.store.Users.FindBy("login", "octocat"))
+	baseCommit := service.findCommitExact(repo, mainSha)
+	if baseCommit == nil {
+		t.Fatalf("missing base commit %s", mainSha)
+	}
+	commitA := service.insertCommit(repo, stringField(baseCommit, "tree_sha"), []string{mainSha}, "Commit A", actor)
+	commitB := service.insertCommit(repo, stringField(baseCommit, "tree_sha"), []string{mainSha}, "Commit B", actor)
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+stringField(commitA, "sha")+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+
+	nonFastForward := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/git/refs/heads/feature", `{"sha":"`+stringField(commitB, "sha")+`"}`, "Bearer test_token_user1")
+	if nonFastForward.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("non-fast-forward status = %d, body = %s", nonFastForward.Code, nonFastForward.Body.String())
+	}
+	if !strings.Contains(nonFastForward.Body.String(), "Update is not a fast-forward") {
+		t.Fatalf("unexpected non-fast-forward body: %s", nonFastForward.Body.String())
+	}
+
+	forced := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/git/refs/heads/feature", `{"sha":"`+stringField(commitB, "sha")+`","force":true}`, "Bearer test_token_user1")
+	if forced.Code != http.StatusOK {
+		t.Fatalf("forced status = %d, body = %s", forced.Code, forced.Body.String())
+	}
+}
+
 func TestGitHubCreatePullRejectsMissingBranches(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
@@ -538,6 +577,81 @@ func TestGitHubMergeRejectsDraftPull(t *testing.T) {
 	}
 }
 
+func TestGitHubMergeHonorsRepoPoliciesMethodAndBranchDeletion(t *testing.T) {
+	service, handler := newGitHubTestServiceHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+	repo := service.lookupRepo("octocat", "hello-world")
+	actor := firstRecord(service.store.Users.FindBy("login", "octocat"))
+	baseCommit := service.findCommitExact(repo, mainSha)
+	if baseCommit == nil {
+		t.Fatalf("missing base commit %s", mainSha)
+	}
+	headCommit := service.insertCommit(repo, stringField(baseCommit, "tree_sha"), []string{mainSha}, "Feature commit", actor)
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+stringField(headCommit, "sha")+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	patchRepo := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world", `{"allow_merge_commit":false,"delete_branch_on_merge":true}`, "Bearer test_token_user1")
+	if patchRepo.Code != http.StatusOK {
+		t.Fatalf("patch repo status = %d, body = %s", patchRepo.Code, patchRepo.Body.String())
+	}
+	defaultMerge := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{}`, "Bearer test_token_user1")
+	if defaultMerge.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("default merge status = %d, body = %s", defaultMerge.Code, defaultMerge.Body.String())
+	}
+	if !strings.Contains(defaultMerge.Body.String(), "Merge commits are not allowed on this repository.") {
+		t.Fatalf("unexpected default merge body: %s", defaultMerge.Body.String())
+	}
+
+	merge := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{"merge_method":"squash","commit_title":"Squash feature","commit_message":"Body"}`, "Bearer test_token_user1")
+	if merge.Code != http.StatusOK {
+		t.Fatalf("merge status = %d, body = %s", merge.Code, merge.Body.String())
+	}
+	var mergeBody struct {
+		Sha string `json:"sha"`
+	}
+	decodeGitHubBody(t, merge, &mergeBody)
+	if mergeBody.Sha == "" {
+		t.Fatalf("missing merge sha: %s", merge.Body.String())
+	}
+
+	commit := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/git/commits/"+mergeBody.Sha, "", "Bearer test_token_user1")
+	if commit.Code != http.StatusOK {
+		t.Fatalf("commit status = %d, body = %s", commit.Code, commit.Body.String())
+	}
+	var commitBody struct {
+		Commit struct {
+			Message string `json:"message"`
+		} `json:"commit"`
+		Parents []struct {
+			Sha string `json:"sha"`
+		} `json:"parents"`
+	}
+	decodeGitHubBody(t, commit, &commitBody)
+	if commitBody.Commit.Message != "Squash feature\n\nBody" || len(commitBody.Parents) != 1 || commitBody.Parents[0].Sha != mainSha {
+		t.Fatalf("unexpected merge commit: %#v, body = %s", commitBody, commit.Body.String())
+	}
+
+	feature := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches/feature", "", "Bearer test_token_user1")
+	if feature.Code != http.StatusNotFound {
+		t.Fatalf("feature branch status = %d, body = %s", feature.Code, feature.Body.String())
+	}
+}
+
 func TestGitHubPullFilesRequirePrivateRepoReadAccess(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
@@ -647,6 +761,33 @@ func TestGitHubPatchRepoPrivateSyncsVisibility(t *testing.T) {
 	decodeGitHubBody(t, res, &body)
 	if !body.Private || body.Visibility != "private" {
 		t.Fatalf("unexpected repo visibility: %#v", body)
+	}
+}
+
+func TestGitHubCreateRepoHonorsFeatureFlags(t *testing.T) {
+	handler := newGitHubTestHandler(nil)
+
+	res := doGitHubJSON(handler, http.MethodPost, "/user/repos", `{"name":"configured","has_issues":false,"has_projects":false,"has_wiki":false,"allow_merge_commit":false,"allow_squash_merge":false,"allow_rebase_merge":false,"delete_branch_on_merge":true}`, "Bearer test_token_user1")
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		HasIssues           bool `json:"has_issues"`
+		HasProjects         bool `json:"has_projects"`
+		HasWiki             bool `json:"has_wiki"`
+		AllowMergeCommit    bool `json:"allow_merge_commit"`
+		AllowSquashMerge    bool `json:"allow_squash_merge"`
+		AllowRebaseMerge    bool `json:"allow_rebase_merge"`
+		DeleteBranchOnMerge bool `json:"delete_branch_on_merge"`
+	}
+	decodeGitHubBody(t, res, &body)
+	if body.HasIssues || body.HasProjects || body.HasWiki || body.AllowMergeCommit || body.AllowSquashMerge || body.AllowRebaseMerge || !body.DeleteBranchOnMerge {
+		t.Fatalf("unexpected repo flags: %#v, body = %s", body, res.Body.String())
+	}
+
+	issue := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/configured/issues", `{"title":"Bug"}`, "Bearer test_token_user1")
+	if issue.Code != http.StatusNotFound {
+		t.Fatalf("issue status = %d, body = %s", issue.Code, issue.Body.String())
 	}
 }
 

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -533,6 +533,149 @@ func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
 	}
 }
 
+func TestGitHubMergedPullCannotBeReopened(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+	merge := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{}`, "Bearer test_token_user1")
+	if merge.Code != http.StatusOK {
+		t.Fatalf("merge status = %d, body = %s", merge.Code, merge.Body.String())
+	}
+
+	issueReopen := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/issues/1", `{"state":"open"}`, "Bearer test_token_user1")
+	if issueReopen.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("issue reopen status = %d, body = %s", issueReopen.Code, issueReopen.Body.String())
+	}
+	pullReopen := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/pulls/1", `{"state":"open"}`, "Bearer test_token_user1")
+	if pullReopen.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("pull reopen status = %d, body = %s", pullReopen.Code, pullReopen.Body.String())
+	}
+
+	repo := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world", "", "Bearer test_token_user1")
+	if repo.Code != http.StatusOK {
+		t.Fatalf("repo status = %d, body = %s", repo.Code, repo.Body.String())
+	}
+	var repoBody struct {
+		OpenIssuesCount int `json:"open_issues_count"`
+	}
+	decodeGitHubBody(t, repo, &repoBody)
+	if repoBody.OpenIssuesCount != 0 {
+		t.Fatalf("open_issues_count = %d, body = %s", repoBody.OpenIssuesCount, repo.Body.String())
+	}
+
+	pull := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")
+	if pull.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body = %s", pull.Code, pull.Body.String())
+	}
+	var pullBody struct {
+		State  string `json:"state"`
+		Merged bool   `json:"merged"`
+	}
+	decodeGitHubBody(t, pull, &pullBody)
+	if pullBody.State != "closed" || !pullBody.Merged {
+		t.Fatalf("merged pull was reopened: %#v, body = %s", pullBody, pull.Body.String())
+	}
+}
+
+func TestGitHubCrossRepoMergeMaterializesHeadGitObjects(t *testing.T) {
+	service, handler := newGitHubTestServiceHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "forker", Email: "forker@example.com"},
+		},
+		Repos: []RepoSeed{
+			{Owner: "octocat", Name: "hello-world"},
+			{Owner: "forker", Name: "hello-world"},
+		},
+	})
+
+	forkBranches := doGitHubJSON(handler, http.MethodGet, "/repos/forker/hello-world/branches", "", "Bearer test_token_admin")
+	if forkBranches.Code != http.StatusOK {
+		t.Fatalf("fork branches status = %d, body = %s", forkBranches.Code, forkBranches.Body.String())
+	}
+	forkMainSha := defaultBranchSha(t, forkBranches, "main")
+	forkRepo := service.lookupRepo("forker", "hello-world")
+	forkMainCommit := service.findCommitExact(forkRepo, forkMainSha)
+	if forkMainCommit == nil {
+		t.Fatalf("missing fork main commit %s", forkMainSha)
+	}
+	actor := firstRecord(service.store.Users.FindBy("login", "forker"))
+	headCommit := service.insertCommit(forkRepo, stringField(forkMainCommit, "tree_sha"), []string{forkMainSha}, "Fork feature", actor)
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/forker/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+stringField(headCommit, "sha")+`"}`, "Bearer test_token_admin")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Fork feature","head":"forker:feature","base":"main"}`, "Bearer test_token_admin")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+	merge := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{}`, "Bearer test_token_admin")
+	if merge.Code != http.StatusOK {
+		t.Fatalf("merge status = %d, body = %s", merge.Code, merge.Body.String())
+	}
+	var mergeBody struct {
+		Sha string `json:"sha"`
+	}
+	decodeGitHubBody(t, merge, &mergeBody)
+
+	commit := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/git/commits/"+mergeBody.Sha, "", "Bearer test_token_admin")
+	if commit.Code != http.StatusOK {
+		t.Fatalf("merge commit status = %d, body = %s", commit.Code, commit.Body.String())
+	}
+	var commitBody struct {
+		Commit struct {
+			Tree struct {
+				Sha string `json:"sha"`
+			} `json:"tree"`
+		} `json:"commit"`
+		Parents []struct {
+			Sha string `json:"sha"`
+		} `json:"parents"`
+	}
+	decodeGitHubBody(t, commit, &commitBody)
+	if commitBody.Commit.Tree.Sha == "" || len(commitBody.Parents) != 2 {
+		t.Fatalf("unexpected merge commit: %#v, body = %s", commitBody, commit.Body.String())
+	}
+
+	tree := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/git/trees/"+commitBody.Commit.Tree.Sha, "", "Bearer test_token_admin")
+	if tree.Code != http.StatusOK {
+		t.Fatalf("merge tree status = %d, body = %s", tree.Code, tree.Body.String())
+	}
+	headParent := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/git/commits/"+commitBody.Parents[1].Sha, "", "Bearer test_token_admin")
+	if headParent.Code != http.StatusOK {
+		t.Fatalf("head parent status = %d, body = %s", headParent.Code, headParent.Body.String())
+	}
+	var headParentBody struct {
+		Parents []struct {
+			Sha string `json:"sha"`
+		} `json:"parents"`
+	}
+	decodeGitHubBody(t, headParent, &headParentBody)
+	if len(headParentBody.Parents) != 1 {
+		t.Fatalf("unexpected head parent commit: %#v, body = %s", headParentBody, headParent.Body.String())
+	}
+	forkParent := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/git/commits/"+headParentBody.Parents[0].Sha, "", "Bearer test_token_admin")
+	if forkParent.Code != http.StatusOK {
+		t.Fatalf("fork parent status = %d, body = %s", forkParent.Code, forkParent.Body.String())
+	}
+}
+
 func TestGitHubMergeRejectsDraftPull(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -55,6 +55,7 @@ func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
 	if branches.Code != http.StatusOK || !strings.Contains(branches.Body.String(), `"name":"main"`) {
 		t.Fatalf("unexpected branches: status = %d, body = %s", branches.Code, branches.Body.String())
 	}
+	mainSha := defaultBranchSha(t, branches, "main")
 
 	issue := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues", `{"title":"Bug","body":"broken"}`, "Bearer test_token_user1")
 	if issue.Code != http.StatusCreated {
@@ -74,7 +75,7 @@ func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
 		t.Fatalf("comment status = %d, body = %s", comment.Code, comment.Body.String())
 	}
 
-	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"abc123"}`, "Bearer test_token_user1")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
 	if ref.Code != http.StatusCreated {
 		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
 	}
@@ -85,6 +86,108 @@ func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
 	}
 	if !strings.Contains(pr.Body.String(), `"number":2`) {
 		t.Fatalf("unexpected pull body: %s", pr.Body.String())
+	}
+}
+
+func TestGitHubRejectsRefsToMissingCommits(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	res := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/missing","sha":"abc123"}`, "Bearer test_token_user1")
+	if res.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "Invalid sha") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	merge := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{}`, "Bearer test_token_user1")
+	if merge.Code != http.StatusOK {
+		t.Fatalf("merge status = %d, body = %s", merge.Code, merge.Body.String())
+	}
+	var mergeBody struct {
+		Sha string `json:"sha"`
+	}
+	decodeGitHubBody(t, merge, &mergeBody)
+	if mergeBody.Sha == "" {
+		t.Fatalf("missing merge sha: %s", merge.Body.String())
+	}
+
+	commit := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/git/commits/"+mergeBody.Sha, "", "Bearer test_token_user1")
+	if commit.Code != http.StatusOK {
+		t.Fatalf("commit status = %d, body = %s", commit.Code, commit.Body.String())
+	}
+}
+
+func TestGitHubPullFilesRequirePrivateRepoReadAccess(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "private-repo", Private: true}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/private-repo/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/private-repo/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/private-repo/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	files := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/private-repo/pulls/1/files", "", "")
+	if files.Code != http.StatusUnauthorized {
+		t.Fatalf("files status = %d, body = %s", files.Code, files.Body.String())
+	}
+}
+
+func TestGitHubPatchRepoPrivateSyncsVisibility(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	res := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world", `{"private":true}`, "Bearer test_token_admin")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		Private    bool   `json:"private"`
+		Visibility string `json:"visibility"`
+	}
+	decodeGitHubBody(t, res, &body)
+	if !body.Private || body.Visibility != "private" {
+		t.Fatalf("unexpected repo visibility: %#v", body)
 	}
 }
 
@@ -175,4 +278,25 @@ func decodeGitHubBody(t *testing.T, res *httptest.ResponseRecorder, target any) 
 	if err := decoder.Decode(target); err != nil {
 		t.Fatalf("decode body %q: %v", res.Body.String(), err)
 	}
+}
+
+func defaultBranchSha(t *testing.T, res *httptest.ResponseRecorder, branchName string) string {
+	t.Helper()
+	var branches []struct {
+		Name   string `json:"name"`
+		Commit struct {
+			Sha string `json:"sha"`
+		} `json:"commit"`
+	}
+	decodeGitHubBody(t, res, &branches)
+	for _, branch := range branches {
+		if branch.Name == branchName {
+			if branch.Commit.Sha == "" {
+				t.Fatalf("branch %s missing sha: %s", branchName, res.Body.String())
+			}
+			return branch.Commit.Sha
+		}
+	}
+	t.Fatalf("branch %s not found: %s", branchName, res.Body.String())
+	return ""
 }

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -142,6 +142,20 @@ func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
 	if commit.Code != http.StatusOK {
 		t.Fatalf("commit status = %d, body = %s", commit.Code, commit.Body.String())
 	}
+
+	pull := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")
+	if pull.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body = %s", pull.Code, pull.Body.String())
+	}
+	var pullBody struct {
+		MergedBy *struct {
+			Login string `json:"login"`
+		} `json:"merged_by"`
+	}
+	decodeGitHubBody(t, pull, &pullBody)
+	if pullBody.MergedBy == nil || pullBody.MergedBy.Login != "octocat" {
+		t.Fatalf("unexpected merged_by: %#v, body = %s", pullBody.MergedBy, pull.Body.String())
+	}
 }
 
 func TestGitHubPullFilesRequirePrivateRepoReadAccess(t *testing.T) {
@@ -188,6 +202,30 @@ func TestGitHubPatchRepoPrivateSyncsVisibility(t *testing.T) {
 	decodeGitHubBody(t, res, &body)
 	if !body.Private || body.Visibility != "private" {
 		t.Fatalf("unexpected repo visibility: %#v", body)
+	}
+}
+
+func TestGitHubRejectsPublicRepoMutationByNonCollaborator(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "intruder", Email: "intruder@example.com"},
+		},
+		Tokens: map[string]TokenSeed{
+			"intruder_token": {Login: "intruder", Scopes: []string{"repo", "user"}},
+		},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer intruder_token")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+
+	res := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/intruder","sha":"`+mainSha+`"}`, "Bearer intruder_token")
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }
 
@@ -244,6 +282,48 @@ func TestGitHubOAuthIssuesUsableToken(t *testing.T) {
 	}
 }
 
+func TestGitHubOAuthRejectsCodeForDifferentClient(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		OAuthApps: []OAuthAppSeed{
+			{
+				ClientID:     "client-a",
+				ClientSecret: "secret-a",
+				Name:         "App A",
+				RedirectURIs: []string{"http://localhost:3000/callback-a"},
+			},
+			{
+				ClientID:     "client-b",
+				ClientSecret: "secret-b",
+				Name:         "App B",
+				RedirectURIs: []string{"http://localhost:3000/callback-b"},
+			},
+		},
+	})
+
+	code := authorizeGitHubCode(t, handler, "client-a", "http://localhost:3000/callback-a")
+	token := doGitHubJSON(handler, http.MethodPost, "/login/oauth/access_token", `{"code":"`+code+`","client_id":"client-b","client_secret":"secret-b"}`, "")
+
+	assertBadVerificationCode(t, token)
+}
+
+func TestGitHubOAuthRejectsMismatchedRedirectURI(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		OAuthApps: []OAuthAppSeed{{
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+			Name:         "Test App",
+			RedirectURIs: []string{"http://localhost:3000/callback", "http://localhost:3000/other-callback"},
+		}},
+	})
+
+	code := authorizeGitHubCode(t, handler, "client-id", "http://localhost:3000/callback")
+	token := doGitHubJSON(handler, http.MethodPost, "/login/oauth/access_token", `{"code":"`+code+`","client_id":"client-id","client_secret":"client-secret","redirect_uri":"http://localhost:3000/other-callback"}`, "")
+
+	assertBadVerificationCode(t, token)
+}
+
 func newGitHubTestHandler(seed *SeedConfig) http.Handler {
 	router := corehttp.NewRouter()
 	Register(router, Options{Store: corestore.New(), BaseURL: testBaseURL, Seed: seed})
@@ -270,6 +350,48 @@ func doGitHubJSON(handler http.Handler, method string, target string, body strin
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 	return res
+}
+
+func authorizeGitHubCode(t *testing.T, handler http.Handler, clientID string, redirectURI string) string {
+	t.Helper()
+	form := url.Values{
+		"login":        {"octocat"},
+		"redirect_uri": {redirectURI},
+		"scope":        {"repo user"},
+		"state":        {"state-1"},
+		"client_id":    {clientID},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/login/oauth/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", res.Code, res.Body.String())
+	}
+	location, err := url.Parse(res.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := location.Query().Get("code")
+	if code == "" {
+		t.Fatalf("missing code in callback location: %s", location.String())
+	}
+	return code
+}
+
+func assertBadVerificationCode(t *testing.T, res *httptest.ResponseRecorder) {
+	t.Helper()
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		Error       string `json:"error"`
+		AccessToken string `json:"access_token"`
+	}
+	decodeGitHubBody(t, res, &body)
+	if body.Error != "bad_verification_code" || body.AccessToken != "" {
+		t.Fatalf("unexpected token response: %#v, body = %s", body, res.Body.String())
+	}
 }
 
 func decodeGitHubBody(t *testing.T, res *httptest.ResponseRecorder, target any) {

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -33,6 +33,32 @@ func TestGitHubCurrentUserUsesDefaultToken(t *testing.T) {
 	}
 }
 
+func TestGitHubConfiguredTokensReplaceDefaultTokens(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Tokens: map[string]TokenSeed{
+			"test_token_admin": {Login: "octocat", Scopes: []string{"user"}},
+		},
+	})
+
+	res := doGitHubJSON(handler, http.MethodGet, "/user", "", "Bearer test_token_admin")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		Login string `json:"login"`
+	}
+	decodeGitHubBody(t, res, &body)
+	if body.Login != "octocat" {
+		t.Fatalf("configured token did not replace default admin token: %#v", body)
+	}
+
+	defaultUserToken := doGitHubJSON(handler, http.MethodGet, "/user", "", "Bearer test_token_user1")
+	if defaultUserToken.Code != http.StatusUnauthorized {
+		t.Fatalf("default token remained active: status = %d, body = %s", defaultUserToken.Code, defaultUserToken.Body.String())
+	}
+}
+
 func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Name: "The Octocat", Email: "octocat@github.com"}},
@@ -87,6 +113,49 @@ func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
 	}
 	if !strings.Contains(pr.Body.String(), `"number":2`) {
 		t.Fatalf("unexpected pull body: %s", pr.Body.String())
+	}
+}
+
+func TestGitHubListPullsFiltersForkHeadByOwnerAndBranch(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "forker", Email: "forker@example.com"},
+		},
+		Repos: []RepoSeed{
+			{Owner: "octocat", Name: "hello-world"},
+			{Owner: "forker", Name: "hello-world"},
+		},
+	})
+
+	forkBranches := doGitHubJSON(handler, http.MethodGet, "/repos/forker/hello-world/branches", "", "Bearer test_token_admin")
+	if forkBranches.Code != http.StatusOK {
+		t.Fatalf("fork branches status = %d, body = %s", forkBranches.Code, forkBranches.Body.String())
+	}
+	forkMainSha := defaultBranchSha(t, forkBranches, "main")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/forker/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+forkMainSha+`"}`, "Bearer test_token_admin")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Fork feature","head":"forker:feature","base":"main"}`, "Bearer test_token_admin")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	list := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls?head=forker:feature", "", "Bearer test_token_admin")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", list.Code, list.Body.String())
+	}
+	var body []struct {
+		Number int `json:"number"`
+		Head   struct {
+			Label string `json:"label"`
+		} `json:"head"`
+	}
+	decodeGitHubBody(t, list, &body)
+	if len(body) != 1 || body[0].Head.Label != "forker:feature" {
+		t.Fatalf("unexpected filtered pulls: %#v, body = %s", body, list.Body.String())
 	}
 }
 
@@ -197,6 +266,18 @@ func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
 	commit := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/git/commits/"+mergeBody.Sha, "", "Bearer test_token_user1")
 	if commit.Code != http.StatusOK {
 		t.Fatalf("commit status = %d, body = %s", commit.Code, commit.Body.String())
+	}
+	var commitBody struct {
+		Author *struct {
+			Login string `json:"login"`
+		} `json:"author"`
+		Committer *struct {
+			Login string `json:"login"`
+		} `json:"committer"`
+	}
+	decodeGitHubBody(t, commit, &commitBody)
+	if commitBody.Author == nil || commitBody.Author.Login != "octocat" || commitBody.Committer == nil || commitBody.Committer.Login != "octocat" {
+		t.Fatalf("unexpected commit identity: %#v, body = %s", commitBody, commit.Body.String())
 	}
 
 	pull := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -1176,6 +1176,68 @@ func TestGitHubRejectsPublicRepoMutationByNonCollaborator(t *testing.T) {
 	}
 }
 
+func TestGitHubRejectsRepoMutationByReadOnlyCollaborator(t *testing.T) {
+	service, handler := newGitHubTestServiceHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "reader", Email: "reader@example.com"},
+		},
+		Tokens: map[string]TokenSeed{
+			"reader_token": {Login: "reader", Scopes: []string{"repo", "user"}},
+		},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+	repo := service.lookupRepo("octocat", "hello-world")
+	reader := firstRecord(service.store.Users.FindBy("login", "reader"))
+	service.store.Collaborators.Insert(corestore.Record{
+		"repo_id":    intField(repo, "id"),
+		"user_id":    intField(reader, "id"),
+		"permission": "pull",
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer reader_token")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+
+	res := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/reader","sha":"`+mainSha+`"}`, "Bearer reader_token")
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestGitHubAllowsRepoMutationByPushCollaborator(t *testing.T) {
+	service, handler := newGitHubTestServiceHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "writer", Email: "writer@example.com"},
+		},
+		Tokens: map[string]TokenSeed{
+			"writer_token": {Login: "writer", Scopes: []string{"repo", "user"}},
+		},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+	repo := service.lookupRepo("octocat", "hello-world")
+	writer := firstRecord(service.store.Users.FindBy("login", "writer"))
+	service.store.Collaborators.Insert(corestore.Record{
+		"repo_id":    intField(repo, "id"),
+		"user_id":    intField(writer, "id"),
+		"permission": "push",
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer writer_token")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+
+	res := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/writer","sha":"`+mainSha+`"}`, "Bearer writer_token")
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestGitHubFailedIssuePatchDoesNotAdjustOpenIssueCount(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -146,6 +146,18 @@ func TestGitHubPatchPullRejectsMissingBaseBranch(t *testing.T) {
 	if patch.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("patch status = %d, body = %s", patch.Code, patch.Body.String())
 	}
+
+	repo := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world", "", "Bearer test_token_user1")
+	if repo.Code != http.StatusOK {
+		t.Fatalf("repo status = %d, body = %s", repo.Code, repo.Body.String())
+	}
+	var repoBody struct {
+		OpenIssuesCount int `json:"open_issues_count"`
+	}
+	decodeGitHubBody(t, repo, &repoBody)
+	if repoBody.OpenIssuesCount != 1 {
+		t.Fatalf("open_issues_count = %d, body = %s", repoBody.OpenIssuesCount, repo.Body.String())
+	}
 }
 
 func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
@@ -346,6 +358,54 @@ func TestGitHubRepoScopeRequiredForPrivateReadAndRepoMutation(t *testing.T) {
 	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/user-only","sha":"`+mainSha+`"}`, "Bearer user_only_token")
 	if ref.Code != http.StatusForbidden {
 		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+}
+
+func TestGitHubAdminCanReadPrivateRepo(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "private-repo", Private: true}},
+	})
+
+	res := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/private-repo", "", "Bearer test_token_admin")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestGitHubOrgMembershipDoesNotGrantPrivateUserRepoWithMatchingID(t *testing.T) {
+	service, handler := newGitHubTestServiceHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "member", Email: "member@example.com"}},
+		Orgs:  []OrgSeed{{Login: "shared-id-org", Name: "Shared ID Org"}},
+		Tokens: map[string]TokenSeed{
+			"member_token": {Login: "member", Scopes: []string{"repo", "user"}},
+		},
+		Repos: []RepoSeed{{Owner: "ghost", Name: "private-repo", Private: true}},
+	})
+	ghost := firstRecord(service.store.Users.FindBy("login", "ghost"))
+	member := firstRecord(service.store.Users.FindBy("login", "member"))
+	org := firstRecord(service.store.Orgs.FindBy("login", "shared-id-org"))
+	if ghost == nil || member == nil || org == nil {
+		t.Fatal("missing seed records")
+	}
+	if intField(ghost, "id") != intField(org, "id") {
+		t.Fatalf("test setup expected matching user and org ids, got user=%d org=%d", intField(ghost, "id"), intField(org, "id"))
+	}
+	team := service.store.Teams.Insert(corestore.Record{
+		"org_id":     intField(org, "id"),
+		"slug":       "engineering",
+		"name":       "Engineering",
+		"permission": "pull",
+	})
+	service.store.TeamMembers.Insert(corestore.Record{
+		"team_id": intField(team, "id"),
+		"user_id": intField(member, "id"),
+		"role":    "member",
+	})
+
+	res := doGitHubJSON(handler, http.MethodGet, "/repos/ghost/private-repo", "", "Bearer member_token")
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }
 
@@ -568,12 +628,18 @@ func TestGitHubOAuthRejectsMismatchedRedirectURI(t *testing.T) {
 }
 
 func newGitHubTestHandler(seed *SeedConfig) http.Handler {
+	_, handler := newGitHubTestServiceHandler(seed)
+	return handler
+}
+
+func newGitHubTestServiceHandler(seed *SeedConfig) (*Service, http.Handler) {
 	router := corehttp.NewRouter()
-	Register(router, Options{Store: corestore.New(), BaseURL: testBaseURL, Seed: seed})
+	service := New(Options{Store: corestore.New(), BaseURL: testBaseURL, Seed: seed})
+	service.RegisterRoutes(router)
 	router.NotFound(func(c *corehttp.Context) {
 		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
 	})
-	return router
+	return service, router
 }
 
 func doGitHubJSON(handler http.Handler, method string, target string, body string, authorization string) *httptest.ResponseRecorder {

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -33,6 +33,23 @@ func TestGitHubCurrentUserUsesDefaultToken(t *testing.T) {
 	}
 }
 
+func TestGitHubDefaultUserTokenUsesDefaultOctocat(t *testing.T) {
+	handler := newGitHubTestHandler(nil)
+	res := doGitHubJSON(handler, http.MethodGet, "/user", "", "Bearer test_token_user1")
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		Login string `json:"login"`
+		Email string `json:"email"`
+	}
+	decodeGitHubBody(t, res, &body)
+	if body.Login != "octocat" || body.Email != "octocat@github.com" {
+		t.Fatalf("unexpected user: %#v", body)
+	}
+}
+
 func TestGitHubConfiguredTokensReplaceDefaultTokens(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
@@ -425,6 +442,14 @@ func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
 		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
 	}
 
+	stale := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{"sha":"deadbeef"}`, "Bearer test_token_user1")
+	if stale.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("stale merge status = %d, body = %s", stale.Code, stale.Body.String())
+	}
+	if !strings.Contains(stale.Body.String(), "Head sha is out of date") {
+		t.Fatalf("unexpected stale merge body: %s", stale.Body.String())
+	}
+
 	merge := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{}`, "Bearer test_token_user1")
 	if merge.Code != http.StatusOK {
 		t.Fatalf("merge status = %d, body = %s", merge.Code, merge.Body.String())
@@ -466,6 +491,50 @@ func TestGitHubMergeCreatesResolvableCommit(t *testing.T) {
 	decodeGitHubBody(t, pull, &pullBody)
 	if pullBody.MergedBy == nil || pullBody.MergedBy.Login != "octocat" {
 		t.Fatalf("unexpected merged_by: %#v, body = %s", pullBody.MergedBy, pull.Body.String())
+	}
+}
+
+func TestGitHubMergeRejectsDraftPull(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main","draft":true}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	merge := doGitHubJSON(handler, http.MethodPut, "/repos/octocat/hello-world/pulls/1/merge", `{}`, "Bearer test_token_user1")
+	if merge.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("merge status = %d, body = %s", merge.Code, merge.Body.String())
+	}
+	if !strings.Contains(merge.Body.String(), "Draft pull requests cannot be merged.") {
+		t.Fatalf("unexpected merge body: %s", merge.Body.String())
+	}
+
+	pull := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")
+	if pull.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body = %s", pull.Code, pull.Body.String())
+	}
+	var body struct {
+		State  string `json:"state"`
+		Merged bool   `json:"merged"`
+	}
+	decodeGitHubBody(t, pull, &body)
+	if body.State != "open" || body.Merged {
+		t.Fatalf("draft pull was merged: %#v, body = %s", body, pull.Body.String())
 	}
 }
 
@@ -837,6 +906,23 @@ func TestGitHubOAuthIssuesUsableToken(t *testing.T) {
 	user := doGitHubJSON(handler, http.MethodGet, "/user", "", "Bearer "+tokenBody.AccessToken)
 	if user.Code != http.StatusOK || !strings.Contains(user.Body.String(), `"login":"octocat"`) {
 		t.Fatalf("user status = %d, body = %s", user.Code, user.Body.String())
+	}
+}
+
+func TestGitHubDoesNotRegisterConflictingLoginOAuthUserinfo(t *testing.T) {
+	handler := newGitHubTestHandler(nil)
+
+	conflicting := doGitHubJSON(handler, http.MethodGet, "/login/oauth/userinfo", "", "Bearer test_token_admin")
+	if conflicting.Code != http.StatusNotFound {
+		t.Fatalf("conflicting userinfo status = %d, body = %s", conflicting.Code, conflicting.Body.String())
+	}
+
+	userinfo := doGitHubJSON(handler, http.MethodGet, "/userinfo", "", "Bearer test_token_admin")
+	if userinfo.Code != http.StatusOK {
+		t.Fatalf("userinfo status = %d, body = %s", userinfo.Code, userinfo.Body.String())
+	}
+	if !strings.Contains(userinfo.Body.String(), `"preferred_username":"admin"`) {
+		t.Fatalf("unexpected userinfo body: %s", userinfo.Body.String())
 	}
 }
 

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -199,6 +199,141 @@ func TestGitHubPullRequestIsVisibleThroughIssuesAPI(t *testing.T) {
 	}
 }
 
+func TestGitHubListIssuesAppliesFilters(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "alice", Email: "alice@example.com"},
+		},
+		Tokens: map[string]TokenSeed{
+			"octo_token":  {Login: "octocat", Scopes: []string{"repo", "user"}},
+			"alice_token": {Login: "alice", Scopes: []string{"repo", "user"}},
+		},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	for _, request := range []struct {
+		body  string
+		token string
+	}{
+		{`{"title":"Bug","assignees":["octocat"],"labels":["bug"]}`, "octo_token"},
+		{`{"title":"Docs","assignees":["alice"],"labels":["docs"]}`, "octo_token"},
+		{`{"title":"No owner","labels":["bug"]}`, "alice_token"},
+	} {
+		res := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues", request.body, "Bearer "+request.token)
+		if res.Code != http.StatusCreated {
+			t.Fatalf("issue status = %d, body = %s", res.Code, res.Body.String())
+		}
+	}
+
+	assertIssueTitles := func(target string, want ...string) {
+		t.Helper()
+		res := doGitHubJSON(handler, http.MethodGet, target, "", "Bearer octo_token")
+		if res.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, body = %s", target, res.Code, res.Body.String())
+		}
+		var body []struct {
+			Title string `json:"title"`
+		}
+		decodeGitHubBody(t, res, &body)
+		if len(body) != len(want) {
+			t.Fatalf("%s returned %#v, want %#v, body = %s", target, body, want, res.Body.String())
+		}
+		for i, title := range want {
+			if body[i].Title != title {
+				t.Fatalf("%s returned %#v, want %#v, body = %s", target, body, want, res.Body.String())
+			}
+		}
+	}
+
+	assertIssueTitles("/repos/octocat/hello-world/issues?labels=docs", "Docs")
+	assertIssueTitles("/repos/octocat/hello-world/issues?assignee=alice", "Docs")
+	assertIssueTitles("/repos/octocat/hello-world/issues?assignee=none", "No owner")
+	assertIssueTitles("/repos/octocat/hello-world/issues?creator=alice", "No owner")
+	assertIssueTitles("/repos/octocat/hello-world/issues?since=9999-01-01T00:00:00Z")
+}
+
+func TestGitHubPullFormattingIncludesSyncedIssueMetadata(t *testing.T) {
+	service, handler := newGitHubTestServiceHandler(&SeedConfig{
+		Users: []UserSeed{
+			{Login: "octocat", Email: "octocat@github.com"},
+			{Login: "alice", Email: "alice@example.com"},
+		},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	patchIssue := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/issues/1", `{"assignees":["alice"],"labels":["bug"]}`, "Bearer test_token_user1")
+	if patchIssue.Code != http.StatusOK {
+		t.Fatalf("issue patch status = %d, body = %s", patchIssue.Code, patchIssue.Body.String())
+	}
+
+	repo := service.lookupRepo("octocat", "hello-world")
+	alice := firstRecord(service.store.Users.FindBy("login", "alice"))
+	milestoneRow := service.store.Milestones.Insert(corestore.Record{
+		"node_id":       "",
+		"repo_id":       intField(repo, "id"),
+		"number":        1,
+		"title":         "v1",
+		"description":   nil,
+		"state":         "open",
+		"open_issues":   1,
+		"closed_issues": 0,
+		"due_on":        nil,
+		"closed_at":     nil,
+		"creator_id":    intField(alice, "id"),
+	})
+	milestone, _ := service.store.Milestones.Update(intField(milestoneRow, "id"), corestore.Record{"node_id": generateNodeID("Milestone", intField(milestoneRow, "id"))})
+	if issue := service.findPullIssue(intField(repo, "id"), 1); issue != nil {
+		service.store.Issues.Update(intField(issue, "id"), corestore.Record{"milestone_id": intField(milestone, "id")})
+	}
+	if pull := service.findPullByNumber(intField(repo, "id"), 1); pull != nil {
+		service.store.PullRequests.Update(intField(pull, "id"), corestore.Record{"milestone_id": intField(milestone, "id")})
+	}
+
+	pull := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")
+	if pull.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body = %s", pull.Code, pull.Body.String())
+	}
+	var body struct {
+		Assignee *struct {
+			Login string `json:"login"`
+		} `json:"assignee"`
+		Assignees []struct {
+			Login string `json:"login"`
+		} `json:"assignees"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		Milestone *struct {
+			Title string `json:"title"`
+		} `json:"milestone"`
+	}
+	decodeGitHubBody(t, pull, &body)
+	if body.Assignee == nil || body.Assignee.Login != "alice" || len(body.Assignees) != 1 || body.Assignees[0].Login != "alice" {
+		t.Fatalf("unexpected assignees: %#v, body = %s", body, pull.Body.String())
+	}
+	if len(body.Labels) != 1 || body.Labels[0].Name != "bug" {
+		t.Fatalf("unexpected labels: %#v, body = %s", body.Labels, pull.Body.String())
+	}
+	if body.Milestone == nil || body.Milestone.Title != "v1" {
+		t.Fatalf("unexpected milestone: %#v, body = %s", body.Milestone, pull.Body.String())
+	}
+}
+
 func TestGitHubRepoWithoutTopicsReturnsEmptyArrays(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -185,6 +186,49 @@ func TestGitHubPullFilesRequirePrivateRepoReadAccess(t *testing.T) {
 	}
 }
 
+func TestGitHubPublicRepoListsHidePrivateRepos(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Orgs:  []OrgSeed{{Login: "my-org", Name: "My Org"}},
+		Repos: []RepoSeed{
+			{Owner: "octocat", Name: "public-repo"},
+			{Owner: "octocat", Name: "private-repo", Private: true},
+			{Owner: "my-org", Name: "public-org-repo"},
+			{Owner: "my-org", Name: "private-org-repo", Private: true},
+		},
+	})
+
+	userRepos := doGitHubJSON(handler, http.MethodGet, "/users/octocat/repos", "", "")
+	if userRepos.Code != http.StatusOK {
+		t.Fatalf("user repos status = %d, body = %s", userRepos.Code, userRepos.Body.String())
+	}
+	var userBody []struct {
+		FullName    string          `json:"full_name"`
+		Private     bool            `json:"private"`
+		Permissions map[string]bool `json:"permissions"`
+	}
+	decodeGitHubBody(t, userRepos, &userBody)
+	if len(userBody) != 1 || userBody[0].FullName != "octocat/public-repo" || userBody[0].Private {
+		t.Fatalf("unexpected user repos: %#v, body = %s", userBody, userRepos.Body.String())
+	}
+	if userBody[0].Permissions["admin"] || !userBody[0].Permissions["pull"] {
+		t.Fatalf("unexpected public permissions: %#v", userBody[0].Permissions)
+	}
+
+	orgRepos := doGitHubJSON(handler, http.MethodGet, "/orgs/my-org/repos", "", "")
+	if orgRepos.Code != http.StatusOK {
+		t.Fatalf("org repos status = %d, body = %s", orgRepos.Code, orgRepos.Body.String())
+	}
+	var orgBody []struct {
+		FullName string `json:"full_name"`
+		Private  bool   `json:"private"`
+	}
+	decodeGitHubBody(t, orgRepos, &orgBody)
+	if len(orgBody) != 1 || orgBody[0].FullName != "my-org/public-org-repo" || orgBody[0].Private {
+		t.Fatalf("unexpected org repos: %#v, body = %s", orgBody, orgRepos.Body.String())
+	}
+}
+
 func TestGitHubPatchRepoPrivateSyncsVisibility(t *testing.T) {
 	handler := newGitHubTestHandler(&SeedConfig{
 		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
@@ -226,6 +270,105 @@ func TestGitHubRejectsPublicRepoMutationByNonCollaborator(t *testing.T) {
 	res := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/intruder","sha":"`+mainSha+`"}`, "Bearer intruder_token")
 	if res.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestGitHubFailedIssuePatchDoesNotAdjustOpenIssueCount(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	issue := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues", `{"title":"Bug"}`, "Bearer test_token_user1")
+	if issue.Code != http.StatusCreated {
+		t.Fatalf("issue status = %d, body = %s", issue.Code, issue.Body.String())
+	}
+
+	failedPatch := doGitHubJSON(handler, http.MethodPatch, "/repos/octocat/hello-world/issues/1", `{"state":"closed","labels":[999]}`, "Bearer test_token_user1")
+	if failedPatch.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("patch status = %d, body = %s", failedPatch.Code, failedPatch.Body.String())
+	}
+
+	repo := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world", "", "Bearer test_token_user1")
+	if repo.Code != http.StatusOK {
+		t.Fatalf("repo status = %d, body = %s", repo.Code, repo.Body.String())
+	}
+	var repoBody struct {
+		OpenIssuesCount int `json:"open_issues_count"`
+	}
+	decodeGitHubBody(t, repo, &repoBody)
+	if repoBody.OpenIssuesCount != 1 {
+		t.Fatalf("open_issues_count = %d, body = %s", repoBody.OpenIssuesCount, repo.Body.String())
+	}
+
+	gotIssue := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/issues/1", "", "Bearer test_token_user1")
+	if gotIssue.Code != http.StatusOK {
+		t.Fatalf("get issue status = %d, body = %s", gotIssue.Code, gotIssue.Body.String())
+	}
+	var issueBody struct {
+		State string `json:"state"`
+	}
+	decodeGitHubBody(t, gotIssue, &issueBody)
+	if issueBody.State != "open" {
+		t.Fatalf("issue state = %s, body = %s", issueBody.State, gotIssue.Body.String())
+	}
+}
+
+func TestGitHubPullIssueCommentsSyncPullCommentCount(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world"}},
+	})
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK {
+		t.Fatalf("branches status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+	mainSha := defaultBranchSha(t, branches, "main")
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"`+mainSha+`"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+
+	comment := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues/1/comments", `{"body":"looks good"}`, "Bearer test_token_user1")
+	if comment.Code != http.StatusCreated {
+		t.Fatalf("comment status = %d, body = %s", comment.Code, comment.Body.String())
+	}
+	var commentBody struct {
+		ID int `json:"id"`
+	}
+	decodeGitHubBody(t, comment, &commentBody)
+
+	pull := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")
+	if pull.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body = %s", pull.Code, pull.Body.String())
+	}
+	var pullBody struct {
+		Comments int `json:"comments"`
+	}
+	decodeGitHubBody(t, pull, &pullBody)
+	if pullBody.Comments != 1 {
+		t.Fatalf("pull comments after create = %d, body = %s", pullBody.Comments, pull.Body.String())
+	}
+
+	deleted := doGitHubJSON(handler, http.MethodDelete, "/repos/octocat/hello-world/issues/comments/"+strconv.Itoa(commentBody.ID), "", "Bearer test_token_user1")
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, body = %s", deleted.Code, deleted.Body.String())
+	}
+
+	pull = doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/pulls/1", "", "Bearer test_token_user1")
+	if pull.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body = %s", pull.Code, pull.Body.String())
+	}
+	decodeGitHubBody(t, pull, &pullBody)
+	if pullBody.Comments != 0 {
+		t.Fatalf("pull comments after delete = %d, body = %s", pullBody.Comments, pull.Body.String())
 	}
 }
 

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -1,0 +1,178 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const testBaseURL = "http://localhost:4000"
+
+func TestGitHubCurrentUserUsesDefaultToken(t *testing.T) {
+	handler := newGitHubTestHandler(nil)
+	res := doGitHubJSON(handler, http.MethodGet, "/user", "", "Bearer test_token_admin")
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		Login string `json:"login"`
+		Email string `json:"email"`
+	}
+	decodeGitHubBody(t, res, &body)
+	if body.Login != "admin" || body.Email != "admin@localhost" {
+		t.Fatalf("unexpected user: %#v", body)
+	}
+}
+
+func TestGitHubReposIssuesCommentsAndPulls(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Name: "The Octocat", Email: "octocat@github.com"}},
+		Repos: []RepoSeed{{Owner: "octocat", Name: "hello-world", Description: "Hello", Topics: []string{"hello"}, Language: "Go"}},
+	})
+
+	repo := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world", "", "Bearer test_token_user1")
+	if repo.Code != http.StatusOK {
+		t.Fatalf("repo status = %d, body = %s", repo.Code, repo.Body.String())
+	}
+	var repoBody struct {
+		FullName      string `json:"full_name"`
+		DefaultBranch string `json:"default_branch"`
+	}
+	decodeGitHubBody(t, repo, &repoBody)
+	if repoBody.FullName != "octocat/hello-world" || repoBody.DefaultBranch != "main" {
+		t.Fatalf("unexpected repo: %#v", repoBody)
+	}
+
+	branches := doGitHubJSON(handler, http.MethodGet, "/repos/octocat/hello-world/branches", "", "Bearer test_token_user1")
+	if branches.Code != http.StatusOK || !strings.Contains(branches.Body.String(), `"name":"main"`) {
+		t.Fatalf("unexpected branches: status = %d, body = %s", branches.Code, branches.Body.String())
+	}
+
+	issue := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues", `{"title":"Bug","body":"broken"}`, "Bearer test_token_user1")
+	if issue.Code != http.StatusCreated {
+		t.Fatalf("issue status = %d, body = %s", issue.Code, issue.Body.String())
+	}
+	var issueBody struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+	}
+	decodeGitHubBody(t, issue, &issueBody)
+	if issueBody.Number != 1 || issueBody.Title != "Bug" {
+		t.Fatalf("unexpected issue: %#v", issueBody)
+	}
+
+	comment := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/issues/1/comments", `{"body":"confirmed"}`, "Bearer test_token_user1")
+	if comment.Code != http.StatusCreated || !strings.Contains(comment.Body.String(), "confirmed") {
+		t.Fatalf("comment status = %d, body = %s", comment.Code, comment.Body.String())
+	}
+
+	ref := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/git/refs", `{"ref":"refs/heads/feature","sha":"abc123"}`, "Bearer test_token_user1")
+	if ref.Code != http.StatusCreated {
+		t.Fatalf("ref status = %d, body = %s", ref.Code, ref.Body.String())
+	}
+
+	pr := doGitHubJSON(handler, http.MethodPost, "/repos/octocat/hello-world/pulls", `{"title":"Feature","head":"feature","base":"main"}`, "Bearer test_token_user1")
+	if pr.Code != http.StatusCreated {
+		t.Fatalf("pull status = %d, body = %s", pr.Code, pr.Body.String())
+	}
+	if !strings.Contains(pr.Body.String(), `"number":2`) {
+		t.Fatalf("unexpected pull body: %s", pr.Body.String())
+	}
+}
+
+func TestGitHubOAuthIssuesUsableToken(t *testing.T) {
+	handler := newGitHubTestHandler(&SeedConfig{
+		Users: []UserSeed{{Login: "octocat", Email: "octocat@github.com"}},
+		OAuthApps: []OAuthAppSeed{{
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+			Name:         "Test App",
+			RedirectURIs: []string{"http://localhost:3000/callback"},
+		}},
+	})
+
+	form := url.Values{
+		"login":        {"octocat"},
+		"redirect_uri": {"http://localhost:3000/callback"},
+		"scope":        {"repo user"},
+		"state":        {"state-1"},
+		"client_id":    {"client-id"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/login/oauth/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", res.Code, res.Body.String())
+	}
+	location, err := url.Parse(res.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := location.Query().Get("code")
+	if code == "" || location.Query().Get("state") != "state-1" {
+		t.Fatalf("unexpected callback location: %s", location.String())
+	}
+
+	token := doGitHubJSON(handler, http.MethodPost, "/login/oauth/access_token", `{"code":"`+code+`","client_id":"client-id","client_secret":"client-secret"}`, "")
+	if token.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", token.Code, token.Body.String())
+	}
+	var tokenBody struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+	}
+	decodeGitHubBody(t, token, &tokenBody)
+	if tokenBody.AccessToken == "" || tokenBody.TokenType != "bearer" {
+		t.Fatalf("unexpected token: %#v", tokenBody)
+	}
+
+	user := doGitHubJSON(handler, http.MethodGet, "/user", "", "Bearer "+tokenBody.AccessToken)
+	if user.Code != http.StatusOK || !strings.Contains(user.Body.String(), `"login":"octocat"`) {
+		t.Fatalf("user status = %d, body = %s", user.Code, user.Body.String())
+	}
+}
+
+func newGitHubTestHandler(seed *SeedConfig) http.Handler {
+	router := corehttp.NewRouter()
+	Register(router, Options{Store: corestore.New(), BaseURL: testBaseURL, Seed: seed})
+	router.NotFound(func(c *corehttp.Context) {
+		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+	})
+	return router
+}
+
+func doGitHubJSON(handler http.Handler, method string, target string, body string, authorization string) *httptest.ResponseRecorder {
+	var reader *strings.Reader
+	if body == "" {
+		reader = strings.NewReader("")
+	} else {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, target, reader)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
+}
+
+func decodeGitHubBody(t *testing.T, res *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(res.Body.Bytes()))
+	if err := decoder.Decode(target); err != nil {
+		t.Fatalf("decode body %q: %v", res.Body.String(), err)
+	}
+}

--- a/internal/services/github/store.go
+++ b/internal/services/github/store.go
@@ -1,0 +1,53 @@
+package github
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Users         *corestore.Collection
+	Orgs          *corestore.Collection
+	Teams         *corestore.Collection
+	TeamMembers   *corestore.Collection
+	Repos         *corestore.Collection
+	Collaborators *corestore.Collection
+	Issues        *corestore.Collection
+	PullRequests  *corestore.Collection
+	Labels        *corestore.Collection
+	Milestones    *corestore.Collection
+	Comments      *corestore.Collection
+	Branches      *corestore.Collection
+	Refs          *corestore.Collection
+	Commits       *corestore.Collection
+	Trees         *corestore.Collection
+	Blobs         *corestore.Collection
+	OAuthApps     *corestore.Collection
+	OAuthCodes    *corestore.Collection
+	OAuthTokens   *corestore.Collection
+	Tokens        *corestore.Collection
+	Webhooks      *corestore.Collection
+}
+
+func NewStore(runtimeStore *corestore.Store) Store {
+	return Store{
+		Users:         runtimeStore.MustCollection("github.users", "login"),
+		Orgs:          runtimeStore.MustCollection("github.orgs", "login"),
+		Teams:         runtimeStore.MustCollection("github.teams", "org_id", "slug"),
+		TeamMembers:   runtimeStore.MustCollection("github.team_members", "team_id", "user_id"),
+		Repos:         runtimeStore.MustCollection("github.repos", "owner_id", "full_name"),
+		Collaborators: runtimeStore.MustCollection("github.collaborators", "repo_id", "user_id"),
+		Issues:        runtimeStore.MustCollection("github.issues", "repo_id", "number"),
+		PullRequests:  runtimeStore.MustCollection("github.pull_requests", "repo_id", "number"),
+		Labels:        runtimeStore.MustCollection("github.labels", "repo_id"),
+		Milestones:    runtimeStore.MustCollection("github.milestones", "repo_id", "number"),
+		Comments:      runtimeStore.MustCollection("github.comments", "repo_id"),
+		Branches:      runtimeStore.MustCollection("github.branches", "repo_id"),
+		Refs:          runtimeStore.MustCollection("github.refs", "repo_id"),
+		Commits:       runtimeStore.MustCollection("github.commits", "repo_id", "sha"),
+		Trees:         runtimeStore.MustCollection("github.trees", "repo_id", "sha"),
+		Blobs:         runtimeStore.MustCollection("github.blobs", "repo_id", "sha"),
+		OAuthApps:     runtimeStore.MustCollection("github.oauth_apps", "client_id"),
+		OAuthCodes:    runtimeStore.MustCollection("github.oauth_codes", "code", "client_id"),
+		OAuthTokens:   runtimeStore.MustCollection("github.oauth_tokens", "tokenString", "login"),
+		Tokens:        runtimeStore.MustCollection("github.tokens", "tokenString", "login"),
+		Webhooks:      runtimeStore.MustCollection("github.webhooks", "repo_id", "org_id"),
+	}
+}

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,7 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
-      'Services: []string{"aws", "resend", "vercel"}',
+      'Services: []string{"aws", "github", "resend", "vercel"}',
     );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
@@ -224,8 +224,8 @@ require (
   it("rejects services not available in the native Vercel scaffold", () => {
     const cwd = tempDir();
 
-    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "github" })).toThrow(
-      "currently supports native services: aws, resend, vercel",
+    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "google" })).toThrow(
+      "currently supports native services: aws, github, resend, vercel",
     );
   });
 

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-const SUPPORTED_VERCEL_SERVICES = ["aws", "resend", "vercel"] as const;
+const SUPPORTED_VERCEL_SERVICES = ["aws", "github", "resend", "vercel"] as const;
 const REQUIRED_GO_VERSION = "1.24";
 const DEFAULT_REWRITE = {
   source: "/emulate/:path*",

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -60,7 +60,7 @@ const vercel = program.command("vercel").description("Vercel preview helpers");
 vercel
   .command("init")
   .description("Scaffold an experimental Vercel Go Function")
-  .option("-s, --service <services>", "Comma-separated native services to enable", "aws,resend,vercel")
+  .option("-s, --service <services>", "Comma-separated native services to enable", "aws,github,resend,vercel")
   .option("--force", "Overwrite generated files")
   .action((opts) => {
     vercelInitCommand({

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -317,7 +317,7 @@ Then use these in your app to construct API and OAuth URLs. See each service's s
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `aws`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `aws`, `github`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 Fully stateful GitHub REST API emulation. Creates, updates, and deletes persist in memory and affect related entities.
 
+The experimental native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
+
 ## Start
 
 ```bash

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service vercel` to limit the function to one service.
+The scaffold currently enables the native `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -30,6 +30,7 @@ var mutatingMethods = map[string]struct{}{
 var (
 	htmlRootAttrRE = regexp.MustCompile(`(action|href)="(/[^"]*?)"`)
 	htmlRootURLRE  = regexp.MustCompile(`url\('(/[^']*?)'\)`)
+	linkURLRE      = regexp.MustCompile(`<([^>]*)>`)
 	defaultHandler = NewHandler(Options{})
 )
 
@@ -308,6 +309,13 @@ func writeRewrittenResponse(w http.ResponseWriter, r *http.Request, recorder *re
 	if location := headers.Get("Location"); strings.HasPrefix(location, "/") {
 		headers.Set("Location", rewriteRootPath(publicPrefix, location))
 	}
+	if links, ok := headers["Link"]; ok {
+		rewritten := make([]string, len(links))
+		for i, link := range links {
+			rewritten[i] = rewriteLinkHeader(link, publicPrefix)
+		}
+		headers["Link"] = rewritten
+	}
 
 	body := recorder.body.Bytes()
 	contentType := headers.Get("Content-Type")
@@ -344,6 +352,29 @@ func rewriteHTML(html string, publicPrefix string) string {
 		return `url('` + rewriteRootPath(publicPrefix, parts[1]) + `')`
 	})
 	return html
+}
+
+func rewriteLinkHeader(link string, publicPrefix string) string {
+	return linkURLRE.ReplaceAllStringFunc(link, func(match string) string {
+		parts := linkURLRE.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		return "<" + rewriteServiceLinkTarget(parts[1], publicPrefix) + ">"
+	})
+}
+
+func rewriteServiceLinkTarget(target string, publicPrefix string) string {
+	if strings.HasPrefix(target, "/") {
+		return rewriteRootPath(publicPrefix, target)
+	}
+	parsed, err := url.Parse(target)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return target
+	}
+	parsed.Path = rewriteRootPath(publicPrefix, parsed.Path)
+	parsed.RawPath = ""
+	return parsed.String()
 }
 
 func rewriteRootPath(publicPrefix string, target string) string {

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"aws", "resend", "vercel"}
+var defaultServices = []string{"aws", "github", "resend", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -123,6 +123,38 @@ func TestHandlerForwardsGitHubService(t *testing.T) {
 	}
 }
 
+func TestHandlerRewritesGitHubPaginationLinksThroughPublicServicePrefix(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"github"}})
+	for _, name := range []string{"one", "two"} {
+		req := newJSONRequest(http.MethodPost, "https://preview.example.com/emulate/github/user/repos", `{"name":"`+name+`"}`)
+		req.Host = "preview.example.com"
+		req.Header.Set("Authorization", "Bearer test_token_admin")
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+		if res.Code != http.StatusCreated {
+			t.Fatalf("create %s status = %d, body = %s", name, res.Code, res.Body.String())
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/github/user/repos?per_page=1", nil)
+	req.Host = "preview.example.com"
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	link := res.Header().Get("Link")
+	if !strings.Contains(link, "https://preview.example.com/emulate/github/user/repos?page=2&per_page=1") {
+		t.Fatalf("missing rewritten GitHub pagination link: %s", link)
+	}
+	if strings.Contains(link, "https://preview.example.com/user/repos") || strings.Contains(link, "</user/repos") {
+		t.Fatalf("contains unrewritten GitHub pagination link: %s", link)
+	}
+}
+
 func TestHandlerRewritesHTMLRootPathsThroughPublicServicePrefix(t *testing.T) {
 	handler := NewHandler(Options{Services: []string{"resend"}})
 	createEmail(t, handler, "Rewritten")

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -35,7 +35,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "aws,resend,vercel" {
+	if strings.Join(body.Services, ",") != "aws,github,resend,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -106,6 +106,23 @@ func TestHandlerForwardsVercelService(t *testing.T) {
 	}
 }
 
+func TestHandlerForwardsGitHubService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"github"}})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/github/user", nil)
+	req.Host = "preview.example.com"
+	req.Header.Set("Authorization", "Bearer test_token_admin")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"login":"admin"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestHandlerRewritesHTMLRootPathsThroughPublicServicePrefix(t *testing.T) {
 	handler := NewHandler(Options{Services: []string{"resend"}})
 	createEmail(t, handler, "Rewritten")
@@ -135,7 +152,7 @@ func TestHandlerRewritesHTMLRootPathsThroughPublicServicePrefix(t *testing.T) {
 
 func TestHandlerReturnsUnknownService(t *testing.T) {
 	handler := NewHandler(Options{})
-	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/github/user", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/google/user", nil)
 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
@@ -143,7 +160,7 @@ func TestHandlerReturnsUnknownService(t *testing.T) {
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "Unknown service: github") {
+	if !strings.Contains(res.Body.String(), "Unknown service: google") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }


### PR DESCRIPTION
- Adds a dependency-free native GitHub REST and OAuth service covering users, orgs, repos, issues, comments, pull requests, git data, rate limit, meta, and seed data.

- Mounts GitHub in the native runtime and CLI seed parser while keeping npm distribution and TypeScript packages in place.

- Includes GitHub in Vercel Go Function preview defaults and updates docs, skills, help text, and focused tests.