### PR TITLE
Add Go Apple Sign In foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,10 @@ Sign in with Apple emulation with authorization code flow, PKCE support, RS256 I
 
 The native Go runtime implements the Apple OIDC flow below for local CLI runs and Vercel Go Function previews. To expose Apple on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service apple`. The generated route serves Apple at `/emulate/apple/*`.
 
+PKCE is supported with `code_challenge` and `code_challenge_method` on authorization, then `code_verifier` on token exchange.
+
+Private email users receive the generated relay email in both the `id_token` and first authorization `user` JSON.
+
 - `GET /.well-known/openid-configuration` - OIDC discovery document
 - `GET /auth/keys` - JSON Web Key Set (JWKS)
 - `GET /auth/authorize` - authorization endpoint (shows user picker)

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.
 
-The experimental native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
+The native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
 
 ### Users
 - `GET /user` - authenticated user
@@ -645,6 +645,8 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
 
+The native Go runtime implements the Apple OIDC flow below for local CLI runs and Vercel Go Function previews. To expose Apple on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service apple`. The generated route serves Apple at `/emulate/apple/*`.
+
 - `GET /.well-known/openid-configuration` - OIDC discovery document
 - `GET /auth/keys` - JSON Web Key Set (JWKS)
 - `GET /auth/authorize` - authorization endpoint (shows user picker)
@@ -726,7 +728,7 @@ Manual STS requests can use `POST /sts/` with an `Action` form parameter. In the
 
 Resend email API emulation with local capture for sent emails, domains, API keys, audiences, contacts, and an inbox UI. Set `RESEND_BASE_URL` before importing the official Resend Node.js SDK and the SDK will send to the emulator.
 
-The experimental native Go runtime serves the same current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime serves the same current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 To expose the native Resend emulator in a Vercel preview without separate infrastructure, run `npx emulate vercel init --service resend`. The generated route serves Resend at `/emulate/resend/*`.
 
@@ -755,7 +757,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -796,7 +798,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/docs/apple/page.mdx
+++ b/apps/web/app/docs/apple/page.mdx
@@ -14,17 +14,17 @@ The native Go runtime implements the Apple OIDC flow below for local CLI runs an
 
 ## Authorization Flow
 
-1. Redirect the user to `/auth/authorize` with `client_id`, `redirect_uri`, `scope`, `state`, and optionally `nonce` and `response_mode`
+1. Redirect the user to `/auth/authorize` with `client_id`, `redirect_uri`, `scope`, `state`, and optionally `nonce`, `response_mode`, `code_challenge`, and `code_challenge_method`
 2. The emulator renders a user picker page where the user selects a seeded account
 3. On selection, the emulator redirects (or auto-submits a form for `form_post` mode) to `redirect_uri` with `code` and `state`
 4. On the first authorization per user/client pair, a `user` JSON blob is also included (matching Apple's real behavior)
-5. Exchange the code for tokens via `POST /auth/token`
+5. Exchange the code for tokens via `POST /auth/token`, including `code_verifier` when PKCE was used
 
 ## ID Token
 
 The `id_token` is an RS256 JWT containing `sub`, `email`, `email_verified`, `is_private_email`, `real_user_status`, `auth_time`, and optional `nonce`.
 
-Users with `is_private_email: true` in the seed config receive a generated `@privaterelay.appleid.com` email in the `id_token` instead of their real email, matching Apple's Hide My Email behavior.
+Users with `is_private_email: true` in the seed config receive a generated `@privaterelay.appleid.com` email in the `id_token` and first authorization `user` JSON instead of their real email, matching Apple's Hide My Email behavior.
 
 ## Supported Parameters
 
@@ -59,6 +59,14 @@ Users with `is_private_email: true` in the seed config receive a generated `@pri
     <tr>
       <td><code>response_mode</code></td>
       <td><code>query</code> (default), <code>form_post</code>, or <code>fragment</code></td>
+    </tr>
+    <tr>
+      <td><code>code_challenge</code></td>
+      <td>PKCE challenge (optional)</td>
+    </tr>
+    <tr>
+      <td><code>code_challenge_method</code></td>
+      <td><code>plain</code> or <code>S256</code> (optional)</td>
     </tr>
   </tbody>
 </table>

--- a/apps/web/app/docs/apple/page.mdx
+++ b/apps/web/app/docs/apple/page.mdx
@@ -2,6 +2,8 @@
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
 
+The native Go runtime implements the Apple OIDC flow below for local CLI runs and Vercel Go Function previews. To expose Apple on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service apple`. The generated route serves Apple at `/emulate/apple/*`.
+
 ## Endpoints
 
 - `GET /.well-known/openid-configuration` - OIDC discovery document

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -2,7 +2,7 @@
 
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.
 
-The experimental native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
+The native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
 
 ## Users
 

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/apps/web/app/docs/resend/page.mdx
+++ b/apps/web/app/docs/resend/page.mdx
@@ -4,7 +4,7 @@ Resend email API emulation with email sending, domain management, API keys, audi
 
 Set `RESEND_BASE_URL` before importing the official `resend` Node.js SDK and the SDK will call the emulator without code changes.
 
-The experimental native Go runtime implements the current Resend routes below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime implements the current Resend routes below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 ## Vercel Preview
 

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -20,6 +20,7 @@ import (
 
 	coreconfig "github.com/vercel-labs/emulate/internal/core/config"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
+	"github.com/vercel-labs/emulate/internal/services/apple"
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/vercel"
@@ -105,6 +106,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		return 1
 	}
 	var seedServices []string
+	var appleSeed *apple.SeedConfig
 	var githubSeed *github.SeedConfig
 	var resendSeed *resend.SeedConfig
 	var vercelSeed *vercel.SeedConfig
@@ -115,7 +117,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for github, resend, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, resend, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
@@ -142,6 +144,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			for token, user := range tokens {
 				githubSeed.Tokens[token] = user
 			}
+		}
+		if raw, ok := loaded.Data["apple"]; ok {
+			var cfg apple.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse apple seed config: %v\n", err)
+				return 1
+			}
+			appleSeed = &cfg
 		}
 		if raw, ok := loaded.Data["resend"]; ok {
 			var cfg resend.SeedConfig
@@ -177,6 +187,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		Version:    version,
 		BaseURL:    baseURL,
 		Services:   services,
+		AppleSeed:  appleSeed,
 		GitHubSeed: githubSeed,
 		ResendSeed: resendSeed,
 		VercelSeed: vercelSeed,
@@ -191,7 +202,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "emulate %s native Go runtime is experimental.\n", version)
+	fmt.Fprintf(stdout, "emulate %s native Go runtime.\n", version)
 	fmt.Fprintf(stdout, "Listening on %s\n", baseURL)
 	fmt.Fprintf(stdout, "Health check: %s%s\n", strings.TrimRight(baseURL, "/"), emuruntime.HealthPath)
 
@@ -306,7 +317,7 @@ func runList(args []string, stdout io.Writer, stderr io.Writer) int {
 }
 
 func printHelp(w io.Writer) {
-	fmt.Fprintf(w, "emulate %s native Go runtime experimental\n\n", version)
+	fmt.Fprintf(w, "emulate %s native Go runtime\n\n", version)
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  npx emulate [start] [options]")
 	fmt.Fprintln(w, "  npx emulate init [--service <service>]")
@@ -317,8 +328,6 @@ func printHelp(w io.Writer) {
 	fmt.Fprintln(w, "      --seed <file>          Path to JSON seed config file (YAML not supported in native Go yet)")
 	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
 	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless (not supported in native Go yet)")
-	fmt.Fprintln(w, "\nThe published TypeScript CLI remains the default user-facing runtime.")
-	fmt.Fprintln(w, "Use npx emulate for current production behavior.")
 }
 
 func printStartHelp(w io.Writer) {
@@ -368,7 +377,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"github", "resend", "vercel"}
+	return []string{"apple", "github", "resend", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -258,6 +258,53 @@ func TestRunStartSeedsGitHubFromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsAppleFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"apple":{"users":[{"email":"apple@example.com","name":"Apple User"}],"oauth_clients":[{"client_id":"com.example.app","team_id":"TEAM001","name":"My Apple App","redirect_uris":["http://localhost:3000/callback"]}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "apple" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	var discovery struct {
+		Issuer                string `json:"issuer"`
+		AuthorizationEndpoint string `json:"authorization_endpoint"`
+		JWKSURI               string `json:"jwks_uri"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d/.well-known/openid-configuration", port), &discovery)
+	if discovery.Issuer != fmt.Sprintf("http://localhost:%d", port) || discovery.AuthorizationEndpoint == "" || discovery.JWKSURI == "" {
+		t.Fatalf("unexpected discovery: %#v", discovery)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartRejectsYAMLSeedConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.yaml")
@@ -293,7 +340,7 @@ func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
 				t.Fatal("start with unsupported seed service exited successfully")
 			}
 			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for github, resend, and vercel") || !strings.Contains(errText, "aws") {
+			if !strings.Contains(errText, "only supports --seed for apple, github, resend, and vercel") || !strings.Contains(errText, "aws") {
 				t.Fatalf("unexpected stderr: %s", errText)
 			}
 		})

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -7,6 +7,7 @@ import (
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
 	"github.com/vercel-labs/emulate/internal/core/store"
 	"github.com/vercel-labs/emulate/internal/core/ui"
+	"github.com/vercel-labs/emulate/internal/services/apple"
 	"github.com/vercel-labs/emulate/internal/services/aws"
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/resend"
@@ -21,6 +22,7 @@ type ServerOptions struct {
 	Services   []string
 	Store      *store.Store
 	AssetStore *coreassets.Store
+	AppleSeed  *apple.SeedConfig
 	GitHubSeed *github.SeedConfig
 	ResendSeed *resend.SeedConfig
 	VercelSeed *vercel.SeedConfig
@@ -101,6 +103,13 @@ func NewServer(options ServerOptions) *Server {
 			Store:   runtimeStore,
 			BaseURL: options.BaseURL,
 			Seed:    options.GitHubSeed,
+		})
+	}
+	if serviceEnabled(services, "apple") {
+		apple.Register(router, apple.Options{
+			Store:   runtimeStore,
+			BaseURL: options.BaseURL,
+			Seed:    options.AppleSeed,
 		})
 	}
 	router.NotFound(func(c *corehttp.Context) {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -198,6 +198,31 @@ func TestNewHandlerDoesNotMountResendWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMountsAppleWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"apple"}, BaseURL: "http://localhost:4014"})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"http://localhost:4014"`) || !strings.Contains(res.Body.String(), `"jwks_uri":"http://localhost:4014/auth/keys"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountAppleWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/auth/keys", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestNewHandlerMountsVercelWhenEnabled(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"vercel"}, BaseURL: "http://localhost:4010"})
 

--- a/internal/services/apple/helpers.go
+++ b/internal/services/apple/helpers.go
@@ -2,6 +2,7 @@ package apple
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -100,6 +101,14 @@ func nullableString(value string) any {
 	return value
 }
 
+func appleEmailForUser(user corestore.Record) string {
+	email := stringField(user, "email")
+	if boolField(user, "is_private_email") && stringField(user, "private_relay_email") != "" {
+		return stringField(user, "private_relay_email")
+	}
+	return email
+}
+
 func stringSliceValue(value any) []string {
 	switch v := value.(type) {
 	case []string:
@@ -139,4 +148,22 @@ func matchesRedirectURI(candidate string, allowed []string) bool {
 		}
 	}
 	return false
+}
+
+func verifyPKCEChallenge(challenge string, method string, verifier string) bool {
+	if challenge == "" {
+		return true
+	}
+	if verifier == "" {
+		return false
+	}
+	switch strings.ToLower(method) {
+	case "", "plain":
+		return verifier == challenge
+	case "s256":
+		digest := sha256.Sum256([]byte(verifier))
+		return base64.RawURLEncoding.EncodeToString(digest[:]) == challenge
+	default:
+		return false
+	}
 }

--- a/internal/services/apple/helpers.go
+++ b/internal/services/apple/helpers.go
@@ -1,0 +1,142 @@
+package apple
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func generateAppleUID() string {
+	prefix := strings.ToUpper(generateHex(3))
+	middle := generateHex(16)
+	suffix := strings.ToUpper(generateHex(2))
+	return prefix + "." + middle + "." + suffix
+}
+
+func generatePrivateRelayEmail() string {
+	return generateHex(12) + "@privaterelay.appleid.com"
+}
+
+func generateHex(size int) string {
+	raw := make([]byte, size)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(raw)
+}
+
+func generateToken(prefix string) string {
+	raw := make([]byte, 20)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func intField(record corestore.Record, key string) int {
+	if record == nil {
+		return 0
+	}
+	switch value := record[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		number, _ := value.Int64()
+		return int(number)
+	default:
+		return 0
+	}
+}
+
+func stringField(record corestore.Record, key string) string {
+	if record == nil {
+		return ""
+	}
+	return stringValue(record[key])
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func boolField(record corestore.Record, key string) bool {
+	if record == nil {
+		return false
+	}
+	value, _ := record[key].(bool)
+	return value
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		out := make([]string, len(v))
+		copy(out, v)
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func matchesRedirectURI(candidate string, allowed []string) bool {
+	if candidate == "" {
+		return true
+	}
+	candidateURL, err := url.Parse(candidate)
+	if err != nil {
+		return false
+	}
+	for _, registered := range allowed {
+		registeredURL, err := url.Parse(registered)
+		if err != nil {
+			continue
+		}
+		if candidateURL.Scheme == registeredURL.Scheme &&
+			candidateURL.Host == registeredURL.Host &&
+			strings.TrimRight(candidateURL.Path, "/") == strings.TrimRight(registeredURL.Path, "/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/apple/jwt.go
+++ b/internal/services/apple/jwt.go
@@ -46,16 +46,12 @@ func (s *jwtSigner) jwks() map[string]any {
 }
 
 func createIDToken(user corestore.Record, clientID string, nonce string, baseURL string) (string, error) {
-	email := stringField(user, "email")
-	if boolField(user, "is_private_email") && stringField(user, "private_relay_email") != "" {
-		email = stringField(user, "private_relay_email")
-	}
 	now := time.Now().Unix()
 	claims := map[string]any{
 		"iss":              baseURL,
 		"aud":              clientID,
 		"sub":              stringField(user, "uid"),
-		"email":            email,
+		"email":            appleEmailForUser(user),
 		"email_verified":   stringValue(user["email_verified"]),
 		"is_private_email": stringValue(user["is_private_email"]),
 		"real_user_status": intField(user, "real_user_status"),

--- a/internal/services/apple/jwt.go
+++ b/internal/services/apple/jwt.go
@@ -1,0 +1,90 @@
+package apple
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const keyID = "emulate-apple-1"
+
+var signer = mustJWTSigner()
+
+type jwtSigner struct {
+	privateKey *rsa.PrivateKey
+}
+
+func mustJWTSigner() *jwtSigner {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	return &jwtSigner{privateKey: privateKey}
+}
+
+func (s *jwtSigner) jwks() map[string]any {
+	publicKey := s.privateKey.Public().(*rsa.PublicKey)
+	return map[string]any{
+		"keys": []map[string]any{
+			{
+				"kty": "RSA",
+				"use": "sig",
+				"kid": keyID,
+				"alg": "RS256",
+				"n":   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+			},
+		},
+	}
+}
+
+func createIDToken(user corestore.Record, clientID string, nonce string, baseURL string) (string, error) {
+	email := stringField(user, "email")
+	if boolField(user, "is_private_email") && stringField(user, "private_relay_email") != "" {
+		email = stringField(user, "private_relay_email")
+	}
+	now := time.Now().Unix()
+	claims := map[string]any{
+		"iss":              baseURL,
+		"aud":              clientID,
+		"sub":              stringField(user, "uid"),
+		"email":            email,
+		"email_verified":   stringValue(user["email_verified"]),
+		"is_private_email": stringValue(user["is_private_email"]),
+		"real_user_status": intField(user, "real_user_status"),
+		"nonce_supported":  true,
+		"auth_time":        now,
+		"iat":              now,
+		"exp":              now + 3600,
+	}
+	if nonce != "" {
+		claims["nonce"] = nonce
+	}
+	return signer.sign(claims)
+}
+
+func (s *jwtSigner) sign(claims map[string]any) (string, error) {
+	header := map[string]any{"alg": "RS256", "kid": keyID, "typ": "JWT"}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, s.privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}

--- a/internal/services/apple/routes_oauth.go
+++ b/internal/services/apple/routes_oauth.go
@@ -35,6 +35,7 @@ func (s *Service) handleOpenIDConfiguration(c *corehttp.Context) {
 		"subject_types_supported":               []string{"pairwise"},
 		"id_token_signing_alg_values_supported": []string{"RS256"},
 		"scopes_supported":                      []string{"openid", "email", "name"},
+		"code_challenge_methods_supported":      []string{"plain", "S256"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_post"},
 		"claims_supported": []string{
 			"aud",
@@ -64,6 +65,8 @@ func (s *Service) handleAuthorize(c *corehttp.Context) {
 	state := c.Query("state")
 	nonce := c.Query("nonce")
 	responseMode := c.Query("response_mode")
+	codeChallenge := c.Query("code_challenge")
+	codeChallengeMethod := c.Query("code_challenge_method")
 	if responseMode == "" {
 		responseMode = "query"
 	}
@@ -105,13 +108,15 @@ func (s *Service) handleAuthorize(c *corehttp.Context) {
 				Email:      email,
 				FormAction: "/auth/authorize/callback",
 				HiddenFields: map[string]string{
-					"email":         email,
-					"redirect_uri":  redirectURI,
-					"scope":         scope,
-					"state":         state,
-					"nonce":         nonce,
-					"client_id":     clientID,
-					"response_mode": responseMode,
+					"email":                 email,
+					"redirect_uri":          redirectURI,
+					"scope":                 scope,
+					"state":                 state,
+					"nonce":                 nonce,
+					"client_id":             clientID,
+					"response_mode":         responseMode,
+					"code_challenge":        codeChallenge,
+					"code_challenge_method": codeChallengeMethod,
 				},
 			}))
 		}
@@ -131,6 +136,8 @@ func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
 	clientID := c.Request.Form.Get("client_id")
 	nonce := c.Request.Form.Get("nonce")
 	responseMode := c.Request.Form.Get("response_mode")
+	codeChallenge := c.Request.Form.Get("code_challenge")
+	codeChallengeMethod := c.Request.Form.Get("code_challenge_method")
 	if responseMode == "" {
 		responseMode = "query"
 	}
@@ -153,14 +160,16 @@ func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
 
 	code := generateHex(20)
 	s.store.OAuthCodes.Insert(corestore.Record{
-		"code":          code,
-		"email":         email,
-		"scope":         scope,
-		"redirect_uri":  redirectURI,
-		"client_id":     clientID,
-		"nonce":         nonce,
-		"response_mode": responseMode,
-		"created_at_ms": time.Now().UnixMilli(),
+		"code":                  code,
+		"email":                 email,
+		"scope":                 scope,
+		"redirect_uri":          redirectURI,
+		"client_id":             clientID,
+		"nonce":                 nonce,
+		"response_mode":         responseMode,
+		"code_challenge":        codeChallenge,
+		"code_challenge_method": codeChallengeMethod,
+		"created_at_ms":         time.Now().UnixMilli(),
 	})
 
 	userJSON := ""
@@ -173,7 +182,7 @@ func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
 					"firstName": stringField(user, "given_name"),
 					"lastName":  stringField(user, "family_name"),
 				},
-				"email": stringField(user, "email"),
+				"email": appleEmailForUser(user),
 			})
 			userJSON = string(raw)
 		}
@@ -242,6 +251,10 @@ func (s *Service) handleAuthorizationCodeToken(c *corehttp.Context) {
 		return
 	}
 	if pendingRedirectURI := stringField(pending, "redirect_uri"); pendingRedirectURI != "" && redirectURI != "" && redirectURI != pendingRedirectURI {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	if !verifyPKCEChallenge(stringField(pending, "code_challenge"), stringField(pending, "code_challenge_method"), c.Request.Form.Get("code_verifier")) {
 		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
 		return
 	}

--- a/internal/services/apple/routes_oauth.go
+++ b/internal/services/apple/routes_oauth.go
@@ -193,14 +193,16 @@ func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
 		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid redirect_uri.")
 		return
 	}
+	if responseMode == "fragment" {
+		fragment, _ := url.ParseQuery(target.Fragment)
+		addAuthorizationResponseValues(fragment, code, state, userJSON)
+		target.Fragment = fragment.Encode()
+		target.RawFragment = ""
+		c.Redirect(http.StatusFound, target.String())
+		return
+	}
 	query := target.Query()
-	query.Set("code", code)
-	if state != "" {
-		query.Set("state", state)
-	}
-	if userJSON != "" {
-		query.Set("user", userJSON)
-	}
+	addAuthorizationResponseValues(query, code, state, userJSON)
 	target.RawQuery = query.Encode()
 	c.Redirect(http.StatusFound, target.String())
 }
@@ -230,6 +232,16 @@ func (s *Service) handleAuthorizationCodeToken(c *corehttp.Context) {
 	}
 	if time.Since(pendingCodeCreatedAt(pending)) > pendingCodeTTL {
 		s.deleteOAuthCode(code)
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	clientID := c.Request.Form.Get("client_id")
+	redirectURI := c.Request.Form.Get("redirect_uri")
+	if pendingClientID := stringField(pending, "client_id"); pendingClientID != "" && clientID != pendingClientID {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	if pendingRedirectURI := stringField(pending, "redirect_uri"); pendingRedirectURI != "" && redirectURI != "" && redirectURI != pendingRedirectURI {
 		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
 		return
 	}
@@ -317,6 +329,16 @@ func pendingCodeCreatedAt(row corestore.Record) time.Time {
 		return time.Now()
 	}
 	return time.UnixMilli(int64(millis))
+}
+
+func addAuthorizationResponseValues(values url.Values, code string, state string, userJSON string) {
+	values.Set("code", code)
+	if state != "" {
+		values.Set("state", state)
+	}
+	if userJSON != "" {
+		values.Set("user", userJSON)
+	}
 }
 
 func writeOAuthError(c *corehttp.Context, status int, code string, description string) {

--- a/internal/services/apple/routes_oauth.go
+++ b/internal/services/apple/routes_oauth.go
@@ -1,0 +1,327 @@
+package apple
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+const pendingCodeTTL = 5 * time.Minute
+
+func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
+	router.Get("/.well-known/openid-configuration", s.handleOpenIDConfiguration)
+	router.Get("/auth/keys", s.handleKeys)
+	router.Get("/auth/authorize", s.handleAuthorize)
+	router.Post("/auth/authorize/callback", s.handleAuthorizeCallback)
+	router.Post("/auth/token", s.handleToken)
+	router.Post("/auth/revoke", s.handleRevoke)
+}
+
+func (s *Service) handleOpenIDConfiguration(c *corehttp.Context) {
+	c.JSON(http.StatusOK, map[string]any{
+		"issuer":                                s.baseURL,
+		"authorization_endpoint":                s.baseURL + "/auth/authorize",
+		"token_endpoint":                        s.baseURL + "/auth/token",
+		"revocation_endpoint":                   s.baseURL + "/auth/revoke",
+		"jwks_uri":                              s.baseURL + "/auth/keys",
+		"response_types_supported":              []string{"code"},
+		"response_modes_supported":              []string{"query", "fragment", "form_post"},
+		"subject_types_supported":               []string{"pairwise"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"scopes_supported":                      []string{"openid", "email", "name"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_post"},
+		"claims_supported": []string{
+			"aud",
+			"email",
+			"email_verified",
+			"exp",
+			"iat",
+			"is_private_email",
+			"iss",
+			"nonce",
+			"nonce_supported",
+			"real_user_status",
+			"sub",
+			"transfer_sub",
+		},
+	})
+}
+
+func (s *Service) handleKeys(c *corehttp.Context) {
+	c.JSON(http.StatusOK, signer.jwks())
+}
+
+func (s *Service) handleAuthorize(c *corehttp.Context) {
+	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
+	scope := c.Query("scope")
+	state := c.Query("state")
+	nonce := c.Query("nonce")
+	responseMode := c.Query("response_mode")
+	if responseMode == "" {
+		responseMode = "query"
+	}
+
+	clientName := ""
+	if len(s.store.OAuthClients.All()) > 0 {
+		client := firstRecord(s.store.OAuthClients.FindBy("client_id", clientID))
+		if client == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		clientName = stringField(client, "name")
+	}
+
+	subtitle := "Choose a seeded user to continue."
+	if clientName != "" {
+		subtitle = "Sign in to <strong>" + ui.EscapeHTML(clientName) + "</strong> with your Apple ID."
+	}
+
+	users := s.store.Users.All()
+	var body strings.Builder
+	if len(users) == 0 {
+		body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+	} else {
+		for _, user := range users {
+			email := stringField(user, "email")
+			letter := "?"
+			if email != "" {
+				letter = strings.ToUpper(email[:1])
+			}
+			body.WriteString(ui.RenderUserButton(ui.UserButtonOptions{
+				Letter:     letter,
+				Login:      email,
+				Name:       stringField(user, "name"),
+				Email:      email,
+				FormAction: "/auth/authorize/callback",
+				HiddenFields: map[string]string{
+					"email":         email,
+					"redirect_uri":  redirectURI,
+					"scope":         scope,
+					"state":         state,
+					"nonce":         nonce,
+					"client_id":     clientID,
+					"response_mode": responseMode,
+				},
+			}))
+		}
+	}
+	c.HTML(http.StatusOK, ui.RenderCardPage("Sign in with Apple", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+}
+
+func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
+	if err := c.Request.ParseForm(); err != nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid form body.")
+		return
+	}
+	email := c.Request.Form.Get("email")
+	redirectURI := c.Request.Form.Get("redirect_uri")
+	scope := c.Request.Form.Get("scope")
+	state := c.Request.Form.Get("state")
+	clientID := c.Request.Form.Get("client_id")
+	nonce := c.Request.Form.Get("nonce")
+	responseMode := c.Request.Form.Get("response_mode")
+	if responseMode == "" {
+		responseMode = "query"
+	}
+
+	if firstRecord(s.store.Users.FindBy("email", email)) == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "User not found.")
+		return
+	}
+	if len(s.store.OAuthClients.All()) > 0 {
+		client := firstRecord(s.store.OAuthClients.FindBy("client_id", clientID))
+		if client == nil {
+			writeOAuthError(c, http.StatusBadRequest, "invalid_client", "Application not found.")
+			return
+		}
+		if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+			writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Redirect URI mismatch.")
+			return
+		}
+	}
+
+	code := generateHex(20)
+	s.store.OAuthCodes.Insert(corestore.Record{
+		"code":          code,
+		"email":         email,
+		"scope":         scope,
+		"redirect_uri":  redirectURI,
+		"client_id":     clientID,
+		"nonce":         nonce,
+		"response_mode": responseMode,
+		"created_at_ms": time.Now().UnixMilli(),
+	})
+
+	userJSON := ""
+	pairKey := email + ":" + clientID
+	if firstRecord(s.store.FirstAuth.FindBy("pair_key", pairKey)) == nil {
+		s.store.FirstAuth.Insert(corestore.Record{"pair_key": pairKey})
+		if user := firstRecord(s.store.Users.FindBy("email", email)); user != nil {
+			raw, _ := json.Marshal(map[string]any{
+				"name": map[string]string{
+					"firstName": stringField(user, "given_name"),
+					"lastName":  stringField(user, "family_name"),
+				},
+				"email": stringField(user, "email"),
+			})
+			userJSON = string(raw)
+		}
+	}
+
+	if responseMode == "form_post" {
+		fields := map[string]string{"code": code, "state": state}
+		if userJSON != "" {
+			fields["user"] = userJSON
+		}
+		c.HTML(http.StatusOK, ui.RenderFormPostPage(redirectURI, fields, ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+
+	target, err := url.Parse(redirectURI)
+	if err != nil || target == nil || target.Scheme == "" {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid redirect_uri.")
+		return
+	}
+	query := target.Query()
+	query.Set("code", code)
+	if state != "" {
+		query.Set("state", state)
+	}
+	if userJSON != "" {
+		query.Set("user", userJSON)
+	}
+	target.RawQuery = query.Encode()
+	c.Redirect(http.StatusFound, target.String())
+}
+
+func (s *Service) handleToken(c *corehttp.Context) {
+	if err := c.Request.ParseForm(); err != nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid form body.")
+		return
+	}
+	grantType := c.Request.Form.Get("grant_type")
+	switch grantType {
+	case "authorization_code":
+		s.handleAuthorizationCodeToken(c)
+	case "refresh_token":
+		s.handleRefreshToken(c)
+	default:
+		writeOAuthError(c, http.StatusBadRequest, "unsupported_grant_type", "Only authorization_code and refresh_token are supported.")
+	}
+}
+
+func (s *Service) handleAuthorizationCodeToken(c *corehttp.Context) {
+	code := c.Request.Form.Get("code")
+	pending := firstRecord(s.store.OAuthCodes.FindBy("code", code))
+	if pending == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	if time.Since(pendingCodeCreatedAt(pending)) > pendingCodeTTL {
+		s.deleteOAuthCode(code)
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	s.deleteOAuthCode(code)
+
+	user := firstRecord(s.store.Users.FindBy("email", stringField(pending, "email")))
+	if user == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "User not found.")
+		return
+	}
+
+	refreshToken := generateToken("r_apple_")
+	s.store.RefreshTokens.Insert(corestore.Record{
+		"token":     refreshToken,
+		"email":     stringField(user, "email"),
+		"client_id": stringField(pending, "client_id"),
+		"scope":     stringField(pending, "scope"),
+		"nonce":     stringField(pending, "nonce"),
+	})
+	idToken, err := createIDToken(user, stringField(pending, "client_id"), stringField(pending, "nonce"), s.baseURL)
+	if err != nil {
+		writeOAuthError(c, http.StatusInternalServerError, "server_error", "Failed to sign id_token.")
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"access_token":  generateToken("apple_"),
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"refresh_token": refreshToken,
+		"id_token":      idToken,
+	})
+}
+
+func (s *Service) handleRefreshToken(c *corehttp.Context) {
+	refreshToken := c.Request.Form.Get("refresh_token")
+	stored := firstRecord(s.store.RefreshTokens.FindBy("token", refreshToken))
+	if stored == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The refresh_token is invalid.")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("email", stringField(stored, "email")))
+	if user == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "User not found.")
+		return
+	}
+	clientID := stringField(stored, "client_id")
+	if clientID == "" {
+		clientID = c.Request.Form.Get("client_id")
+	}
+	idToken, err := createIDToken(user, clientID, stringField(stored, "nonce"), s.baseURL)
+	if err != nil {
+		writeOAuthError(c, http.StatusInternalServerError, "server_error", "Failed to sign id_token.")
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"access_token": generateToken("apple_"),
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"id_token":     idToken,
+	})
+}
+
+func (s *Service) handleRevoke(c *corehttp.Context) {
+	if err := c.Request.ParseForm(); err == nil {
+		s.deleteRefreshToken(c.Request.Form.Get("token"))
+	}
+	c.Writer.WriteHeader(http.StatusOK)
+}
+
+func (s *Service) deleteOAuthCode(code string) {
+	for _, row := range s.store.OAuthCodes.FindBy("code", code) {
+		s.store.OAuthCodes.Delete(intField(row, "id"))
+	}
+}
+
+func (s *Service) deleteRefreshToken(token string) {
+	for _, row := range s.store.RefreshTokens.FindBy("token", token) {
+		s.store.RefreshTokens.Delete(intField(row, "id"))
+	}
+}
+
+func pendingCodeCreatedAt(row corestore.Record) time.Time {
+	millis := intField(row, "created_at_ms")
+	if millis == 0 {
+		return time.Now()
+	}
+	return time.UnixMilli(int64(millis))
+}
+
+func writeOAuthError(c *corehttp.Context, status int, code string, description string) {
+	c.JSON(status, map[string]any{
+		"error":             code,
+		"error_description": description,
+	})
+}

--- a/internal/services/apple/service.go
+++ b/internal/services/apple/service.go
@@ -1,0 +1,148 @@
+package apple
+
+import (
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const serviceLabel = "Apple"
+
+type Options struct {
+	Store   *corestore.Store
+	BaseURL string
+	Seed    *SeedConfig
+}
+
+type SeedConfig struct {
+	Port         int               `json:"port,omitempty"`
+	Users        []UserSeed        `json:"users"`
+	OAuthClients []OAuthClientSeed `json:"oauth_clients"`
+}
+
+type UserSeed struct {
+	Email          string `json:"email"`
+	Name           string `json:"name"`
+	GivenName      string `json:"given_name"`
+	FamilyName     string `json:"family_name"`
+	IsPrivateEmail bool   `json:"is_private_email"`
+}
+
+type OAuthClientSeed struct {
+	ClientID     string   `json:"client_id"`
+	TeamID       string   `json:"team_id"`
+	KeyID        string   `json:"key_id"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris"`
+}
+
+type Service struct {
+	store   Store
+	baseURL string
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	baseURL := strings.TrimRight(options.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:4000"
+	}
+	service := &Service{
+		store:   NewStore(runtimeStore),
+		baseURL: baseURL,
+	}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, baseURL string, config SeedConfig) {
+	New(Options{Store: runtimeStore, BaseURL: baseURL, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerOAuthRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if firstRecord(s.store.Users.FindBy("email", "testuser@icloud.com")) != nil {
+		return
+	}
+	s.store.Users.Insert(corestore.Record{
+		"uid":                 generateAppleUID(),
+		"email":               "testuser@icloud.com",
+		"name":                "Test User",
+		"given_name":          "Test",
+		"family_name":         "User",
+		"email_verified":      true,
+		"is_private_email":    false,
+		"private_relay_email": nil,
+		"real_user_status":    2,
+	})
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	for _, seed := range config.Users {
+		email := strings.TrimSpace(seed.Email)
+		if email == "" || firstRecord(s.store.Users.FindBy("email", email)) != nil {
+			continue
+		}
+		name := seed.Name
+		if name == "" {
+			name = strings.Split(email, "@")[0]
+		}
+		nameParts := strings.Fields(name)
+		givenName := seed.GivenName
+		if givenName == "" && len(nameParts) > 0 {
+			givenName = nameParts[0]
+		}
+		familyName := seed.FamilyName
+		if familyName == "" && len(nameParts) > 1 {
+			familyName = strings.Join(nameParts[1:], " ")
+		}
+		privateRelayEmail := any(nil)
+		if seed.IsPrivateEmail {
+			privateRelayEmail = generatePrivateRelayEmail()
+		}
+		s.store.Users.Insert(corestore.Record{
+			"uid":                 generateAppleUID(),
+			"email":               email,
+			"name":                name,
+			"given_name":          givenName,
+			"family_name":         familyName,
+			"email_verified":      true,
+			"is_private_email":    seed.IsPrivateEmail,
+			"private_relay_email": privateRelayEmail,
+			"real_user_status":    2,
+		})
+	}
+
+	for _, seed := range config.OAuthClients {
+		clientID := strings.TrimSpace(seed.ClientID)
+		if clientID == "" || firstRecord(s.store.OAuthClients.FindBy("client_id", clientID)) != nil {
+			continue
+		}
+		keyID := seed.KeyID
+		if keyID == "" {
+			keyID = "TESTKEY001"
+		}
+		s.store.OAuthClients.Insert(corestore.Record{
+			"client_id":     clientID,
+			"team_id":       seed.TeamID,
+			"key_id":        keyID,
+			"name":          seed.Name,
+			"redirect_uris": seed.RedirectURIs,
+		})
+	}
+}

--- a/internal/services/apple/service_test.go
+++ b/internal/services/apple/service_test.go
@@ -1,6 +1,7 @@
 package apple
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -16,12 +17,16 @@ import (
 const testBaseURL = "http://localhost:4004"
 
 func newTestHandler() http.Handler {
+	return newTestHandlerWithSeed(&SeedConfig{
+		Users: []UserSeed{{Email: "testuser@example.com", Name: "Test User"}},
+	})
+}
+
+func newTestHandlerWithSeed(seed *SeedConfig) http.Handler {
 	router := corehttp.NewRouter()
 	Register(router, Options{
 		BaseURL: testBaseURL,
-		Seed: &SeedConfig{
-			Users: []UserSeed{{Email: "testuser@example.com", Name: "Test User"}},
-		},
+		Seed:    seed,
 	})
 	router.NotFound(func(c *corehttp.Context) {
 		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
@@ -38,7 +43,9 @@ func TestOpenIDConfiguration(t *testing.T) {
 	if body["issuer"] != testBaseURL || body["authorization_endpoint"] != testBaseURL+"/auth/authorize" {
 		t.Fatalf("unexpected discovery: %#v", body)
 	}
-	if !containsString(body["claims_supported"], "is_private_email") || !containsString(body["response_modes_supported"], "form_post") {
+	if !containsString(body["claims_supported"], "is_private_email") ||
+		!containsString(body["response_modes_supported"], "form_post") ||
+		!containsString(body["code_challenge_methods_supported"], "S256") {
 		t.Fatalf("missing discovery metadata: %#v", body)
 	}
 }
@@ -138,6 +145,25 @@ func TestAuthorizationCodeIsSingleUse(t *testing.T) {
 	}
 }
 
+func TestPKCES256Flow(t *testing.T) {
+	handler := newTestHandler()
+	verifier := "pkce-verifier-12345"
+	code, _, _ := getAuthCode(t, handler, authCodeOptions{
+		CodeChallenge:       s256Challenge(verifier),
+		CodeChallengeMethod: "S256",
+	})
+
+	res, body := exchangeCode(t, handler, code, tokenExchangeOptions{CodeVerifier: "wrong-verifier"})
+	if res.Code != http.StatusBadRequest || body["error"] != "invalid_grant" {
+		t.Fatalf("unexpected wrong verifier response: status=%d body=%#v", res.Code, body)
+	}
+
+	res, body = exchangeCode(t, handler, code, tokenExchangeOptions{CodeVerifier: verifier})
+	if res.Code != http.StatusOK || body["id_token"] == "" {
+		t.Fatalf("unexpected verifier success response: status=%d body=%#v", res.Code, body)
+	}
+}
+
 func TestUserJSONOnlyOnFirstAuthorization(t *testing.T) {
 	handler := newTestHandler()
 	_, _, userJSON := getAuthCode(t, handler, authCodeOptions{})
@@ -155,6 +181,34 @@ func TestUserJSONOnlyOnFirstAuthorization(t *testing.T) {
 	_, _, secondUserJSON := getAuthCode(t, handler, authCodeOptions{})
 	if secondUserJSON != "" {
 		t.Fatalf("second auth included user JSON: %s", secondUserJSON)
+	}
+}
+
+func TestPrivateEmailUsesRelayInUserJSONAndIDToken(t *testing.T) {
+	handler := newTestHandlerWithSeed(&SeedConfig{
+		Users: []UserSeed{{Email: "private@example.com", Name: "Private User", IsPrivateEmail: true}},
+	})
+	code, _, userJSON := getAuthCode(t, handler, authCodeOptions{Email: "private@example.com"})
+	if userJSON == "" {
+		t.Fatalf("missing first auth user JSON")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(userJSON), &parsed); err != nil {
+		t.Fatalf("invalid user JSON: %v", err)
+	}
+	userEmail := stringValue(parsed["email"])
+	if userEmail == "private@example.com" || !strings.HasSuffix(userEmail, "@privaterelay.appleid.com") {
+		t.Fatalf("user JSON leaked real email: %#v", parsed)
+	}
+
+	res, tokenBody := exchangeCode(t, handler, code)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	claims := decodeJWTClaims(t, stringValue(tokenBody["id_token"]))
+	if claims["email"] != userEmail {
+		t.Fatalf("email mismatch between user JSON and id_token: user=%q claims=%#v", userEmail, claims)
 	}
 }
 
@@ -232,13 +286,15 @@ func TestSeedFromConfig(t *testing.T) {
 }
 
 type authCodeOptions struct {
-	Email        string
-	ClientID     string
-	RedirectURI  string
-	Scope        string
-	State        string
-	Nonce        string
-	ResponseMode string
+	Email               string
+	ClientID            string
+	RedirectURI         string
+	Scope               string
+	State               string
+	Nonce               string
+	ResponseMode        string
+	CodeChallenge       string
+	CodeChallengeMethod string
 }
 
 func getAuthCode(t *testing.T, handler http.Handler, opts authCodeOptions) (string, string, string) {
@@ -252,13 +308,15 @@ func getAuthCode(t *testing.T, handler http.Handler, opts authCodeOptions) (stri
 	responseMode := firstNonEmpty(opts.ResponseMode, "query")
 
 	form := url.Values{
-		"email":         []string{email},
-		"redirect_uri":  []string{redirectURI},
-		"scope":         []string{scope},
-		"state":         []string{state},
-		"nonce":         []string{nonce},
-		"client_id":     []string{clientID},
-		"response_mode": []string{responseMode},
+		"email":                 []string{email},
+		"redirect_uri":          []string{redirectURI},
+		"scope":                 []string{scope},
+		"state":                 []string{state},
+		"nonce":                 []string{nonce},
+		"client_id":             []string{clientID},
+		"response_mode":         []string{responseMode},
+		"code_challenge":        []string{opts.CodeChallenge},
+		"code_challenge_method": []string{opts.CodeChallengeMethod},
 	}
 	res := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/auth/authorize/callback", strings.NewReader(form.Encode()))
@@ -290,8 +348,9 @@ func getAuthCode(t *testing.T, handler http.Handler, opts authCodeOptions) (stri
 }
 
 type tokenExchangeOptions struct {
-	ClientID    string
-	RedirectURI string
+	ClientID     string
+	RedirectURI  string
+	CodeVerifier string
 }
 
 func exchangeCode(t *testing.T, handler http.Handler, code string, opts ...tokenExchangeOptions) (*httptest.ResponseRecorder, map[string]any) {
@@ -306,6 +365,9 @@ func exchangeCode(t *testing.T, handler http.Handler, code string, opts ...token
 		"client_id":     []string{firstNonEmpty(options.ClientID, "test-client")},
 		"client_secret": []string{"fake"},
 		"redirect_uri":  []string{firstNonEmpty(options.RedirectURI, "http://localhost:3000/callback")},
+	}
+	if options.CodeVerifier != "" {
+		form.Set("code_verifier", options.CodeVerifier)
 	}
 	return requestJSON(t, handler, http.MethodPost, "/auth/token", form.Encode())
 }
@@ -374,4 +436,9 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func s256Challenge(verifier string) string {
+	digest := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(digest[:])
 }

--- a/internal/services/apple/service_test.go
+++ b/internal/services/apple/service_test.go
@@ -1,0 +1,330 @@
+package apple
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const testBaseURL = "http://localhost:4004"
+
+func newTestHandler() http.Handler {
+	router := corehttp.NewRouter()
+	Register(router, Options{
+		BaseURL: testBaseURL,
+		Seed: &SeedConfig{
+			Users: []UserSeed{{Email: "testuser@example.com", Name: "Test User"}},
+		},
+	})
+	router.NotFound(func(c *corehttp.Context) {
+		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
+	})
+	return router
+}
+
+func TestOpenIDConfiguration(t *testing.T) {
+	handler := newTestHandler()
+	res, body := requestJSON(t, handler, http.MethodGet, "/.well-known/openid-configuration", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if body["issuer"] != testBaseURL || body["authorization_endpoint"] != testBaseURL+"/auth/authorize" {
+		t.Fatalf("unexpected discovery: %#v", body)
+	}
+	if !containsString(body["claims_supported"], "is_private_email") || !containsString(body["response_modes_supported"], "form_post") {
+		t.Fatalf("missing discovery metadata: %#v", body)
+	}
+}
+
+func TestKeys(t *testing.T) {
+	handler := newTestHandler()
+	res, body := requestJSON(t, handler, http.MethodGet, "/auth/keys", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	keys, _ := body["keys"].([]any)
+	if len(keys) != 1 {
+		t.Fatalf("unexpected keys: %#v", body)
+	}
+	key := keys[0].(map[string]any)
+	if key["kty"] != "RSA" || key["kid"] != keyID || key["alg"] != "RS256" || key["e"] != "AQAB" || key["n"] == "" {
+		t.Fatalf("unexpected key: %#v", key)
+	}
+}
+
+func TestAuthorizePage(t *testing.T) {
+	handler := newTestHandler()
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/authorize?client_id=test-client&redirect_uri="+url.QueryEscape("http://localhost:3000/callback")+"&response_type=code&scope=openid%20email%20name", nil)
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK || !strings.Contains(res.Header().Get("Content-Type"), "text/html") || !strings.Contains(res.Body.String(), "Sign in") {
+		t.Fatalf("unexpected authorize page: status=%d body=%s", res.Code, res.Body.String())
+	}
+}
+
+func TestAuthorizationCodeFlow(t *testing.T) {
+	handler := newTestHandler()
+	code, state, userJSON := getAuthCode(t, handler, authCodeOptions{})
+	if code == "" || state != "test-state" {
+		t.Fatalf("unexpected callback values: code=%q state=%q", code, state)
+	}
+	if userJSON == "" {
+		t.Fatalf("missing first authorization user JSON")
+	}
+
+	res, tokenBody := exchangeCode(t, handler, code)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.HasPrefix(stringValue(tokenBody["access_token"]), "apple_") ||
+		!strings.HasPrefix(stringValue(tokenBody["refresh_token"]), "r_apple_") ||
+		tokenBody["token_type"] != "Bearer" ||
+		int(tokenBody["expires_in"].(float64)) != 3600 {
+		t.Fatalf("unexpected token response: %#v", tokenBody)
+	}
+	claims := decodeJWTClaims(t, stringValue(tokenBody["id_token"]))
+	if claims["iss"] != testBaseURL || claims["aud"] != "test-client" || claims["email"] != "testuser@example.com" {
+		t.Fatalf("unexpected claims: %#v", claims)
+	}
+	if claims["email_verified"] != "true" || claims["is_private_email"] != "false" || claims["nonce"] != "test-nonce" || claims["nonce_supported"] != true {
+		t.Fatalf("unexpected Apple claim types: %#v", claims)
+	}
+}
+
+func TestRefreshTokenFlow(t *testing.T) {
+	handler := newTestHandler()
+	code, _, _ := getAuthCode(t, handler, authCodeOptions{})
+	res, tokenBody := exchangeCode(t, handler, code)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	refreshToken := stringValue(tokenBody["refresh_token"])
+
+	form := url.Values{
+		"grant_type":    []string{"refresh_token"},
+		"refresh_token": []string{refreshToken},
+		"client_id":     []string{"test-client"},
+		"client_secret": []string{"fake"},
+	}
+	res, body := requestJSON(t, handler, http.MethodPost, "/auth/token", form.Encode())
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.HasPrefix(stringValue(body["access_token"]), "apple_") || body["id_token"] == "" {
+		t.Fatalf("unexpected refresh response: %#v", body)
+	}
+	if _, ok := body["refresh_token"]; ok {
+		t.Fatalf("refresh response issued a new refresh token: %#v", body)
+	}
+}
+
+func TestAuthorizationCodeIsSingleUse(t *testing.T) {
+	handler := newTestHandler()
+	code, _, _ := getAuthCode(t, handler, authCodeOptions{})
+	res, _ := exchangeCode(t, handler, code)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	res, body := exchangeCode(t, handler, code)
+	if res.Code != http.StatusBadRequest || body["error"] != "invalid_grant" {
+		t.Fatalf("unexpected second exchange: status=%d body=%#v", res.Code, body)
+	}
+}
+
+func TestUserJSONOnlyOnFirstAuthorization(t *testing.T) {
+	handler := newTestHandler()
+	_, _, userJSON := getAuthCode(t, handler, authCodeOptions{})
+	if userJSON == "" {
+		t.Fatalf("missing first auth user JSON")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(userJSON), &parsed); err != nil {
+		t.Fatalf("invalid user JSON: %v", err)
+	}
+	if parsed["email"] != "testuser@example.com" {
+		t.Fatalf("unexpected user JSON: %#v", parsed)
+	}
+
+	_, _, secondUserJSON := getAuthCode(t, handler, authCodeOptions{})
+	if secondUserJSON != "" {
+		t.Fatalf("second auth included user JSON: %s", secondUserJSON)
+	}
+}
+
+func TestFormPostResponseMode(t *testing.T) {
+	handler := newTestHandler()
+	code, state, _ := getAuthCode(t, handler, authCodeOptions{ResponseMode: "form_post"})
+	if code == "" || state != "test-state" {
+		t.Fatalf("unexpected form_post values: code=%q state=%q", code, state)
+	}
+}
+
+func TestUnsupportedGrantType(t *testing.T) {
+	handler := newTestHandler()
+	form := url.Values{
+		"grant_type":    []string{"client_credentials"},
+		"client_id":     []string{"test-client"},
+		"client_secret": []string{"fake"},
+	}
+	res, body := requestJSON(t, handler, http.MethodPost, "/auth/token", form.Encode())
+	if res.Code != http.StatusBadRequest || body["error"] != "unsupported_grant_type" {
+		t.Fatalf("unexpected unsupported grant response: status=%d body=%#v", res.Code, body)
+	}
+}
+
+func TestSeedFromConfig(t *testing.T) {
+	runtimeStore := corestore.New()
+	SeedFromConfig(runtimeStore, testBaseURL, SeedConfig{
+		Users: []UserSeed{{Email: "private@example.com", Name: "Private User", IsPrivateEmail: true}},
+		OAuthClients: []OAuthClientSeed{{
+			ClientID:     "com.example.app",
+			TeamID:       "TEAM001",
+			Name:         "My Apple App",
+			RedirectURIs: []string{"http://localhost:3000/callback"},
+		}},
+	})
+	store := NewStore(runtimeStore)
+	if firstRecord(store.Users.FindBy("email", "private@example.com")) == nil {
+		t.Fatalf("missing seeded user")
+	}
+	client := firstRecord(store.OAuthClients.FindBy("client_id", "com.example.app"))
+	if client == nil || stringField(client, "key_id") != "TESTKEY001" {
+		t.Fatalf("unexpected seeded client: %#v", client)
+	}
+}
+
+type authCodeOptions struct {
+	Email        string
+	ClientID     string
+	RedirectURI  string
+	Scope        string
+	State        string
+	Nonce        string
+	ResponseMode string
+}
+
+func getAuthCode(t *testing.T, handler http.Handler, opts authCodeOptions) (string, string, string) {
+	t.Helper()
+	email := firstNonEmpty(opts.Email, "testuser@example.com")
+	clientID := firstNonEmpty(opts.ClientID, "test-client")
+	redirectURI := firstNonEmpty(opts.RedirectURI, "http://localhost:3000/callback")
+	scope := firstNonEmpty(opts.Scope, "openid email name")
+	state := firstNonEmpty(opts.State, "test-state")
+	nonce := firstNonEmpty(opts.Nonce, "test-nonce")
+	responseMode := firstNonEmpty(opts.ResponseMode, "query")
+
+	form := url.Values{
+		"email":         []string{email},
+		"redirect_uri":  []string{redirectURI},
+		"scope":         []string{scope},
+		"state":         []string{state},
+		"nonce":         []string{nonce},
+		"client_id":     []string{clientID},
+		"response_mode": []string{responseMode},
+	}
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/auth/authorize/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusFound && res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if responseMode == "form_post" {
+		html := res.Body.String()
+		return htmlInputValue(html, "code"), htmlInputValue(html, "state"), htmlInputValue(html, "user")
+	}
+	location := res.Header().Get("Location")
+	if location == "" {
+		t.Fatalf("missing redirect location: %s", res.Body.String())
+	}
+	target, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("invalid redirect location: %v", err)
+	}
+	return target.Query().Get("code"), target.Query().Get("state"), target.Query().Get("user")
+}
+
+func exchangeCode(t *testing.T, handler http.Handler, code string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	form := url.Values{
+		"grant_type":    []string{"authorization_code"},
+		"code":          []string{code},
+		"client_id":     []string{"test-client"},
+		"client_secret": []string{"fake"},
+		"redirect_uri":  []string{"http://localhost:3000/callback"},
+	}
+	return requestJSON(t, handler, http.MethodPost, "/auth/token", form.Encode())
+}
+
+func requestJSON(t *testing.T, handler http.Handler, method string, path string, body string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	var parsed map[string]any
+	if strings.Contains(res.Header().Get("Content-Type"), "application/json") && res.Body.Len() > 0 {
+		if err := json.Unmarshal(res.Body.Bytes(), &parsed); err != nil {
+			t.Fatalf("failed to parse response JSON: %v\nbody: %s", err, res.Body.String())
+		}
+	}
+	return res, parsed
+}
+
+func decodeJWTClaims(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("invalid token: %s", token)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("invalid claims encoding: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		t.Fatalf("invalid claims JSON: %v", err)
+	}
+	return claims
+}
+
+func htmlInputValue(html string, name string) string {
+	pattern := `name="` + name + `" value="`
+	start := strings.Index(html, pattern)
+	if start < 0 {
+		return ""
+	}
+	start += len(pattern)
+	end := strings.Index(html[start:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return strings.NewReplacer("&quot;", `"`, "&#39;", "'", "&#x27;", "'", "&amp;", "&", "&lt;", "<", "&gt;", ">").Replace(html[start : start+end])
+}
+
+func containsString(value any, needle string) bool {
+	for _, item := range stringSliceValue(value) {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/services/apple/service_test.go
+++ b/internal/services/apple/service_test.go
@@ -166,6 +166,37 @@ func TestFormPostResponseMode(t *testing.T) {
 	}
 }
 
+func TestFragmentResponseMode(t *testing.T) {
+	handler := newTestHandler()
+	code, state, userJSON := getAuthCode(t, handler, authCodeOptions{ResponseMode: "fragment"})
+	if code == "" || state != "test-state" {
+		t.Fatalf("unexpected fragment values: code=%q state=%q", code, state)
+	}
+	if userJSON == "" {
+		t.Fatalf("missing first authorization user JSON")
+	}
+}
+
+func TestAuthorizationCodeRejectsMismatchedClientID(t *testing.T) {
+	handler := newTestHandler()
+	code, _, _ := getAuthCode(t, handler, authCodeOptions{})
+
+	res, body := exchangeCode(t, handler, code, tokenExchangeOptions{ClientID: "other-client"})
+	if res.Code != http.StatusBadRequest || body["error"] != "invalid_grant" {
+		t.Fatalf("unexpected mismatched client response: status=%d body=%#v", res.Code, body)
+	}
+}
+
+func TestAuthorizationCodeRejectsMismatchedRedirectURI(t *testing.T) {
+	handler := newTestHandler()
+	code, _, _ := getAuthCode(t, handler, authCodeOptions{})
+
+	res, body := exchangeCode(t, handler, code, tokenExchangeOptions{RedirectURI: "http://localhost:3000/other"})
+	if res.Code != http.StatusBadRequest || body["error"] != "invalid_grant" {
+		t.Fatalf("unexpected mismatched redirect response: status=%d body=%#v", res.Code, body)
+	}
+}
+
 func TestUnsupportedGrantType(t *testing.T) {
 	handler := newTestHandler()
 	form := url.Values{
@@ -248,17 +279,33 @@ func getAuthCode(t *testing.T, handler http.Handler, opts authCodeOptions) (stri
 	if err != nil {
 		t.Fatalf("invalid redirect location: %v", err)
 	}
+	if responseMode == "fragment" {
+		fragment, err := url.ParseQuery(target.Fragment)
+		if err != nil {
+			t.Fatalf("invalid redirect fragment: %v", err)
+		}
+		return fragment.Get("code"), fragment.Get("state"), fragment.Get("user")
+	}
 	return target.Query().Get("code"), target.Query().Get("state"), target.Query().Get("user")
 }
 
-func exchangeCode(t *testing.T, handler http.Handler, code string) (*httptest.ResponseRecorder, map[string]any) {
+type tokenExchangeOptions struct {
+	ClientID    string
+	RedirectURI string
+}
+
+func exchangeCode(t *testing.T, handler http.Handler, code string, opts ...tokenExchangeOptions) (*httptest.ResponseRecorder, map[string]any) {
 	t.Helper()
+	options := tokenExchangeOptions{}
+	if len(opts) > 0 {
+		options = opts[0]
+	}
 	form := url.Values{
 		"grant_type":    []string{"authorization_code"},
 		"code":          []string{code},
-		"client_id":     []string{"test-client"},
+		"client_id":     []string{firstNonEmpty(options.ClientID, "test-client")},
 		"client_secret": []string{"fake"},
-		"redirect_uri":  []string{"http://localhost:3000/callback"},
+		"redirect_uri":  []string{firstNonEmpty(options.RedirectURI, "http://localhost:3000/callback")},
 	}
 	return requestJSON(t, handler, http.MethodPost, "/auth/token", form.Encode())
 }

--- a/internal/services/apple/store.go
+++ b/internal/services/apple/store.go
@@ -1,0 +1,21 @@
+package apple
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Users         *corestore.Collection
+	OAuthClients  *corestore.Collection
+	OAuthCodes    *corestore.Collection
+	RefreshTokens *corestore.Collection
+	FirstAuth     *corestore.Collection
+}
+
+func NewStore(runtimeStore *corestore.Store) Store {
+	return Store{
+		Users:         runtimeStore.MustCollection("apple.users", "uid", "email"),
+		OAuthClients:  runtimeStore.MustCollection("apple.oauth_clients", "client_id"),
+		OAuthCodes:    runtimeStore.MustCollection("apple.oauth_codes", "code", "client_id", "email"),
+		RefreshTokens: runtimeStore.MustCollection("apple.refresh_tokens", "token", "client_id", "email"),
+		FirstAuth:     runtimeStore.MustCollection("apple.first_auth", "pair_key"),
+	}
+}

--- a/packages/@emulators/apple/README.md
+++ b/packages/@emulators/apple/README.md
@@ -24,6 +24,10 @@ npm install @emulators/apple
 
 OIDC authorization code flow with RS256 ID tokens. On first auth per user/client pair, a `user` JSON blob is included.
 
+PKCE is supported with `code_challenge` and `code_challenge_method` on authorization, then `code_verifier` on token exchange.
+
+Private email users receive the generated relay email in both the `id_token` and first authorization `user` JSON.
+
 ## Seed Configuration
 
 ```yaml

--- a/packages/@emulators/apple/README.md
+++ b/packages/@emulators/apple/README.md
@@ -4,6 +4,8 @@ Sign in with Apple emulation with authorization code flow, PKCE support, RS256 I
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
+The native Go runtime implements this Apple OIDC flow for local CLI runs and Vercel Go Function previews. To expose Apple on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service apple`.
+
 ## Install
 
 ```bash

--- a/packages/@emulators/resend/README.md
+++ b/packages/@emulators/resend/README.md
@@ -8,7 +8,7 @@ Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in repl
 
 Set `RESEND_BASE_URL` before importing the official `resend` Node.js SDK and the SDK will call the emulator without code changes.
 
-The experimental native Go runtime implements the current Resend routes listed below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime implements the current Resend routes listed below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 ## Install
 

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,7 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
-      'Services: []string{"aws", "github", "resend", "vercel"}',
+      'Services: []string{"apple", "aws", "github", "resend", "vercel"}',
     );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
@@ -225,7 +225,7 @@ require (
     const cwd = tempDir();
 
     expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "google" })).toThrow(
-      "currently supports native services: aws, github, resend, vercel",
+      "currently supports native services: apple, aws, github, resend, vercel",
     );
   });
 

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-const SUPPORTED_VERCEL_SERVICES = ["aws", "github", "resend", "vercel"] as const;
+const SUPPORTED_VERCEL_SERVICES = ["apple", "aws", "github", "resend", "vercel"] as const;
 const REQUIRED_GO_VERSION = "1.24";
 const DEFAULT_REWRITE = {
   source: "/emulate/:path*",

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -59,8 +59,8 @@ const vercel = program.command("vercel").description("Vercel preview helpers");
 
 vercel
   .command("init")
-  .description("Scaffold an experimental Vercel Go Function")
-  .option("-s, --service <services>", "Comma-separated native services to enable", "aws,github,resend,vercel")
+  .description("Scaffold a Vercel Go Function preview route")
+  .option("-s, --service <services>", "Comma-separated native services to enable", "apple,aws,github,resend,vercel")
   .option("--force", "Overwrite generated files")
   .action((opts) => {
     vercelInitCommand({

--- a/skills/apple/SKILL.md
+++ b/skills/apple/SKILL.md
@@ -105,7 +105,9 @@ apple:
 
 When no OAuth clients are configured, the emulator accepts any `client_id`. With clients configured, strict validation is enforced for `client_id` and `redirect_uri`.
 
-Users with `is_private_email: true` get a generated `@privaterelay.appleid.com` email in the `id_token` instead of their real email.
+Users with `is_private_email: true` get a generated `@privaterelay.appleid.com` email in the `id_token` and first authorization `user` JSON instead of their real email.
+
+PKCE is supported. Pass `code_challenge` and `code_challenge_method` on authorize, then `code_verifier` on token exchange.
 
 ## API Endpoints
 

--- a/skills/apple/SKILL.md
+++ b/skills/apple/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
 
+The native Go runtime implements this Apple OIDC flow for local CLI runs and Vercel Go Function previews. To expose Apple on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service apple`; the generated route serves Apple at `/emulate/apple/*`.
+
 ## Start
 
 ```bash

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -317,7 +317,7 @@ Then use these in your app to construct API and OAuth URLs. See each service's s
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `aws`, `github`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 Fully stateful GitHub REST API emulation. Creates, updates, and deletes persist in memory and affect related entities.
 
-The experimental native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
+The native Go runtime implements the core SDK-facing GitHub surface for local CLI runs and Vercel Go Function previews: users, orgs, seeded repositories, repository CRUD, topics, languages, branches, refs, issues, issue comments, pull requests, OAuth authorize/token flows, rate limit, and metadata. The JavaScript `@emulators/github` package remains the broader GitHub emulator while native parity continues to expand.
 
 ## Start
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -10,7 +10,7 @@ Fully stateful Resend API emulation. Emails, domains, API keys, audiences, and c
 
 No real emails are sent. Every call to `POST /emails` stores the message locally so you can inspect it programmatically or in the browser.
 
-The experimental native Go runtime implements the current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` Node.js SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime implements the current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` Node.js SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 ## Vercel Preview
 

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"aws", "github", "resend", "vercel"}
+var defaultServices = []string{"apple", "aws", "github", "resend", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -35,7 +35,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "aws,github,resend,vercel" {
+	if strings.Join(body.Services, ",") != "apple,aws,github,resend,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -119,6 +119,23 @@ func TestHandlerForwardsGitHubService(t *testing.T) {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 	if !strings.Contains(res.Body.String(), `"login":"admin"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestHandlerForwardsAppleService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"apple"}})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/apple/.well-known/openid-configuration", nil)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"https://preview.example.com/emulate/apple"`) ||
+		!strings.Contains(res.Body.String(), `"jwks_uri":"https://preview.example.com/emulate/apple/auth/keys"`) {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }


### PR DESCRIPTION
- Adds a native Go Apple OIDC service with discovery, JWKS, authorization, token, refresh, revoke, seed handling, and RS256 id_token signing.

- Wires Apple into the native runtime, JSON seed loading, and Vercel Go Function preview scaffolding.

- Updates docs, skills, and help text to frame Go as the emulator engine path.