### PR TITLE
Add Go Microsoft Entra foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,13 +661,17 @@ Private email users receive the generated relay email in both the `id_token` and
 
 Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with authorization code flow, PKCE, client credentials, RS256 ID tokens, and OIDC discovery.
 
+The native Go runtime implements the Microsoft OIDC, token, and Graph profile routes below for local CLI runs and Vercel Go Function previews. To expose Microsoft on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service microsoft`. The generated route serves Microsoft at `/emulate/microsoft/*`.
+
 - `GET /.well-known/openid-configuration` - OIDC discovery document
 - `GET /:tenant/v2.0/.well-known/openid-configuration` - tenant-scoped OIDC discovery
 - `GET /discovery/v2.0/keys` - JSON Web Key Set (JWKS)
 - `GET /oauth2/v2.0/authorize` - authorization endpoint (shows user picker)
 - `POST /oauth2/v2.0/token` - token exchange (authorization code, refresh token, client credentials)
+- `POST /:tenant/oauth2/token` - v1 token endpoint with `resource` to `.default` scope translation
 - `GET /oidc/userinfo` - OpenID Connect user info
 - `GET /v1.0/me` - Microsoft Graph user profile
+- `GET /v1.0/users/:id` - Microsoft Graph user by ID
 - `GET /oauth2/v2.0/logout` - end session / logout
 - `POST /oauth2/v2.0/revoke` - token revocation
 
@@ -761,7 +765,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `microsoft`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -802,7 +806,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `microsoft`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/docs/microsoft/page.mdx
+++ b/apps/web/app/docs/microsoft/page.mdx
@@ -2,6 +2,8 @@
 
 Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with authorization code flow, PKCE, client credentials, RS256 ID tokens, OIDC discovery, and a Microsoft Graph `/v1.0/me` endpoint.
 
+The native Go runtime implements the Microsoft OIDC, token, and Graph profile routes below for local CLI runs and Vercel Go Function previews. To expose Microsoft on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service microsoft`. The generated route serves Microsoft at `/emulate/microsoft/*`.
+
 ## Endpoints
 
 - `GET /.well-known/openid-configuration` - OIDC discovery document
@@ -9,8 +11,10 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 - `GET /discovery/v2.0/keys` - JSON Web Key Set (JWKS)
 - `GET /oauth2/v2.0/authorize` - authorization endpoint (shows user picker)
 - `POST /oauth2/v2.0/token` - token exchange (authorization code, refresh token, and client credentials grants)
+- `POST /:tenant/oauth2/token` - v1 token endpoint with `resource` to `.default` scope translation
 - `GET /oidc/userinfo` - OpenID Connect user info
 - `GET /v1.0/me` - Microsoft Graph user profile
+- `GET /v1.0/users/:id` - Microsoft Graph user by ID
 - `GET /oauth2/v2.0/logout` - end session / logout
 - `POST /oauth2/v2.0/revoke` - token revocation
 

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `microsoft`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `microsoft`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -22,6 +22,7 @@ import (
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 	"github.com/vercel-labs/emulate/internal/services/apple"
 	"github.com/vercel-labs/emulate/internal/services/github"
+	"github.com/vercel-labs/emulate/internal/services/microsoft"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
@@ -108,6 +109,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 	var seedServices []string
 	var appleSeed *apple.SeedConfig
 	var githubSeed *github.SeedConfig
+	var microsoftSeed *microsoft.SeedConfig
 	var resendSeed *resend.SeedConfig
 	var vercelSeed *vercel.SeedConfig
 	if *seedValue != "" {
@@ -117,7 +119,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, resend, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, microsoft, resend, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
@@ -153,6 +155,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			}
 			appleSeed = &cfg
 		}
+		if raw, ok := loaded.Data["microsoft"]; ok {
+			var cfg microsoft.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse microsoft seed config: %v\n", err)
+				return 1
+			}
+			microsoftSeed = &cfg
+		}
 		if raw, ok := loaded.Data["resend"]; ok {
 			var cfg resend.SeedConfig
 			if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -184,13 +194,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		baseURL = fmt.Sprintf("http://localhost:%d", port)
 	}
 	server := emuruntime.NewServer(emuruntime.ServerOptions{
-		Version:    version,
-		BaseURL:    baseURL,
-		Services:   services,
-		AppleSeed:  appleSeed,
-		GitHubSeed: githubSeed,
-		ResendSeed: resendSeed,
-		VercelSeed: vercelSeed,
+		Version:       version,
+		BaseURL:       baseURL,
+		Services:      services,
+		AppleSeed:     appleSeed,
+		GitHubSeed:    githubSeed,
+		MicrosoftSeed: microsoftSeed,
+		ResendSeed:    resendSeed,
+		VercelSeed:    vercelSeed,
 	})
 	httpServer := &nethttp.Server{
 		Handler:           server.Handler,
@@ -377,7 +388,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"apple", "github", "resend", "vercel"}
+	return []string{"apple", "github", "microsoft", "resend", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -305,6 +305,53 @@ func TestRunStartSeedsAppleFromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsMicrosoftFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"microsoft":{"users":[{"email":"ms@example.com","name":"Microsoft User","tenant_id":"tenant-1"}],"oauth_clients":[{"client_id":"ms-client","client_secret":"ms-secret","name":"Microsoft App","redirect_uris":["http://localhost:3000/callback"],"tenant_id":"tenant-1"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "microsoft" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	var discovery struct {
+		Issuer                string `json:"issuer"`
+		AuthorizationEndpoint string `json:"authorization_endpoint"`
+		JWKSURI               string `json:"jwks_uri"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d/tenant-1/v2.0/.well-known/openid-configuration", port), &discovery)
+	if discovery.Issuer != fmt.Sprintf("http://localhost:%d/tenant-1/v2.0", port) || discovery.AuthorizationEndpoint == "" || discovery.JWKSURI == "" {
+		t.Fatalf("unexpected discovery: %#v", discovery)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartRejectsYAMLSeedConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.yaml")
@@ -340,7 +387,7 @@ func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
 				t.Fatal("start with unsupported seed service exited successfully")
 			}
 			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for apple, github, resend, and vercel") || !strings.Contains(errText, "aws") {
+			if !strings.Contains(errText, "only supports --seed for apple, github, microsoft, resend, and vercel") || !strings.Contains(errText, "aws") {
 				t.Fatalf("unexpected stderr: %s", errText)
 			}
 		})

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/apple"
 	"github.com/vercel-labs/emulate/internal/services/aws"
 	"github.com/vercel-labs/emulate/internal/services/github"
+	"github.com/vercel-labs/emulate/internal/services/microsoft"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
@@ -17,15 +18,16 @@ import (
 const HealthPath = "/_emulate/health"
 
 type ServerOptions struct {
-	Version    string
-	BaseURL    string
-	Services   []string
-	Store      *store.Store
-	AssetStore *coreassets.Store
-	AppleSeed  *apple.SeedConfig
-	GitHubSeed *github.SeedConfig
-	ResendSeed *resend.SeedConfig
-	VercelSeed *vercel.SeedConfig
+	Version       string
+	BaseURL       string
+	Services      []string
+	Store         *store.Store
+	AssetStore    *coreassets.Store
+	AppleSeed     *apple.SeedConfig
+	GitHubSeed    *github.SeedConfig
+	MicrosoftSeed *microsoft.SeedConfig
+	ResendSeed    *resend.SeedConfig
+	VercelSeed    *vercel.SeedConfig
 }
 
 type Server struct {
@@ -110,6 +112,13 @@ func NewServer(options ServerOptions) *Server {
 			Store:   runtimeStore,
 			BaseURL: options.BaseURL,
 			Seed:    options.AppleSeed,
+		})
+	}
+	if serviceEnabled(services, "microsoft") {
+		microsoft.Register(router, microsoft.Options{
+			Store:   runtimeStore,
+			BaseURL: options.BaseURL,
+			Seed:    options.MicrosoftSeed,
 		})
 	}
 	router.NotFound(func(c *corehttp.Context) {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -223,6 +223,32 @@ func TestNewHandlerDoesNotMountAppleWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMountsMicrosoftWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"microsoft"}, BaseURL: "http://localhost:4015"})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"http://localhost:4015/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"`) ||
+		!strings.Contains(res.Body.String(), `"jwks_uri":"http://localhost:4015/discovery/v2.0/keys"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountMicrosoftWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/discovery/v2.0/keys", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestNewHandlerMountsVercelWhenEnabled(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"vercel"}, BaseURL: "http://localhost:4010"})
 

--- a/internal/services/microsoft/helpers.go
+++ b/internal/services/microsoft/helpers.go
@@ -1,0 +1,185 @@
+package microsoft
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const defaultTenantID = "9188040d-6c67-4c5b-b112-36a304b66dad"
+
+func generateOID() string {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", raw[0:4], raw[4:6], raw[6:8], raw[8:10], raw[10:16])
+}
+
+func generateHex(size int) string {
+	raw := make([]byte, size)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(raw)
+}
+
+func generateToken(prefix string) string {
+	raw := make([]byte, 20)
+	if _, err := rand.Read(raw); err != nil {
+		panic(err)
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func intField(record corestore.Record, key string) int {
+	if record == nil {
+		return 0
+	}
+	switch value := record[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		number, _ := value.Int64()
+		return int(number)
+	default:
+		return 0
+	}
+}
+
+func stringField(record corestore.Record, key string) string {
+	if record == nil {
+		return ""
+	}
+	return stringValue(record[key])
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		out := make([]string, len(v))
+		copy(out, v)
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func matchesRedirectURI(candidate string, allowed []string) bool {
+	if candidate == "" {
+		return true
+	}
+	candidateURL, err := url.Parse(candidate)
+	if err != nil {
+		return false
+	}
+	for _, registered := range allowed {
+		registeredURL, err := url.Parse(registered)
+		if err != nil {
+			continue
+		}
+		if candidateURL.Scheme == registeredURL.Scheme &&
+			candidateURL.Host == registeredURL.Host &&
+			strings.TrimRight(candidateURL.Path, "/") == strings.TrimRight(registeredURL.Path, "/") {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyPKCEChallenge(challenge string, method string, verifier string) bool {
+	if challenge == "" {
+		return true
+	}
+	if verifier == "" {
+		return false
+	}
+	switch strings.ToLower(method) {
+	case "", "plain":
+		return subtle.ConstantTimeCompare([]byte(verifier), []byte(challenge)) == 1
+	case "s256":
+		digest := sha256.Sum256([]byte(verifier))
+		return base64.RawURLEncoding.EncodeToString(digest[:]) == challenge
+	default:
+		return false
+	}
+}
+
+func constantTimeSecretEqual(candidate string, expected string) bool {
+	if candidate == "" || expected == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(candidate), []byte(expected)) == 1
+}
+
+func bearerToken(req *http.Request) string {
+	header := strings.TrimSpace(req.Header.Get("Authorization"))
+	if header == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(header, prefix))
+}
+
+func splitScopes(scope string) []string {
+	fields := strings.Fields(scope)
+	if len(fields) == 0 {
+		return []string{}
+	}
+	return fields
+}
+
+func normalizeTenant(tenant string) string {
+	switch tenant {
+	case "", "common", "organizations", "consumers":
+		return defaultTenantID
+	default:
+		return tenant
+	}
+}

--- a/internal/services/microsoft/jwt.go
+++ b/internal/services/microsoft/jwt.go
@@ -1,0 +1,92 @@
+package microsoft
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const keyID = "emulate-microsoft-1"
+
+var signer = mustJWTSigner()
+
+type jwtSigner struct {
+	privateKey *rsa.PrivateKey
+}
+
+func mustJWTSigner() *jwtSigner {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	return &jwtSigner{privateKey: privateKey}
+}
+
+func (s *jwtSigner) jwks() map[string]any {
+	publicKey := s.privateKey.Public().(*rsa.PublicKey)
+	return map[string]any{
+		"keys": []map[string]any{
+			{
+				"kty": "RSA",
+				"use": "sig",
+				"kid": keyID,
+				"alg": "RS256",
+				"n":   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+			},
+		},
+	}
+}
+
+func createIDToken(user corestore.Record, clientID string, nonce string, baseURL string) (string, error) {
+	now := time.Now().Unix()
+	tenantID := stringField(user, "tenant_id")
+	if tenantID == "" {
+		tenantID = defaultTenantID
+	}
+	claims := map[string]any{
+		"iss":                baseURL + "/" + tenantID + "/v2.0",
+		"aud":                clientID,
+		"sub":                stringField(user, "oid"),
+		"email":              stringField(user, "email"),
+		"name":               stringField(user, "name"),
+		"given_name":         stringField(user, "given_name"),
+		"family_name":        stringField(user, "family_name"),
+		"preferred_username": stringField(user, "preferred_username"),
+		"oid":                stringField(user, "oid"),
+		"tid":                tenantID,
+		"ver":                "2.0",
+		"iat":                now,
+		"exp":                now + 3600,
+	}
+	if nonce != "" {
+		claims["nonce"] = nonce
+	}
+	return signer.sign(claims)
+}
+
+func (s *jwtSigner) sign(claims map[string]any) (string, error) {
+	header := map[string]any{"alg": "RS256", "kid": keyID, "typ": "JWT"}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, s.privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}

--- a/internal/services/microsoft/routes_oauth.go
+++ b/internal/services/microsoft/routes_oauth.go
@@ -1,0 +1,626 @@
+package microsoft
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+const pendingCodeTTL = 10 * time.Minute
+
+func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
+	router.Get("/.well-known/openid-configuration", s.handleOpenIDConfiguration)
+	router.Get("/:tenant/v2.0/.well-known/openid-configuration", s.handleTenantOpenIDConfiguration)
+	router.Get("/discovery/v2.0/keys", s.handleKeys)
+	router.Get("/oauth2/v2.0/authorize", s.handleAuthorize)
+	router.Post("/oauth2/v2.0/authorize/callback", s.handleAuthorizeCallback)
+	router.Post("/oauth2/v2.0/token", s.handleToken)
+	router.Post("/:tenant/oauth2/token", s.handleV1Token)
+	router.Get("/oidc/userinfo", s.handleUserinfo)
+	router.Get("/v1.0/me", s.handleGraphMe)
+	router.Get("/v1.0/users/:id", s.handleGraphUserByID)
+	router.Get("/oauth2/v2.0/logout", s.handleLogout)
+	router.Post("/oauth2/v2.0/revoke", s.handleRevoke)
+}
+
+func (s *Service) handleOpenIDConfiguration(c *corehttp.Context) {
+	c.JSON(http.StatusOK, s.openIDConfiguration(defaultTenantID))
+}
+
+func (s *Service) handleTenantOpenIDConfiguration(c *corehttp.Context) {
+	c.JSON(http.StatusOK, s.openIDConfiguration(normalizeTenant(c.Param("tenant"))))
+}
+
+func (s *Service) openIDConfiguration(tenantID string) map[string]any {
+	return map[string]any{
+		"issuer":                                s.baseURL + "/" + tenantID + "/v2.0",
+		"authorization_endpoint":                s.baseURL + "/oauth2/v2.0/authorize",
+		"token_endpoint":                        s.baseURL + "/oauth2/v2.0/token",
+		"userinfo_endpoint":                     s.baseURL + "/oidc/userinfo",
+		"end_session_endpoint":                  s.baseURL + "/oauth2/v2.0/logout",
+		"jwks_uri":                              s.baseURL + "/discovery/v2.0/keys",
+		"response_types_supported":              []string{"code"},
+		"response_modes_supported":              []string{"query", "fragment", "form_post"},
+		"subject_types_supported":               []string{"pairwise"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"scopes_supported":                      []string{"openid", "email", "profile", "offline_access", "User.Read", ".default"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token", "client_credentials"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_post", "client_secret_basic"},
+		"claims_supported": []string{
+			"aud",
+			"email",
+			"exp",
+			"family_name",
+			"given_name",
+			"iat",
+			"iss",
+			"name",
+			"nonce",
+			"oid",
+			"preferred_username",
+			"sub",
+			"tid",
+			"ver",
+		},
+		"code_challenge_methods_supported": []string{"plain", "S256"},
+	}
+}
+
+func (s *Service) handleKeys(c *corehttp.Context) {
+	c.JSON(http.StatusOK, signer.jwks())
+}
+
+func (s *Service) handleAuthorize(c *corehttp.Context) {
+	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
+	scope := c.Query("scope")
+	state := c.Query("state")
+	nonce := c.Query("nonce")
+	responseMode := c.Query("response_mode")
+	codeChallenge := c.Query("code_challenge")
+	codeChallengeMethod := c.Query("code_challenge_method")
+	if responseMode == "" {
+		responseMode = "query"
+	}
+
+	clientName := ""
+	if len(s.store.OAuthClients.All()) > 0 {
+		client := firstRecord(s.store.OAuthClients.FindBy("client_id", clientID))
+		if client == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		clientName = stringField(client, "name")
+	}
+
+	subtitle := "Choose a seeded user to continue."
+	if clientName != "" {
+		subtitle = "Sign in to <strong>" + ui.EscapeHTML(clientName) + "</strong> with your Microsoft account."
+	}
+
+	users := s.store.Users.All()
+	var body strings.Builder
+	if len(users) == 0 {
+		body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+	} else {
+		for _, user := range users {
+			email := stringField(user, "email")
+			letter := "?"
+			if email != "" {
+				letter = strings.ToUpper(email[:1])
+			}
+			body.WriteString(ui.RenderUserButton(ui.UserButtonOptions{
+				Letter:     letter,
+				Login:      email,
+				Name:       stringField(user, "name"),
+				Email:      email,
+				FormAction: "/oauth2/v2.0/authorize/callback",
+				HiddenFields: map[string]string{
+					"email":                 email,
+					"redirect_uri":          redirectURI,
+					"scope":                 scope,
+					"state":                 state,
+					"nonce":                 nonce,
+					"client_id":             clientID,
+					"response_mode":         responseMode,
+					"code_challenge":        codeChallenge,
+					"code_challenge_method": codeChallengeMethod,
+				},
+			}))
+		}
+	}
+	c.HTML(http.StatusOK, ui.RenderCardPage("Sign in with Microsoft", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+}
+
+func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
+	if err := c.Request.ParseForm(); err != nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid form body.")
+		return
+	}
+	email := c.Request.Form.Get("email")
+	redirectURI := c.Request.Form.Get("redirect_uri")
+	scope := c.Request.Form.Get("scope")
+	state := c.Request.Form.Get("state")
+	clientID := c.Request.Form.Get("client_id")
+	nonce := c.Request.Form.Get("nonce")
+	responseMode := c.Request.Form.Get("response_mode")
+	codeChallenge := c.Request.Form.Get("code_challenge")
+	codeChallengeMethod := c.Request.Form.Get("code_challenge_method")
+	if responseMode == "" {
+		responseMode = "query"
+	}
+
+	if firstRecord(s.store.Users.FindBy("email", email)) == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "User not found.")
+		return
+	}
+	if len(s.store.OAuthClients.All()) > 0 {
+		client := firstRecord(s.store.OAuthClients.FindBy("client_id", clientID))
+		if client == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+	}
+
+	code := generateHex(20)
+	s.store.OAuthCodes.Insert(corestore.Record{
+		"code":                  code,
+		"email":                 email,
+		"scope":                 scope,
+		"redirect_uri":          redirectURI,
+		"client_id":             clientID,
+		"nonce":                 nonce,
+		"code_challenge":        codeChallenge,
+		"code_challenge_method": codeChallengeMethod,
+		"created_at_ms":         time.Now().UnixMilli(),
+	})
+
+	if responseMode == "form_post" {
+		c.HTML(http.StatusOK, ui.RenderFormPostPage(redirectURI, map[string]string{"code": code, "state": state}, ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+
+	target, err := url.Parse(redirectURI)
+	if err != nil || target == nil || target.Scheme == "" {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid redirect_uri.")
+		return
+	}
+	if responseMode == "fragment" {
+		fragment, _ := url.ParseQuery(target.Fragment)
+		addAuthorizationResponseValues(fragment, code, state)
+		target.Fragment = fragment.Encode()
+		target.RawFragment = ""
+		c.Redirect(http.StatusFound, target.String())
+		return
+	}
+	query := target.Query()
+	addAuthorizationResponseValues(query, code, state)
+	target.RawQuery = query.Encode()
+	c.Redirect(http.StatusFound, target.String())
+}
+
+func (s *Service) handleToken(c *corehttp.Context) {
+	body, err := parseTokenBody(c.Request)
+	if err != nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid token request body.")
+		return
+	}
+	s.handleParsedToken(c, body)
+}
+
+func (s *Service) handleV1Token(c *corehttp.Context) {
+	body, err := parseTokenBody(c.Request)
+	if err != nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_request", "Invalid token request body.")
+		return
+	}
+	if body["scope"] == "" && body["resource"] != "" {
+		resource := strings.TrimRight(body["resource"], "/")
+		if resource != "" {
+			body["scope"] = resource + "/.default"
+		}
+	}
+	s.handleParsedToken(c, body)
+}
+
+func (s *Service) handleParsedToken(c *corehttp.Context, body map[string]string) {
+	clientID := body["client_id"]
+	clientSecret := body["client_secret"]
+	applyBasicCredentials(c.Request, &clientID, &clientSecret)
+
+	switch body["grant_type"] {
+	case "authorization_code":
+		s.handleAuthorizationCodeToken(c, body, clientID, clientSecret)
+	case "refresh_token":
+		s.handleRefreshToken(c, body, clientID, clientSecret)
+	case "client_credentials":
+		s.handleClientCredentialsToken(c, body, clientID, clientSecret)
+	default:
+		writeOAuthError(c, http.StatusBadRequest, "unsupported_grant_type", "Only authorization_code, refresh_token, and client_credentials are supported.")
+	}
+}
+
+func (s *Service) handleAuthorizationCodeToken(c *corehttp.Context, body map[string]string, clientID string, clientSecret string) {
+	if !s.validateClient(c, clientID, clientSecret) {
+		return
+	}
+	code := body["code"]
+	pending := firstRecord(s.store.OAuthCodes.FindBy("code", code))
+	if pending == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	if time.Since(pendingCodeCreatedAt(pending)) > pendingCodeTTL {
+		s.deleteOAuthCode(code)
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	if pendingClientID := stringField(pending, "client_id"); pendingClientID != "" && clientID != pendingClientID {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The code is incorrect or expired.")
+		return
+	}
+	if pendingRedirectURI := stringField(pending, "redirect_uri"); pendingRedirectURI != "" && body["redirect_uri"] != "" && body["redirect_uri"] != pendingRedirectURI {
+		s.deleteOAuthCode(code)
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The redirect_uri does not match the one used in the authorization request.")
+		return
+	}
+	if !verifyPKCEChallenge(stringField(pending, "code_challenge"), stringField(pending, "code_challenge_method"), body["code_verifier"]) {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "PKCE verification failed.")
+		return
+	}
+	s.deleteOAuthCode(code)
+
+	user := firstRecord(s.store.Users.FindBy("email", stringField(pending, "email")))
+	if user == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "User not found.")
+		return
+	}
+
+	accessToken := generateToken("microsoft_")
+	refreshToken := generateToken("r_microsoft_")
+	scope := stringField(pending, "scope")
+	if scope == "" {
+		scope = "openid email profile"
+	}
+	s.store.AccessTokens.Insert(corestore.Record{
+		"token":     accessToken,
+		"login":     stringField(user, "email"),
+		"client_id": stringField(pending, "client_id"),
+		"scopes":    splitScopes(scope),
+		"kind":      "user",
+	})
+	s.store.RefreshTokens.Insert(corestore.Record{
+		"token":     refreshToken,
+		"email":     stringField(user, "email"),
+		"client_id": stringField(pending, "client_id"),
+		"scope":     scope,
+		"nonce":     stringField(pending, "nonce"),
+	})
+
+	idToken, err := createIDToken(user, stringField(pending, "client_id"), stringField(pending, "nonce"), s.baseURL)
+	if err != nil {
+		writeOAuthError(c, http.StatusInternalServerError, "server_error", "Failed to sign id_token.")
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"access_token":  accessToken,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"scope":         scope,
+		"refresh_token": refreshToken,
+		"id_token":      idToken,
+	})
+}
+
+func (s *Service) handleRefreshToken(c *corehttp.Context, body map[string]string, clientID string, clientSecret string) {
+	if !s.validateClient(c, clientID, clientSecret) {
+		return
+	}
+	refreshToken := body["refresh_token"]
+	stored := firstRecord(s.store.RefreshTokens.FindBy("token", refreshToken))
+	if stored == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The refresh_token is invalid.")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("email", stringField(stored, "email")))
+	if user == nil {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "User not found.")
+		return
+	}
+	s.deleteRefreshToken(refreshToken)
+
+	accessToken := generateToken("microsoft_")
+	newRefreshToken := generateToken("r_microsoft_")
+	scope := stringField(stored, "scope")
+	if scope == "" {
+		scope = "openid email profile"
+	}
+	storedClientID := stringField(stored, "client_id")
+	if storedClientID == "" {
+		storedClientID = clientID
+	}
+	s.store.AccessTokens.Insert(corestore.Record{
+		"token":     accessToken,
+		"login":     stringField(user, "email"),
+		"client_id": storedClientID,
+		"scopes":    splitScopes(scope),
+		"kind":      "user",
+	})
+	s.store.RefreshTokens.Insert(corestore.Record{
+		"token":     newRefreshToken,
+		"email":     stringField(user, "email"),
+		"client_id": storedClientID,
+		"scope":     scope,
+		"nonce":     stringField(stored, "nonce"),
+	})
+
+	idToken, err := createIDToken(user, storedClientID, stringField(stored, "nonce"), s.baseURL)
+	if err != nil {
+		writeOAuthError(c, http.StatusInternalServerError, "server_error", "Failed to sign id_token.")
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"access_token":  accessToken,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"scope":         scope,
+		"refresh_token": newRefreshToken,
+		"id_token":      idToken,
+	})
+}
+
+func (s *Service) handleClientCredentialsToken(c *corehttp.Context, body map[string]string, clientID string, clientSecret string) {
+	if !s.validateClient(c, clientID, clientSecret) {
+		return
+	}
+	scope := body["scope"]
+	if scope == "" {
+		scope = ".default"
+	}
+	accessToken := generateToken("microsoft_")
+	s.store.AccessTokens.Insert(corestore.Record{
+		"token":     accessToken,
+		"login":     clientID,
+		"client_id": clientID,
+		"scopes":    splitScopes(scope),
+		"kind":      "client",
+	})
+	c.JSON(http.StatusOK, map[string]any{
+		"access_token": accessToken,
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"scope":        scope,
+	})
+}
+
+func (s *Service) validateClient(c *corehttp.Context, clientID string, clientSecret string) bool {
+	if len(s.store.OAuthClients.All()) == 0 {
+		return true
+	}
+	client := firstRecord(s.store.OAuthClients.FindBy("client_id", clientID))
+	if client == nil {
+		writeOAuthError(c, http.StatusUnauthorized, "invalid_client", "The client_id is incorrect.")
+		return false
+	}
+	if !constantTimeSecretEqual(clientSecret, stringField(client, "client_secret")) {
+		writeOAuthError(c, http.StatusUnauthorized, "invalid_client", "The client_secret is incorrect.")
+		return false
+	}
+	return true
+}
+
+func (s *Service) handleUserinfo(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		writeOAuthError(c, http.StatusUnauthorized, "invalid_token", "Authentication required.")
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"sub":                stringField(user, "oid"),
+		"email":              stringField(user, "email"),
+		"name":               stringField(user, "name"),
+		"given_name":         stringField(user, "given_name"),
+		"family_name":        stringField(user, "family_name"),
+		"preferred_username": stringField(user, "preferred_username"),
+	})
+}
+
+func (s *Service) handleGraphMe(c *corehttp.Context) {
+	user, ok := s.currentUser(c)
+	if !ok {
+		writeGraphError(c, http.StatusUnauthorized, "InvalidAuthenticationToken", "Authentication required.")
+		return
+	}
+	c.JSON(http.StatusOK, s.graphUser(user))
+}
+
+func (s *Service) handleGraphUserByID(c *corehttp.Context) {
+	user := firstRecord(s.store.Users.FindBy("oid", c.Param("id")))
+	if user == nil {
+		writeGraphError(c, http.StatusNotFound, "Request_ResourceNotFound", "Resource '"+c.Param("id")+"' does not exist or one of its queried reference-property objects are not present.")
+		return
+	}
+	c.JSON(http.StatusOK, s.graphUser(user))
+}
+
+func (s *Service) graphUser(user corestore.Record) map[string]any {
+	return map[string]any{
+		"@odata.context":    s.baseURL + "/v1.0/$metadata#users/$entity",
+		"id":                stringField(user, "oid"),
+		"displayName":       stringField(user, "name"),
+		"givenName":         stringField(user, "given_name"),
+		"surname":           stringField(user, "family_name"),
+		"mail":              stringField(user, "email"),
+		"userPrincipalName": stringField(user, "preferred_username"),
+	}
+}
+
+func (s *Service) currentUser(c *corehttp.Context) (corestore.Record, bool) {
+	token := bearerToken(c.Request)
+	if token == "" {
+		return nil, false
+	}
+	row := firstRecord(s.store.AccessTokens.FindBy("token", token))
+	if row == nil || stringField(row, "kind") != "user" {
+		return nil, false
+	}
+	user := firstRecord(s.store.Users.FindBy("email", stringField(row, "login")))
+	return user, user != nil
+}
+
+func (s *Service) handleLogout(c *corehttp.Context) {
+	redirectURI := c.Query("post_logout_redirect_uri")
+	if redirectURI == "" {
+		c.Text(http.StatusOK, "Logged out")
+		return
+	}
+	if len(s.store.OAuthClients.All()) > 0 {
+		allowed := false
+		for _, client := range s.store.OAuthClients.All() {
+			if matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			c.Text(http.StatusBadRequest, "Invalid post_logout_redirect_uri")
+			return
+		}
+	}
+	c.Redirect(http.StatusFound, redirectURI)
+}
+
+func (s *Service) handleRevoke(c *corehttp.Context) {
+	body, err := parseTokenBody(c.Request)
+	if err == nil {
+		token := body["token"]
+		s.deleteAccessToken(token)
+		s.deleteRefreshToken(token)
+	}
+	c.Writer.WriteHeader(http.StatusOK)
+}
+
+func parseTokenBody(req *http.Request) (map[string]string, error) {
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	if strings.Contains(req.Header.Get("Content-Type"), "application/json") {
+		var parsed map[string]any
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			return out, nil
+		}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return out, nil
+		}
+		for key, value := range parsed {
+			if s, ok := value.(string); ok {
+				out[key] = s
+			}
+		}
+		return out, nil
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return nil, err
+	}
+	for key := range values {
+		out[key] = values.Get(key)
+	}
+	return out, nil
+}
+
+func applyBasicCredentials(req *http.Request, clientID *string, clientSecret *string) {
+	header := strings.TrimSpace(req.Header.Get("Authorization"))
+	if !strings.HasPrefix(header, "Basic ") {
+		return
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(strings.TrimPrefix(header, "Basic ")))
+	if err != nil {
+		return
+	}
+	id, secret, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		return
+	}
+	if *clientID == "" {
+		if unescaped, err := url.QueryUnescape(id); err == nil {
+			*clientID = unescaped
+		} else {
+			*clientID = id
+		}
+	}
+	if *clientSecret == "" {
+		if unescaped, err := url.QueryUnescape(secret); err == nil {
+			*clientSecret = unescaped
+		} else {
+			*clientSecret = secret
+		}
+	}
+}
+
+func (s *Service) deleteOAuthCode(code string) {
+	for _, row := range s.store.OAuthCodes.FindBy("code", code) {
+		s.store.OAuthCodes.Delete(intField(row, "id"))
+	}
+}
+
+func (s *Service) deleteRefreshToken(token string) {
+	for _, row := range s.store.RefreshTokens.FindBy("token", token) {
+		s.store.RefreshTokens.Delete(intField(row, "id"))
+	}
+}
+
+func (s *Service) deleteAccessToken(token string) {
+	for _, row := range s.store.AccessTokens.FindBy("token", token) {
+		s.store.AccessTokens.Delete(intField(row, "id"))
+	}
+}
+
+func pendingCodeCreatedAt(row corestore.Record) time.Time {
+	millis := intField(row, "created_at_ms")
+	if millis == 0 {
+		return time.Now()
+	}
+	return time.UnixMilli(int64(millis))
+}
+
+func addAuthorizationResponseValues(values url.Values, code string, state string) {
+	values.Set("code", code)
+	if state != "" {
+		values.Set("state", state)
+	}
+}
+
+func writeOAuthError(c *corehttp.Context, status int, code string, description string) {
+	c.JSON(status, map[string]any{
+		"error":             code,
+		"error_description": description,
+	})
+}
+
+func writeGraphError(c *corehttp.Context, status int, code string, message string) {
+	c.JSON(status, map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	})
+}

--- a/internal/services/microsoft/routes_oauth.go
+++ b/internal/services/microsoft/routes_oauth.go
@@ -338,6 +338,11 @@ func (s *Service) handleRefreshToken(c *corehttp.Context, body map[string]string
 		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The refresh_token is invalid.")
 		return
 	}
+	storedClientID := stringField(stored, "client_id")
+	if storedClientID != "" && clientID != storedClientID {
+		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "The refresh_token is invalid.")
+		return
+	}
 	user := firstRecord(s.store.Users.FindBy("email", stringField(stored, "email")))
 	if user == nil {
 		writeOAuthError(c, http.StatusBadRequest, "invalid_grant", "User not found.")
@@ -351,7 +356,6 @@ func (s *Service) handleRefreshToken(c *corehttp.Context, body map[string]string
 	if scope == "" {
 		scope = "openid email profile"
 	}
-	storedClientID := stringField(stored, "client_id")
 	if storedClientID == "" {
 		storedClientID = clientID
 	}

--- a/internal/services/microsoft/service.go
+++ b/internal/services/microsoft/service.go
@@ -1,0 +1,146 @@
+package microsoft
+
+import (
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const serviceLabel = "Microsoft"
+
+type Options struct {
+	Store   *corestore.Store
+	BaseURL string
+	Seed    *SeedConfig
+}
+
+type SeedConfig struct {
+	Port         int               `json:"port,omitempty"`
+	Users        []UserSeed        `json:"users"`
+	OAuthClients []OAuthClientSeed `json:"oauth_clients"`
+}
+
+type UserSeed struct {
+	Email      string `json:"email"`
+	Name       string `json:"name"`
+	GivenName  string `json:"given_name"`
+	FamilyName string `json:"family_name"`
+	TenantID   string `json:"tenant_id"`
+}
+
+type OAuthClientSeed struct {
+	ClientID     string   `json:"client_id"`
+	ClientSecret string   `json:"client_secret"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris"`
+	TenantID     string   `json:"tenant_id"`
+}
+
+type Service struct {
+	store   Store
+	baseURL string
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	baseURL := strings.TrimRight(options.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:4000"
+	}
+	service := &Service{
+		store:   NewStore(runtimeStore),
+		baseURL: baseURL,
+	}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, baseURL string, config SeedConfig) {
+	New(Options{Store: runtimeStore, BaseURL: baseURL, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerOAuthRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if firstRecord(s.store.Users.FindBy("email", "testuser@outlook.com")) != nil {
+		return
+	}
+	s.store.Users.Insert(corestore.Record{
+		"oid":                generateOID(),
+		"email":              "testuser@outlook.com",
+		"name":               "Test User",
+		"given_name":         "Test",
+		"family_name":        "User",
+		"email_verified":     true,
+		"tenant_id":          defaultTenantID,
+		"preferred_username": "testuser@outlook.com",
+	})
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	for _, seed := range config.Users {
+		email := strings.TrimSpace(seed.Email)
+		if email == "" || firstRecord(s.store.Users.FindBy("email", email)) != nil {
+			continue
+		}
+		name := seed.Name
+		if name == "" {
+			name = strings.Split(email, "@")[0]
+		}
+		nameParts := strings.Fields(name)
+		givenName := seed.GivenName
+		if givenName == "" && len(nameParts) > 0 {
+			givenName = nameParts[0]
+		}
+		familyName := seed.FamilyName
+		if familyName == "" && len(nameParts) > 1 {
+			familyName = strings.Join(nameParts[1:], " ")
+		}
+		tenantID := seed.TenantID
+		if tenantID == "" {
+			tenantID = defaultTenantID
+		}
+		s.store.Users.Insert(corestore.Record{
+			"oid":                generateOID(),
+			"email":              email,
+			"name":               name,
+			"given_name":         givenName,
+			"family_name":        familyName,
+			"email_verified":     true,
+			"tenant_id":          tenantID,
+			"preferred_username": email,
+		})
+	}
+
+	for _, seed := range config.OAuthClients {
+		clientID := strings.TrimSpace(seed.ClientID)
+		if clientID == "" || firstRecord(s.store.OAuthClients.FindBy("client_id", clientID)) != nil {
+			continue
+		}
+		tenantID := seed.TenantID
+		if tenantID == "" {
+			tenantID = defaultTenantID
+		}
+		s.store.OAuthClients.Insert(corestore.Record{
+			"client_id":     clientID,
+			"client_secret": seed.ClientSecret,
+			"name":          seed.Name,
+			"redirect_uris": seed.RedirectURIs,
+			"tenant_id":     tenantID,
+		})
+	}
+}

--- a/internal/services/microsoft/service_test.go
+++ b/internal/services/microsoft/service_test.go
@@ -1,0 +1,431 @@
+package microsoft
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const testBaseURL = "http://localhost:4015"
+
+func newTestHandler(seed *SeedConfig) http.Handler {
+	router := corehttp.NewRouter()
+	Register(router, Options{
+		Store:   corestore.New(),
+		BaseURL: testBaseURL,
+		Seed:    seed,
+	})
+	return router
+}
+
+func microsoftSeed() *SeedConfig {
+	return &SeedConfig{
+		Users: []UserSeed{
+			{Email: "testuser@example.com", Name: "Test User", GivenName: "Test", FamilyName: "User", TenantID: "tenant-1"},
+		},
+		OAuthClients: []OAuthClientSeed{
+			{
+				ClientID:     "test-client",
+				ClientSecret: "test-secret",
+				Name:         "Test App",
+				RedirectURIs: []string{"http://localhost:3000/callback"},
+				TenantID:     "tenant-1",
+			},
+		},
+	}
+}
+
+func TestMicrosoftOpenIDConfigurationAndKeys(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+
+	res := doRequest(handler, http.MethodGet, "/.well-known/openid-configuration", "", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var discovery map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &discovery); err != nil {
+		t.Fatal(err)
+	}
+	if discovery["issuer"] != testBaseURL+"/"+defaultTenantID+"/v2.0" {
+		t.Fatalf("issuer = %#v", discovery["issuer"])
+	}
+	if discovery["authorization_endpoint"] != testBaseURL+"/oauth2/v2.0/authorize" || discovery["jwks_uri"] != testBaseURL+"/discovery/v2.0/keys" {
+		t.Fatalf("unexpected discovery: %#v", discovery)
+	}
+
+	res = doRequest(handler, http.MethodGet, "/tenant-1/v2.0/.well-known/openid-configuration", "", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("tenant status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &discovery); err != nil {
+		t.Fatal(err)
+	}
+	if discovery["issuer"] != testBaseURL+"/tenant-1/v2.0" {
+		t.Fatalf("tenant issuer = %#v", discovery["issuer"])
+	}
+
+	res = doRequest(handler, http.MethodGet, "/discovery/v2.0/keys", "", "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("keys status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var keys struct {
+		Keys []map[string]string `json:"keys"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &keys); err != nil {
+		t.Fatal(err)
+	}
+	if len(keys.Keys) != 1 || keys.Keys[0]["kid"] != keyID || keys.Keys[0]["kty"] != "RSA" {
+		t.Fatalf("unexpected keys: %#v", keys)
+	}
+}
+
+func TestMicrosoftAuthorizationCodeFlow(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+	code := getAuthCode(t, handler, map[string]string{})
+
+	body := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+	}
+	res := doFormRequest(handler, "/oauth2/v2.0/token", body, "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var tokenBody struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &tokenBody); err != nil {
+		t.Fatal(err)
+	}
+	if tokenBody.AccessToken == "" || tokenBody.RefreshToken == "" || tokenBody.IDToken == "" || tokenBody.TokenType != "Bearer" {
+		t.Fatalf("unexpected token body: %#v", tokenBody)
+	}
+	if tokenBody.Scope != "openid email profile" {
+		t.Fatalf("scope = %q", tokenBody.Scope)
+	}
+
+	claims := decodeJWTClaims(t, tokenBody.IDToken)
+	if claims["email"] != "testuser@example.com" || claims["tid"] != "tenant-1" || claims["aud"] != "test-client" {
+		t.Fatalf("unexpected claims: %#v", claims)
+	}
+
+	userinfo := doRequest(handler, http.MethodGet, "/oidc/userinfo", "", "Bearer "+tokenBody.AccessToken)
+	if userinfo.Code != http.StatusOK || !strings.Contains(userinfo.Body.String(), `"preferred_username":"testuser@example.com"`) {
+		t.Fatalf("userinfo status = %d, body = %s", userinfo.Code, userinfo.Body.String())
+	}
+
+	me := doRequest(handler, http.MethodGet, "/v1.0/me", "", "Bearer "+tokenBody.AccessToken)
+	if me.Code != http.StatusOK || !strings.Contains(me.Body.String(), `"displayName":"Test User"`) {
+		t.Fatalf("me status = %d, body = %s", me.Code, me.Body.String())
+	}
+}
+
+func TestMicrosoftAuthorizationCodeIsSingleUseAndValidatesRedirect(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+	code := getAuthCode(t, handler, map[string]string{})
+
+	wrongRedirect := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+		"redirect_uri":  {"http://localhost:3000/wrong"},
+	}
+	res := doFormRequest(handler, "/oauth2/v2.0/token", wrongRedirect, "")
+	if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "redirect_uri") {
+		t.Fatalf("wrong redirect status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	reuse := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+	}
+	res = doFormRequest(handler, "/oauth2/v2.0/token", reuse, "")
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("reused status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestMicrosoftPKCES256AndFragmentResponseMode(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+	verifier := "correct horse battery staple"
+	challengeBytes := sha256Sum(verifier)
+	challenge := base64.RawURLEncoding.EncodeToString(challengeBytes)
+	code := getAuthCode(t, handler, map[string]string{
+		"response_mode":         "fragment",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+	})
+
+	wrongVerifier := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"code_verifier": {"wrong"},
+	}
+	res := doFormRequest(handler, "/oauth2/v2.0/token", wrongVerifier, "")
+	if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "PKCE") {
+		t.Fatalf("wrong verifier status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	correctVerifier := wrongVerifier
+	correctVerifier.Set("code_verifier", verifier)
+	res = doFormRequest(handler, "/oauth2/v2.0/token", correctVerifier, "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("correct verifier status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestMicrosoftRefreshTokenRotates(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+	code := getAuthCode(t, handler, map[string]string{})
+	token := exchangeCode(t, handler, code)
+
+	refresh := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {token.RefreshToken},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+	}
+	res := doFormRequest(handler, "/oauth2/v2.0/token", refresh, "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("refresh status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var refreshed struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &refreshed); err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.AccessToken == "" || refreshed.RefreshToken == "" || refreshed.RefreshToken == token.RefreshToken {
+		t.Fatalf("unexpected refreshed token: %#v", refreshed)
+	}
+
+	res = doFormRequest(handler, "/oauth2/v2.0/token", refresh, "")
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("old refresh status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestMicrosoftFormPostLogoutAndRevoke(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+	code := getAuthCode(t, handler, map[string]string{"response_mode": "form_post"})
+	token := exchangeCode(t, handler, code)
+
+	logout := doRequest(handler, http.MethodGet, "/oauth2/v2.0/logout?post_logout_redirect_uri="+url.QueryEscape("http://localhost:3000/callback"), "", "")
+	if logout.Code != http.StatusFound || logout.Header().Get("Location") != "http://localhost:3000/callback" {
+		t.Fatalf("logout status = %d, location = %s, body = %s", logout.Code, logout.Header().Get("Location"), logout.Body.String())
+	}
+
+	revoke := doFormRequest(handler, "/oauth2/v2.0/revoke", url.Values{"token": {token.AccessToken}}, "")
+	if revoke.Code != http.StatusOK {
+		t.Fatalf("revoke status = %d, body = %s", revoke.Code, revoke.Body.String())
+	}
+	userinfo := doRequest(handler, http.MethodGet, "/oidc/userinfo", "", "Bearer "+token.AccessToken)
+	if userinfo.Code != http.StatusUnauthorized {
+		t.Fatalf("userinfo after revoke status = %d, body = %s", userinfo.Code, userinfo.Body.String())
+	}
+}
+
+func TestMicrosoftClientCredentialsAndV1Resource(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("test-client:test-secret"))
+	res := doFormRequest(handler, "/tenant-1/oauth2/token", url.Values{
+		"grant_type": {"client_credentials"},
+		"resource":   {"https://graph.microsoft.com"},
+	}, basic)
+	if res.Code != http.StatusOK {
+		t.Fatalf("client credentials status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body struct {
+		AccessToken string `json:"access_token"`
+		Scope       string `json:"scope"`
+		IDToken     string `json:"id_token"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.AccessToken == "" || body.Scope != "https://graph.microsoft.com/.default" || body.IDToken != "" {
+		t.Fatalf("unexpected client credentials body: %#v", body)
+	}
+}
+
+func TestMicrosoftRejectsWrongClientSecret(t *testing.T) {
+	handler := newTestHandler(microsoftSeed())
+	code := getAuthCode(t, handler, map[string]string{})
+	res := doFormRequest(handler, "/oauth2/v2.0/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"test-client"},
+		"client_secret": {"wrong"},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+	}, "")
+	if res.Code != http.StatusUnauthorized || !strings.Contains(res.Body.String(), "invalid_client") {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestMicrosoftGraphUserByIDAndSeedConfig(t *testing.T) {
+	store := corestore.New()
+	SeedFromConfig(store, testBaseURL, *microsoftSeed())
+	service := New(Options{Store: store, BaseURL: testBaseURL})
+	user := firstRecord(service.store.Users.FindBy("email", "testuser@example.com"))
+	if user == nil {
+		t.Fatal("missing seeded user")
+	}
+
+	router := corehttp.NewRouter()
+	service.RegisterRoutes(router)
+	res := doRequest(router, http.MethodGet, "/v1.0/users/"+stringField(user, "oid"), "", "")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), `"userPrincipalName":"testuser@example.com"`) {
+		t.Fatalf("user status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+}
+
+func getAuthCode(t *testing.T, handler http.Handler, overrides map[string]string) string {
+	t.Helper()
+	values := url.Values{
+		"email":                 {"testuser@example.com"},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"scope":                 {"openid email profile"},
+		"state":                 {"test-state"},
+		"nonce":                 {"test-nonce"},
+		"client_id":             {"test-client"},
+		"response_mode":         {"query"},
+		"code_challenge":        {""},
+		"code_challenge_method": {""},
+	}
+	for key, value := range overrides {
+		values.Set(key, value)
+	}
+	res := doFormRequest(handler, "/oauth2/v2.0/authorize/callback", values, "")
+	if res.Code != http.StatusFound && res.Code != http.StatusOK {
+		t.Fatalf("callback status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if values.Get("response_mode") == "form_post" {
+		code := matchHTMLInput(res.Body.String(), "code")
+		if code == "" {
+			t.Fatalf("missing form_post code in %s", res.Body.String())
+		}
+		return code
+	}
+	location := res.Header().Get("Location")
+	if location == "" {
+		t.Fatalf("missing redirect location: %s", res.Body.String())
+	}
+	parsed, err := url.Parse(location)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values.Get("response_mode") == "fragment" {
+		fragment, err := url.ParseQuery(parsed.Fragment)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fragment.Get("code")
+	}
+	return parsed.Query().Get("code")
+}
+
+func exchangeCode(t *testing.T, handler http.Handler, code string) tokenResponse {
+	t.Helper()
+	res := doFormRequest(handler, "/oauth2/v2.0/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+	}, "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", res.Code, res.Body.String())
+	}
+	var body tokenResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func doRequest(handler http.Handler, method string, target string, body string, authorization string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
+}
+
+func doFormRequest(handler http.Handler, target string, values url.Values, authorization string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(values.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
+}
+
+func decodeJWTClaims(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("invalid token: %s", token)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		t.Fatal(err)
+	}
+	return claims
+}
+
+func matchHTMLInput(html string, name string) string {
+	marker := `name="` + name + `" value="`
+	start := strings.Index(html, marker)
+	if start < 0 {
+		return ""
+	}
+	start += len(marker)
+	end := strings.Index(html[start:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return html[start : start+end]
+}
+
+func sha256Sum(value string) []byte {
+	sum := sha256.Sum256([]byte(value))
+	return sum[:]
+}

--- a/internal/services/microsoft/service_test.go
+++ b/internal/services/microsoft/service_test.go
@@ -228,6 +228,42 @@ func TestMicrosoftRefreshTokenRotates(t *testing.T) {
 	}
 }
 
+func TestMicrosoftRefreshTokenRejectsMismatchedClient(t *testing.T) {
+	seed := microsoftSeed()
+	seed.OAuthClients = append(seed.OAuthClients, OAuthClientSeed{
+		ClientID:     "other-client",
+		ClientSecret: "other-secret",
+		Name:         "Other App",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+		TenantID:     "tenant-1",
+	})
+	handler := newTestHandler(seed)
+	code := getAuthCode(t, handler, map[string]string{})
+	token := exchangeCode(t, handler, code)
+
+	wrongClient := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {token.RefreshToken},
+		"client_id":     {"other-client"},
+		"client_secret": {"other-secret"},
+	}
+	res := doFormRequest(handler, "/oauth2/v2.0/token", wrongClient, "")
+	if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "invalid_grant") {
+		t.Fatalf("wrong client refresh status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	originalClient := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {token.RefreshToken},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+	}
+	res = doFormRequest(handler, "/oauth2/v2.0/token", originalClient, "")
+	if res.Code != http.StatusOK {
+		t.Fatalf("original client refresh status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestMicrosoftFormPostLogoutAndRevoke(t *testing.T) {
 	handler := newTestHandler(microsoftSeed())
 	code := getAuthCode(t, handler, map[string]string{"response_mode": "form_post"})

--- a/internal/services/microsoft/store.go
+++ b/internal/services/microsoft/store.go
@@ -1,0 +1,21 @@
+package microsoft
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Users         *corestore.Collection
+	OAuthClients  *corestore.Collection
+	OAuthCodes    *corestore.Collection
+	RefreshTokens *corestore.Collection
+	AccessTokens  *corestore.Collection
+}
+
+func NewStore(runtimeStore *corestore.Store) Store {
+	return Store{
+		Users:         runtimeStore.MustCollection("microsoft.users", "oid", "email"),
+		OAuthClients:  runtimeStore.MustCollection("microsoft.oauth_clients", "client_id"),
+		OAuthCodes:    runtimeStore.MustCollection("microsoft.oauth_codes", "code", "client_id", "email"),
+		RefreshTokens: runtimeStore.MustCollection("microsoft.refresh_tokens", "token", "client_id", "email"),
+		AccessTokens:  runtimeStore.MustCollection("microsoft.access_tokens", "token", "login"),
+	}
+}

--- a/packages/@emulators/microsoft/README.md
+++ b/packages/@emulators/microsoft/README.md
@@ -4,6 +4,8 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
+The native Go runtime implements the Microsoft OIDC, token, and Graph profile routes below for local CLI runs and Vercel Go Function previews. To expose Microsoft on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service microsoft`.
+
 ## Install
 
 ```bash
@@ -17,6 +19,7 @@ npm install @emulators/microsoft
 - `GET /discovery/v2.0/keys` — JSON Web Key Set (JWKS)
 - `GET /oauth2/v2.0/authorize` — authorization endpoint (shows user picker)
 - `POST /oauth2/v2.0/token` — token exchange (authorization code, refresh token, client credentials)
+- `POST /:tenant/oauth2/token` — v1 token endpoint with `resource` to `.default` scope translation
 - `GET /oidc/userinfo` — OpenID Connect user info
 - `GET /v1.0/me` — Microsoft Graph user profile
 - `GET /v1.0/users/:id` — Microsoft Graph user by ID

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,7 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
-      'Services: []string{"apple", "aws", "github", "resend", "vercel"}',
+      'Services: []string{"apple", "aws", "github", "microsoft", "resend", "vercel"}',
     );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
@@ -225,7 +225,7 @@ require (
     const cwd = tempDir();
 
     expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "google" })).toThrow(
-      "currently supports native services: apple, aws, github, resend, vercel",
+      "currently supports native services: apple, aws, github, microsoft, resend, vercel",
     );
   });
 

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-const SUPPORTED_VERCEL_SERVICES = ["apple", "aws", "github", "resend", "vercel"] as const;
+const SUPPORTED_VERCEL_SERVICES = ["apple", "aws", "github", "microsoft", "resend", "vercel"] as const;
 const REQUIRED_GO_VERSION = "1.24";
 const DEFAULT_REWRITE = {
   source: "/emulate/:path*",

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -60,7 +60,7 @@ const vercel = program.command("vercel").description("Vercel preview helpers");
 vercel
   .command("init")
   .description("Scaffold a Vercel Go Function preview route")
-  .option("-s, --service <services>", "Comma-separated native services to enable", "apple,aws,github,resend,vercel")
+  .option("-s, --service <services>", "Comma-separated native services to enable", "apple,aws,github,microsoft,resend,vercel")
   .option("--force", "Overwrite generated files")
   .action((opts) => {
     vercelInitCommand({

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -60,7 +60,11 @@ const vercel = program.command("vercel").description("Vercel preview helpers");
 vercel
   .command("init")
   .description("Scaffold a Vercel Go Function preview route")
-  .option("-s, --service <services>", "Comma-separated native services to enable", "apple,aws,github,microsoft,resend,vercel")
+  .option(
+    "-s, --service <services>",
+    "Comma-separated native services to enable",
+    "apple,aws,github,microsoft,resend,vercel",
+  )
   .option("--force", "Overwrite generated files")
   .action((opts) => {
     vercelInitCommand({

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -317,7 +317,7 @@ Then use these in your app to construct API and OAuth URLs. See each service's s
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `microsoft`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/microsoft/SKILL.md
+++ b/skills/microsoft/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with authorization code flow, PKCE, client credentials, RS256 ID tokens, OIDC discovery, and a Microsoft Graph `/v1.0/me` endpoint.
 
+The native Go runtime implements this Microsoft OIDC, token, and Graph profile surface for local CLI runs and Vercel Go Function previews. To expose Microsoft on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service microsoft`; the generated route serves Microsoft at `/emulate/microsoft/*`.
+
 ## Start
 
 ```bash
@@ -43,6 +45,7 @@ MICROSOFT_EMULATOR_URL=http://localhost:4005
 | `https://login.microsoftonline.com/.well-known/openid-configuration` | `$MICROSOFT_EMULATOR_URL/.well-known/openid-configuration` |
 | `https://login.microsoftonline.com/common/oauth2/v2.0/authorize` | `$MICROSOFT_EMULATOR_URL/oauth2/v2.0/authorize` |
 | `https://login.microsoftonline.com/common/oauth2/v2.0/token` | `$MICROSOFT_EMULATOR_URL/oauth2/v2.0/token` |
+| `https://login.microsoftonline.com/{tenant}/oauth2/token` | `$MICROSOFT_EMULATOR_URL/{tenant}/oauth2/token` |
 | `https://login.microsoftonline.com/common/discovery/v2.0/keys` | `$MICROSOFT_EMULATOR_URL/discovery/v2.0/keys` |
 | `https://graph.microsoft.com/oidc/userinfo` | `$MICROSOFT_EMULATOR_URL/oidc/userinfo` |
 | `https://graph.microsoft.com/v1.0/me` | `$MICROSOFT_EMULATOR_URL/v1.0/me` |
@@ -185,7 +188,7 @@ Query parameters:
 | `scope` | Space-separated scopes (`openid email profile User.Read`) |
 | `state` | Opaque state for CSRF protection |
 | `nonce` | Nonce for ID token (optional) |
-| `response_mode` | `query` (default) or `form_post` |
+| `response_mode` | `query` (default), `fragment`, or `form_post` |
 | `code_challenge` | PKCE challenge (optional) |
 | `code_challenge_method` | `plain` or `S256` (optional) |
 
@@ -219,6 +222,8 @@ The `id_token` is an RS256 JWT containing `sub`, `oid`, `tid` (tenant ID), `emai
 For PKCE, include `code_verifier` in the token request.
 
 Supports `Authorization: Basic` header with base64-encoded `client_id:client_secret` as an alternative to body parameters.
+
+The v1 token endpoint at `/{tenant}/oauth2/token` accepts a `resource` parameter and translates it to a `.default` scope for local service-to-service flows.
 
 ### Client Credentials
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `microsoft`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `microsoft`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"apple", "aws", "github", "resend", "vercel"}
+var defaultServices = []string{"apple", "aws", "github", "microsoft", "resend", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -35,7 +35,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "apple,aws,github,resend,vercel" {
+	if strings.Join(body.Services, ",") != "apple,aws,github,microsoft,resend,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -136,6 +136,23 @@ func TestHandlerForwardsAppleService(t *testing.T) {
 	}
 	if !strings.Contains(res.Body.String(), `"issuer":"https://preview.example.com/emulate/apple"`) ||
 		!strings.Contains(res.Body.String(), `"jwks_uri":"https://preview.example.com/emulate/apple/auth/keys"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestHandlerForwardsMicrosoftService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"microsoft"}})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/microsoft/.well-known/openid-configuration", nil)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"https://preview.example.com/emulate/microsoft/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"`) ||
+		!strings.Contains(res.Body.String(), `"jwks_uri":"https://preview.example.com/emulate/microsoft/discovery/v2.0/keys"`) {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }


### PR DESCRIPTION
- Adds a native Microsoft OAuth/OIDC service with JWKS, RS256 ID tokens, token grants, Graph profile routes, logout, revoke, and JSON seed support.

- Wires Microsoft into the Go runtime, CLI seed loading, Vercel preview handler, scaffold defaults, docs, and agent skills.

- Covers authorization code, PKCE, refresh rotation, client credentials, v1 resource translation, runtime, CLI, and Vercel forwarding behavior in tests.