### PR TITLE
Add Go Slack foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,8 @@ When more than one of Apple, Google, and Microsoft is enabled on one native Go s
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks.
 
+The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. To expose Slack on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service slack`. The generated route serves Slack at `/emulate/slack/*`.
+
 ### Auth & Chat
 - `POST /api/auth.test` - test authentication
 - `POST /api/chat.postMessage` - post message (supports threads via `thread_ts`)
@@ -769,7 +771,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -810,7 +812,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ When more than one of Apple, Google, and Microsoft is enabled on one native Go s
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks.
 
-The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. To expose Slack on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service slack`. The generated route serves Slack at `/emulate/slack/*`.
+The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. In native CLI runs with multiple services enabled, open `/slack` for the message inspector. When only Slack is enabled, and in Vercel Go Function previews, the inspector is available at the service root. To expose Slack on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service slack`. The generated route serves Slack at `/emulate/slack/*`.
 
 ### Auth & Chat
 - `POST /api/auth.test` - test authentication

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/apps/web/app/docs/slack/page.mdx
+++ b/apps/web/app/docs/slack/page.mdx
@@ -2,6 +2,14 @@
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. State changes dispatch `event_callback` payloads to configured webhook URLs.
 
+The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. To expose Slack on a Vercel preview without separate infrastructure, run:
+
+```bash
+npx emulate vercel init --service slack
+```
+
+The generated route serves Slack at `/emulate/slack/*`.
+
 ## Auth
 
 - `POST /api/auth.test` - test authentication

--- a/apps/web/app/docs/slack/page.mdx
+++ b/apps/web/app/docs/slack/page.mdx
@@ -1,8 +1,8 @@
 # Slack API
 
-Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. State changes dispatch `event_callback` payloads to configured webhook URLs.
+Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. In embedded JavaScript mode, state changes also dispatch `event_callback` payloads to configured webhook URLs.
 
-The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. To expose Slack on a Vercel preview without separate infrastructure, run:
+The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. It stores message and reaction state but does not deliver outbound Slack Events API callbacks yet. To expose Slack on a Vercel preview without separate infrastructure, run:
 
 ```bash
 npx emulate vercel init --service slack
@@ -63,7 +63,7 @@ The generated route serves Slack at `/emulate/slack/*`.
 
 ## Event Dispatching
 
-When messages are posted or reactions change, the emulator dispatches `event_callback` payloads to configured webhook URLs matching Slack's Events API format:
+In embedded JavaScript mode, when messages are posted or reactions change, the emulator dispatches `event_callback` payloads to configured webhook URLs matching Slack's Events API format:
 
 - `message` events on `chat.postMessage`, `chat.update`, `chat.delete`
 - `reaction_added` / `reaction_removed` events on `reactions.add` / `reactions.remove`

--- a/apps/web/app/docs/slack/page.mdx
+++ b/apps/web/app/docs/slack/page.mdx
@@ -2,7 +2,7 @@
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. In embedded JavaScript mode, state changes also dispatch `event_callback` payloads to configured webhook URLs.
 
-The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. It stores message and reaction state but does not deliver outbound Slack Events API callbacks yet. To expose Slack on a Vercel preview without separate infrastructure, run:
+The native Go runtime implements the Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. It stores message and reaction state but does not deliver outbound Slack Events API callbacks yet. In native CLI runs with multiple services enabled, open `/slack` for the message inspector. When only Slack is enabled, and in Vercel Go Function previews, the inspector is available at the service root. To expose Slack on a Vercel preview without separate infrastructure, run:
 
 ```bash
 npx emulate vercel init --service slack

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
 	"github.com/vercel-labs/emulate/internal/services/resend"
+	"github.com/vercel-labs/emulate/internal/services/slack"
 	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
 
@@ -113,6 +114,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 	var googleSeed *google.SeedConfig
 	var microsoftSeed *microsoft.SeedConfig
 	var resendSeed *resend.SeedConfig
+	var slackSeed *slack.SeedConfig
 	var vercelSeed *vercel.SeedConfig
 	if *seedValue != "" {
 		loaded, err := coreconfig.Load(coreconfig.LoadOptions{Path: *seedValue})
@@ -121,7 +123,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, google, microsoft, resend, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, google, microsoft, resend, slack, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
@@ -181,6 +183,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			}
 			resendSeed = &cfg
 		}
+		if raw, ok := loaded.Data["slack"]; ok {
+			var cfg slack.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse slack seed config: %v\n", err)
+				return 1
+			}
+			slackSeed = &cfg
+		}
 		if raw, ok := loaded.Data["vercel"]; ok {
 			var cfg vercel.SeedConfig
 			if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -212,6 +222,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		GoogleSeed:    googleSeed,
 		MicrosoftSeed: microsoftSeed,
 		ResendSeed:    resendSeed,
+		SlackSeed:     slackSeed,
 		VercelSeed:    vercelSeed,
 	})
 	httpServer := &nethttp.Server{
@@ -399,7 +410,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"apple", "github", "google", "microsoft", "resend", "vercel"}
+	return []string{"apple", "github", "google", "microsoft", "resend", "slack", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -258,6 +258,70 @@ func TestRunStartSeedsGitHubFromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsSlackFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"slack":{"team":{"name":"Acme Corp","domain":"acme"},"users":[{"name":"alice","email":"alice@acme.com"}],"channels":[{"name":"engineering","topic":"Code talk"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "slack" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/api/team.info", port), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer xoxb-test-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("team.info status = %d", resp.StatusCode)
+	}
+	var team struct {
+		OK   bool `json:"ok"`
+		Team struct {
+			Name   string `json:"name"`
+			Domain string `json:"domain"`
+		} `json:"team"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&team); err != nil {
+		t.Fatal(err)
+	}
+	if !team.OK || team.Team.Name != "Acme Corp" || team.Team.Domain != "acme" {
+		t.Fatalf("unexpected team body: %#v", team)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartSeedsAppleFromJSONConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.json")
@@ -387,7 +451,7 @@ func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
 				t.Fatal("start with unsupported seed service exited successfully")
 			}
 			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for apple, github, google, microsoft, resend, and vercel") || !strings.Contains(errText, "aws") {
+			if !strings.Contains(errText, "only supports --seed for apple, github, google, microsoft, resend, slack, and vercel") || !strings.Contains(errText, "aws") {
 				t.Fatalf("unexpected stderr: %s", errText)
 			}
 		})

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
 	"github.com/vercel-labs/emulate/internal/services/resend"
+	"github.com/vercel-labs/emulate/internal/services/slack"
 	"github.com/vercel-labs/emulate/internal/services/vercel"
 )
 
@@ -30,6 +31,7 @@ type ServerOptions struct {
 	GoogleSeed    *google.SeedConfig
 	MicrosoftSeed *microsoft.SeedConfig
 	ResendSeed    *resend.SeedConfig
+	SlackSeed     *slack.SeedConfig
 	VercelSeed    *vercel.SeedConfig
 }
 
@@ -104,6 +106,13 @@ func NewServer(options ServerOptions) *Server {
 		resend.Register(router, resend.Options{
 			Store: runtimeStore,
 			Seed:  options.ResendSeed,
+		})
+	}
+	if serviceEnabled(services, "slack") {
+		slack.Register(router, slack.Options{
+			Store:   runtimeStore,
+			BaseURL: options.BaseURL,
+			Seed:    options.SlackSeed,
 		})
 	}
 	if serviceEnabled(services, "vercel") {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -110,9 +110,10 @@ func NewServer(options ServerOptions) *Server {
 	}
 	if serviceEnabled(services, "slack") {
 		slack.Register(router, slack.Options{
-			Store:   runtimeStore,
-			BaseURL: options.BaseURL,
-			Seed:    options.SlackSeed,
+			Store:         runtimeStore,
+			BaseURL:       options.BaseURL,
+			Seed:          options.SlackSeed,
+			RootInspector: len(services) == 1,
 		})
 	}
 	if serviceEnabled(services, "vercel") {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -225,6 +225,56 @@ func TestNewHandlerDoesNotMountSlackWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerSlackDoesNotShadowAWSRootListBuckets(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"aws", "slack"}})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260519/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=abcdef")
+	req.Header.Set("X-Amz-Date", "20260519T000000Z")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/xml" {
+		t.Fatalf("content type = %q, body = %s", got, res.Body.String())
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "<ListAllMyBucketsResult>") || strings.Contains(body, "Slack Inspector") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestNewHandlerMultiServiceSlackServesInspectorAtSlackPath(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"aws", "slack"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/slack", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	body := res.Body.String()
+	if !strings.Contains(body, "Message Inspector") || !strings.Contains(body, `href="/slack?channel=`) {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestNewHandlerSlackOnlyServesRootInspector(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"slack"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "Message Inspector") {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestNewHandlerMountsAppleWhenEnabled(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"apple"}, BaseURL: "http://localhost:4014"})
 

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -198,6 +198,33 @@ func TestNewHandlerDoesNotMountResendWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMountsSlackWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"slack"}})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/auth.test", nil)
+	req.Header.Set("Authorization", "Bearer xoxb-test-token")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"team":"Emulate"`) || !strings.Contains(res.Body.String(), `"user_id":"U000000001"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountSlackWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/api/auth.test", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestNewHandlerMountsAppleWhenEnabled(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"apple"}, BaseURL: "http://localhost:4014"})
 

--- a/internal/services/slack/helpers.go
+++ b/internal/services/slack/helpers.go
@@ -1,0 +1,312 @@
+package slack
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+var timestampState = struct {
+	sync.Mutex
+	second  int64
+	counter int
+}{}
+
+func generateSlackID(prefix string) string {
+	raw := make([]byte, 5)
+	if _, err := rand.Read(raw); err != nil {
+		return prefix + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return prefix + strings.ToUpper(hex.EncodeToString(raw))[:9]
+}
+
+func generateSlackToken() string {
+	raw := make([]byte, 20)
+	if _, err := rand.Read(raw); err != nil {
+		return "xoxb-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return "xoxb-" + base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func generateSlackCode() string {
+	raw := make([]byte, 20)
+	if _, err := rand.Read(raw); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(raw)
+}
+
+func generateSlackTS() string {
+	now := time.Now().Unix()
+	timestampState.Lock()
+	defer timestampState.Unlock()
+	if now != timestampState.second {
+		timestampState.second = now
+		timestampState.counter = 0
+	}
+	timestampState.counter++
+	return fmt.Sprintf("%d.%06d", now, timestampState.counter)
+}
+
+func slackOK(c *corehttp.Context, data map[string]any) {
+	out := map[string]any{"ok": true}
+	for key, value := range data {
+		out[key] = value
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func slackError(c *corehttp.Context, errorName string) {
+	c.JSON(http.StatusOK, map[string]any{"ok": false, "error": errorName})
+}
+
+func parseSlackBody(r *http.Request) map[string]any {
+	if r.Method == http.MethodGet {
+		return valuesToMap(r.URL.Query())
+	}
+	contentType := r.Header.Get("Content-Type")
+	raw, _ := io.ReadAll(r.Body)
+	if strings.Contains(contentType, "application/json") {
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err == nil && body != nil {
+			return body
+		}
+		return map[string]any{}
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return map[string]any{}
+	}
+	return valuesToMap(values)
+}
+
+func valuesToMap(values url.Values) map[string]any {
+	out := map[string]any{}
+	for key, value := range values {
+		if len(value) > 0 {
+			out[key] = value[len(value)-1]
+		}
+	}
+	return out
+}
+
+func (s *Service) authenticatedUser(c *corehttp.Context) (corestore.Record, bool) {
+	token := bearerToken(c.Header("Authorization"))
+	if token == "" {
+		slackError(c, "not_authed")
+		return nil, false
+	}
+	tokenRecord := firstRecord(s.store.Tokens.FindBy("token", token))
+	if tokenRecord == nil {
+		slackError(c, "not_authed")
+		return nil, false
+	}
+	user := s.findUser(stringField(tokenRecord, "login"))
+	if user == nil {
+		slackError(c, "invalid_auth")
+		return nil, false
+	}
+	return user, true
+}
+
+func bearerToken(value string) string {
+	value = strings.TrimSpace(value)
+	for _, prefix := range []string{"Bearer ", "bearer ", "token ", "Token "} {
+		if strings.HasPrefix(value, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(value, prefix))
+		}
+	}
+	return value
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func stringField(record corestore.Record, field string) string {
+	if record == nil {
+		return ""
+	}
+	return stringValue(record[field])
+}
+
+func intField(record corestore.Record, field string) int {
+	if record == nil {
+		return 0
+	}
+	switch value := record[field].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		n, _ := value.Int64()
+		return int(n)
+	default:
+		n, _ := strconv.Atoi(fmt.Sprint(value))
+		return n
+	}
+}
+
+func boolField(record corestore.Record, field string) bool {
+	if record == nil {
+		return false
+	}
+	switch value := record[field].(type) {
+	case bool:
+		return value
+	case string:
+		return value == "true"
+	default:
+		return false
+	}
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func boolValue(value any) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	default:
+		return false
+	}
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, stringValue(item))
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func recordSliceValue(value any) []map[string]any {
+	switch v := value.(type) {
+	case []map[string]any:
+		out := make([]map[string]any, 0, len(v))
+		for _, item := range v {
+			out = append(out, cloneMap(item))
+		}
+		return out
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for _, item := range v {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, cloneMap(m))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func mapValue(value any) map[string]any {
+	if m, ok := value.(map[string]any); ok {
+		return cloneMap(m)
+	}
+	return map[string]any{}
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(values []string, target string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != target {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func constantTimeEqual(a string, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func matchesRedirectURI(value string, allowed []string) bool {
+	if value == "" {
+		return true
+	}
+	valueURL, err := url.Parse(value)
+	if err != nil {
+		return false
+	}
+	for _, candidate := range allowed {
+		candidateURL, err := url.Parse(candidate)
+		if err != nil {
+			continue
+		}
+		if valueURL.Scheme == candidateURL.Scheme &&
+			valueURL.Host == candidateURL.Host &&
+			strings.TrimRight(valueURL.Path, "/") == strings.TrimRight(candidateURL.Path, "/") {
+			return true
+		}
+	}
+	return false
+}
+
+func createdUnix(value string) int64 {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Now().Unix()
+	}
+	return parsed.Unix()
+}

--- a/internal/services/slack/routes_auth_team_users.go
+++ b/internal/services/slack/routes_auth_team_users.go
@@ -1,0 +1,193 @@
+package slack
+
+import (
+	"strconv"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+)
+
+func (s *Service) registerAuthRoutes(router *corehttp.Router) {
+	router.Post("/api/auth.test", s.handleAuthTest)
+	router.Get("/api/auth.test", s.handleAuthTest)
+}
+
+func (s *Service) registerTeamRoutes(router *corehttp.Router) {
+	router.Post("/api/team.info", s.handleTeamInfo)
+	router.Get("/api/team.info", s.handleTeamInfo)
+	router.Post("/api/bots.info", s.handleBotInfo)
+	router.Get("/api/bots.info", s.handleBotInfo)
+}
+
+func (s *Service) registerUserRoutes(router *corehttp.Router) {
+	router.Post("/api/users.list", s.handleUsersList)
+	router.Get("/api/users.list", s.handleUsersList)
+	router.Post("/api/users.info", s.handleUsersInfo)
+	router.Get("/api/users.info", s.handleUsersInfo)
+	router.Post("/api/users.lookupByEmail", s.handleUsersLookupByEmail)
+	router.Get("/api/users.lookupByEmail", s.handleUsersLookupByEmail)
+}
+
+func (s *Service) handleAuthTest(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	team := firstRecord(s.store.Teams.All())
+	domain := "emulate"
+	teamName := "Emulate"
+	teamID := "T000000001"
+	if team != nil {
+		domain = stringField(team, "domain")
+		teamName = stringField(team, "name")
+		teamID = stringField(team, "team_id")
+	}
+	body := map[string]any{
+		"url":     "https://" + domain + ".slack.com/",
+		"team":    teamName,
+		"user":    stringField(user, "name"),
+		"team_id": teamID,
+		"user_id": stringField(user, "user_id"),
+	}
+	if boolField(user, "is_bot") {
+		body["bot_id"] = stringField(user, "user_id")
+	}
+	slackOK(c, body)
+}
+
+func (s *Service) handleTeamInfo(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	team := firstRecord(s.store.Teams.All())
+	if team == nil {
+		slackError(c, "team_not_found")
+		return
+	}
+	slackOK(c, map[string]any{
+		"team": map[string]any{
+			"id":     stringField(team, "team_id"),
+			"name":   stringField(team, "name"),
+			"domain": stringField(team, "domain"),
+		},
+	})
+}
+
+func (s *Service) handleBotInfo(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	bot := firstRecord(s.store.Bots.FindBy("bot_id", stringValue(body["bot"])))
+	if bot == nil {
+		slackError(c, "bot_not_found")
+		return
+	}
+	slackOK(c, map[string]any{
+		"bot": map[string]any{
+			"id":      stringField(bot, "bot_id"),
+			"name":    stringField(bot, "name"),
+			"deleted": boolField(bot, "deleted"),
+			"icons":   mapValue(bot["icons"]),
+		},
+	})
+}
+
+func (s *Service) handleUsersList(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	limit := normalizeLimit(stringValue(body["limit"]), 100, 1000)
+	cursor := stringValue(body["cursor"])
+	users := []map[string]any{}
+	for _, user := range s.store.Users.All() {
+		if boolField(user, "deleted") {
+			continue
+		}
+		users = append(users, formatUser(user))
+	}
+	page, nextCursor := pageByID(users, "id", cursor, limit)
+	slackOK(c, map[string]any{
+		"members":           page,
+		"response_metadata": map[string]any{"next_cursor": nextCursor},
+	})
+}
+
+func (s *Service) handleUsersInfo(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	user := firstRecord(s.store.Users.FindBy("user_id", stringValue(body["user"])))
+	if user == nil {
+		slackError(c, "user_not_found")
+		return
+	}
+	slackOK(c, map[string]any{"user": formatUser(user)})
+}
+
+func (s *Service) handleUsersLookupByEmail(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	email := stringValue(body["email"])
+	if email == "" {
+		slackError(c, "users_not_found")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("email", email))
+	if user == nil {
+		slackError(c, "users_not_found")
+		return
+	}
+	slackOK(c, map[string]any{"user": formatUser(user)})
+}
+
+func formatUser(user map[string]any) map[string]any {
+	return map[string]any{
+		"id":        stringField(user, "user_id"),
+		"team_id":   stringField(user, "team_id"),
+		"name":      stringField(user, "name"),
+		"real_name": stringField(user, "real_name"),
+		"is_admin":  boolField(user, "is_admin"),
+		"is_bot":    boolField(user, "is_bot"),
+		"deleted":   boolField(user, "deleted"),
+		"profile":   mapValue(user["profile"]),
+	}
+}
+
+func normalizeLimit(value string, fallback int, max int) int {
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit <= 0 {
+		limit = fallback
+	}
+	if limit > max {
+		return max
+	}
+	return limit
+}
+
+func pageByID(items []map[string]any, idField string, cursor string, limit int) ([]map[string]any, string) {
+	start := 0
+	if cursor != "" {
+		for index, item := range items {
+			if stringValue(item[idField]) == cursor {
+				start = index
+				break
+			}
+		}
+	}
+	if start >= len(items) {
+		return []map[string]any{}, ""
+	}
+	end := start + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	next := ""
+	if end < len(items) {
+		next = stringValue(items[end][idField])
+	}
+	return items[start:end], next
+}

--- a/internal/services/slack/routes_chat_conversations.go
+++ b/internal/services/slack/routes_chat_conversations.go
@@ -317,13 +317,18 @@ func (s *Service) incrementThreadReply(channelID string, threadTS string, userID
 	if parent == nil {
 		return
 	}
-	replyUsers := stringSliceValue(parent["reply_users"])
-	if !containsString(replyUsers, userID) {
-		replyUsers = append(replyUsers, userID)
-	}
-	s.store.Messages.Update(intField(parent, "id"), corestore.Record{
-		"reply_count": intField(parent, "reply_count") + 1,
-		"reply_users": replyUsers,
+	s.store.Messages.UpdateFunc(intField(parent, "id"), func(current corestore.Record) (corestore.Record, bool) {
+		if stringField(current, "channel_id") != channelID || stringField(current, "ts") != threadTS {
+			return nil, false
+		}
+		replyUsers := stringSliceValue(current["reply_users"])
+		if !containsString(replyUsers, userID) {
+			replyUsers = append(replyUsers, userID)
+		}
+		return corestore.Record{
+			"reply_count": intField(current, "reply_count") + 1,
+			"reply_users": replyUsers,
+		}, true
 	})
 }
 

--- a/internal/services/slack/routes_chat_conversations.go
+++ b/internal/services/slack/routes_chat_conversations.go
@@ -1,0 +1,383 @@
+package slack
+
+import (
+	"sort"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerChatRoutes(router *corehttp.Router) {
+	router.Post("/api/chat.postMessage", s.handleChatPostMessage)
+	router.Post("/api/chat.update", s.handleChatUpdate)
+	router.Post("/api/chat.delete", s.handleChatDelete)
+	router.Post("/api/chat.meMessage", s.handleChatMeMessage)
+}
+
+func (s *Service) registerConversationRoutes(router *corehttp.Router) {
+	router.Post("/api/conversations.list", s.handleConversationsList)
+	router.Get("/api/conversations.list", s.handleConversationsList)
+	router.Post("/api/conversations.info", s.handleConversationsInfo)
+	router.Get("/api/conversations.info", s.handleConversationsInfo)
+	router.Post("/api/conversations.create", s.handleConversationsCreate)
+	router.Post("/api/conversations.history", s.handleConversationsHistory)
+	router.Get("/api/conversations.history", s.handleConversationsHistory)
+	router.Post("/api/conversations.replies", s.handleConversationsReplies)
+	router.Get("/api/conversations.replies", s.handleConversationsReplies)
+	router.Post("/api/conversations.join", s.handleConversationsJoin)
+	router.Post("/api/conversations.leave", s.handleConversationsLeave)
+	router.Post("/api/conversations.members", s.handleConversationsMembers)
+	router.Get("/api/conversations.members", s.handleConversationsMembers)
+}
+
+func (s *Service) handleChatPostMessage(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := s.findChannel(stringValue(body["channel"]))
+	if channel == nil {
+		slackError(c, "channel_not_found")
+		return
+	}
+	text := stringValue(body["text"])
+	threadTS := stringValue(body["thread_ts"])
+	message := s.insertMessage(messageInput{
+		ChannelID: stringField(channel, "channel_id"),
+		User:      stringField(user, "user_id"),
+		Text:      text,
+		ThreadTS:  threadTS,
+	})
+	if threadTS != "" {
+		s.incrementThreadReply(stringField(channel, "channel_id"), threadTS, stringField(user, "user_id"))
+	}
+	slackOK(c, map[string]any{
+		"channel": stringField(channel, "channel_id"),
+		"ts":      stringField(message, "ts"),
+		"message": map[string]any{
+			"text":      stringField(message, "text"),
+			"user":      stringField(message, "user"),
+			"type":      stringField(message, "type"),
+			"ts":        stringField(message, "ts"),
+			"thread_ts": stringField(message, "thread_ts"),
+		},
+	})
+}
+
+func (s *Service) handleChatUpdate(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := stringValue(body["channel"])
+	ts := stringValue(body["ts"])
+	text := stringValue(body["text"])
+	message := s.findMessage(channel, ts)
+	if message == nil {
+		slackError(c, "message_not_found")
+		return
+	}
+	s.store.Messages.Update(intField(message, "id"), corestore.Record{"text": text})
+	slackOK(c, map[string]any{"channel": channel, "ts": ts, "text": text})
+}
+
+func (s *Service) handleChatDelete(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := stringValue(body["channel"])
+	ts := stringValue(body["ts"])
+	message := s.findMessage(channel, ts)
+	if message == nil {
+		slackError(c, "message_not_found")
+		return
+	}
+	s.store.Messages.Delete(intField(message, "id"))
+	slackOK(c, map[string]any{"channel": channel, "ts": ts})
+}
+
+func (s *Service) handleChatMeMessage(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := s.findChannel(stringValue(body["channel"]))
+	if channel == nil {
+		slackError(c, "channel_not_found")
+		return
+	}
+	message := s.insertMessage(messageInput{
+		ChannelID: stringField(channel, "channel_id"),
+		User:      stringField(user, "user_id"),
+		Text:      stringValue(body["text"]),
+		Subtype:   "me_message",
+	})
+	slackOK(c, map[string]any{"channel": stringField(channel, "channel_id"), "ts": stringField(message, "ts")})
+}
+
+func (s *Service) handleConversationsList(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	limit := normalizeLimit(stringValue(body["limit"]), 100, 1000)
+	cursor := stringValue(body["cursor"])
+	channels := []map[string]any{}
+	for _, channel := range s.store.Channels.All() {
+		if boolField(channel, "is_archived") {
+			continue
+		}
+		channels = append(channels, formatChannel(channel))
+	}
+	page, nextCursor := pageByID(channels, "id", cursor, limit)
+	slackOK(c, map[string]any{
+		"channels":          page,
+		"response_metadata": map[string]any{"next_cursor": nextCursor},
+	})
+}
+
+func (s *Service) handleConversationsInfo(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := firstRecord(s.store.Channels.FindBy("channel_id", stringValue(body["channel"])))
+	if channel == nil {
+		slackError(c, "channel_not_found")
+		return
+	}
+	slackOK(c, map[string]any{"channel": formatChannel(channel)})
+}
+
+func (s *Service) handleConversationsCreate(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		slackError(c, "invalid_name_specials")
+		return
+	}
+	if firstRecord(s.store.Channels.FindBy("name", name)) != nil {
+		slackError(c, "name_taken")
+		return
+	}
+	teamID := "T000000001"
+	if team := firstRecord(s.store.Teams.All()); team != nil {
+		teamID = stringField(team, "team_id")
+	}
+	channel := s.store.Channels.Insert(channelRecord(channelInput{
+		ChannelID: generateSlackID("C"),
+		TeamID:    teamID,
+		Name:      name,
+		IsPrivate: boolValue(body["is_private"]),
+		Creator:   stringField(user, "user_id"),
+		Members:   []string{stringField(user, "user_id")},
+		Now:       createdUnix(""),
+	}))
+	slackOK(c, map[string]any{"channel": formatChannel(channel)})
+}
+
+func (s *Service) handleConversationsHistory(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channelID := stringValue(body["channel"])
+	limit := normalizeLimit(stringValue(body["limit"]), 100, 1000)
+	cursor := stringValue(body["cursor"])
+	if firstRecord(s.store.Channels.FindBy("channel_id", channelID)) == nil {
+		slackError(c, "channel_not_found")
+		return
+	}
+	messages := []map[string]any{}
+	for _, message := range s.store.Messages.FindBy("channel_id", channelID) {
+		threadTS := stringField(message, "thread_ts")
+		if threadTS != "" && threadTS != stringField(message, "ts") {
+			continue
+		}
+		messages = append(messages, formatMessage(message))
+	}
+	sort.SliceStable(messages, func(i int, j int) bool {
+		return stringValue(messages[i]["ts"]) > stringValue(messages[j]["ts"])
+	})
+	page, nextCursor := pageByID(messages, "ts", cursor, limit)
+	slackOK(c, map[string]any{
+		"messages":          page,
+		"has_more":          nextCursor != "",
+		"response_metadata": map[string]any{"next_cursor": nextCursor},
+	})
+}
+
+func (s *Service) handleConversationsReplies(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channelID := stringValue(body["channel"])
+	ts := stringValue(body["ts"])
+	if channelID == "" || ts == "" {
+		slackError(c, "channel_not_found")
+		return
+	}
+	messages := []map[string]any{}
+	for _, message := range s.store.Messages.FindBy("channel_id", channelID) {
+		if stringField(message, "ts") == ts || stringField(message, "thread_ts") == ts {
+			messages = append(messages, formatMessage(message))
+		}
+	}
+	sort.SliceStable(messages, func(i int, j int) bool {
+		return stringValue(messages[i]["ts"]) < stringValue(messages[j]["ts"])
+	})
+	slackOK(c, map[string]any{"messages": messages, "has_more": false})
+}
+
+func (s *Service) handleConversationsJoin(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := firstRecord(s.store.Channels.FindBy("channel_id", stringValue(body["channel"])))
+	if channel == nil {
+		slackError(c, "channel_not_found")
+		return
+	}
+	userID := stringField(user, "user_id")
+	members := stringSliceValue(channel["members"])
+	if !containsString(members, userID) {
+		members = append(members, userID)
+		channel, _ = s.store.Channels.Update(intField(channel, "id"), corestore.Record{"members": members, "num_members": len(members)})
+	}
+	slackOK(c, map[string]any{"channel": formatChannel(channel)})
+}
+
+func (s *Service) handleConversationsLeave(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := firstRecord(s.store.Channels.FindBy("channel_id", stringValue(body["channel"])))
+	if channel == nil {
+		slackError(c, "channel_not_found")
+		return
+	}
+	members := removeString(stringSliceValue(channel["members"]), stringField(user, "user_id"))
+	s.store.Channels.Update(intField(channel, "id"), corestore.Record{"members": members, "num_members": len(members)})
+	slackOK(c, map[string]any{})
+}
+
+func (s *Service) handleConversationsMembers(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	channel := firstRecord(s.store.Channels.FindBy("channel_id", stringValue(body["channel"])))
+	if channel == nil {
+		slackError(c, "channel_not_found")
+		return
+	}
+	slackOK(c, map[string]any{
+		"members":           stringSliceValue(channel["members"]),
+		"response_metadata": map[string]any{"next_cursor": ""},
+	})
+}
+
+type messageInput struct {
+	ChannelID string
+	User      string
+	Text      string
+	Subtype   string
+	ThreadTS  string
+}
+
+func (s *Service) insertMessage(input messageInput) corestore.Record {
+	return s.store.Messages.Insert(corestore.Record{
+		"ts":          generateSlackTS(),
+		"channel_id":  input.ChannelID,
+		"user":        input.User,
+		"text":        input.Text,
+		"type":        "message",
+		"subtype":     nullableString(input.Subtype),
+		"thread_ts":   nullableString(input.ThreadTS),
+		"reply_count": 0,
+		"reply_users": []string{},
+		"reactions":   []map[string]any{},
+	})
+}
+
+func (s *Service) incrementThreadReply(channelID string, threadTS string, userID string) {
+	parent := s.findMessage(channelID, threadTS)
+	if parent == nil {
+		return
+	}
+	replyUsers := stringSliceValue(parent["reply_users"])
+	if !containsString(replyUsers, userID) {
+		replyUsers = append(replyUsers, userID)
+	}
+	s.store.Messages.Update(intField(parent, "id"), corestore.Record{
+		"reply_count": intField(parent, "reply_count") + 1,
+		"reply_users": replyUsers,
+	})
+}
+
+func (s *Service) findMessage(channelID string, ts string) corestore.Record {
+	for _, message := range s.store.Messages.FindBy("channel_id", channelID) {
+		if stringField(message, "ts") == ts {
+			return message
+		}
+	}
+	return nil
+}
+
+func formatChannel(channel corestore.Record) map[string]any {
+	return map[string]any{
+		"id":          stringField(channel, "channel_id"),
+		"name":        stringField(channel, "name"),
+		"is_channel":  boolField(channel, "is_channel"),
+		"is_private":  boolField(channel, "is_private"),
+		"is_archived": boolField(channel, "is_archived"),
+		"topic":       mapValue(channel["topic"]),
+		"purpose":     mapValue(channel["purpose"]),
+		"creator":     stringField(channel, "creator"),
+		"num_members": intField(channel, "num_members"),
+		"created":     createdUnix(stringField(channel, "created_at")),
+	}
+}
+
+func formatMessage(message corestore.Record) map[string]any {
+	out := map[string]any{
+		"type": stringField(message, "type"),
+		"user": stringField(message, "user"),
+		"text": stringField(message, "text"),
+		"ts":   stringField(message, "ts"),
+	}
+	if value := stringField(message, "subtype"); value != "" {
+		out["subtype"] = value
+	}
+	if value := stringField(message, "thread_ts"); value != "" {
+		out["thread_ts"] = value
+	}
+	if count := intField(message, "reply_count"); count > 0 {
+		out["reply_count"] = count
+		out["reply_users"] = stringSliceValue(message["reply_users"])
+	}
+	reactions := recordSliceValue(message["reactions"])
+	if len(reactions) > 0 {
+		out["reactions"] = reactions
+	}
+	return out
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/services/slack/routes_chat_conversations.go
+++ b/internal/services/slack/routes_chat_conversations.go
@@ -55,13 +55,7 @@ func (s *Service) handleChatPostMessage(c *corehttp.Context) {
 	slackOK(c, map[string]any{
 		"channel": stringField(channel, "channel_id"),
 		"ts":      stringField(message, "ts"),
-		"message": map[string]any{
-			"text":      stringField(message, "text"),
-			"user":      stringField(message, "user"),
-			"type":      stringField(message, "type"),
-			"ts":        stringField(message, "ts"),
-			"thread_ts": stringField(message, "thread_ts"),
-		},
+		"message": formatMessage(message),
 	})
 }
 
@@ -94,7 +88,11 @@ func (s *Service) handleChatDelete(c *corehttp.Context) {
 		slackError(c, "message_not_found")
 		return
 	}
+	threadTS := stringField(message, "thread_ts")
 	s.store.Messages.Delete(intField(message, "id"))
+	if threadTS != "" && threadTS != ts {
+		s.refreshThreadReplyMetadata(channel, threadTS)
+	}
 	slackOK(c, map[string]any{"channel": channel, "ts": ts})
 }
 
@@ -327,6 +325,34 @@ func (s *Service) incrementThreadReply(channelID string, threadTS string, userID
 		}
 		return corestore.Record{
 			"reply_count": intField(current, "reply_count") + 1,
+			"reply_users": replyUsers,
+		}, true
+	})
+}
+
+func (s *Service) refreshThreadReplyMetadata(channelID string, threadTS string) {
+	parent := s.findMessage(channelID, threadTS)
+	if parent == nil {
+		return
+	}
+	replyCount := 0
+	replyUsers := []string{}
+	for _, message := range s.store.Messages.FindBy("channel_id", channelID) {
+		if stringField(message, "ts") == threadTS || stringField(message, "thread_ts") != threadTS {
+			continue
+		}
+		replyCount++
+		userID := stringField(message, "user")
+		if userID != "" && !containsString(replyUsers, userID) {
+			replyUsers = append(replyUsers, userID)
+		}
+	}
+	s.store.Messages.UpdateFunc(intField(parent, "id"), func(current corestore.Record) (corestore.Record, bool) {
+		if stringField(current, "channel_id") != channelID || stringField(current, "ts") != threadTS {
+			return nil, false
+		}
+		return corestore.Record{
+			"reply_count": replyCount,
 			"reply_users": replyUsers,
 		}, true
 	})

--- a/internal/services/slack/routes_oauth.go
+++ b/internal/services/slack/routes_oauth.go
@@ -126,6 +126,7 @@ func (s *Service) handleOAuthAccess(c *corehttp.Context) {
 	codeValue := stringValue(body["code"])
 	clientID := stringValue(body["client_id"])
 	clientSecret := stringValue(body["client_secret"])
+	redirectURI := stringValue(body["redirect_uri"])
 	if s.store.OAuthApps.Count() > 0 {
 		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
 		if app == nil || !constantTimeEqual(clientSecret, stringField(app, "client_secret")) {
@@ -142,6 +143,10 @@ func (s *Service) handleOAuthAccess(c *corehttp.Context) {
 		return
 	}
 	if stringField(code, "client_id") != "" && clientID != "" && stringField(code, "client_id") != clientID {
+		slackError(c, "invalid_code")
+		return
+	}
+	if pendingRedirectURI := stringField(code, "redirect_uri"); pendingRedirectURI != "" && redirectURI != "" && redirectURI != pendingRedirectURI {
 		slackError(c, "invalid_code")
 		return
 	}

--- a/internal/services/slack/routes_oauth.go
+++ b/internal/services/slack/routes_oauth.go
@@ -1,0 +1,183 @@
+package slack
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+const pendingCodeTTL = 10 * time.Minute
+
+func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
+	router.Get("/oauth/v2/authorize", s.handleAuthorize)
+	router.Post("/oauth/v2/authorize/callback", s.handleAuthorizeCallback)
+	router.Post("/api/oauth.v2.access", s.handleOAuthAccess)
+}
+
+func (s *Service) handleAuthorize(c *corehttp.Context) {
+	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
+	scope := c.Query("scope")
+	state := c.Query("state")
+
+	appName := ""
+	if s.store.OAuthApps.Count() > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(app["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		appName = stringField(app, "name")
+	}
+
+	subtitle := "Choose a user to authorize."
+	if appName != "" {
+		subtitle = "Authorize <strong>" + ui.EscapeHTML(appName) + "</strong> to access your Slack workspace."
+	}
+	var body strings.Builder
+	users := s.store.Users.All()
+	count := 0
+	for _, user := range users {
+		if boolField(user, "deleted") || boolField(user, "is_bot") {
+			continue
+		}
+		name := stringField(user, "name")
+		letter := "?"
+		if name != "" {
+			letter = strings.ToUpper(name[:1])
+		}
+		body.WriteString(ui.RenderUserButton(ui.UserButtonOptions{
+			Letter:     letter,
+			Login:      name,
+			Name:       stringField(user, "real_name"),
+			Email:      stringField(user, "email"),
+			FormAction: "/oauth/v2/authorize/callback",
+			HiddenFields: map[string]string{
+				"user_id":      stringField(user, "user_id"),
+				"redirect_uri": redirectURI,
+				"scope":        scope,
+				"state":        state,
+				"client_id":    clientID,
+			},
+		}))
+		count++
+	}
+	if count == 0 {
+		body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+	}
+	c.HTML(http.StatusOK, ui.RenderCardPage("Sign in to Slack", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+}
+
+func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
+	if err := c.Request.ParseForm(); err != nil {
+		c.JSON(http.StatusBadRequest, map[string]any{"ok": false, "error": "invalid_request"})
+		return
+	}
+	userID := c.Request.Form.Get("user_id")
+	redirectURI := c.Request.Form.Get("redirect_uri")
+	scope := c.Request.Form.Get("scope")
+	state := c.Request.Form.Get("state")
+	clientID := c.Request.Form.Get("client_id")
+	if s.findUser(userID) == nil {
+		c.JSON(http.StatusBadRequest, map[string]any{"ok": false, "error": "user_not_found"})
+		return
+	}
+	if s.store.OAuthApps.Count() > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil || (redirectURI != "" && !matchesRedirectURI(redirectURI, stringSliceValue(app["redirect_uris"]))) {
+			c.JSON(http.StatusBadRequest, map[string]any{"ok": false, "error": "invalid_client_id"})
+			return
+		}
+	}
+	target, err := url.Parse(redirectURI)
+	if err != nil || target == nil || target.Scheme == "" {
+		c.JSON(http.StatusBadRequest, map[string]any{"ok": false, "error": "invalid_redirect_uri"})
+		return
+	}
+	code := generateSlackCode()
+	s.store.OAuthCodes.Insert(corestore.Record{
+		"code":          code,
+		"user_id":       userID,
+		"scope":         scope,
+		"redirect_uri":  redirectURI,
+		"client_id":     clientID,
+		"created_at_ms": time.Now().UnixMilli(),
+	})
+	query := target.Query()
+	query.Set("code", code)
+	if state != "" {
+		query.Set("state", state)
+	}
+	target.RawQuery = query.Encode()
+	c.Redirect(http.StatusFound, target.String())
+}
+
+func (s *Service) handleOAuthAccess(c *corehttp.Context) {
+	body := parseSlackBody(c.Request)
+	codeValue := stringValue(body["code"])
+	clientID := stringValue(body["client_id"])
+	clientSecret := stringValue(body["client_secret"])
+	if s.store.OAuthApps.Count() > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil || !constantTimeEqual(clientSecret, stringField(app, "client_secret")) {
+			slackError(c, "invalid_client_id")
+			return
+		}
+	}
+	code := firstRecord(s.store.OAuthCodes.FindBy("code", codeValue))
+	if code == nil || time.Now().UnixMilli()-int64(intField(code, "created_at_ms")) > pendingCodeTTL.Milliseconds() {
+		if code != nil {
+			s.store.OAuthCodes.Delete(intField(code, "id"))
+		}
+		slackError(c, "invalid_code")
+		return
+	}
+	if stringField(code, "client_id") != "" && clientID != "" && stringField(code, "client_id") != clientID {
+		slackError(c, "invalid_code")
+		return
+	}
+	s.store.OAuthCodes.Delete(intField(code, "id"))
+	user := s.findUser(stringField(code, "user_id"))
+	if user == nil {
+		slackError(c, "invalid_code")
+		return
+	}
+	accessToken := generateSlackToken()
+	scopes := strings.FieldsFunc(stringField(code, "scope"), func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	s.store.Tokens.Insert(corestore.Record{
+		"token":  accessToken,
+		"login":  stringField(user, "user_id"),
+		"scopes": scopes,
+	})
+	team := firstRecord(s.store.Teams.All())
+	teamID := "T000000001"
+	teamName := "Emulate"
+	if team != nil {
+		teamID = stringField(team, "team_id")
+		teamName = stringField(team, "name")
+	}
+	scope := stringField(code, "scope")
+	if scope == "" {
+		scope = "chat:write,channels:read"
+	}
+	slackOK(c, map[string]any{
+		"access_token": accessToken,
+		"token_type":   "bot",
+		"scope":        scope,
+		"bot_user_id":  stringField(user, "user_id"),
+		"app_id":       clientID,
+		"team":         map[string]any{"id": teamID, "name": teamName},
+		"authed_user":  map[string]any{"id": stringField(user, "user_id")},
+	})
+}

--- a/internal/services/slack/routes_reactions.go
+++ b/internal/services/slack/routes_reactions.go
@@ -1,0 +1,119 @@
+package slack
+
+import (
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerReactionRoutes(router *corehttp.Router) {
+	router.Post("/api/reactions.add", s.handleReactionsAdd)
+	router.Post("/api/reactions.remove", s.handleReactionsRemove)
+	router.Post("/api/reactions.get", s.handleReactionsGet)
+	router.Get("/api/reactions.get", s.handleReactionsGet)
+}
+
+func (s *Service) handleReactionsAdd(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		slackError(c, "invalid_name")
+		return
+	}
+	message := s.findMessage(stringValue(body["channel"]), stringValue(body["timestamp"]))
+	if message == nil {
+		slackError(c, "message_not_found")
+		return
+	}
+	userID := stringField(user, "user_id")
+	reactions := recordSliceValue(message["reactions"])
+	for index, reaction := range reactions {
+		if stringValue(reaction["name"]) != name {
+			continue
+		}
+		users := stringSliceValue(reaction["users"])
+		if containsString(users, userID) {
+			slackError(c, "already_reacted")
+			return
+		}
+		users = append(users, userID)
+		reactions[index]["users"] = users
+		reactions[index]["count"] = len(users)
+		s.store.Messages.Update(intField(message, "id"), corestore.Record{"reactions": reactions})
+		slackOK(c, map[string]any{})
+		return
+	}
+	reactions = append(reactions, map[string]any{"name": name, "users": []string{userID}, "count": 1})
+	s.store.Messages.Update(intField(message, "id"), corestore.Record{"reactions": reactions})
+	slackOK(c, map[string]any{})
+}
+
+func (s *Service) handleReactionsRemove(c *corehttp.Context) {
+	user, ok := s.authenticatedUser(c)
+	if !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		slackError(c, "invalid_name")
+		return
+	}
+	message := s.findMessage(stringValue(body["channel"]), stringValue(body["timestamp"]))
+	if message == nil {
+		slackError(c, "message_not_found")
+		return
+	}
+	userID := stringField(user, "user_id")
+	reactions := recordSliceValue(message["reactions"])
+	next := []map[string]any{}
+	removed := false
+	for _, reaction := range reactions {
+		if stringValue(reaction["name"]) != name {
+			next = append(next, reaction)
+			continue
+		}
+		users := stringSliceValue(reaction["users"])
+		if !containsString(users, userID) {
+			next = append(next, reaction)
+			continue
+		}
+		removed = true
+		users = removeString(users, userID)
+		if len(users) > 0 {
+			reaction["users"] = users
+			reaction["count"] = len(users)
+			next = append(next, reaction)
+		}
+	}
+	if !removed {
+		slackError(c, "no_reaction")
+		return
+	}
+	s.store.Messages.Update(intField(message, "id"), corestore.Record{"reactions": next})
+	slackOK(c, map[string]any{})
+}
+
+func (s *Service) handleReactionsGet(c *corehttp.Context) {
+	if _, ok := s.authenticatedUser(c); !ok {
+		return
+	}
+	body := parseSlackBody(c.Request)
+	message := s.findMessage(stringValue(body["channel"]), stringValue(body["timestamp"]))
+	if message == nil {
+		slackError(c, "message_not_found")
+		return
+	}
+	slackOK(c, map[string]any{
+		"type": "message",
+		"message": map[string]any{
+			"type":      stringField(message, "type"),
+			"text":      stringField(message, "text"),
+			"ts":        stringField(message, "ts"),
+			"reactions": recordSliceValue(message["reactions"]),
+		},
+	})
+}

--- a/internal/services/slack/routes_reactions.go
+++ b/internal/services/slack/routes_reactions.go
@@ -23,31 +23,51 @@ func (s *Service) handleReactionsAdd(c *corehttp.Context) {
 		slackError(c, "invalid_name")
 		return
 	}
-	message := s.findMessage(stringValue(body["channel"]), stringValue(body["timestamp"]))
+	channelID := stringValue(body["channel"])
+	timestamp := stringValue(body["timestamp"])
+	message := s.findMessage(channelID, timestamp)
 	if message == nil {
 		slackError(c, "message_not_found")
 		return
 	}
 	userID := stringField(user, "user_id")
-	reactions := recordSliceValue(message["reactions"])
-	for index, reaction := range reactions {
-		if stringValue(reaction["name"]) != name {
-			continue
+	foundCurrent := false
+	alreadyReacted := false
+	_, updated := s.store.Messages.UpdateFunc(intField(message, "id"), func(current corestore.Record) (corestore.Record, bool) {
+		if stringField(current, "channel_id") != channelID || stringField(current, "ts") != timestamp {
+			return nil, false
 		}
-		users := stringSliceValue(reaction["users"])
-		if containsString(users, userID) {
-			slackError(c, "already_reacted")
-			return
+		foundCurrent = true
+		reactions := recordSliceValue(current["reactions"])
+		for index, reaction := range reactions {
+			if stringValue(reaction["name"]) != name {
+				continue
+			}
+			users := stringSliceValue(reaction["users"])
+			if containsString(users, userID) {
+				alreadyReacted = true
+				return nil, false
+			}
+			users = append(users, userID)
+			reactions[index]["users"] = users
+			reactions[index]["count"] = len(users)
+			return corestore.Record{"reactions": reactions}, true
 		}
-		users = append(users, userID)
-		reactions[index]["users"] = users
-		reactions[index]["count"] = len(users)
-		s.store.Messages.Update(intField(message, "id"), corestore.Record{"reactions": reactions})
-		slackOK(c, map[string]any{})
+		reactions = append(reactions, map[string]any{"name": name, "users": []string{userID}, "count": 1})
+		return corestore.Record{"reactions": reactions}, true
+	})
+	if !foundCurrent {
+		slackError(c, "message_not_found")
 		return
 	}
-	reactions = append(reactions, map[string]any{"name": name, "users": []string{userID}, "count": 1})
-	s.store.Messages.Update(intField(message, "id"), corestore.Record{"reactions": reactions})
+	if alreadyReacted {
+		slackError(c, "already_reacted")
+		return
+	}
+	if !updated {
+		slackError(c, "message_not_found")
+		return
+	}
 	slackOK(c, map[string]any{})
 }
 
@@ -62,38 +82,58 @@ func (s *Service) handleReactionsRemove(c *corehttp.Context) {
 		slackError(c, "invalid_name")
 		return
 	}
-	message := s.findMessage(stringValue(body["channel"]), stringValue(body["timestamp"]))
+	channelID := stringValue(body["channel"])
+	timestamp := stringValue(body["timestamp"])
+	message := s.findMessage(channelID, timestamp)
 	if message == nil {
 		slackError(c, "message_not_found")
 		return
 	}
 	userID := stringField(user, "user_id")
-	reactions := recordSliceValue(message["reactions"])
-	next := []map[string]any{}
+	foundCurrent := false
 	removed := false
-	for _, reaction := range reactions {
-		if stringValue(reaction["name"]) != name {
-			next = append(next, reaction)
-			continue
+	_, updated := s.store.Messages.UpdateFunc(intField(message, "id"), func(current corestore.Record) (corestore.Record, bool) {
+		if stringField(current, "channel_id") != channelID || stringField(current, "ts") != timestamp {
+			return nil, false
 		}
-		users := stringSliceValue(reaction["users"])
-		if !containsString(users, userID) {
-			next = append(next, reaction)
-			continue
+		foundCurrent = true
+		reactions := recordSliceValue(current["reactions"])
+		next := []map[string]any{}
+		for _, reaction := range reactions {
+			if stringValue(reaction["name"]) != name {
+				next = append(next, reaction)
+				continue
+			}
+			users := stringSliceValue(reaction["users"])
+			if !containsString(users, userID) {
+				next = append(next, reaction)
+				continue
+			}
+			removed = true
+			users = removeString(users, userID)
+			if len(users) > 0 {
+				reaction["users"] = users
+				reaction["count"] = len(users)
+				next = append(next, reaction)
+			}
 		}
-		removed = true
-		users = removeString(users, userID)
-		if len(users) > 0 {
-			reaction["users"] = users
-			reaction["count"] = len(users)
-			next = append(next, reaction)
+		if !removed {
+			return nil, false
 		}
+		return corestore.Record{"reactions": next}, true
+	})
+	if !foundCurrent {
+		slackError(c, "message_not_found")
+		return
 	}
 	if !removed {
 		slackError(c, "no_reaction")
 		return
 	}
-	s.store.Messages.Update(intField(message, "id"), corestore.Record{"reactions": next})
+	if !updated {
+		slackError(c, "message_not_found")
+		return
+	}
 	slackOK(c, map[string]any{})
 }
 

--- a/internal/services/slack/routes_webhooks_inspector.go
+++ b/internal/services/slack/routes_webhooks_inspector.go
@@ -20,7 +20,10 @@ func (s *Service) registerWebhookRoutes(router *corehttp.Router) {
 }
 
 func (s *Service) registerInspectorRoutes(router *corehttp.Router) {
-	router.Get("/", s.handleInspector)
+	router.Get("/slack", s.handleInspector)
+	if s.rootInspector {
+		router.Get("/", s.handleInspector)
+	}
 }
 
 func (s *Service) handleIncomingWebhook(c *corehttp.Context) {
@@ -113,6 +116,10 @@ func (s *Service) handleInspector(c *corehttp.Context) {
 		}
 	}
 	var sidebar strings.Builder
+	inspectorPath := c.Request.URL.Path
+	if inspectorPath == "" {
+		inspectorPath = "/"
+	}
 	for _, channel := range channels {
 		className := ""
 		if stringField(channel, "channel_id") == stringField(active, "channel_id") {
@@ -122,7 +129,9 @@ func (s *Service) handleInspector(c *corehttp.Context) {
 		if boolField(channel, "is_private") {
 			prefix = "private "
 		}
-		sidebar.WriteString(`<a href="/?channel=`)
+		sidebar.WriteString(`<a href="`)
+		sidebar.WriteString(ui.EscapeAttr(inspectorPath))
+		sidebar.WriteString(`?channel=`)
 		sidebar.WriteString(url.QueryEscape(stringField(channel, "channel_id")))
 		sidebar.WriteString(`"`)
 		sidebar.WriteString(className)

--- a/internal/services/slack/routes_webhooks_inspector.go
+++ b/internal/services/slack/routes_webhooks_inspector.go
@@ -1,0 +1,223 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+func (s *Service) registerWebhookRoutes(router *corehttp.Router) {
+	router.Post("/services/:teamId/:botId/:token", s.handleIncomingWebhook)
+}
+
+func (s *Service) registerInspectorRoutes(router *corehttp.Router) {
+	router.Get("/", s.handleInspector)
+}
+
+func (s *Service) handleIncomingWebhook(c *corehttp.Context) {
+	body, ok := parseWebhookBody(c)
+	if !ok {
+		c.Text(http.StatusBadRequest, "invalid_payload")
+		return
+	}
+	text := stringValue(body["text"])
+	if text == "" && body["blocks"] == nil && body["attachments"] == nil {
+		c.Text(http.StatusBadRequest, "no_text")
+		return
+	}
+	channelName := stringValue(body["channel"])
+	threadTS := stringValue(body["thread_ts"])
+	webhook := firstRecord(s.store.IncomingWebhooks.FindBy("token", c.Param("token")))
+	var channel corestore.Record
+	if channelName != "" {
+		channel = s.findChannel(channelName)
+	}
+	if channel == nil && webhook != nil {
+		channel = s.findChannel(stringField(webhook, "default_channel"))
+	}
+	if channel == nil {
+		channel = s.findChannel("general")
+	}
+	if channel == nil {
+		c.Text(http.StatusNotFound, "channel_not_found")
+		return
+	}
+	if text == "" {
+		text = "(rich message)"
+	}
+	s.insertMessage(messageInput{
+		ChannelID: stringField(channel, "channel_id"),
+		User:      c.Param("botId"),
+		Text:      text,
+		Subtype:   "bot_message",
+		ThreadTS:  threadTS,
+	})
+	c.Text(http.StatusOK, "ok")
+}
+
+func parseWebhookBody(c *corehttp.Context) (map[string]any, bool) {
+	raw, _ := io.ReadAll(c.Request.Body)
+	body := map[string]any{}
+	if strings.Contains(c.Header("Content-Type"), "application/json") {
+		if err := json.Unmarshal(raw, &body); err != nil {
+			return nil, false
+		}
+		return body, true
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return nil, false
+	}
+	body = valuesToMap(values)
+	if payload := stringValue(body["payload"]); payload != "" {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+			return nil, false
+		}
+		return parsed, true
+	}
+	return body, true
+}
+
+func (s *Service) handleInspector(c *corehttp.Context) {
+	channels := []corestore.Record{}
+	for _, channel := range s.store.Channels.All() {
+		if !boolField(channel, "is_archived") {
+			channels = append(channels, channel)
+		}
+	}
+	if len(channels) == 0 {
+		c.HTML(http.StatusOK, ui.RenderSettingsPage("Slack Inspector", `<p class="empty">No channels</p>`, `<p class="empty">No channels in the emulator store.</p>`, ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	active := channels[0]
+	if requested := c.Query("channel"); requested != "" {
+		for _, channel := range channels {
+			if stringField(channel, "channel_id") == requested {
+				active = channel
+				break
+			}
+		}
+	}
+	var sidebar strings.Builder
+	for _, channel := range channels {
+		className := ""
+		if stringField(channel, "channel_id") == stringField(active, "channel_id") {
+			className = ` class="active"`
+		}
+		prefix := "# "
+		if boolField(channel, "is_private") {
+			prefix = "private "
+		}
+		sidebar.WriteString(`<a href="/?channel=`)
+		sidebar.WriteString(url.QueryEscape(stringField(channel, "channel_id")))
+		sidebar.WriteString(`"`)
+		sidebar.WriteString(className)
+		sidebar.WriteString(`>`)
+		sidebar.WriteString(ui.EscapeHTML(prefix + stringField(channel, "name")))
+		sidebar.WriteString(`</a>`)
+	}
+	userNames := map[string]string{}
+	for _, user := range s.store.Users.All() {
+		userNames[stringField(user, "user_id")] = stringField(user, "name")
+		userNames[stringField(user, "name")] = stringField(user, "name")
+	}
+	for _, bot := range s.store.Bots.All() {
+		userNames[stringField(bot, "bot_id")] = stringField(bot, "name")
+	}
+	messages := s.store.Messages.FindBy("channel_id", stringField(active, "channel_id"))
+	sort.SliceStable(messages, func(i int, j int) bool {
+		return stringField(messages[i], "ts") > stringField(messages[j], "ts")
+	})
+	var messageHTML strings.Builder
+	if len(messages) == 0 {
+		messageHTML.WriteString(`<p class="empty">No messages yet. Post one with chat.postMessage or an incoming webhook.</p>`)
+	} else {
+		limit := len(messages)
+		if limit > 50 {
+			limit = 50
+		}
+		for _, message := range messages[:limit] {
+			messageHTML.WriteString(renderInspectorMessage(message, userNames))
+		}
+	}
+	topic := stringValue(mapValue(active["topic"])["value"])
+	if topic == "" {
+		topic = "No topic set"
+	}
+	stats := fmt.Sprintf("%d users, %d channels, %d messages", s.store.Users.Count(), len(channels), s.store.Messages.Count())
+	body := `<div class="s-card">
+  <div class="s-card-header">
+    <div class="s-icon">#</div>
+    <div>
+      <div class="s-title">` + ui.EscapeHTML(stringField(active, "name")) + `</div>
+      <div class="s-subtitle">` + ui.EscapeHTML(topic) + ` - ` + strconv.Itoa(intField(active, "num_members")) + ` members</div>
+    </div>
+  </div>
+  <div class="section-heading">Messages <span class="user-meta">` + ui.EscapeHTML(stats) + `</span></div>
+  ` + messageHTML.String() + `
+</div>`
+	teamName := "Slack"
+	if team := firstRecord(s.store.Teams.All()); team != nil {
+		teamName = stringField(team, "name")
+	}
+	c.HTML(http.StatusOK, ui.RenderSettingsPage(teamName+" - Message Inspector", sidebar.String(), body, ui.PageOptions{Service: serviceLabel}))
+}
+
+func renderInspectorMessage(message map[string]any, userNames map[string]string) string {
+	displayName := userNames[stringField(message, "user")]
+	if displayName == "" {
+		displayName = stringField(message, "user")
+	}
+	letter := "?"
+	if displayName != "" {
+		letter = strings.ToUpper(displayName[:1])
+	}
+	if stringField(message, "subtype") == "bot_message" {
+		letter = "B"
+	}
+	botBadge := ""
+	if stringField(message, "subtype") == "bot_message" {
+		botBadge = ` <span class="badge badge-granted">bot</span>`
+	}
+	threadBadge := ""
+	if count := intField(message, "reply_count"); count > 0 {
+		label := "replies"
+		if count == 1 {
+			label = "reply"
+		}
+		threadBadge = ` <span class="badge badge-requested">` + strconv.Itoa(count) + ` ` + label + `</span>`
+	}
+	return `<div class="org-row">
+  <span class="org-icon">` + ui.EscapeHTML(letter) + `</span>
+  <span class="org-name">` + ui.EscapeHTML(displayName) + botBadge + `</span>
+  <span class="user-meta">` + ui.EscapeHTML(stringField(message, "ts")) + `</span>
+</div>
+<div class="info-text">` + ui.EscapeHTML(stringField(message, "text")) + threadBadge + renderInspectorReactions(recordSliceValue(message["reactions"])) + `</div>`
+}
+
+func renderInspectorReactions(reactions []map[string]any) string {
+	if len(reactions) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	out.WriteString(`<div>`)
+	for _, reaction := range reactions {
+		out.WriteString(`<span class="badge badge-granted">:`)
+		out.WriteString(ui.EscapeHTML(stringValue(reaction["name"])))
+		out.WriteString(`: `)
+		out.WriteString(strconv.Itoa(intField(reaction, "count")))
+		out.WriteString(`</span>`)
+	}
+	out.WriteString(`</div>`)
+	return out.String()
+}

--- a/internal/services/slack/routes_webhooks_inspector.go
+++ b/internal/services/slack/routes_webhooks_inspector.go
@@ -61,13 +61,17 @@ func (s *Service) handleIncomingWebhook(c *corehttp.Context) {
 	if text == "" {
 		text = "(rich message)"
 	}
+	channelID := stringField(channel, "channel_id")
 	s.insertMessage(messageInput{
-		ChannelID: stringField(channel, "channel_id"),
+		ChannelID: channelID,
 		User:      c.Param("botId"),
 		Text:      text,
 		Subtype:   "bot_message",
 		ThreadTS:  threadTS,
 	})
+	if threadTS != "" {
+		s.incrementThreadReply(channelID, threadTS, c.Param("botId"))
+	}
 	c.Text(http.StatusOK, "ok")
 }
 

--- a/internal/services/slack/routes_webhooks_inspector.go
+++ b/internal/services/slack/routes_webhooks_inspector.go
@@ -37,11 +37,15 @@ func (s *Service) handleIncomingWebhook(c *corehttp.Context) {
 	channelName := stringValue(body["channel"])
 	threadTS := stringValue(body["thread_ts"])
 	webhook := firstRecord(s.store.IncomingWebhooks.FindBy("token", c.Param("token")))
+	if webhook == nil || stringField(webhook, "team_id") != c.Param("teamId") || stringField(webhook, "bot_id") != c.Param("botId") {
+		c.Text(http.StatusNotFound, "no_service")
+		return
+	}
 	var channel corestore.Record
 	if channelName != "" {
 		channel = s.findChannel(channelName)
 	}
-	if channel == nil && webhook != nil {
+	if channel == nil {
 		channel = s.findChannel(stringField(webhook, "default_channel"))
 	}
 	if channel == nil {

--- a/internal/services/slack/service.go
+++ b/internal/services/slack/service.go
@@ -155,6 +155,12 @@ func (s *Service) SeedDefaults() {
 		"login":  userID,
 		"scopes": []string{"chat:write", "channels:read", "users:read", "reactions:write"},
 	})
+	s.store.Bots.Insert(corestore.Record{
+		"bot_id":  "B000000001",
+		"name":    "emulate-bot",
+		"deleted": false,
+		"icons":   map[string]any{"image_48": ""},
+	})
 	s.store.IncomingWebhooks.Insert(corestore.Record{
 		"token":           "X000000001",
 		"team_id":         teamID,
@@ -236,17 +242,28 @@ func (s *Service) SeedFromConfig(config SeedConfig) {
 		}))
 	}
 
+	preferredBotID := ""
 	for _, bot := range config.Bots {
 		name := strings.TrimSpace(bot.Name)
-		if name == "" || s.findBotByName(name) != nil {
+		if name == "" {
 			continue
 		}
+		if existing := s.findBotByName(name); existing != nil {
+			if preferredBotID == "" {
+				preferredBotID = stringField(existing, "bot_id")
+			}
+			continue
+		}
+		botID := generateSlackID("B")
 		s.store.Bots.Insert(corestore.Record{
-			"bot_id":  generateSlackID("B"),
+			"bot_id":  botID,
 			"name":    name,
 			"deleted": false,
 			"icons":   map[string]any{"image_48": ""},
 		})
+		if preferredBotID == "" {
+			preferredBotID = botID
+		}
 	}
 
 	for _, app := range config.OAuthApps {
@@ -261,9 +278,19 @@ func (s *Service) SeedFromConfig(config SeedConfig) {
 		})
 	}
 
-	botID := "B000000001"
-	if bot := firstRecord(s.store.Bots.All()); bot != nil {
-		botID = stringField(bot, "bot_id")
+	botID := preferredBotID
+	if botID == "" {
+		if bot := firstRecord(s.store.Bots.FindBy("bot_id", "B000000001")); bot != nil {
+			botID = stringField(bot, "bot_id")
+		}
+	}
+	if botID == "" {
+		if bot := firstRecord(s.store.Bots.All()); bot != nil {
+			botID = stringField(bot, "bot_id")
+		}
+	}
+	if botID == "" {
+		botID = "B000000001"
 	}
 	for _, webhook := range config.IncomingWebhooks {
 		channel := strings.TrimSpace(webhook.Channel)

--- a/internal/services/slack/service.go
+++ b/internal/services/slack/service.go
@@ -11,9 +11,10 @@ import (
 const serviceLabel = "Slack"
 
 type Options struct {
-	Store   *corestore.Store
-	BaseURL string
-	Seed    *SeedConfig
+	Store         *corestore.Store
+	BaseURL       string
+	Seed          *SeedConfig
+	RootInspector bool
 }
 
 type SeedConfig struct {
@@ -63,9 +64,10 @@ type IncomingWebhookSeed struct {
 }
 
 type Service struct {
-	store        Store
-	runtimeStore *corestore.Store
-	baseURL      string
+	store         Store
+	runtimeStore  *corestore.Store
+	baseURL       string
+	rootInspector bool
 }
 
 func Register(router *corehttp.Router, options Options) {
@@ -83,9 +85,10 @@ func New(options Options) *Service {
 		baseURL = "http://localhost:4000"
 	}
 	service := &Service{
-		store:        NewStore(runtimeStore),
-		runtimeStore: runtimeStore,
-		baseURL:      baseURL,
+		store:         NewStore(runtimeStore),
+		runtimeStore:  runtimeStore,
+		baseURL:       baseURL,
+		rootInspector: options.RootInspector,
 	}
 	service.SeedDefaults()
 	if options.Seed != nil {

--- a/internal/services/slack/service.go
+++ b/internal/services/slack/service.go
@@ -1,0 +1,377 @@
+package slack
+
+import (
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const serviceLabel = "Slack"
+
+type Options struct {
+	Store   *corestore.Store
+	BaseURL string
+	Seed    *SeedConfig
+}
+
+type SeedConfig struct {
+	Port             int                   `json:"port,omitempty"`
+	Team             *TeamSeed             `json:"team"`
+	Users            []UserSeed            `json:"users"`
+	Channels         []ChannelSeed         `json:"channels"`
+	Bots             []BotSeed             `json:"bots"`
+	OAuthApps        []OAuthAppSeed        `json:"oauth_apps"`
+	IncomingWebhooks []IncomingWebhookSeed `json:"incoming_webhooks"`
+	SigningSecret    string                `json:"signing_secret"`
+}
+
+type TeamSeed struct {
+	Name   string `json:"name"`
+	Domain string `json:"domain"`
+}
+
+type UserSeed struct {
+	Name     string `json:"name"`
+	RealName string `json:"real_name"`
+	Email    string `json:"email"`
+	IsAdmin  bool   `json:"is_admin"`
+}
+
+type ChannelSeed struct {
+	Name      string `json:"name"`
+	Topic     string `json:"topic"`
+	Purpose   string `json:"purpose"`
+	IsPrivate bool   `json:"is_private"`
+}
+
+type BotSeed struct {
+	Name string `json:"name"`
+}
+
+type OAuthAppSeed struct {
+	ClientID     string   `json:"client_id"`
+	ClientSecret string   `json:"client_secret"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris"`
+}
+
+type IncomingWebhookSeed struct {
+	Channel string `json:"channel"`
+	Label   string `json:"label"`
+}
+
+type Service struct {
+	store        Store
+	runtimeStore *corestore.Store
+	baseURL      string
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	baseURL := strings.TrimRight(options.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:4000"
+	}
+	service := &Service{
+		store:        NewStore(runtimeStore),
+		runtimeStore: runtimeStore,
+		baseURL:      baseURL,
+	}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, baseURL string, config SeedConfig) {
+	New(Options{Store: runtimeStore, BaseURL: baseURL, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerAuthRoutes(router)
+	s.registerChatRoutes(router)
+	s.registerConversationRoutes(router)
+	s.registerUserRoutes(router)
+	s.registerReactionRoutes(router)
+	s.registerTeamRoutes(router)
+	s.registerOAuthRoutes(router)
+	s.registerWebhookRoutes(router)
+	s.registerInspectorRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if firstRecord(s.store.Teams.FindBy("team_id", "T000000001")) != nil {
+		return
+	}
+	teamID := "T000000001"
+	userID := "U000000001"
+	s.store.Teams.Insert(corestore.Record{
+		"team_id": teamID,
+		"name":    "Emulate",
+		"domain":  "emulate",
+	})
+	s.store.Users.Insert(userRecord(userInput{
+		UserID:   userID,
+		TeamID:   teamID,
+		Name:     "admin",
+		RealName: "Admin User",
+		Email:    "admin@emulate.dev",
+		IsAdmin:  true,
+	}))
+	now := time.Now().Unix()
+	s.store.Channels.Insert(channelRecord(channelInput{
+		ChannelID: "C000000001",
+		TeamID:    teamID,
+		Name:      "general",
+		Topic:     "General discussion",
+		Purpose:   "A place for general discussion",
+		Creator:   userID,
+		Members:   []string{userID},
+		Now:       now,
+	}))
+	s.store.Channels.Insert(channelRecord(channelInput{
+		ChannelID: "C000000002",
+		TeamID:    teamID,
+		Name:      "random",
+		Topic:     "Random stuff",
+		Purpose:   "A place for non-work-related chatter",
+		Creator:   userID,
+		Members:   []string{userID},
+		Now:       now,
+	}))
+	s.store.Tokens.Insert(corestore.Record{
+		"token":  "xoxb-test-token",
+		"login":  userID,
+		"scopes": []string{"chat:write", "channels:read", "users:read", "reactions:write"},
+	})
+	s.store.IncomingWebhooks.Insert(corestore.Record{
+		"token":           "X000000001",
+		"team_id":         teamID,
+		"bot_id":          "B000000001",
+		"default_channel": "general",
+		"label":           "Default Webhook",
+		"url":             "/services/T000000001/B000000001/X000000001",
+	})
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	if config.Team != nil {
+		if team := firstRecord(s.store.Teams.All()); team != nil {
+			patch := corestore.Record{}
+			if config.Team.Name != "" {
+				patch["name"] = config.Team.Name
+			}
+			if config.Team.Domain != "" {
+				patch["domain"] = config.Team.Domain
+			}
+			if len(patch) > 0 {
+				s.store.Teams.Update(intField(team, "id"), patch)
+			}
+		}
+	}
+
+	team := firstRecord(s.store.Teams.All())
+	teamID := "T000000001"
+	if team != nil {
+		teamID = stringField(team, "team_id")
+	}
+	for _, user := range config.Users {
+		name := strings.TrimSpace(user.Name)
+		if name == "" || firstRecord(s.store.Users.FindBy("name", name)) != nil {
+			continue
+		}
+		email := user.Email
+		if email == "" {
+			email = name + "@emulate.dev"
+		}
+		realName := user.RealName
+		if realName == "" {
+			realName = name
+		}
+		s.store.Users.Insert(userRecord(userInput{
+			UserID:   generateSlackID("U"),
+			TeamID:   teamID,
+			Name:     name,
+			RealName: realName,
+			Email:    email,
+			IsAdmin:  user.IsAdmin,
+		}))
+	}
+
+	for _, channel := range config.Channels {
+		name := strings.TrimSpace(channel.Name)
+		if name == "" || firstRecord(s.store.Channels.FindBy("name", name)) != nil {
+			continue
+		}
+		users := s.store.Users.All()
+		members := make([]string, 0, len(users))
+		for _, user := range users {
+			members = append(members, stringField(user, "user_id"))
+		}
+		creator := "U000000001"
+		if len(members) > 0 {
+			creator = members[0]
+		}
+		s.store.Channels.Insert(channelRecord(channelInput{
+			ChannelID: generateSlackID("C"),
+			TeamID:    teamID,
+			Name:      name,
+			Topic:     channel.Topic,
+			Purpose:   channel.Purpose,
+			IsPrivate: channel.IsPrivate,
+			Creator:   creator,
+			Members:   members,
+			Now:       time.Now().Unix(),
+		}))
+	}
+
+	for _, bot := range config.Bots {
+		name := strings.TrimSpace(bot.Name)
+		if name == "" || s.findBotByName(name) != nil {
+			continue
+		}
+		s.store.Bots.Insert(corestore.Record{
+			"bot_id":  generateSlackID("B"),
+			"name":    name,
+			"deleted": false,
+			"icons":   map[string]any{"image_48": ""},
+		})
+	}
+
+	for _, app := range config.OAuthApps {
+		if app.ClientID == "" || firstRecord(s.store.OAuthApps.FindBy("client_id", app.ClientID)) != nil {
+			continue
+		}
+		s.store.OAuthApps.Insert(corestore.Record{
+			"client_id":     app.ClientID,
+			"client_secret": app.ClientSecret,
+			"name":          app.Name,
+			"redirect_uris": app.RedirectURIs,
+		})
+	}
+
+	botID := "B000000001"
+	if bot := firstRecord(s.store.Bots.All()); bot != nil {
+		botID = stringField(bot, "bot_id")
+	}
+	for _, webhook := range config.IncomingWebhooks {
+		channel := strings.TrimSpace(webhook.Channel)
+		if channel == "" {
+			continue
+		}
+		token := generateSlackID("X")
+		label := webhook.Label
+		if label == "" {
+			label = channel
+		}
+		s.store.IncomingWebhooks.Insert(corestore.Record{
+			"token":           token,
+			"team_id":         teamID,
+			"bot_id":          botID,
+			"default_channel": channel,
+			"label":           label,
+			"url":             "/services/" + teamID + "/" + botID + "/" + token,
+		})
+	}
+	if config.SigningSecret != "" {
+		s.runtimeStore.SetData("slack.signing_secret", config.SigningSecret)
+	}
+}
+
+type userInput struct {
+	UserID   string
+	TeamID   string
+	Name     string
+	RealName string
+	Email    string
+	IsAdmin  bool
+	IsBot    bool
+}
+
+func userRecord(input userInput) corestore.Record {
+	return corestore.Record{
+		"user_id":   input.UserID,
+		"team_id":   input.TeamID,
+		"name":      input.Name,
+		"real_name": input.RealName,
+		"email":     input.Email,
+		"is_admin":  input.IsAdmin,
+		"is_bot":    input.IsBot,
+		"deleted":   false,
+		"profile": map[string]any{
+			"display_name": input.Name,
+			"real_name":    input.RealName,
+			"email":        input.Email,
+			"image_48":     "",
+			"image_192":    "",
+		},
+	}
+}
+
+type channelInput struct {
+	ChannelID string
+	TeamID    string
+	Name      string
+	Topic     string
+	Purpose   string
+	IsPrivate bool
+	Creator   string
+	Members   []string
+	Now       int64
+}
+
+func channelRecord(input channelInput) corestore.Record {
+	return corestore.Record{
+		"channel_id":  input.ChannelID,
+		"team_id":     input.TeamID,
+		"name":        input.Name,
+		"is_channel":  !input.IsPrivate,
+		"is_private":  input.IsPrivate,
+		"is_archived": false,
+		"topic":       map[string]any{"value": input.Topic, "creator": input.Creator, "last_set": input.Now},
+		"purpose":     map[string]any{"value": input.Purpose, "creator": input.Creator, "last_set": input.Now},
+		"members":     append([]string(nil), input.Members...),
+		"creator":     input.Creator,
+		"num_members": len(input.Members),
+	}
+}
+
+func (s *Service) findUser(value string) corestore.Record {
+	if value == "" {
+		return nil
+	}
+	if user := firstRecord(s.store.Users.FindBy("user_id", value)); user != nil {
+		return user
+	}
+	return firstRecord(s.store.Users.FindBy("name", value))
+}
+
+func (s *Service) findChannel(value string) corestore.Record {
+	if value == "" {
+		return nil
+	}
+	if channel := firstRecord(s.store.Channels.FindBy("channel_id", value)); channel != nil {
+		return channel
+	}
+	return firstRecord(s.store.Channels.FindBy("name", strings.TrimPrefix(value, "#")))
+}
+
+func (s *Service) findBotByName(name string) corestore.Record {
+	for _, bot := range s.store.Bots.All() {
+		if stringField(bot, "name") == name {
+			return bot
+		}
+	}
+	return nil
+}

--- a/internal/services/slack/service_test.go
+++ b/internal/services/slack/service_test.go
@@ -373,6 +373,38 @@ func TestSlackIncomingWebhookAndInspector(t *testing.T) {
 	}
 }
 
+func TestSlackIncomingWebhookThreadReplyUpdatesParentMetadata(t *testing.T) {
+	service, handler := newSlackTestService()
+
+	post := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"general","text":"parent"}`, true)
+	var posted struct {
+		OK bool   `json:"ok"`
+		TS string `json:"ts"`
+	}
+	mustDecodeSlackJSON(t, post.Body.Bytes(), &posted)
+	if !posted.OK || posted.TS == "" {
+		t.Fatalf("unexpected post body: %#v", posted)
+	}
+
+	webhook := firstRecord(service.store.IncomingWebhooks.All())
+	reply := slackRequest(handler, http.MethodPost, stringField(webhook, "url"), `{"text":"webhook reply","thread_ts":"`+posted.TS+`"}`, false)
+	if reply.Code != http.StatusOK || reply.Body.String() != "ok" {
+		t.Fatalf("webhook reply status = %d body = %s", reply.Code, reply.Body.String())
+	}
+
+	parent := service.findMessage("C000000001", posted.TS)
+	if parent == nil {
+		t.Fatal("parent message missing")
+	}
+	if intField(parent, "reply_count") != 1 {
+		t.Fatalf("reply_count = %d, parent = %#v", intField(parent, "reply_count"), parent)
+	}
+	replyUsers := stringSliceValue(parent["reply_users"])
+	if len(replyUsers) != 1 || replyUsers[0] != "B000000001" {
+		t.Fatalf("unexpected reply users: %#v", replyUsers)
+	}
+}
+
 func TestSlackIncomingWebhookRejectsInvalidPathSecrets(t *testing.T) {
 	service, handler := newSlackTestService()
 

--- a/internal/services/slack/service_test.go
+++ b/internal/services/slack/service_test.go
@@ -1,0 +1,296 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func TestSlackAuthTeamAndUsers(t *testing.T) {
+	_, handler := newSlackTestService()
+
+	res := slackRequest(handler, http.MethodPost, "/api/auth.test", "", false)
+	var unauth map[string]any
+	mustDecodeSlackJSON(t, res.Body.Bytes(), &unauth)
+	if unauth["ok"] != false || unauth["error"] != "not_authed" {
+		t.Fatalf("unexpected unauth body: %#v", unauth)
+	}
+
+	res = slackRequest(handler, http.MethodPost, "/api/auth.test", "", true)
+	var auth struct {
+		OK     bool   `json:"ok"`
+		Team   string `json:"team"`
+		UserID string `json:"user_id"`
+	}
+	mustDecodeSlackJSON(t, res.Body.Bytes(), &auth)
+	if !auth.OK || auth.Team != "Emulate" || auth.UserID != "U000000001" {
+		t.Fatalf("unexpected auth body: %#v", auth)
+	}
+
+	res = slackRequest(handler, http.MethodPost, "/api/users.lookupByEmail", `{"email":"admin@emulate.dev"}`, true)
+	var lookup struct {
+		OK   bool `json:"ok"`
+		User struct {
+			ID      string `json:"id"`
+			Profile struct {
+				Email string `json:"email"`
+			} `json:"profile"`
+		} `json:"user"`
+	}
+	mustDecodeSlackJSON(t, res.Body.Bytes(), &lookup)
+	if !lookup.OK || lookup.User.ID != "U000000001" || lookup.User.Profile.Email != "admin@emulate.dev" {
+		t.Fatalf("unexpected lookup body: %#v", lookup)
+	}
+}
+
+func TestSlackChatConversationsAndReactions(t *testing.T) {
+	_, handler := newSlackTestService()
+
+	post := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"general","text":"hello world"}`, true)
+	var posted struct {
+		OK      bool   `json:"ok"`
+		Channel string `json:"channel"`
+		TS      string `json:"ts"`
+		Message struct {
+			Text string `json:"text"`
+		} `json:"message"`
+	}
+	mustDecodeSlackJSON(t, post.Body.Bytes(), &posted)
+	if !posted.OK || posted.Channel != "C000000001" || posted.TS == "" || posted.Message.Text != "hello world" {
+		t.Fatalf("unexpected post body: %#v", posted)
+	}
+
+	reply := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"C000000001","text":"reply","thread_ts":"`+posted.TS+`"}`, true)
+	var replyBody struct {
+		OK      bool `json:"ok"`
+		Message struct {
+			ThreadTS string `json:"thread_ts"`
+		} `json:"message"`
+	}
+	mustDecodeSlackJSON(t, reply.Body.Bytes(), &replyBody)
+	if !replyBody.OK || replyBody.Message.ThreadTS != posted.TS {
+		t.Fatalf("unexpected reply body: %#v", replyBody)
+	}
+
+	history := slackRequest(handler, http.MethodPost, "/api/conversations.history", `{"channel":"C000000001"}`, true)
+	var historyBody struct {
+		OK       bool `json:"ok"`
+		Messages []struct {
+			TS         string   `json:"ts"`
+			ReplyCount int      `json:"reply_count"`
+			ReplyUsers []string `json:"reply_users"`
+		} `json:"messages"`
+	}
+	mustDecodeSlackJSON(t, history.Body.Bytes(), &historyBody)
+	if !historyBody.OK || len(historyBody.Messages) != 1 || historyBody.Messages[0].ReplyCount != 1 {
+		t.Fatalf("unexpected history body: %#v", historyBody)
+	}
+
+	replies := slackRequest(handler, http.MethodPost, "/api/conversations.replies", `{"channel":"C000000001","ts":"`+posted.TS+`"}`, true)
+	var repliesBody struct {
+		OK       bool          `json:"ok"`
+		Messages []interface{} `json:"messages"`
+	}
+	mustDecodeSlackJSON(t, replies.Body.Bytes(), &repliesBody)
+	if !repliesBody.OK || len(repliesBody.Messages) != 2 {
+		t.Fatalf("unexpected replies body: %#v", repliesBody)
+	}
+
+	addReaction := slackRequest(handler, http.MethodPost, "/api/reactions.add", `{"channel":"C000000001","timestamp":"`+posted.TS+`","name":"thumbsup"}`, true)
+	var addBody map[string]any
+	mustDecodeSlackJSON(t, addReaction.Body.Bytes(), &addBody)
+	if addBody["ok"] != true {
+		t.Fatalf("unexpected reaction add body: %#v", addBody)
+	}
+	getReaction := slackRequest(handler, http.MethodPost, "/api/reactions.get", `{"channel":"C000000001","timestamp":"`+posted.TS+`"}`, true)
+	if !strings.Contains(getReaction.Body.String(), `"name":"thumbsup"`) {
+		t.Fatalf("reaction missing: %s", getReaction.Body.String())
+	}
+}
+
+func TestSlackConversationsCreateJoinLeaveAndDelete(t *testing.T) {
+	_, handler := newSlackTestService()
+
+	create := slackRequest(handler, http.MethodPost, "/api/conversations.create", `{"name":"eng"}`, true)
+	var created struct {
+		OK      bool `json:"ok"`
+		Channel struct {
+			ID         string `json:"id"`
+			Name       string `json:"name"`
+			NumMembers int    `json:"num_members"`
+		} `json:"channel"`
+	}
+	mustDecodeSlackJSON(t, create.Body.Bytes(), &created)
+	if !created.OK || created.Channel.Name != "eng" || created.Channel.ID == "" || created.Channel.NumMembers != 1 {
+		t.Fatalf("unexpected create body: %#v", created)
+	}
+
+	duplicate := slackRequest(handler, http.MethodPost, "/api/conversations.create", `{"name":"eng"}`, true)
+	if !strings.Contains(duplicate.Body.String(), `"error":"name_taken"`) {
+		t.Fatalf("unexpected duplicate body: %s", duplicate.Body.String())
+	}
+
+	leave := slackRequest(handler, http.MethodPost, "/api/conversations.leave", `{"channel":"`+created.Channel.ID+`"}`, true)
+	if !strings.Contains(leave.Body.String(), `"ok":true`) {
+		t.Fatalf("unexpected leave body: %s", leave.Body.String())
+	}
+	join := slackRequest(handler, http.MethodPost, "/api/conversations.join", `{"channel":"`+created.Channel.ID+`"}`, true)
+	if !strings.Contains(join.Body.String(), `"num_members":1`) {
+		t.Fatalf("unexpected join body: %s", join.Body.String())
+	}
+
+	message := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"`+created.Channel.ID+`","text":"delete me"}`, true)
+	var posted struct {
+		TS string `json:"ts"`
+	}
+	mustDecodeSlackJSON(t, message.Body.Bytes(), &posted)
+	deleted := slackRequest(handler, http.MethodPost, "/api/chat.delete", `{"channel":"`+created.Channel.ID+`","ts":"`+posted.TS+`"}`, true)
+	if !strings.Contains(deleted.Body.String(), `"ok":true`) {
+		t.Fatalf("unexpected delete body: %s", deleted.Body.String())
+	}
+}
+
+func TestSlackOAuthFlow(t *testing.T) {
+	service, handler := newSlackTestService()
+	service.store.OAuthApps.Insert(corestore.Record{
+		"client_id":     "12345.67890",
+		"client_secret": "test-secret",
+		"name":          "Test App",
+		"redirect_uris": []string{"http://localhost:3000/callback"},
+	})
+
+	auth := slackRequest(handler, http.MethodGet, "/oauth/v2/authorize?client_id=12345.67890&redirect_uri=http://localhost:3000/callback&scope=chat:write&state=xyz", "", false)
+	if auth.Code != http.StatusOK || !strings.Contains(auth.Body.String(), "Sign in to Slack") || !strings.Contains(auth.Body.String(), "Test App") {
+		t.Fatalf("unexpected auth page status = %d body = %s", auth.Code, auth.Body.String())
+	}
+
+	form := url.Values{
+		"user_id":      {"U000000001"},
+		"redirect_uri": {"http://localhost:3000/callback"},
+		"scope":        {"chat:write"},
+		"state":        {"xyz"},
+		"client_id":    {"12345.67890"},
+	}
+	callback := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:4018/oauth/v2/authorize/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	handler.ServeHTTP(callback, req)
+	if callback.Code != http.StatusFound {
+		t.Fatalf("callback status = %d body = %s", callback.Code, callback.Body.String())
+	}
+	location, err := url.Parse(callback.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := location.Query().Get("code")
+	if code == "" || location.Query().Get("state") != "xyz" {
+		t.Fatalf("unexpected callback location: %s", callback.Header().Get("Location"))
+	}
+
+	token := slackRequest(handler, http.MethodPost, "/api/oauth.v2.access", "code="+code+"&client_id=12345.67890&client_secret=test-secret", false)
+	token.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	var tokenBody struct {
+		OK          bool   `json:"ok"`
+		AccessToken string `json:"access_token"`
+		Team        struct {
+			Name string `json:"name"`
+		} `json:"team"`
+		AuthedUser struct {
+			ID string `json:"id"`
+		} `json:"authed_user"`
+	}
+	mustDecodeSlackJSON(t, token.Body.Bytes(), &tokenBody)
+	if !tokenBody.OK || !strings.HasPrefix(tokenBody.AccessToken, "xoxb-") || tokenBody.Team.Name != "Emulate" || tokenBody.AuthedUser.ID != "U000000001" {
+		t.Fatalf("unexpected token body: %#v", tokenBody)
+	}
+}
+
+func TestSlackIncomingWebhookAndInspector(t *testing.T) {
+	service, handler := newSlackTestService()
+	webhook := firstRecord(service.store.IncomingWebhooks.All())
+	res := slackRequest(handler, http.MethodPost, stringField(webhook, "url"), `{"text":"Deploy succeeded!"}`, false)
+	if res.Code != http.StatusOK || res.Body.String() != "ok" {
+		t.Fatalf("webhook status = %d body = %s", res.Code, res.Body.String())
+	}
+	messages := service.store.Messages.FindBy("channel_id", "C000000001")
+	if len(messages) != 1 || stringField(messages[0], "text") != "Deploy succeeded!" || stringField(messages[0], "subtype") != "bot_message" {
+		t.Fatalf("unexpected stored webhook messages: %#v", messages)
+	}
+
+	page := slackRequest(handler, http.MethodGet, "/?channel=C000000001", "", false)
+	if page.Code != http.StatusOK || !strings.Contains(page.Body.String(), "Message Inspector") || !strings.Contains(page.Body.String(), "Deploy succeeded!") {
+		t.Fatalf("unexpected inspector page status = %d body = %s", page.Code, page.Body.String())
+	}
+}
+
+func TestSlackSeedFromConfig(t *testing.T) {
+	store := corestore.New()
+	service := New(Options{
+		Store:   store,
+		BaseURL: "http://localhost:4018",
+		Seed: &SeedConfig{
+			Team: &TeamSeed{Name: "Acme Corp", Domain: "acme"},
+			Users: []UserSeed{
+				{Name: "alice", RealName: "Alice Smith", Email: "alice@acme.com", IsAdmin: true},
+				{Name: "bob", Email: "bob@acme.com"},
+			},
+			Channels:         []ChannelSeed{{Name: "engineering", Topic: "Code talk"}, {Name: "secret", IsPrivate: true}},
+			Bots:             []BotSeed{{Name: "deploy-bot"}},
+			OAuthApps:        []OAuthAppSeed{{ClientID: "client", ClientSecret: "secret", Name: "Slack App", RedirectURIs: []string{"http://localhost/callback"}}},
+			IncomingWebhooks: []IncomingWebhookSeed{{Channel: "engineering", Label: "Deploys"}},
+			SigningSecret:    "test-signing-secret",
+		},
+	})
+	team := firstRecord(service.store.Teams.All())
+	if stringField(team, "name") != "Acme Corp" || stringField(team, "domain") != "acme" {
+		t.Fatalf("unexpected team: %#v", team)
+	}
+	if service.store.Users.Count() != 3 || service.store.Channels.Count() != 4 || service.store.Bots.Count() != 1 || service.store.OAuthApps.Count() != 1 {
+		t.Fatalf("unexpected seeded counts: users=%d channels=%d bots=%d oauth=%d", service.store.Users.Count(), service.store.Channels.Count(), service.store.Bots.Count(), service.store.OAuthApps.Count())
+	}
+	secret := firstRecord(service.store.Channels.FindBy("name", "secret"))
+	if secret == nil || !boolField(secret, "is_private") {
+		t.Fatalf("secret channel missing or not private: %#v", secret)
+	}
+	signingSecret, ok := store.GetData("slack.signing_secret")
+	if !ok || signingSecret != "test-signing-secret" {
+		t.Fatalf("unexpected signing secret: %#v ok=%v", signingSecret, ok)
+	}
+}
+
+func newSlackTestService() (*Service, http.Handler) {
+	service := New(Options{Store: corestore.New(), BaseURL: "http://localhost:4018"})
+	router := corehttp.NewRouter()
+	service.RegisterRoutes(router)
+	return service, router
+}
+
+func slackRequest(handler http.Handler, method string, path string, body string, auth bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, "http://localhost:4018"+path, strings.NewReader(body))
+	if body != "" {
+		if strings.Contains(body, "=") && !strings.HasPrefix(strings.TrimSpace(body), "{") {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		} else {
+			req.Header.Set("Content-Type", "application/json")
+		}
+	}
+	if auth {
+		req.Header.Set("Authorization", "Bearer xoxb-test-token")
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
+}
+
+func mustDecodeSlackJSON(t *testing.T, raw []byte, target any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, target); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, string(raw))
+	}
+}

--- a/internal/services/slack/service_test.go
+++ b/internal/services/slack/service_test.go
@@ -428,7 +428,7 @@ func TestSlackSeedFromConfig(t *testing.T) {
 }
 
 func newSlackTestService() (*Service, http.Handler) {
-	service := New(Options{Store: corestore.New(), BaseURL: "http://localhost:4018"})
+	service := New(Options{Store: corestore.New(), BaseURL: "http://localhost:4018", RootInspector: true})
 	router := corehttp.NewRouter()
 	service.RegisterRoutes(router)
 	return service, router

--- a/internal/services/slack/service_test.go
+++ b/internal/services/slack/service_test.go
@@ -2,10 +2,12 @@ package slack
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
@@ -124,6 +126,119 @@ func TestSlackChatConversationsAndReactions(t *testing.T) {
 	getReaction := slackRequest(handler, http.MethodPost, "/api/reactions.get", `{"channel":"C000000001","timestamp":"`+posted.TS+`"}`, true)
 	if !strings.Contains(getReaction.Body.String(), `"name":"thumbsup"`) {
 		t.Fatalf("reaction missing: %s", getReaction.Body.String())
+	}
+}
+
+func TestSlackThreadReplyCountHandlesConcurrentReplies(t *testing.T) {
+	service, handler := newSlackTestService()
+
+	post := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"general","text":"parent"}`, true)
+	var posted struct {
+		OK bool   `json:"ok"`
+		TS string `json:"ts"`
+	}
+	mustDecodeSlackJSON(t, post.Body.Bytes(), &posted)
+	if !posted.OK || posted.TS == "" {
+		t.Fatalf("unexpected post body: %#v", posted)
+	}
+
+	const replies = 50
+	errCh := make(chan string, replies)
+	var wg sync.WaitGroup
+	for index := 0; index < replies; index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			res := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", fmt.Sprintf(`{"channel":"C000000001","text":"reply %d","thread_ts":"%s"}`, index, posted.TS), true)
+			if !strings.Contains(res.Body.String(), `"ok":true`) {
+				errCh <- fmt.Sprintf("reply %d failed: %s", index, res.Body.String())
+			}
+		}(index)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+	if t.Failed() {
+		return
+	}
+
+	parent := service.findMessage("C000000001", posted.TS)
+	if parent == nil || intField(parent, "reply_count") != replies {
+		t.Fatalf("unexpected parent after replies: %#v", parent)
+	}
+	replyUsers := stringSliceValue(parent["reply_users"])
+	if len(replyUsers) != 1 || replyUsers[0] != "U000000001" {
+		t.Fatalf("unexpected reply users: %#v", replyUsers)
+	}
+}
+
+func TestSlackReactionsHandleConcurrentDistinctUsers(t *testing.T) {
+	service, handler := newSlackTestService()
+
+	const reactors = 40
+	tokens := make([]string, 0, reactors)
+	for index := 0; index < reactors; index++ {
+		userID := fmt.Sprintf("UCONC%06d", index)
+		token := fmt.Sprintf("xoxb-concurrent-%d", index)
+		tokens = append(tokens, token)
+		service.store.Users.Insert(userRecord(userInput{
+			UserID:   userID,
+			TeamID:   "T000000001",
+			Name:     fmt.Sprintf("reactor%d", index),
+			RealName: fmt.Sprintf("Reactor %d", index),
+			Email:    fmt.Sprintf("reactor%d@example.com", index),
+		}))
+		service.store.Tokens.Insert(corestore.Record{
+			"token":  token,
+			"login":  userID,
+			"scopes": []string{"reactions:write"},
+		})
+	}
+
+	post := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"general","text":"react here"}`, true)
+	var posted struct {
+		OK bool   `json:"ok"`
+		TS string `json:"ts"`
+	}
+	mustDecodeSlackJSON(t, post.Body.Bytes(), &posted)
+	if !posted.OK || posted.TS == "" {
+		t.Fatalf("unexpected post body: %#v", posted)
+	}
+
+	errCh := make(chan string, reactors)
+	var wg sync.WaitGroup
+	for index, token := range tokens {
+		wg.Add(1)
+		go func(index int, token string) {
+			defer wg.Done()
+			res := slackRequestWithToken(handler, http.MethodPost, "/api/reactions.add", fmt.Sprintf(`{"channel":"C000000001","timestamp":"%s","name":"eyes"}`, posted.TS), token)
+			if !strings.Contains(res.Body.String(), `"ok":true`) {
+				errCh <- fmt.Sprintf("reaction %d failed: %s", index, res.Body.String())
+			}
+		}(index, token)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+	if t.Failed() {
+		return
+	}
+
+	message := service.findMessage("C000000001", posted.TS)
+	if message == nil {
+		t.Fatal("posted message missing")
+	}
+	reactions := recordSliceValue(message["reactions"])
+	if len(reactions) != 1 || stringValue(reactions[0]["name"]) != "eyes" || intField(reactions[0], "count") != reactors {
+		t.Fatalf("unexpected reactions: %#v", reactions)
+	}
+	users := stringSliceValue(reactions[0]["users"])
+	if len(users) != reactors {
+		t.Fatalf("unexpected reaction users: %#v", users)
 	}
 }
 
@@ -320,6 +435,14 @@ func newSlackTestService() (*Service, http.Handler) {
 }
 
 func slackRequest(handler http.Handler, method string, path string, body string, auth bool) *httptest.ResponseRecorder {
+	token := ""
+	if auth {
+		token = "xoxb-test-token"
+	}
+	return slackRequestWithToken(handler, method, path, body, token)
+}
+
+func slackRequestWithToken(handler http.Handler, method string, path string, body string, token string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(method, "http://localhost:4018"+path, strings.NewReader(body))
 	if body != "" {
 		if strings.Contains(body, "=") && !strings.HasPrefix(strings.TrimSpace(body), "{") {
@@ -328,8 +451,8 @@ func slackRequest(handler http.Handler, method string, path string, body string,
 			req.Header.Set("Content-Type", "application/json")
 		}
 	}
-	if auth {
-		req.Header.Set("Authorization", "Bearer xoxb-test-token")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)

--- a/internal/services/slack/service_test.go
+++ b/internal/services/slack/service_test.go
@@ -47,6 +47,19 @@ func TestSlackAuthTeamAndUsers(t *testing.T) {
 	if !lookup.OK || lookup.User.ID != "U000000001" || lookup.User.Profile.Email != "admin@emulate.dev" {
 		t.Fatalf("unexpected lookup body: %#v", lookup)
 	}
+
+	res = slackRequest(handler, http.MethodPost, "/api/bots.info", `{"bot":"B000000001"}`, true)
+	var botInfo struct {
+		OK  bool `json:"ok"`
+		Bot struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"bot"`
+	}
+	mustDecodeSlackJSON(t, res.Body.Bytes(), &botInfo)
+	if !botInfo.OK || botInfo.Bot.ID != "B000000001" || botInfo.Bot.Name == "" {
+		t.Fatalf("unexpected bot info body: %#v", botInfo)
+	}
 }
 
 func TestSlackChatConversationsAndReactions(t *testing.T) {
@@ -193,8 +206,24 @@ func TestSlackOAuthFlow(t *testing.T) {
 		t.Fatalf("unexpected callback location: %s", callback.Header().Get("Location"))
 	}
 
-	token := slackRequest(handler, http.MethodPost, "/api/oauth.v2.access", "code="+code+"&client_id=12345.67890&client_secret=test-secret", false)
-	token.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	wrongRedirect := slackRequest(handler, http.MethodPost, "/api/oauth.v2.access", url.Values{
+		"code":          {code},
+		"client_id":     {"12345.67890"},
+		"client_secret": {"test-secret"},
+		"redirect_uri":  {"http://localhost:3000/wrong"},
+	}.Encode(), false)
+	var wrongRedirectBody map[string]any
+	mustDecodeSlackJSON(t, wrongRedirect.Body.Bytes(), &wrongRedirectBody)
+	if wrongRedirectBody["ok"] != false || wrongRedirectBody["error"] != "invalid_code" {
+		t.Fatalf("unexpected wrong redirect body: %#v", wrongRedirectBody)
+	}
+
+	token := slackRequest(handler, http.MethodPost, "/api/oauth.v2.access", url.Values{
+		"code":          {code},
+		"client_id":     {"12345.67890"},
+		"client_secret": {"test-secret"},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+	}.Encode(), false)
 	var tokenBody struct {
 		OK          bool   `json:"ok"`
 		AccessToken string `json:"access_token"`
@@ -229,6 +258,25 @@ func TestSlackIncomingWebhookAndInspector(t *testing.T) {
 	}
 }
 
+func TestSlackIncomingWebhookRejectsInvalidPathSecrets(t *testing.T) {
+	service, handler := newSlackTestService()
+
+	for _, path := range []string{
+		"/services/T000000001/B000000001/not-real",
+		"/services/T000000001/B999999999/X000000001",
+		"/services/T999999999/B000000001/X000000001",
+	} {
+		res := slackRequest(handler, http.MethodPost, path, `{"text":"should not post","channel":"general"}`, false)
+		if res.Code != http.StatusNotFound || res.Body.String() != "no_service" {
+			t.Fatalf("%s status = %d body = %s", path, res.Code, res.Body.String())
+		}
+	}
+
+	if service.store.Messages.Count() != 0 {
+		t.Fatalf("invalid webhook paths stored messages: %#v", service.store.Messages.All())
+	}
+}
+
 func TestSlackSeedFromConfig(t *testing.T) {
 	store := corestore.New()
 	service := New(Options{
@@ -251,7 +299,7 @@ func TestSlackSeedFromConfig(t *testing.T) {
 	if stringField(team, "name") != "Acme Corp" || stringField(team, "domain") != "acme" {
 		t.Fatalf("unexpected team: %#v", team)
 	}
-	if service.store.Users.Count() != 3 || service.store.Channels.Count() != 4 || service.store.Bots.Count() != 1 || service.store.OAuthApps.Count() != 1 {
+	if service.store.Users.Count() != 3 || service.store.Channels.Count() != 4 || service.store.Bots.Count() != 2 || service.store.OAuthApps.Count() != 1 {
 		t.Fatalf("unexpected seeded counts: users=%d channels=%d bots=%d oauth=%d", service.store.Users.Count(), service.store.Channels.Count(), service.store.Bots.Count(), service.store.OAuthApps.Count())
 	}
 	secret := firstRecord(service.store.Channels.FindBy("name", "secret"))

--- a/internal/services/slack/service_test.go
+++ b/internal/services/slack/service_test.go
@@ -80,6 +80,13 @@ func TestSlackChatConversationsAndReactions(t *testing.T) {
 	if !posted.OK || posted.Channel != "C000000001" || posted.TS == "" || posted.Message.Text != "hello world" {
 		t.Fatalf("unexpected post body: %#v", posted)
 	}
+	var postedRaw struct {
+		Message map[string]any `json:"message"`
+	}
+	mustDecodeSlackJSON(t, post.Body.Bytes(), &postedRaw)
+	if _, ok := postedRaw.Message["thread_ts"]; ok {
+		t.Fatalf("top-level message included thread_ts: %#v", postedRaw.Message)
+	}
 
 	reply := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"C000000001","text":"reply","thread_ts":"`+posted.TS+`"}`, true)
 	var replyBody struct {
@@ -126,6 +133,78 @@ func TestSlackChatConversationsAndReactions(t *testing.T) {
 	getReaction := slackRequest(handler, http.MethodPost, "/api/reactions.get", `{"channel":"C000000001","timestamp":"`+posted.TS+`"}`, true)
 	if !strings.Contains(getReaction.Body.String(), `"name":"thumbsup"`) {
 		t.Fatalf("reaction missing: %s", getReaction.Body.String())
+	}
+}
+
+func TestSlackChatDeleteThreadReplyRefreshesParentMetadata(t *testing.T) {
+	service, handler := newSlackTestService()
+
+	post := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"general","text":"parent"}`, true)
+	var posted struct {
+		OK bool   `json:"ok"`
+		TS string `json:"ts"`
+	}
+	mustDecodeSlackJSON(t, post.Body.Bytes(), &posted)
+	if !posted.OK || posted.TS == "" {
+		t.Fatalf("unexpected post body: %#v", posted)
+	}
+
+	firstReply := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"C000000001","text":"first","thread_ts":"`+posted.TS+`"}`, true)
+	var firstReplyBody struct {
+		OK bool   `json:"ok"`
+		TS string `json:"ts"`
+	}
+	mustDecodeSlackJSON(t, firstReply.Body.Bytes(), &firstReplyBody)
+	if !firstReplyBody.OK || firstReplyBody.TS == "" {
+		t.Fatalf("unexpected first reply body: %#v", firstReplyBody)
+	}
+
+	secondReply := slackRequest(handler, http.MethodPost, "/api/chat.postMessage", `{"channel":"C000000001","text":"second","thread_ts":"`+posted.TS+`"}`, true)
+	var secondReplyBody struct {
+		OK bool   `json:"ok"`
+		TS string `json:"ts"`
+	}
+	mustDecodeSlackJSON(t, secondReply.Body.Bytes(), &secondReplyBody)
+	if !secondReplyBody.OK || secondReplyBody.TS == "" {
+		t.Fatalf("unexpected second reply body: %#v", secondReplyBody)
+	}
+
+	parent := service.findMessage("C000000001", posted.TS)
+	if parent == nil || intField(parent, "reply_count") != 2 {
+		t.Fatalf("unexpected parent before delete: %#v", parent)
+	}
+
+	deletedFirst := slackRequest(handler, http.MethodPost, "/api/chat.delete", `{"channel":"C000000001","ts":"`+firstReplyBody.TS+`"}`, true)
+	if !strings.Contains(deletedFirst.Body.String(), `"ok":true`) {
+		t.Fatalf("unexpected first delete body: %s", deletedFirst.Body.String())
+	}
+	parent = service.findMessage("C000000001", posted.TS)
+	replyUsers := stringSliceValue(parent["reply_users"])
+	if intField(parent, "reply_count") != 1 || len(replyUsers) != 1 || replyUsers[0] != "U000000001" {
+		t.Fatalf("unexpected parent after first delete: %#v", parent)
+	}
+
+	deletedSecond := slackRequest(handler, http.MethodPost, "/api/chat.delete", `{"channel":"C000000001","ts":"`+secondReplyBody.TS+`"}`, true)
+	if !strings.Contains(deletedSecond.Body.String(), `"ok":true`) {
+		t.Fatalf("unexpected second delete body: %s", deletedSecond.Body.String())
+	}
+	parent = service.findMessage("C000000001", posted.TS)
+	replyUsers = stringSliceValue(parent["reply_users"])
+	if intField(parent, "reply_count") != 0 || len(replyUsers) != 0 {
+		t.Fatalf("unexpected parent after second delete: %#v", parent)
+	}
+
+	history := slackRequest(handler, http.MethodPost, "/api/conversations.history", `{"channel":"C000000001"}`, true)
+	var historyBody struct {
+		OK       bool             `json:"ok"`
+		Messages []map[string]any `json:"messages"`
+	}
+	mustDecodeSlackJSON(t, history.Body.Bytes(), &historyBody)
+	if !historyBody.OK || len(historyBody.Messages) != 1 {
+		t.Fatalf("unexpected history body: %#v", historyBody)
+	}
+	if _, ok := historyBody.Messages[0]["reply_count"]; ok {
+		t.Fatalf("history retained reply_count after replies were deleted: %#v", historyBody.Messages[0])
 	}
 }
 

--- a/internal/services/slack/store.go
+++ b/internal/services/slack/store.go
@@ -1,0 +1,29 @@
+package slack
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Teams            *corestore.Collection
+	Users            *corestore.Collection
+	Channels         *corestore.Collection
+	Messages         *corestore.Collection
+	Bots             *corestore.Collection
+	OAuthApps        *corestore.Collection
+	OAuthCodes       *corestore.Collection
+	Tokens           *corestore.Collection
+	IncomingWebhooks *corestore.Collection
+}
+
+func NewStore(store *corestore.Store) Store {
+	return Store{
+		Teams:            store.MustCollection("slack.teams", "team_id"),
+		Users:            store.MustCollection("slack.users", "user_id", "email", "name"),
+		Channels:         store.MustCollection("slack.channels", "channel_id", "name"),
+		Messages:         store.MustCollection("slack.messages", "ts", "channel_id"),
+		Bots:             store.MustCollection("slack.bots", "bot_id"),
+		OAuthApps:        store.MustCollection("slack.oauth_apps", "client_id"),
+		OAuthCodes:       store.MustCollection("slack.oauth_codes", "code"),
+		Tokens:           store.MustCollection("slack.tokens", "token"),
+		IncomingWebhooks: store.MustCollection("slack.incoming_webhooks", "token"),
+	}
+}

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -4,7 +4,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
-The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. To expose Slack on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service slack`.
+The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. In native CLI runs with multiple services enabled, open `/slack` for the message inspector. When only Slack is enabled, and in Vercel Go Function previews, the inspector is available at the service root. To expose Slack on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service slack`.
 
 ## Install
 

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -4,6 +4,8 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
+The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. To expose Slack on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service slack`.
+
 ## Install
 
 ```bash

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,7 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
-      'Services: []string{"apple", "aws", "github", "google", "microsoft", "resend", "vercel"}',
+      'Services: []string{"apple", "aws", "github", "google", "microsoft", "resend", "slack", "vercel"}',
     );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
@@ -35,7 +35,7 @@ describe("createVercelScaffold", () => {
   });
 
   it("includes google in the shared Vercel CLI service default", () => {
-    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe("apple,aws,github,google,microsoft,resend,vercel");
+    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe("apple,aws,github,google,microsoft,resend,slack,vercel");
   });
 
   it("merges the rewrite into an existing vercel.json", () => {
@@ -229,7 +229,7 @@ require (
     const cwd = tempDir();
 
     expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "okta" })).toThrow(
-      "currently supports native services: apple, aws, github, google, microsoft, resend, vercel",
+      "currently supports native services: apple, aws, github, google, microsoft, resend, slack, vercel",
     );
   });
 

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -1,7 +1,16 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-export const SUPPORTED_VERCEL_SERVICES = ["apple", "aws", "github", "google", "microsoft", "resend", "vercel"] as const;
+export const SUPPORTED_VERCEL_SERVICES = [
+  "apple",
+  "aws",
+  "github",
+  "google",
+  "microsoft",
+  "resend",
+  "slack",
+  "vercel",
+] as const;
 export const DEFAULT_VERCEL_SERVICE_OPTION = SUPPORTED_VERCEL_SERVICES.join(",");
 const REQUIRED_GO_VERSION = "1.24";
 const DEFAULT_REWRITE = {

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -317,7 +317,7 @@ Then use these in your app to construct API and OAuth URLs. See each service's s
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. State changes dispatch `event_callback` payloads to configured webhook URLs.
 
+The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. Use `npx emulate vercel init --service slack` for zero infra Vercel preview deployments at `/emulate/slack/*`.
+
 ## Start
 
 ```bash
@@ -33,10 +35,10 @@ Pass tokens as `Authorization: Bearer <token>`. All Web API endpoints require au
 
 ```bash
 curl -X POST http://localhost:4003/api/auth.test \
-  -H "Authorization: Bearer test_token_admin"
+  -H "Authorization: Bearer xoxb-test-token"
 ```
 
-When no token is provided, requests fall back to the first seeded user.
+The native Go runtime seeds `xoxb-test-token` for the default admin user. OAuth token exchange also issues `xoxb-*` tokens.
 
 ## Pointing Your App at the Emulator
 
@@ -305,7 +307,7 @@ Returns a Slack-style response:
   "ok": true,
   "access_token": "xoxb-...",
   "token_type": "bot",
-  "bot_user_id": "B000000001",
+  "bot_user_id": "U000000001",
   "team": { "id": "T000000001", "name": "Emulate" },
   "authed_user": { "id": "U000000001" }
 }
@@ -324,7 +326,7 @@ When messages are posted or reactions are added/removed, the emulator dispatches
 ### Post Messages and React
 
 ```bash
-TOKEN="test_token_admin"
+TOKEN="xoxb-test-token"
 BASE="http://localhost:4003"
 
 # Post a message

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. In embedded JavaScript mode, state changes also dispatch `event_callback` payloads to configured webhook URLs.
 
-The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. It stores message and reaction state but does not deliver outbound Slack Events API callbacks yet. Use `npx emulate vercel init --service slack` for zero infra Vercel preview deployments at `/emulate/slack/*`.
+The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. It stores message and reaction state but does not deliver outbound Slack Events API callbacks yet. In native CLI runs with multiple services enabled, open `/slack` for the message inspector. When only Slack is enabled, and in Vercel Go Function previews, the inspector is available at the service root. Use `npx emulate vercel init --service slack` for zero infra Vercel preview deployments at `/emulate/slack/*`.
 
 ## Start
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -6,9 +6,9 @@ allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 
 # Slack API Emulator
 
-Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. State changes dispatch `event_callback` payloads to configured webhook URLs.
+Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. In embedded JavaScript mode, state changes also dispatch `event_callback` payloads to configured webhook URLs.
 
-The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. Use `npx emulate vercel init --service slack` for zero infra Vercel preview deployments at `/emulate/slack/*`.
+The native Go runtime implements this Slack Web API, OAuth v2, incoming webhook, seed config, and message inspector foundation for local CLI runs and Vercel Go Function previews. It stores message and reaction state but does not deliver outbound Slack Events API callbacks yet. Use `npx emulate vercel init --service slack` for zero infra Vercel preview deployments at `/emulate/slack/*`.
 
 ## Start
 
@@ -315,7 +315,7 @@ Returns a Slack-style response:
 
 ## Event Dispatching
 
-When messages are posted or reactions are added/removed, the emulator dispatches `event_callback` payloads to configured webhook URLs. These payloads match Slack's Events API format:
+In embedded JavaScript mode, when messages are posted or reactions are added/removed, the emulator dispatches `event_callback` payloads to configured webhook URLs. These payloads match Slack's Events API format:
 
 - `message` events on `chat.postMessage`, `chat.update`, `chat.delete`
 - `reaction_added` / `reaction_removed` events on `reactions.add` / `reactions.remove`

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"apple", "aws", "github", "google", "microsoft", "resend", "vercel"}
+var defaultServices = []string{"apple", "aws", "github", "google", "microsoft", "resend", "slack", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -35,7 +35,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "apple,aws,github,google,microsoft,resend,vercel" {
+	if strings.Join(body.Services, ",") != "apple,aws,github,google,microsoft,resend,slack,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -170,6 +170,23 @@ func TestHandlerForwardsGoogleService(t *testing.T) {
 	}
 	if !strings.Contains(res.Body.String(), `"issuer":"https://preview.example.com/emulate/google"`) ||
 		!strings.Contains(res.Body.String(), `"authorization_endpoint":"https://preview.example.com/emulate/google/o/oauth2/v2/auth"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestHandlerForwardsSlackService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"slack"}})
+	req := httptest.NewRequest(http.MethodPost, "https://preview.example.com/emulate/slack/api/auth.test", nil)
+	req.Host = "preview.example.com"
+	req.Header.Set("Authorization", "Bearer xoxb-test-token")
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"team":"Emulate"`) || !strings.Contains(res.Body.String(), `"user_id":"U000000001"`) {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }


### PR DESCRIPTION
- Adds a dependency-free native Slack service with OAuth v2, auth/team/users, chat, conversations, reactions, incoming webhooks, seed handling, and inspector routes.

- Wires Slack into the Go runtime, native CLI seed parsing, and Vercel Go Function scaffold.

- Updates docs, skills, and focused tests for native Slack support while keeping npm and TypeScript package surfaces in place.