### PR TITLE
Add Go Okta foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 The native Go runtime implements the OAuth/OIDC flow with RS256 ID tokens and JWKS, plus Gmail messages, drafts, threads, labels, history, settings filters, Calendar list/events/freebusy, and Drive file list/upload/download routes for local CLI runs and Vercel Go Function previews. To expose Google on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service google`. The generated route serves Google at `/emulate/google/*`.
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use the service specific discovery paths, for example `/google/.well-known/openid-configuration`, because those providers all use the root OIDC discovery path when run alone.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use the service specific discovery paths, for example `/google/.well-known/openid-configuration` or `/okta/.well-known/openid-configuration`, because those providers all use the root OIDC discovery path when run alone.
 
 - `GET /o/oauth2/v2/auth` - authorization endpoint
 - `POST /oauth2/token` - token exchange
@@ -680,6 +680,23 @@ The native Go runtime implements the Microsoft OIDC, token, and Graph profile ro
 - `GET /v1.0/users/:id` - Microsoft Graph user by ID
 - `GET /oauth2/v2.0/logout` - end session / logout
 - `POST /oauth2/v2.0/revoke` - token revocation
+
+## Okta
+
+Okta OAuth 2.0, OpenID Connect, users, groups, apps, and authorization server emulation with authorization code, refresh token, client credentials, PKCE, RS256 ID tokens, JWKS, userinfo, introspection, revocation, and management APIs.
+
+The native Go runtime implements the Okta OIDC and management API routes below for local CLI runs and Vercel Go Function previews. To expose Okta on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service okta`. The generated route serves Okta at `/emulate/okta/*`.
+
+- `GET /.well-known/openid-configuration` - org OIDC discovery document
+- `GET /oauth2/:authServerId/.well-known/openid-configuration` - custom authorization server discovery
+- `GET /oauth2/v1/keys`, `GET /oauth2/:authServerId/v1/keys` - JSON Web Key Set (JWKS)
+- `GET /oauth2/v1/authorize`, `GET /oauth2/:authServerId/v1/authorize` - authorization endpoint (shows user picker)
+- `POST /oauth2/v1/token`, `POST /oauth2/:authServerId/v1/token` - token exchange
+- `GET /oauth2/v1/userinfo`, `GET /oauth2/:authServerId/v1/userinfo` - OpenID Connect user info
+- `POST /oauth2/v1/revoke`, `POST /oauth2/:authServerId/v1/revoke` - token revocation
+- `POST /oauth2/v1/introspect`, `POST /oauth2/:authServerId/v1/introspect` - token introspection
+- `GET /oauth2/v1/logout`, `GET /oauth2/:authServerId/v1/logout` - end session
+- `GET`, `POST`, `PUT`, `DELETE` under `/api/v1/users`, `/api/v1/groups`, `/api/v1/apps`, and `/api/v1/authorizationServers`
 
 ## AWS
 
@@ -786,7 +803,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -827,7 +844,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/docs/apple/page.mdx
+++ b/apps/web/app/docs/apple/page.mdx
@@ -4,7 +4,7 @@ Sign in with Apple emulation with authorization code flow, PKCE support, RS256 I
 
 The native Go runtime implements the Apple OIDC flow below for local CLI runs and Vercel Go Function previews. To expose Apple on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service apple`. The generated route serves Apple at `/emulate/apple/*`.
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## Endpoints
 

--- a/apps/web/app/docs/authentication/page.mdx
+++ b/apps/web/app/docs/authentication/page.mdx
@@ -60,7 +60,7 @@ The Google emulator uses the standard OAuth 2.0 authorization code flow. Configu
 curl http://localhost:4002/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use `/google/.well-known/openid-configuration`, `/apple/.well-known/openid-configuration`, or `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/google/.well-known/openid-configuration`, `/apple/.well-known/openid-configuration`, `/microsoft/.well-known/openid-configuration`, or `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## Slack OAuth
 

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -300,8 +300,8 @@ okta:
   users:
     - login: testuser@example.com
       email: testuser@example.com
-      firstName: Test
-      lastName: User
+      first_name: Test
+      last_name: User
   groups:
     - name: Everyone
       description: All users

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -10,7 +10,7 @@ npx emulate vercel init --service google
 
 The generated route serves Google at `/emulate/google/*`.
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## OAuth & OpenID Connect
 

--- a/apps/web/app/docs/microsoft/page.mdx
+++ b/apps/web/app/docs/microsoft/page.mdx
@@ -4,7 +4,7 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 
 The native Go runtime implements the Microsoft OIDC, token, and Graph profile routes below for local CLI runs and Vercel Go Function previews. To expose Microsoft on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service microsoft`. The generated route serves Microsoft at `/emulate/microsoft/*`.
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## Endpoints
 

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/apps/web/app/docs/okta/page.mdx
+++ b/apps/web/app/docs/okta/page.mdx
@@ -2,6 +2,10 @@
 
 Okta identity provider emulation with OAuth 2.0 / OIDC, user management, groups, apps, and authorization servers. Supports both default org server and custom authorization server paths.
 
+The native Go runtime implements the Okta OIDC and management API routes below for local CLI runs and Vercel Go Function previews. To expose Okta on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service okta`. The generated route serves Okta at `/emulate/okta/*`.
+
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.
+
 ## OAuth / OIDC
 
 Default org server and custom authorization server paths (`/oauth2/:authServerId/...`):

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
+	"github.com/vercel-labs/emulate/internal/services/okta"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/slack"
 	"github.com/vercel-labs/emulate/internal/services/stripe"
@@ -114,6 +115,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 	var githubSeed *github.SeedConfig
 	var googleSeed *google.SeedConfig
 	var microsoftSeed *microsoft.SeedConfig
+	var oktaSeed *okta.SeedConfig
 	var resendSeed *resend.SeedConfig
 	var slackSeed *slack.SeedConfig
 	var stripeSeed *stripe.SeedConfig
@@ -125,7 +127,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, google, microsoft, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, google, microsoft, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
@@ -176,6 +178,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 				return 1
 			}
 			microsoftSeed = &cfg
+		}
+		if raw, ok := loaded.Data["okta"]; ok {
+			var cfg okta.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse okta seed config: %v\n", err)
+				return 1
+			}
+			oktaSeed = &cfg
 		}
 		if raw, ok := loaded.Data["resend"]; ok {
 			var cfg resend.SeedConfig
@@ -231,6 +241,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		GitHubSeed:    githubSeed,
 		GoogleSeed:    googleSeed,
 		MicrosoftSeed: microsoftSeed,
+		OktaSeed:      oktaSeed,
 		ResendSeed:    resendSeed,
 		SlackSeed:     slackSeed,
 		StripeSeed:    stripeSeed,
@@ -421,7 +432,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"apple", "github", "google", "microsoft", "resend", "slack", "stripe", "vercel"}
+	return []string{"apple", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -463,6 +464,57 @@ func TestRunStartSeedsMicrosoftFromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsOktaFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"okta":{"users":[{"login":"okta@example.com","email":"okta@example.com","first_name":"Okta","last_name":"User"}],"oauth_clients":[{"client_id":"okta-client","client_secret":"okta-secret","name":"Okta App","redirect_uris":["http://localhost:3000/callback"],"auth_server_id":"default"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "okta" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	authorizeURL := fmt.Sprintf("http://127.0.0.1:%d/oauth2/default/v1/authorize?client_id=okta-client&redirect_uri=http%%3A%%2F%%2Flocalhost%%3A3000%%2Fcallback&response_type=code", port)
+	resp, err := http.Get(authorizeURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(raw), "okta@example.com") {
+		t.Fatalf("unexpected authorize response status = %d, body = %s", resp.StatusCode, string(raw))
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartRejectsYAMLSeedConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.yaml")
@@ -498,7 +550,7 @@ func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
 				t.Fatal("start with unsupported seed service exited successfully")
 			}
 			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for apple, github, google, microsoft, resend, slack, stripe, and vercel") || !strings.Contains(errText, "aws") {
+			if !strings.Contains(errText, "only supports --seed for apple, github, google, microsoft, okta, resend, slack, stripe, and vercel") || !strings.Contains(errText, "aws") {
 				t.Fatalf("unexpected stderr: %s", errText)
 			}
 		})

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
+	"github.com/vercel-labs/emulate/internal/services/okta"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/slack"
 	"github.com/vercel-labs/emulate/internal/services/stripe"
@@ -31,6 +32,7 @@ type ServerOptions struct {
 	GitHubSeed    *github.SeedConfig
 	GoogleSeed    *google.SeedConfig
 	MicrosoftSeed *microsoft.SeedConfig
+	OktaSeed      *okta.SeedConfig
 	ResendSeed    *resend.SeedConfig
 	SlackSeed     *slack.SeedConfig
 	StripeSeed    *stripe.SeedConfig
@@ -184,6 +186,21 @@ func NewServer(options ServerOptions) *Server {
 			router.Mount("/microsoft", prefixed)
 		}
 	}
+	if serviceEnabled(services, "okta") {
+		okta.Register(router, okta.Options{
+			Store:   runtimeStore,
+			BaseURL: options.BaseURL,
+			Seed:    options.OktaSeed,
+		})
+		if len(ambiguousOIDCServices) > 1 {
+			prefixed := corehttp.NewRouter()
+			okta.Register(prefixed, okta.Options{
+				Store:   runtimeStore,
+				BaseURL: servicePrefixedBaseURL(options.BaseURL, "okta"),
+			})
+			router.Mount("/okta", prefixed)
+		}
+	}
 	router.NotFound(func(c *corehttp.Context) {
 		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
 	})
@@ -209,7 +226,7 @@ func serviceEnabled(services []string, name string) bool {
 
 func enabledRootOIDCServices(services []string) []string {
 	names := []string{}
-	for _, name := range []string{"apple", "google", "microsoft"} {
+	for _, name := range []string{"apple", "google", "microsoft", "okta"} {
 		if serviceEnabled(services, name) {
 			names = append(names, name)
 		}

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -345,9 +345,24 @@ func TestNewHandlerMountsMicrosoftWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMountsOktaWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"okta"}, BaseURL: "http://localhost:4016"})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/oauth2/default/.well-known/openid-configuration", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"http://localhost:4016/oauth2/default"`) ||
+		!strings.Contains(res.Body.String(), `"jwks_uri":"http://localhost:4016/oauth2/default/v1/keys"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestNewHandlerMultiServiceOIDCDiscoveryUsesServicePrefixes(t *testing.T) {
 	handler := NewHandler(ServerOptions{
-		Services: []string{"apple", "google", "microsoft"},
+		Services: []string{"apple", "google", "microsoft", "okta"},
 		BaseURL:  "http://localhost:4010",
 	})
 
@@ -367,6 +382,7 @@ func TestNewHandlerMultiServiceOIDCDiscoveryUsesServicePrefixes(t *testing.T) {
 		{path: "/google/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/google"`},
 		{path: "/apple/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/apple"`},
 		{path: "/microsoft/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/microsoft/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"`},
+		{path: "/okta/oauth2/default/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/okta/oauth2/default"`},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			res := httptest.NewRecorder()
@@ -378,6 +394,17 @@ func TestNewHandlerMultiServiceOIDCDiscoveryUsesServicePrefixes(t *testing.T) {
 				t.Fatalf("missing %s in %s", tc.want, res.Body.String())
 			}
 		})
+	}
+}
+
+func TestNewHandlerDoesNotMountOktaWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/oauth2/default/v1/keys", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
 }
 

--- a/internal/services/okta/helpers.go
+++ b/internal/services/okta/helpers.go
@@ -1,0 +1,396 @@
+package okta
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const (
+	orgAuthServerID          = "org"
+	defaultAuthServerID      = "default"
+	defaultAudience          = "api://default"
+	defaultEveryoneGroupID   = "00g_everyone"
+	defaultEveryoneGroupName = "Everyone"
+)
+
+func oktaID(prefix string) string {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return prefix + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return prefix + hex.EncodeToString(raw)[:17]
+}
+
+func oktaToken(prefix string) string {
+	raw := make([]byte, 20)
+	if _, err := rand.Read(raw); err != nil {
+		return prefix + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func nowISO() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+func oktaError(c *corehttp.Context, status int, code string, summary string) {
+	c.JSON(status, map[string]any{
+		"errorCode":    code,
+		"errorSummary": summary,
+		"errorLink":    code,
+		"errorId":      code + "-" + strconv.FormatInt(time.Now().UnixMilli(), 10),
+		"errorCauses":  []any{},
+		"status":       status,
+	})
+}
+
+func oauthError(c *corehttp.Context, status int, code string, description string) {
+	c.JSON(status, map[string]any{"error": code, "error_description": description})
+}
+
+func readJSONBody(r *http.Request) map[string]any {
+	raw, _ := io.ReadAll(r.Body)
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil || body == nil {
+		return map[string]any{}
+	}
+	return body
+}
+
+func parseTokenBody(r *http.Request) map[string]string {
+	raw, _ := io.ReadAll(r.Body)
+	if len(raw) == 0 {
+		return map[string]string{}
+	}
+	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			return map[string]string{}
+		}
+		out := map[string]string{}
+		for key, value := range body {
+			if text, ok := value.(string); ok {
+				out[key] = text
+			}
+		}
+		return out
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return map[string]string{}
+	}
+	out := map[string]string{}
+	for key, list := range values {
+		if len(list) > 0 {
+			out[key] = list[len(list)-1]
+		}
+	}
+	return out
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func stringField(record corestore.Record, field string) string {
+	if record == nil {
+		return ""
+	}
+	return stringValue(record[field])
+}
+
+func intField(record corestore.Record, field string) int {
+	if record == nil {
+		return 0
+	}
+	return intValue(record[field])
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func intValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		n, _ := strconv.Atoi(v)
+		return n
+	default:
+		n, _ := strconv.Atoi(fmt.Sprint(v))
+		return n
+	}
+}
+
+func boolFromQuery(value string, fallback bool) bool {
+	switch strings.ToLower(value) {
+	case "":
+		return fallback
+	case "true", "1":
+		return true
+	case "false", "0":
+		return false
+	default:
+		return fallback
+	}
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if text, ok := item.(string); ok {
+				out = append(out, text)
+			}
+		}
+		return out
+	case nil:
+		return nil
+	default:
+		return []string{stringValue(v)}
+	}
+}
+
+func mapValue(value any) map[string]any {
+	if m, ok := value.(map[string]any); ok {
+		out := make(map[string]any, len(m))
+		for key, item := range m {
+			out[key] = item
+		}
+		return out
+	}
+	return map[string]any{}
+}
+
+func stringOrNil(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func normalizeUserStatus(value string, fallback string) string {
+	switch value {
+	case "STAGED", "PROVISIONED", "ACTIVE", "SUSPENDED", "DEPROVISIONED":
+		return value
+	default:
+		return fallback
+	}
+}
+
+func normalizeGroupType(value string, fallback string) string {
+	switch value {
+	case "OKTA_GROUP", "BUILT_IN":
+		return value
+	default:
+		return fallback
+	}
+}
+
+func normalizeActiveStatus(value string, fallback string) string {
+	switch value {
+	case "ACTIVE", "INACTIVE":
+		return value
+	default:
+		return fallback
+	}
+}
+
+func userDisplayName(user corestore.Record) string {
+	if displayName := stringField(user, "display_name"); displayName != "" {
+		return displayName
+	}
+	name := strings.TrimSpace(stringField(user, "first_name") + " " + stringField(user, "last_name"))
+	if name != "" {
+		return name
+	}
+	return stringField(user, "login")
+}
+
+func resolveIssuer(baseURL string, authServerID string) string {
+	if authServerID == orgAuthServerID {
+		return baseURL
+	}
+	return baseURL + "/oauth2/" + authServerID
+}
+
+func oauthBasePath(authServerID string) string {
+	if authServerID == orgAuthServerID {
+		return "/oauth2/v1"
+	}
+	return "/oauth2/" + url.PathEscape(authServerID) + "/v1"
+}
+
+func matchesRedirectURI(input string, allowed []string) bool {
+	for _, candidate := range allowed {
+		if input == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func parseScope(scope string) []string {
+	fields := strings.Fields(scope)
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+func scopeHas(scope string, wanted string) bool {
+	for _, item := range parseScope(scope) {
+		if item == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyPKCE(challenge string, method string, verifier string) bool {
+	if challenge == "" {
+		return true
+	}
+	if verifier == "" {
+		return false
+	}
+	if strings.EqualFold(method, "S256") {
+		digest := sha256.Sum256([]byte(verifier))
+		return base64.RawURLEncoding.EncodeToString(digest[:]) == challenge
+	}
+	return verifier == challenge
+}
+
+func constantTimeEqual(left string, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+}
+
+func applyBasicCredentials(r *http.Request, clientID *string, clientSecret *string) {
+	header := r.Header.Get("Authorization")
+	if !strings.HasPrefix(header, "Basic ") {
+		return
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(strings.TrimPrefix(header, "Basic ")))
+	if err != nil {
+		return
+	}
+	parts := strings.SplitN(string(raw), ":", 2)
+	if len(parts) != 2 {
+		return
+	}
+	if *clientID == "" {
+		*clientID, _ = url.QueryUnescape(parts[0])
+	}
+	if *clientSecret == "" {
+		*clientSecret, _ = url.QueryUnescape(parts[1])
+	}
+}
+
+func tokenFromRequest(r *http.Request) string {
+	header := r.Header.Get("Authorization")
+	if strings.HasPrefix(strings.ToLower(header), "bearer ") {
+		return strings.TrimSpace(header[len("Bearer "):])
+	}
+	return ""
+}
+
+func sswsTokenFromRequest(r *http.Request) string {
+	header := r.Header.Get("Authorization")
+	if strings.HasPrefix(strings.ToLower(header), "ssws ") {
+		return strings.TrimSpace(header[len("SSWS "):])
+	}
+	return ""
+}
+
+func sortRecordsNewestFirst(records []corestore.Record) []corestore.Record {
+	out := append([]corestore.Record(nil), records...)
+	sort.SliceStable(out, func(i int, j int) bool {
+		return intField(out[i], "id") > intField(out[j], "id")
+	})
+	return out
+}
+
+func paginate(c *corehttp.Context, records []corestore.Record, format func(corestore.Record) map[string]any) {
+	page := intValue(c.Query("page"))
+	if page < 1 {
+		page = 1
+	}
+	perPage := intValue(c.Query("per_page"))
+	if perPage < 1 {
+		perPage = 200
+	}
+	if perPage > 200 {
+		perPage = 200
+	}
+	total := len(records)
+	start := (page - 1) * perPage
+	if start > total {
+		start = total
+	}
+	end := start + perPage
+	if end > total {
+		end = total
+	}
+	if end < total {
+		next := *c.Request.URL
+		query := next.Query()
+		query.Set("page", strconv.Itoa(page+1))
+		query.Set("per_page", strconv.Itoa(perPage))
+		next.RawQuery = query.Encode()
+		c.Writer.Header().Set("Link", "<"+next.String()+">; rel=\"next\"")
+	}
+	c.Writer.Header().Set("X-Total-Count", strconv.Itoa(total))
+	data := make([]map[string]any, 0, end-start)
+	for _, record := range records[start:end] {
+		data = append(data, format(record))
+	}
+	c.JSON(http.StatusOK, data)
+}
+
+func authServerIDFromParam(value string) string {
+	if value == "" {
+		return orgAuthServerID
+	}
+	return value
+}

--- a/internal/services/okta/helpers.go
+++ b/internal/services/okta/helpers.go
@@ -292,11 +292,15 @@ func verifyPKCE(challenge string, method string, verifier string) bool {
 	if verifier == "" {
 		return false
 	}
-	if strings.EqualFold(method, "S256") {
+	switch strings.ToLower(method) {
+	case "", "plain":
+		return verifier == challenge
+	case "s256":
 		digest := sha256.Sum256([]byte(verifier))
 		return base64.RawURLEncoding.EncodeToString(digest[:]) == challenge
+	default:
+		return false
 	}
-	return verifier == challenge
 }
 
 func constantTimeEqual(left string, right string) bool {

--- a/internal/services/okta/jwt.go
+++ b/internal/services/okta/jwt.go
@@ -1,0 +1,90 @@
+package okta
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const oktaKeyID = "emulate-okta-1"
+
+var oktaSigner = mustOktaJWTSigner()
+
+type jwtSigner struct {
+	privateKey *rsa.PrivateKey
+}
+
+func mustOktaJWTSigner() *jwtSigner {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	return &jwtSigner{privateKey: privateKey}
+}
+
+func (s *jwtSigner) jwks() map[string]any {
+	publicKey := s.privateKey.Public().(*rsa.PublicKey)
+	return map[string]any{
+		"keys": []map[string]any{
+			{
+				"kty": "RSA",
+				"use": "sig",
+				"kid": oktaKeyID,
+				"alg": "RS256",
+				"n":   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+			},
+		},
+	}
+}
+
+func createIDToken(store Store, user corestore.Record, clientID string, nonce string, issuer string, scope string) (string, error) {
+	now := time.Now().Unix()
+	claims := map[string]any{
+		"iss":                issuer,
+		"aud":                clientID,
+		"sub":                stringField(user, "okta_id"),
+		"name":               userDisplayName(user),
+		"preferred_username": stringField(user, "login"),
+		"email":              stringField(user, "email"),
+		"email_verified":     true,
+		"locale":             stringField(user, "locale"),
+		"zoneinfo":           stringField(user, "time_zone"),
+		"auth_time":          now,
+		"iat":                now,
+		"exp":                now + 3600,
+	}
+	if nonce != "" {
+		claims["nonce"] = nonce
+	}
+	if scopeHas(scope, "groups") {
+		claims["groups"] = collectUserGroupNames(store, user)
+	}
+	return oktaSigner.sign(claims)
+}
+
+func (s *jwtSigner) sign(claims map[string]any) (string, error) {
+	header := map[string]any{"alg": "RS256", "kid": oktaKeyID, "typ": "JWT"}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, s.privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}

--- a/internal/services/okta/route_helpers.go
+++ b/internal/services/okta/route_helpers.go
@@ -1,0 +1,186 @@
+package okta
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) requireManagementAuth(c *corehttp.Context) (string, bool) {
+	if token := sswsTokenFromRequest(c.Request); token != "" && token != "invalid-token" {
+		return s.defaultManagementLogin(), true
+	}
+	if token := tokenFromRequest(c.Request); token != "" {
+		if token == "test-token" || token == "mgmt-token" || token == "test_token_admin" {
+			return s.defaultManagementLogin(), true
+		}
+		row := firstRecord(s.store.AccessTokens.FindBy("token", token))
+		if row != nil {
+			if login := stringField(row, "username"); login != "" {
+				return login, true
+			}
+			if clientID := stringField(row, "client_id"); clientID != "" {
+				return clientID, true
+			}
+		}
+	}
+	oktaError(c, http.StatusUnauthorized, "E0000004", "Authentication failed")
+	return "", false
+}
+
+func (s *Service) defaultManagementLogin() string {
+	if user := firstRecord(s.store.Users.All()); user != nil {
+		return stringField(user, "login")
+	}
+	return "admin"
+}
+
+func (s *Service) findUser(ref string) corestore.Record {
+	decoded := decodePathValue(ref)
+	if user := firstRecord(s.store.Users.FindBy("okta_id", decoded)); user != nil {
+		return user
+	}
+	if user := firstRecord(s.store.Users.FindBy("login", decoded)); user != nil {
+		return user
+	}
+	return firstRecord(s.store.Users.FindBy("email", decoded))
+}
+
+func (s *Service) findGroup(ref string) corestore.Record {
+	return firstRecord(s.store.Groups.FindBy("okta_id", decodePathValue(ref)))
+}
+
+func (s *Service) findApp(ref string) corestore.Record {
+	return firstRecord(s.store.Apps.FindBy("okta_id", decodePathValue(ref)))
+}
+
+func (s *Service) findAuthorizationServer(ref string) corestore.Record {
+	return firstRecord(s.store.AuthorizationServers.FindBy("server_id", decodePathValue(ref)))
+}
+
+func decodePathValue(value string) string {
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		return value
+	}
+	return decoded
+}
+
+func userResponse(baseURL string, user corestore.Record) map[string]any {
+	return map[string]any{
+		"id":              stringField(user, "okta_id"),
+		"status":          stringField(user, "status"),
+		"created":         user["created_at"],
+		"activated":       user["activated_at"],
+		"statusChanged":   user["status_changed_at"],
+		"lastLogin":       user["last_login_at"],
+		"lastUpdated":     user["updated_at"],
+		"passwordChanged": user["password_changed_at"],
+		"profile": map[string]any{
+			"login":       stringField(user, "login"),
+			"email":       stringField(user, "email"),
+			"firstName":   stringField(user, "first_name"),
+			"lastName":    stringField(user, "last_name"),
+			"displayName": userDisplayName(user),
+			"locale":      stringField(user, "locale"),
+			"timeZone":    stringField(user, "time_zone"),
+		},
+		"_links": map[string]any{
+			"self": map[string]any{
+				"href": strings.TrimRight(baseURL, "/") + "/api/v1/users/" + url.PathEscape(stringField(user, "okta_id")),
+			},
+		},
+	}
+}
+
+func groupResponse(baseURL string, group corestore.Record) map[string]any {
+	return map[string]any{
+		"id":                    stringField(group, "okta_id"),
+		"created":               group["created_at"],
+		"lastUpdated":           group["updated_at"],
+		"lastMembershipUpdated": group["updated_at"],
+		"objectClass":           []string{"okta:user_group"},
+		"type":                  stringField(group, "type"),
+		"profile": map[string]any{
+			"name":        stringField(group, "name"),
+			"description": group["description"],
+		},
+		"_links": map[string]any{
+			"self": map[string]any{
+				"href": strings.TrimRight(baseURL, "/") + "/api/v1/groups/" + url.PathEscape(stringField(group, "okta_id")),
+			},
+		},
+	}
+}
+
+func appResponse(baseURL string, app corestore.Record) map[string]any {
+	return map[string]any{
+		"id":          stringField(app, "okta_id"),
+		"name":        stringField(app, "name"),
+		"label":       stringField(app, "label"),
+		"status":      stringField(app, "status"),
+		"created":     app["created_at"],
+		"lastUpdated": app["updated_at"],
+		"signOnMode":  stringField(app, "sign_on_mode"),
+		"credentials": mapValue(app["credentials"]),
+		"settings":    mapValue(app["settings"]),
+		"_links": map[string]any{
+			"self": map[string]any{
+				"href": strings.TrimRight(baseURL, "/") + "/api/v1/apps/" + url.PathEscape(stringField(app, "okta_id")),
+			},
+		},
+	}
+}
+
+func authorizationServerResponse(baseURL string, server corestore.Record) map[string]any {
+	serverID := stringField(server, "server_id")
+	return map[string]any{
+		"id":          serverID,
+		"name":        stringField(server, "name"),
+		"description": stringField(server, "description"),
+		"audiences":   stringSliceValue(server["audiences"]),
+		"issuer":      resolveIssuer(baseURL, serverID),
+		"status":      stringField(server, "status"),
+		"created":     server["created_at"],
+		"lastUpdated": server["updated_at"],
+		"_links": map[string]any{
+			"self": map[string]any{
+				"href": strings.TrimRight(baseURL, "/") + "/api/v1/authorizationServers/" + url.PathEscape(serverID),
+			},
+		},
+	}
+}
+
+func bodyMap(body map[string]any, key string) map[string]any {
+	return mapValue(body[key])
+}
+
+func bodyString(body map[string]any, key string) string {
+	return strings.TrimSpace(stringValue(body[key]))
+}
+
+func bodyStringDefault(body map[string]any, key string, fallback string) string {
+	if value := bodyString(body, key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func bodyStringSlice(body map[string]any, key string, fallback []string) []string {
+	value, ok := body[key]
+	if !ok {
+		return append([]string(nil), fallback...)
+	}
+	items := stringSliceValue(value)
+	if len(items) == 0 {
+		return append([]string(nil), fallback...)
+	}
+	return items
+}
+
+func writeNoContent(c *corehttp.Context) {
+	c.Writer.WriteHeader(http.StatusNoContent)
+}

--- a/internal/services/okta/routes_apps.go
+++ b/internal/services/okta/routes_apps.go
@@ -1,0 +1,203 @@
+package okta
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerAppRoutes(router *corehttp.Router) {
+	router.Get("/api/v1/apps", s.handleListApps)
+	router.Post("/api/v1/apps", s.handleCreateApp)
+	router.Get("/api/v1/apps/:appId/users", s.handleAppUsers)
+	router.Put("/api/v1/apps/:appId/users/:userId", s.handleAssignAppUser)
+	router.Delete("/api/v1/apps/:appId/users/:userId", s.handleUnassignAppUser)
+	router.Post("/api/v1/apps/:appId/lifecycle/activate", s.handleActivateApp)
+	router.Post("/api/v1/apps/:appId/lifecycle/deactivate", s.handleDeactivateApp)
+	router.Get("/api/v1/apps/:appId", s.handleGetApp)
+	router.Put("/api/v1/apps/:appId", s.handleUpdateApp)
+	router.Delete("/api/v1/apps/:appId", s.handleDeleteApp)
+}
+
+func (s *Service) handleListApps(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	q := strings.ToLower(c.Query("q"))
+	apps := s.store.Apps.All()
+	filtered := make([]corestore.Record, 0, len(apps))
+	for _, app := range apps {
+		if q != "" && !strings.Contains(strings.ToLower(stringField(app, "name")+" "+stringField(app, "label")), q) {
+			continue
+		}
+		filtered = append(filtered, app)
+	}
+	paginate(c, filtered, func(app corestore.Record) map[string]any {
+		return appResponse(s.baseURL, app)
+	})
+}
+
+func (s *Service) handleCreateApp(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	body := readJSONBody(c.Request)
+	created := s.store.Apps.Insert(corestore.Record{
+		"okta_id":      oktaID("0oa"),
+		"name":         bodyStringDefault(body, "name", "oidc_client"),
+		"label":        bodyStringDefault(body, "label", "Okta App"),
+		"status":       normalizeActiveStatus(bodyString(body, "status"), "ACTIVE"),
+		"sign_on_mode": bodyStringDefault(body, "signOnMode", "OPENID_CONNECT"),
+		"settings":     mapValue(body["settings"]),
+		"credentials":  mapValue(body["credentials"]),
+	})
+	c.JSON(http.StatusCreated, appResponse(s.baseURL, created))
+}
+
+func (s *Service) handleAppUsers(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	app := s.findApp(c.Param("appId"))
+	if app == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: app")
+		return
+	}
+	users := []map[string]any{}
+	for _, assignment := range s.store.AppAssignments.FindBy("app_okta_id", stringField(app, "okta_id")) {
+		user := firstRecord(s.store.Users.FindBy("okta_id", stringField(assignment, "user_okta_id")))
+		if user == nil {
+			continue
+		}
+		users = append(users, map[string]any{
+			"id":          stringField(user, "okta_id"),
+			"scope":       "USER",
+			"credentials": map[string]any{"userName": stringField(user, "login")},
+			"profile":     userResponse(s.baseURL, user)["profile"],
+		})
+	}
+	c.JSON(http.StatusOK, users)
+}
+
+func (s *Service) handleAssignAppUser(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	app := s.findApp(c.Param("appId"))
+	if app == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: app")
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	s.ensureAppAssignment(stringField(app, "okta_id"), stringField(user, "okta_id"))
+	writeNoContent(c)
+}
+
+func (s *Service) handleUnassignAppUser(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	app := s.findApp(c.Param("appId"))
+	if app == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: app")
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	for _, assignment := range s.store.AppAssignments.FindBy("app_okta_id", stringField(app, "okta_id")) {
+		if stringField(assignment, "user_okta_id") == stringField(user, "okta_id") {
+			s.store.AppAssignments.Delete(intField(assignment, "id"))
+		}
+	}
+	writeNoContent(c)
+}
+
+func (s *Service) handleActivateApp(c *corehttp.Context) {
+	s.handleAppLifecycle(c, "ACTIVE")
+}
+
+func (s *Service) handleDeactivateApp(c *corehttp.Context) {
+	s.handleAppLifecycle(c, "INACTIVE")
+}
+
+func (s *Service) handleAppLifecycle(c *corehttp.Context, status string) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	app := s.findApp(c.Param("appId"))
+	if app == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: app")
+		return
+	}
+	updated, _ := s.store.Apps.Update(intField(app, "id"), corestore.Record{"status": status})
+	c.JSON(http.StatusOK, appResponse(s.baseURL, updated))
+}
+
+func (s *Service) handleGetApp(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	app := s.findApp(c.Param("appId"))
+	if app == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: app")
+		return
+	}
+	c.JSON(http.StatusOK, appResponse(s.baseURL, app))
+}
+
+func (s *Service) handleUpdateApp(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	app := s.findApp(c.Param("appId"))
+	if app == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: app")
+		return
+	}
+	body := readJSONBody(c.Request)
+	updated, _ := s.store.Apps.Update(intField(app, "id"), corestore.Record{
+		"name":         firstNonEmpty(bodyString(body, "name"), stringField(app, "name")),
+		"label":        firstNonEmpty(bodyString(body, "label"), stringField(app, "label")),
+		"status":       normalizeActiveStatus(bodyString(body, "status"), stringField(app, "status")),
+		"sign_on_mode": firstNonEmpty(bodyString(body, "signOnMode"), stringField(app, "sign_on_mode")),
+		"settings":     firstMapOrExisting(body["settings"], mapValue(app["settings"])),
+		"credentials":  firstMapOrExisting(body["credentials"], mapValue(app["credentials"])),
+	})
+	c.JSON(http.StatusOK, appResponse(s.baseURL, updated))
+}
+
+func (s *Service) handleDeleteApp(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	app := s.findApp(c.Param("appId"))
+	if app == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: app")
+		return
+	}
+	if stringField(app, "status") != "INACTIVE" {
+		oktaError(c, http.StatusBadRequest, "E0000001", "App must be INACTIVE before deletion")
+		return
+	}
+	for _, assignment := range s.store.AppAssignments.FindBy("app_okta_id", stringField(app, "okta_id")) {
+		s.store.AppAssignments.Delete(intField(assignment, "id"))
+	}
+	s.store.Apps.Delete(intField(app, "id"))
+	writeNoContent(c)
+}
+
+func firstMapOrExisting(value any, fallback map[string]any) map[string]any {
+	if typed, ok := value.(map[string]any); ok {
+		return typed
+	}
+	return fallback
+}

--- a/internal/services/okta/routes_auth_servers.go
+++ b/internal/services/okta/routes_auth_servers.go
@@ -1,0 +1,144 @@
+package okta
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerAuthorizationServerRoutes(router *corehttp.Router) {
+	router.Get("/api/v1/authorizationServers", s.handleListAuthorizationServers)
+	router.Post("/api/v1/authorizationServers", s.handleCreateAuthorizationServer)
+	router.Post("/api/v1/authorizationServers/:authServerId/lifecycle/activate", s.handleActivateAuthorizationServer)
+	router.Post("/api/v1/authorizationServers/:authServerId/lifecycle/deactivate", s.handleDeactivateAuthorizationServer)
+	router.Get("/api/v1/authorizationServers/:authServerId", s.handleGetAuthorizationServer)
+	router.Put("/api/v1/authorizationServers/:authServerId", s.handleUpdateAuthorizationServer)
+	router.Delete("/api/v1/authorizationServers/:authServerId", s.handleDeleteAuthorizationServer)
+}
+
+func (s *Service) handleListAuthorizationServers(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	paginate(c, s.store.AuthorizationServers.All(), func(server corestore.Record) map[string]any {
+		return authorizationServerResponse(s.baseURL, server)
+	})
+}
+
+func (s *Service) handleCreateAuthorizationServer(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	body := readJSONBody(c.Request)
+	name := bodyString(body, "name")
+	if name == "" {
+		oktaError(c, http.StatusBadRequest, "E0000001", "name is required")
+		return
+	}
+	serverID := firstNonEmpty(bodyString(body, "id"), normalizeServerID(name))
+	if firstRecord(s.store.AuthorizationServers.FindBy("server_id", serverID)) != nil {
+		oktaError(c, http.StatusBadRequest, "E0000001", "Authorization server '"+serverID+"' already exists")
+		return
+	}
+	created := s.store.AuthorizationServers.Insert(corestore.Record{
+		"server_id":   serverID,
+		"name":        name,
+		"description": bodyString(body, "description"),
+		"audiences":   bodyStringSlice(body, "audiences", []string{defaultAudience}),
+		"status":      normalizeActiveStatus(bodyString(body, "status"), "ACTIVE"),
+	})
+	c.JSON(http.StatusCreated, authorizationServerResponse(s.baseURL, created))
+}
+
+func (s *Service) handleActivateAuthorizationServer(c *corehttp.Context) {
+	s.handleAuthorizationServerLifecycle(c, "ACTIVE")
+}
+
+func (s *Service) handleDeactivateAuthorizationServer(c *corehttp.Context) {
+	s.handleAuthorizationServerLifecycle(c, "INACTIVE")
+}
+
+func (s *Service) handleAuthorizationServerLifecycle(c *corehttp.Context, status string) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	server := s.findAuthorizationServer(c.Param("authServerId"))
+	if server == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server")
+		return
+	}
+	updated, _ := s.store.AuthorizationServers.Update(intField(server, "id"), corestore.Record{"status": status})
+	c.JSON(http.StatusOK, authorizationServerResponse(s.baseURL, updated))
+}
+
+func (s *Service) handleGetAuthorizationServer(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	server := s.findAuthorizationServer(c.Param("authServerId"))
+	if server == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server")
+		return
+	}
+	c.JSON(http.StatusOK, authorizationServerResponse(s.baseURL, server))
+}
+
+func (s *Service) handleUpdateAuthorizationServer(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	server := s.findAuthorizationServer(c.Param("authServerId"))
+	if server == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server")
+		return
+	}
+	body := readJSONBody(c.Request)
+	updated, _ := s.store.AuthorizationServers.Update(intField(server, "id"), corestore.Record{
+		"name":        firstNonEmpty(bodyString(body, "name"), stringField(server, "name")),
+		"description": firstNonEmpty(bodyString(body, "description"), stringField(server, "description")),
+		"audiences":   bodyStringSlice(body, "audiences", stringSliceValue(server["audiences"])),
+		"status":      normalizeActiveStatus(bodyString(body, "status"), stringField(server, "status")),
+	})
+	c.JSON(http.StatusOK, authorizationServerResponse(s.baseURL, updated))
+}
+
+func (s *Service) handleDeleteAuthorizationServer(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	server := s.findAuthorizationServer(c.Param("authServerId"))
+	if server == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server")
+		return
+	}
+	for _, client := range s.store.OAuthClients.FindBy("auth_server_id", stringField(server, "server_id")) {
+		s.store.OAuthClients.Delete(intField(client, "id"))
+	}
+	s.store.AuthorizationServers.Delete(intField(server, "id"))
+	writeNoContent(c)
+}
+
+func normalizeServerID(name string) string {
+	name = strings.TrimSpace(strings.ToLower(name))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range name {
+		valid := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+		if valid {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return oktaID("as")
+	}
+	return out
+}

--- a/internal/services/okta/routes_groups.go
+++ b/internal/services/okta/routes_groups.go
@@ -1,0 +1,176 @@
+package okta
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerGroupRoutes(router *corehttp.Router) {
+	router.Get("/api/v1/groups", s.handleListGroups)
+	router.Post("/api/v1/groups", s.handleCreateGroup)
+	router.Get("/api/v1/groups/:groupId/users", s.handleGroupUsers)
+	router.Put("/api/v1/groups/:groupId/users/:userId", s.handleAddGroupUser)
+	router.Delete("/api/v1/groups/:groupId/users/:userId", s.handleRemoveGroupUser)
+	router.Get("/api/v1/groups/:groupId", s.handleGetGroup)
+	router.Put("/api/v1/groups/:groupId", s.handleUpdateGroup)
+	router.Delete("/api/v1/groups/:groupId", s.handleDeleteGroup)
+}
+
+func (s *Service) handleListGroups(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	q := strings.ToLower(c.Query("q"))
+	groups := s.store.Groups.All()
+	filtered := make([]corestore.Record, 0, len(groups))
+	for _, group := range groups {
+		if q != "" && !strings.Contains(strings.ToLower(stringField(group, "name")+" "+stringField(group, "description")), q) {
+			continue
+		}
+		filtered = append(filtered, group)
+	}
+	paginate(c, filtered, func(group corestore.Record) map[string]any {
+		return groupResponse(s.baseURL, group)
+	})
+}
+
+func (s *Service) handleCreateGroup(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	body := readJSONBody(c.Request)
+	profile := bodyMap(body, "profile")
+	name := bodyString(profile, "name")
+	if name == "" {
+		oktaError(c, http.StatusBadRequest, "E0000001", "profile.name is required")
+		return
+	}
+	if firstRecord(s.store.Groups.FindBy("name", name)) != nil {
+		oktaError(c, http.StatusBadRequest, "E0000001", "A group with the same name already exists")
+		return
+	}
+	created := s.store.Groups.Insert(corestore.Record{
+		"okta_id":     oktaID("00g"),
+		"type":        normalizeGroupType(bodyString(body, "type"), "OKTA_GROUP"),
+		"name":        name,
+		"description": stringOrNil(bodyString(profile, "description")),
+	})
+	c.JSON(http.StatusCreated, groupResponse(s.baseURL, created))
+}
+
+func (s *Service) handleGroupUsers(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	group := s.findGroup(c.Param("groupId"))
+	if group == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: group")
+		return
+	}
+	users := []map[string]any{}
+	for _, membership := range s.store.GroupMemberships.FindBy("group_okta_id", stringField(group, "okta_id")) {
+		user := firstRecord(s.store.Users.FindBy("okta_id", stringField(membership, "user_okta_id")))
+		if user != nil {
+			users = append(users, userResponse(s.baseURL, user))
+		}
+	}
+	c.JSON(http.StatusOK, users)
+}
+
+func (s *Service) handleAddGroupUser(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	group := s.findGroup(c.Param("groupId"))
+	if group == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: group")
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	s.ensureMembership(stringField(group, "okta_id"), stringField(user, "okta_id"))
+	writeNoContent(c)
+}
+
+func (s *Service) handleRemoveGroupUser(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	group := s.findGroup(c.Param("groupId"))
+	if group == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: group")
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	for _, membership := range s.store.GroupMemberships.FindBy("group_okta_id", stringField(group, "okta_id")) {
+		if stringField(membership, "user_okta_id") == stringField(user, "okta_id") {
+			s.store.GroupMemberships.Delete(intField(membership, "id"))
+		}
+	}
+	writeNoContent(c)
+}
+
+func (s *Service) handleGetGroup(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	group := s.findGroup(c.Param("groupId"))
+	if group == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: group")
+		return
+	}
+	c.JSON(http.StatusOK, groupResponse(s.baseURL, group))
+}
+
+func (s *Service) handleUpdateGroup(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	group := s.findGroup(c.Param("groupId"))
+	if group == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: group")
+		return
+	}
+	body := readJSONBody(c.Request)
+	profile := bodyMap(body, "profile")
+	nextName := firstNonEmpty(bodyString(profile, "name"), stringField(group, "name"))
+	if nextName != stringField(group, "name") {
+		existing := firstRecord(s.store.Groups.FindBy("name", nextName))
+		if existing != nil && stringField(existing, "okta_id") != stringField(group, "okta_id") {
+			oktaError(c, http.StatusBadRequest, "E0000001", "A group with the same name already exists")
+			return
+		}
+	}
+	updated, _ := s.store.Groups.Update(intField(group, "id"), corestore.Record{
+		"name":        nextName,
+		"description": firstNonEmpty(bodyString(profile, "description"), stringField(group, "description")),
+		"type":        normalizeGroupType(bodyString(body, "type"), stringField(group, "type")),
+	})
+	c.JSON(http.StatusOK, groupResponse(s.baseURL, updated))
+}
+
+func (s *Service) handleDeleteGroup(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	group := s.findGroup(c.Param("groupId"))
+	if group == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: group")
+		return
+	}
+	for _, membership := range s.store.GroupMemberships.FindBy("group_okta_id", stringField(group, "okta_id")) {
+		s.store.GroupMemberships.Delete(intField(membership, "id"))
+	}
+	s.store.Groups.Delete(intField(group, "id"))
+	writeNoContent(c)
+}

--- a/internal/services/okta/routes_oauth.go
+++ b/internal/services/okta/routes_oauth.go
@@ -1,0 +1,707 @@
+package okta
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+const pendingCodeTTL = 10 * time.Minute
+
+type resolvedAuthServer struct {
+	id        string
+	issuer    string
+	audiences []string
+}
+
+func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
+	router.Get("/.well-known/openid-configuration", s.handleOrgOpenIDConfiguration)
+	router.Get("/oauth2/:authServerId/.well-known/openid-configuration", s.handleAuthServerOpenIDConfiguration)
+	router.Get("/oauth2/v1/keys", s.handleOrgKeys)
+	router.Get("/oauth2/:authServerId/v1/keys", s.handleAuthServerKeys)
+	router.Get("/oauth2/v1/authorize", s.handleOrgAuthorize)
+	router.Get("/oauth2/:authServerId/v1/authorize", s.handleAuthServerAuthorize)
+	router.Post("/oauth2/v1/authorize/callback", s.handleOrgAuthorizeCallback)
+	router.Post("/oauth2/:authServerId/v1/authorize/callback", s.handleAuthServerAuthorizeCallback)
+	router.Post("/oauth2/v1/token", s.handleOrgToken)
+	router.Post("/oauth2/:authServerId/v1/token", s.handleAuthServerToken)
+	router.Get("/oauth2/v1/userinfo", s.handleOrgUserinfo)
+	router.Get("/oauth2/:authServerId/v1/userinfo", s.handleAuthServerUserinfo)
+	router.Post("/oauth2/v1/revoke", s.handleOrgRevoke)
+	router.Post("/oauth2/:authServerId/v1/revoke", s.handleAuthServerRevoke)
+	router.Post("/oauth2/v1/introspect", s.handleOrgIntrospect)
+	router.Post("/oauth2/:authServerId/v1/introspect", s.handleAuthServerIntrospect)
+	router.Get("/oauth2/v1/logout", s.handleOrgLogout)
+	router.Get("/oauth2/:authServerId/v1/logout", s.handleAuthServerLogout)
+}
+
+func (s *Service) handleOrgOpenIDConfiguration(c *corehttp.Context) {
+	s.handleOpenIDConfiguration(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerOpenIDConfiguration(c *corehttp.Context) {
+	s.handleOpenIDConfiguration(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleOpenIDConfiguration(c *corehttp.Context, authServerID string) {
+	server := s.resolveAuthServer(authServerID)
+	if server == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	oauthBase := oauthBasePath(server.id)
+	oauthURLBase := s.baseURL + oauthBase
+	authMethods := []string{"client_secret_post", "client_secret_basic", "none"}
+	c.JSON(http.StatusOK, map[string]any{
+		"issuer":                                        server.issuer,
+		"authorization_endpoint":                        oauthURLBase + "/authorize",
+		"token_endpoint":                                oauthURLBase + "/token",
+		"userinfo_endpoint":                             oauthURLBase + "/userinfo",
+		"jwks_uri":                                      oauthURLBase + "/keys",
+		"end_session_endpoint":                          oauthURLBase + "/logout",
+		"revocation_endpoint":                           oauthURLBase + "/revoke",
+		"introspection_endpoint":                        oauthURLBase + "/introspect",
+		"registration_endpoint":                         oauthURLBase + "/clients",
+		"response_types_supported":                      []string{"code"},
+		"response_modes_supported":                      []string{"query", "fragment", "form_post"},
+		"grant_types_supported":                         []string{"authorization_code", "refresh_token", "client_credentials"},
+		"subject_types_supported":                       []string{"public"},
+		"id_token_signing_alg_values_supported":         []string{"RS256"},
+		"scopes_supported":                              []string{"openid", "profile", "email", "offline_access", "groups"},
+		"token_endpoint_auth_methods_supported":         authMethods,
+		"revocation_endpoint_auth_methods_supported":    authMethods,
+		"introspection_endpoint_auth_methods_supported": authMethods,
+		"request_parameter_supported":                   false,
+		"request_uri_parameter_supported":               false,
+		"claims_parameter_supported":                    false,
+		"request_object_signing_alg_values_supported":   []string{"RS256"},
+		"code_challenge_methods_supported":              []string{"plain", "S256"},
+		"claims_supported":                              []string{"sub", "iss", "aud", "exp", "iat", "auth_time", "nonce", "name", "preferred_username", "email", "email_verified", "locale", "zoneinfo", "groups"},
+	})
+}
+
+func (s *Service) handleOrgKeys(c *corehttp.Context) {
+	c.JSON(http.StatusOK, oktaSigner.jwks())
+}
+
+func (s *Service) handleAuthServerKeys(c *corehttp.Context) {
+	authServerID := c.Param("authServerId")
+	if s.resolveAuthServer(authServerID) == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	c.JSON(http.StatusOK, oktaSigner.jwks())
+}
+
+func (s *Service) handleOrgAuthorize(c *corehttp.Context) {
+	s.handleAuthorize(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerAuthorize(c *corehttp.Context) {
+	s.handleAuthorize(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleAuthorize(c *corehttp.Context, authServerID string) {
+	if s.resolveAuthServer(authServerID) == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
+	scope := firstNonEmpty(c.Query("scope"), "openid profile email")
+	state := c.Query("state")
+	nonce := c.Query("nonce")
+	responseMode := firstNonEmpty(c.Query("response_mode"), "query")
+	responseType := firstNonEmpty(c.Query("response_type"), "code")
+	codeChallenge := c.Query("code_challenge")
+	codeChallengeMethod := c.Query("code_challenge_method")
+
+	if responseType != "code" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Unsupported response_type", "Only response_type=code is supported.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	if redirectURI == "" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Missing redirect URI", "The redirect_uri parameter is required.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+
+	clientName := ""
+	configuredClients := s.clientsForServer(authServerID)
+	if len(configuredClients) > 0 {
+		client := recordWithField(configuredClients, "client_id", clientID)
+		if client == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if !matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		clientName = stringField(client, "name")
+	}
+
+	var body strings.Builder
+	users := s.store.Users.All()
+	if len(users) == 0 {
+		body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+	} else {
+		for _, user := range users {
+			login := stringField(user, "login")
+			letter := "?"
+			if login != "" {
+				letter = strings.ToUpper(login[:1])
+			}
+			body.WriteString(ui.RenderUserButton(ui.UserButtonOptions{
+				Letter:     letter,
+				Login:      login,
+				Name:       userDisplayName(user),
+				Email:      stringField(user, "email"),
+				FormAction: oauthBasePath(authServerID) + "/authorize/callback",
+				HiddenFields: map[string]string{
+					"user_ref":              stringField(user, "okta_id"),
+					"redirect_uri":          redirectURI,
+					"scope":                 scope,
+					"state":                 state,
+					"nonce":                 nonce,
+					"client_id":             clientID,
+					"response_mode":         responseMode,
+					"code_challenge":        codeChallenge,
+					"code_challenge_method": codeChallengeMethod,
+					"auth_server_id":        authServerID,
+				},
+			}))
+		}
+	}
+
+	subtitle := "Choose a seeded user to continue."
+	if clientName != "" {
+		subtitle = "Sign in to <strong>" + ui.EscapeHTML(clientName) + "</strong> with your Okta account."
+	}
+	c.HTML(http.StatusOK, ui.RenderCardPage("Sign in with Okta", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+}
+
+func (s *Service) handleOrgAuthorizeCallback(c *corehttp.Context) {
+	s.handleAuthorizeCallback(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerAuthorizeCallback(c *corehttp.Context) {
+	s.handleAuthorizeCallback(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleAuthorizeCallback(c *corehttp.Context, authServerID string) {
+	if s.resolveAuthServer(authServerID) == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	if err := c.Request.ParseForm(); err != nil {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Invalid request", "The authorization form body is invalid.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	userRef := c.Request.Form.Get("user_ref")
+	redirectURI := c.Request.Form.Get("redirect_uri")
+	scope := firstNonEmpty(c.Request.Form.Get("scope"), "openid profile email")
+	state := c.Request.Form.Get("state")
+	nonce := c.Request.Form.Get("nonce")
+	clientID := c.Request.Form.Get("client_id")
+	responseMode := firstNonEmpty(c.Request.Form.Get("response_mode"), "query")
+	codeChallenge := c.Request.Form.Get("code_challenge")
+	codeChallengeMethod := c.Request.Form.Get("code_challenge_method")
+
+	if redirectURI == "" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Missing redirect URI", "The redirect_uri parameter is required.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	user := s.findUser(userRef)
+	if user == nil {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Unknown user", "The selected user is not available.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	configuredClients := s.clientsForServer(authServerID)
+	if len(configuredClients) > 0 {
+		client := recordWithField(configuredClients, "client_id", clientID)
+		if client == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if !matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+	}
+
+	code := oktaToken("")
+	s.store.OAuthCodes.Insert(corestore.Record{
+		"code":                  code,
+		"user_okta_id":          stringField(user, "okta_id"),
+		"scope":                 scope,
+		"redirect_uri":          redirectURI,
+		"client_id":             clientID,
+		"nonce":                 nonce,
+		"code_challenge":        codeChallenge,
+		"code_challenge_method": codeChallengeMethod,
+		"auth_server_id":        authServerID,
+		"created_at_ms":         time.Now().UnixMilli(),
+	})
+
+	if responseMode == "form_post" {
+		c.HTML(http.StatusOK, ui.RenderFormPostPage(redirectURI, map[string]string{"code": code, "state": state}, ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	target, err := url.Parse(redirectURI)
+	if err != nil || target == nil || target.Scheme == "" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Invalid redirect URI", "The redirect_uri parameter is invalid.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	if responseMode == "fragment" {
+		fragment, _ := url.ParseQuery(target.Fragment)
+		addAuthorizationResponseValues(fragment, code, state)
+		target.Fragment = fragment.Encode()
+		target.RawFragment = ""
+		c.Redirect(http.StatusFound, target.String())
+		return
+	}
+	query := target.Query()
+	addAuthorizationResponseValues(query, code, state)
+	target.RawQuery = query.Encode()
+	c.Redirect(http.StatusFound, target.String())
+}
+
+func (s *Service) handleOrgToken(c *corehttp.Context) {
+	s.handleToken(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerToken(c *corehttp.Context) {
+	s.handleToken(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleToken(c *corehttp.Context, authServerID string) {
+	server := s.resolveAuthServer(authServerID)
+	if server == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	body := parseTokenBody(c.Request)
+	clientID := body["client_id"]
+	clientSecret := body["client_secret"]
+	applyBasicCredentials(c.Request, &clientID, &clientSecret)
+	client, ok := s.validateClient(c, authServerID, clientID, clientSecret)
+	if !ok {
+		return
+	}
+
+	switch body["grant_type"] {
+	case "authorization_code":
+		s.handleAuthorizationCodeToken(c, server, body, clientID, client)
+	case "refresh_token":
+		s.handleRefreshToken(c, server, body, client)
+	case "client_credentials":
+		s.handleClientCredentialsToken(c, server, body, clientID, client)
+	default:
+		oauthError(c, http.StatusBadRequest, "unsupported_grant_type", "Only authorization_code, refresh_token, and client_credentials are supported.")
+	}
+}
+
+func (s *Service) handleAuthorizationCodeToken(c *corehttp.Context, server *resolvedAuthServer, body map[string]string, clientID string, client corestore.Record) {
+	code := firstRecord(s.store.OAuthCodes.FindBy("code", body["code"]))
+	if code == nil {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Authorization code is invalid or expired.")
+		return
+	}
+	if stringField(code, "auth_server_id") != server.id {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Authorization server mismatch.")
+		return
+	}
+	if time.Since(time.UnixMilli(int64(intField(code, "created_at_ms")))) > pendingCodeTTL {
+		s.deleteOAuthCode(stringField(code, "code"))
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Authorization code is invalid or expired.")
+		return
+	}
+	if redirectURI := stringField(code, "redirect_uri"); redirectURI != "" && body["redirect_uri"] != "" && body["redirect_uri"] != redirectURI {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match.")
+		return
+	}
+	if client != nil && stringField(client, "client_id") != stringField(code, "client_id") {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Authorization code was not issued to this client.")
+		return
+	}
+	if !verifyPKCE(stringField(code, "code_challenge"), stringField(code, "code_challenge_method"), body["code_verifier"]) {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "PKCE verification failed.")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("okta_id", stringField(code, "user_okta_id")))
+	if user == nil {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Unknown user.")
+		return
+	}
+	s.deleteOAuthCode(stringField(code, "code"))
+
+	now := time.Now().Unix()
+	scope := firstNonEmpty(stringField(code, "scope"), "openid profile email")
+	audienceClient := firstNonEmpty(stringField(code, "client_id"), clientID, "okta-client")
+	accessToken := oktaToken("okta_")
+	refreshToken := oktaToken("r_okta_")
+	s.store.AccessTokens.Insert(corestore.Record{
+		"token":          accessToken,
+		"auth_server_id": server.id,
+		"client_id":      audienceClient,
+		"scope":          scope,
+		"issued_at":      now,
+		"expires_at":     now + 3600,
+		"user_okta_id":   stringField(user, "okta_id"),
+		"username":       stringField(user, "login"),
+	})
+	s.store.RefreshTokens.Insert(corestore.Record{
+		"token":          refreshToken,
+		"auth_server_id": server.id,
+		"client_id":      audienceClient,
+		"scope":          scope,
+		"user_okta_id":   stringField(user, "okta_id"),
+		"username":       stringField(user, "login"),
+		"nonce":          stringField(code, "nonce"),
+	})
+	idToken, err := createIDToken(s.store, user, audienceClient, stringField(code, "nonce"), server.issuer, scope)
+	if err != nil {
+		oauthError(c, http.StatusInternalServerError, "server_error", "Failed to sign id_token.")
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
+		"id_token":      idToken,
+		"scope":         scope,
+	})
+}
+
+func (s *Service) handleRefreshToken(c *corehttp.Context, server *resolvedAuthServer, body map[string]string, client corestore.Record) {
+	refresh := firstRecord(s.store.RefreshTokens.FindBy("token", body["refresh_token"]))
+	if refresh == nil {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Invalid refresh token.")
+		return
+	}
+	if stringField(refresh, "auth_server_id") != server.id {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Authorization server mismatch.")
+		return
+	}
+	if client != nil && stringField(client, "client_id") != stringField(refresh, "client_id") {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Refresh token was not issued to this client.")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("okta_id", stringField(refresh, "user_okta_id")))
+	if user == nil {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Unknown user.")
+		return
+	}
+	s.deleteRefreshToken(stringField(refresh, "token"))
+
+	now := time.Now().Unix()
+	scope := firstNonEmpty(body["scope"], stringField(refresh, "scope"), "openid profile email")
+	clientID := stringField(refresh, "client_id")
+	accessToken := oktaToken("okta_")
+	refreshToken := oktaToken("r_okta_")
+	s.store.AccessTokens.Insert(corestore.Record{
+		"token":          accessToken,
+		"auth_server_id": server.id,
+		"client_id":      clientID,
+		"scope":          scope,
+		"issued_at":      now,
+		"expires_at":     now + 3600,
+		"user_okta_id":   stringField(user, "okta_id"),
+		"username":       stringField(user, "login"),
+	})
+	s.store.RefreshTokens.Insert(corestore.Record{
+		"token":          refreshToken,
+		"auth_server_id": server.id,
+		"client_id":      clientID,
+		"scope":          scope,
+		"user_okta_id":   stringField(user, "okta_id"),
+		"username":       stringField(user, "login"),
+		"nonce":          stringField(refresh, "nonce"),
+	})
+	response := map[string]any{
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
+		"scope":         scope,
+	}
+	if scopeHas(scope, "openid") {
+		idToken, err := createIDToken(s.store, user, clientID, stringField(refresh, "nonce"), server.issuer, scope)
+		if err != nil {
+			oauthError(c, http.StatusInternalServerError, "server_error", "Failed to sign id_token.")
+			return
+		}
+		response["id_token"] = idToken
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func (s *Service) handleClientCredentialsToken(c *corehttp.Context, server *resolvedAuthServer, body map[string]string, clientID string, client corestore.Record) {
+	if len(s.clientsForServer(server.id)) > 0 && client == nil {
+		oauthError(c, http.StatusUnauthorized, "invalid_client", "Unknown client.")
+		return
+	}
+	clientID = firstNonEmpty(stringField(client, "client_id"), clientID)
+	if clientID == "" {
+		oauthError(c, http.StatusUnauthorized, "invalid_client", "client_id is required.")
+		return
+	}
+	scope := firstNonEmpty(body["scope"], ".default")
+	now := time.Now().Unix()
+	accessToken := oktaToken("okta_")
+	s.store.AccessTokens.Insert(corestore.Record{
+		"token":          accessToken,
+		"auth_server_id": server.id,
+		"client_id":      clientID,
+		"scope":          scope,
+		"issued_at":      now,
+		"expires_at":     now + 3600,
+		"user_okta_id":   "",
+		"username":       "",
+	})
+	c.JSON(http.StatusOK, map[string]any{
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"access_token": accessToken,
+		"scope":        scope,
+	})
+}
+
+func (s *Service) handleOrgUserinfo(c *corehttp.Context) {
+	s.handleUserinfo(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerUserinfo(c *corehttp.Context) {
+	s.handleUserinfo(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleUserinfo(c *corehttp.Context, authServerID string) {
+	if s.resolveAuthServer(authServerID) == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	token := tokenFromRequest(c.Request)
+	access := firstRecord(s.store.AccessTokens.FindBy("token", token))
+	if access == nil || stringField(access, "auth_server_id") != authServerID || stringField(access, "user_okta_id") == "" || int64(intField(access, "expires_at")) <= time.Now().Unix() {
+		oauthError(c, http.StatusUnauthorized, "invalid_token", "The access token is invalid.")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("okta_id", stringField(access, "user_okta_id")))
+	if user == nil {
+		oauthError(c, http.StatusUnauthorized, "invalid_token", "The access token is invalid.")
+		return
+	}
+	body := map[string]any{
+		"sub":                stringField(user, "okta_id"),
+		"name":               userDisplayName(user),
+		"preferred_username": stringField(user, "login"),
+		"email":              stringField(user, "email"),
+		"email_verified":     true,
+		"locale":             stringField(user, "locale"),
+		"zoneinfo":           stringField(user, "time_zone"),
+	}
+	if scopeHas(stringField(access, "scope"), "groups") {
+		body["groups"] = collectUserGroupNames(s.store, user)
+	}
+	c.JSON(http.StatusOK, body)
+}
+
+func (s *Service) handleOrgRevoke(c *corehttp.Context) {
+	s.handleRevoke(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerRevoke(c *corehttp.Context) {
+	s.handleRevoke(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleRevoke(c *corehttp.Context, authServerID string) {
+	if s.resolveAuthServer(authServerID) == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	body := parseTokenBody(c.Request)
+	s.deleteAccessToken(body["token"])
+	s.deleteRefreshToken(body["token"])
+	c.Writer.WriteHeader(http.StatusOK)
+}
+
+func (s *Service) handleOrgIntrospect(c *corehttp.Context) {
+	s.handleIntrospect(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerIntrospect(c *corehttp.Context) {
+	s.handleIntrospect(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleIntrospect(c *corehttp.Context, authServerID string) {
+	server := s.resolveAuthServer(authServerID)
+	if server == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	body := parseTokenBody(c.Request)
+	clientID := body["client_id"]
+	clientSecret := body["client_secret"]
+	applyBasicCredentials(c.Request, &clientID, &clientSecret)
+	if _, ok := s.validateClient(c, authServerID, clientID, clientSecret); !ok {
+		return
+	}
+	token := body["token"]
+	now := time.Now().Unix()
+	access := firstRecord(s.store.AccessTokens.FindBy("token", token))
+	if access != nil && stringField(access, "auth_server_id") == authServerID && int64(intField(access, "expires_at")) > now {
+		c.JSON(http.StatusOK, map[string]any{
+			"active":     true,
+			"token_type": "Bearer",
+			"scope":      stringField(access, "scope"),
+			"client_id":  stringField(access, "client_id"),
+			"username":   stringOrNil(stringField(access, "username")),
+			"sub":        stringOrNil(stringField(access, "user_okta_id")),
+			"aud":        server.audiences,
+			"iss":        server.issuer,
+			"exp":        intField(access, "expires_at"),
+			"iat":        intField(access, "issued_at"),
+		})
+		return
+	}
+	refresh := firstRecord(s.store.RefreshTokens.FindBy("token", token))
+	if refresh != nil && stringField(refresh, "auth_server_id") == authServerID {
+		c.JSON(http.StatusOK, map[string]any{
+			"active":     true,
+			"token_type": "refresh_token",
+			"scope":      stringField(refresh, "scope"),
+			"client_id":  stringField(refresh, "client_id"),
+			"username":   stringField(refresh, "username"),
+			"sub":        stringField(refresh, "user_okta_id"),
+			"aud":        server.audiences,
+			"iss":        server.issuer,
+		})
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{"active": false})
+}
+
+func (s *Service) handleOrgLogout(c *corehttp.Context) {
+	s.handleLogout(c, orgAuthServerID)
+}
+
+func (s *Service) handleAuthServerLogout(c *corehttp.Context) {
+	s.handleLogout(c, c.Param("authServerId"))
+}
+
+func (s *Service) handleLogout(c *corehttp.Context, authServerID string) {
+	if s.resolveAuthServer(authServerID) == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: authorization server '"+authServerID+"'")
+		return
+	}
+	redirectURI := c.Query("post_logout_redirect_uri")
+	if redirectURI == "" {
+		c.Text(http.StatusOK, "Logged out")
+		return
+	}
+	configuredClients := s.clientsForServer(authServerID)
+	if len(configuredClients) > 0 {
+		allowed := false
+		for _, client := range configuredClients {
+			if matchesRedirectURI(redirectURI, stringSliceValue(client["redirect_uris"])) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			c.Text(http.StatusBadRequest, "Invalid post_logout_redirect_uri")
+			return
+		}
+	}
+	c.Redirect(http.StatusFound, redirectURI)
+}
+
+func (s *Service) resolveAuthServer(authServerID string) *resolvedAuthServer {
+	if authServerID == orgAuthServerID {
+		return &resolvedAuthServer{id: orgAuthServerID, issuer: s.baseURL, audiences: []string{defaultAudience}}
+	}
+	server := firstRecord(s.store.AuthorizationServers.FindBy("server_id", authServerID))
+	if server == nil {
+		return nil
+	}
+	audiences := stringSliceValue(server["audiences"])
+	if len(audiences) == 0 {
+		audiences = []string{defaultAudience}
+	}
+	return &resolvedAuthServer{id: authServerID, issuer: resolveIssuer(s.baseURL, authServerID), audiences: audiences}
+}
+
+func (s *Service) clientsForServer(authServerID string) []corestore.Record {
+	return s.store.OAuthClients.FindBy("auth_server_id", authServerID)
+}
+
+func (s *Service) validateClient(c *corehttp.Context, authServerID string, clientID string, clientSecret string) (corestore.Record, bool) {
+	configuredClients := s.clientsForServer(authServerID)
+	if len(configuredClients) == 0 {
+		return nil, true
+	}
+	client := recordWithField(configuredClients, "client_id", clientID)
+	if client == nil {
+		oauthError(c, http.StatusUnauthorized, "invalid_client", "Unknown client.")
+		return nil, false
+	}
+	if stringField(client, "token_endpoint_auth_method") == "none" {
+		return client, true
+	}
+	if !constantTimeEqual(clientSecret, stringField(client, "client_secret")) {
+		oauthError(c, http.StatusUnauthorized, "invalid_client", "Invalid client credentials.")
+		return nil, false
+	}
+	return client, true
+}
+
+func recordWithField(records []corestore.Record, field string, value string) corestore.Record {
+	for _, record := range records {
+		if stringField(record, field) == value {
+			return record
+		}
+	}
+	return nil
+}
+
+func (s *Service) deleteOAuthCode(code string) {
+	for _, record := range s.store.OAuthCodes.FindBy("code", code) {
+		s.store.OAuthCodes.Delete(intField(record, "id"))
+	}
+}
+
+func (s *Service) deleteAccessToken(token string) {
+	for _, record := range s.store.AccessTokens.FindBy("token", token) {
+		s.store.AccessTokens.Delete(intField(record, "id"))
+	}
+}
+
+func (s *Service) deleteRefreshToken(token string) {
+	for _, record := range s.store.RefreshTokens.FindBy("token", token) {
+		s.store.RefreshTokens.Delete(intField(record, "id"))
+	}
+}
+
+func addAuthorizationResponseValues(values url.Values, code string, state string) {
+	values.Set("code", code)
+	if state != "" {
+		values.Set("state", state)
+	}
+}
+
+func collectUserGroupNames(store Store, user corestore.Record) []string {
+	names := []string{}
+	for _, membership := range store.GroupMemberships.FindBy("user_okta_id", stringField(user, "okta_id")) {
+		group := firstRecord(store.Groups.FindBy("okta_id", stringField(membership, "group_okta_id")))
+		if group != nil {
+			names = append(names, stringField(group, "name"))
+		}
+	}
+	return names
+}

--- a/internal/services/okta/routes_oauth.go
+++ b/internal/services/okta/routes_oauth.go
@@ -146,9 +146,9 @@ func (s *Service) handleAuthorize(c *corehttp.Context, authServerID string) {
 	}
 
 	var body strings.Builder
-	users := s.store.Users.All()
+	users := activeUsers(s.store.Users.All())
 	if len(users) == 0 {
-		body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+		body.WriteString(`<p class="empty">No active users in the emulator store.</p>`)
 	} else {
 		for _, user := range users {
 			login := stringField(user, "login")
@@ -219,6 +219,10 @@ func (s *Service) handleAuthorizeCallback(c *corehttp.Context, authServerID stri
 	user := s.findUser(userRef)
 	if user == nil {
 		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Unknown user", "The selected user is not available.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	if !userIsActive(user) {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("User is not active", "The selected user cannot sign in.", ui.PageOptions{Service: serviceLabel}))
 		return
 	}
 	configuredClients := s.clientsForServer(authServerID)
@@ -294,15 +298,23 @@ func (s *Service) handleToken(c *corehttp.Context, authServerID string) {
 		return
 	}
 
-	switch body["grant_type"] {
+	grantType := body["grant_type"]
+	if !supportedGrantType(grantType) {
+		oauthError(c, http.StatusBadRequest, "unsupported_grant_type", "Only authorization_code, refresh_token, and client_credentials are supported.")
+		return
+	}
+	if !clientAllowsGrant(client, grantType) {
+		oauthError(c, http.StatusBadRequest, "unauthorized_client", "The client is not authorized to use the requested grant_type.")
+		return
+	}
+
+	switch grantType {
 	case "authorization_code":
 		s.handleAuthorizationCodeToken(c, server, body, clientID, client)
 	case "refresh_token":
 		s.handleRefreshToken(c, server, body, client)
 	case "client_credentials":
 		s.handleClientCredentialsToken(c, server, body, clientID, client)
-	default:
-		oauthError(c, http.StatusBadRequest, "unsupported_grant_type", "Only authorization_code, refresh_token, and client_credentials are supported.")
 	}
 }
 
@@ -336,6 +348,10 @@ func (s *Service) handleAuthorizationCodeToken(c *corehttp.Context, server *reso
 	user := firstRecord(s.store.Users.FindBy("okta_id", stringField(code, "user_okta_id")))
 	if user == nil {
 		oauthError(c, http.StatusBadRequest, "invalid_grant", "Unknown user.")
+		return
+	}
+	if !userIsActive(user) {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "User is not active.")
 		return
 	}
 	s.deleteOAuthCode(stringField(code, "code"))
@@ -398,10 +414,20 @@ func (s *Service) handleRefreshToken(c *corehttp.Context, server *resolvedAuthSe
 		oauthError(c, http.StatusBadRequest, "invalid_grant", "Unknown user.")
 		return
 	}
+	if !userIsActive(user) {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "User is not active.")
+		return
+	}
+	storedScope := firstNonEmpty(stringField(refresh, "scope"), "openid profile email")
+	requestedScope := strings.TrimSpace(body["scope"])
+	if requestedScope != "" && !scopeSubset(requestedScope, storedScope) {
+		oauthError(c, http.StatusBadRequest, "invalid_scope", "Requested scope exceeds original grant.")
+		return
+	}
 	s.deleteRefreshToken(stringField(refresh, "token"))
 
 	now := time.Now().Unix()
-	scope := firstNonEmpty(body["scope"], stringField(refresh, "scope"), "openid profile email")
+	scope := firstNonEmpty(requestedScope, storedScope)
 	clientID := stringField(refresh, "client_id")
 	accessToken := oktaToken("okta_")
 	refreshToken := oktaToken("r_okta_")
@@ -630,6 +656,9 @@ func (s *Service) resolveAuthServer(authServerID string) *resolvedAuthServer {
 	if server == nil {
 		return nil
 	}
+	if stringField(server, "status") != "ACTIVE" {
+		return nil
+	}
 	audiences := stringSliceValue(server["audiences"])
 	if len(audiences) == 0 {
 		audiences = []string{defaultAudience}
@@ -659,6 +688,54 @@ func (s *Service) validateClient(c *corehttp.Context, authServerID string, clien
 		return nil, false
 	}
 	return client, true
+}
+
+func supportedGrantType(grantType string) bool {
+	switch grantType {
+	case "authorization_code", "refresh_token", "client_credentials":
+		return true
+	default:
+		return false
+	}
+}
+
+func clientAllowsGrant(client corestore.Record, grantType string) bool {
+	if client == nil {
+		return true
+	}
+	for _, allowed := range stringSliceValue(client["grant_types"]) {
+		if allowed == grantType {
+			return true
+		}
+	}
+	return false
+}
+
+func activeUsers(users []corestore.Record) []corestore.Record {
+	out := make([]corestore.Record, 0, len(users))
+	for _, user := range users {
+		if userIsActive(user) {
+			out = append(out, user)
+		}
+	}
+	return out
+}
+
+func userIsActive(user corestore.Record) bool {
+	return stringField(user, "status") == "ACTIVE"
+}
+
+func scopeSubset(requested string, granted string) bool {
+	grantedSet := map[string]struct{}{}
+	for _, scope := range parseScope(granted) {
+		grantedSet[scope] = struct{}{}
+	}
+	for _, scope := range parseScope(requested) {
+		if _, ok := grantedSet[scope]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func recordWithField(records []corestore.Record, field string, value string) corestore.Record {

--- a/internal/services/okta/routes_users.go
+++ b/internal/services/okta/routes_users.go
@@ -212,7 +212,7 @@ func (s *Service) handlePutUser(c *corehttp.Context) {
 }
 
 func (s *Service) handlePostUser(c *corehttp.Context) {
-	s.handleUpdateUser(c, false)
+	s.handleUpdateUser(c, true)
 }
 
 func (s *Service) handleUpdateUser(c *corehttp.Context, checkDuplicates bool) {

--- a/internal/services/okta/routes_users.go
+++ b/internal/services/okta/routes_users.go
@@ -1,0 +1,314 @@
+package okta
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerUserRoutes(router *corehttp.Router) {
+	router.Get("/api/v1/users", s.handleListUsers)
+	router.Post("/api/v1/users", s.handleCreateUser)
+	router.Get("/api/v1/users/me", s.handleCurrentUser)
+	router.Get("/api/v1/users/:userId/groups", s.handleUserGroups)
+	router.Post("/api/v1/users/:userId/lifecycle/activate", s.handleActivateUser)
+	router.Post("/api/v1/users/:userId/lifecycle/deactivate", s.handleDeactivateUser)
+	router.Post("/api/v1/users/:userId/lifecycle/suspend", s.handleSuspendUser)
+	router.Post("/api/v1/users/:userId/lifecycle/unsuspend", s.handleUnsuspendUser)
+	router.Post("/api/v1/users/:userId/lifecycle/reactivate", s.handleReactivateUser)
+	router.Get("/api/v1/users/:userId", s.handleGetUser)
+	router.Put("/api/v1/users/:userId", s.handlePutUser)
+	router.Post("/api/v1/users/:userId", s.handlePostUser)
+	router.Delete("/api/v1/users/:userId", s.handleDeleteUser)
+}
+
+func (s *Service) handleListUsers(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	q := strings.ToLower(c.Query("q"))
+	search := strings.ToLower(c.Query("search"))
+	filter := c.Query("filter")
+	users := s.store.Users.All()
+	filtered := make([]corestore.Record, 0, len(users))
+	for _, user := range users {
+		searchText := strings.ToLower(strings.Join([]string{
+			stringField(user, "login"),
+			stringField(user, "email"),
+			stringField(user, "first_name"),
+			stringField(user, "last_name"),
+			userDisplayName(user),
+		}, " "))
+		if q != "" && !strings.Contains(searchText, q) {
+			continue
+		}
+		if search != "" && !strings.Contains(searchText, search) {
+			continue
+		}
+		if status := statusFilterValue(filter); status != "" && stringField(user, "status") != status {
+			continue
+		}
+		filtered = append(filtered, user)
+	}
+	paginate(c, filtered, func(user corestore.Record) map[string]any {
+		return userResponse(s.baseURL, user)
+	})
+}
+
+func (s *Service) handleCreateUser(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	body := readJSONBody(c.Request)
+	profile := bodyMap(body, "profile")
+	login := bodyString(profile, "login")
+	email := bodyString(profile, "email")
+	if email == "" {
+		email = login
+	}
+	if login == "" || email == "" {
+		oktaError(c, http.StatusBadRequest, "E0000001", "profile.login and profile.email are required")
+		return
+	}
+	if firstRecord(s.store.Users.FindBy("login", login)) != nil || firstRecord(s.store.Users.FindBy("email", email)) != nil {
+		oktaError(c, http.StatusBadRequest, "E0000001", "A user with the same login or email already exists")
+		return
+	}
+	now := nowISO()
+	activate := boolFromQuery(c.Query("activate"), true)
+	status := "STAGED"
+	var activatedAt any
+	if activate {
+		status = "ACTIVE"
+		activatedAt = now
+	}
+	firstName := bodyStringDefault(profile, "firstName", "Test")
+	lastName := bodyStringDefault(profile, "lastName", "User")
+	displayName := bodyString(profile, "displayName")
+	if displayName == "" {
+		displayName = strings.TrimSpace(firstName + " " + lastName)
+	}
+	if displayName == "" {
+		displayName = login
+	}
+	created := s.store.Users.Insert(corestore.Record{
+		"okta_id":                 oktaID("00u"),
+		"status":                  status,
+		"activated_at":            activatedAt,
+		"status_changed_at":       now,
+		"last_login_at":           nil,
+		"password_changed_at":     nil,
+		"transitioning_to_status": nil,
+		"login":                   login,
+		"email":                   email,
+		"first_name":              firstName,
+		"last_name":               lastName,
+		"display_name":            displayName,
+		"locale":                  bodyStringDefault(profile, "locale", "en-US"),
+		"time_zone":               bodyStringDefault(profile, "timeZone", "UTC"),
+	})
+	if group := firstRecord(s.store.Groups.FindBy("okta_id", defaultEveryoneGroupID)); group != nil {
+		s.ensureMembership(stringField(group, "okta_id"), stringField(created, "okta_id"))
+	}
+	c.JSON(http.StatusCreated, userResponse(s.baseURL, created))
+}
+
+func (s *Service) handleCurrentUser(c *corehttp.Context) {
+	login, ok := s.requireManagementAuth(c)
+	if !ok {
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("login", login))
+	if user == nil {
+		user = firstRecord(s.store.Users.All())
+	}
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	response := userResponse(s.baseURL, user)
+	profile := mapValue(response["profile"])
+	profile["displayName"] = userDisplayName(user)
+	response["profile"] = profile
+	c.JSON(http.StatusOK, response)
+}
+
+func (s *Service) handleUserGroups(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	groups := []map[string]any{}
+	for _, membership := range s.store.GroupMemberships.FindBy("user_okta_id", stringField(user, "okta_id")) {
+		group := firstRecord(s.store.Groups.FindBy("okta_id", stringField(membership, "group_okta_id")))
+		if group == nil {
+			continue
+		}
+		groups = append(groups, map[string]any{
+			"id": stringField(group, "okta_id"),
+			"profile": map[string]any{
+				"name":        stringField(group, "name"),
+				"description": group["description"],
+			},
+			"type": stringField(group, "type"),
+		})
+	}
+	c.JSON(http.StatusOK, groups)
+}
+
+func (s *Service) handleActivateUser(c *corehttp.Context) {
+	s.handleUserLifecycle(c, "ACTIVE")
+}
+
+func (s *Service) handleDeactivateUser(c *corehttp.Context) {
+	s.handleUserLifecycle(c, "DEPROVISIONED")
+}
+
+func (s *Service) handleSuspendUser(c *corehttp.Context) {
+	s.handleUserLifecycle(c, "SUSPENDED")
+}
+
+func (s *Service) handleUnsuspendUser(c *corehttp.Context) {
+	s.handleUserLifecycle(c, "ACTIVE")
+}
+
+func (s *Service) handleReactivateUser(c *corehttp.Context) {
+	s.handleUserLifecycle(c, "PROVISIONED")
+}
+
+func (s *Service) handleUserLifecycle(c *corehttp.Context, status string) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	updated := s.updateUserLifecycle(user, status)
+	c.JSON(http.StatusOK, userResponse(s.baseURL, updated))
+}
+
+func (s *Service) handleGetUser(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	c.JSON(http.StatusOK, userResponse(s.baseURL, user))
+}
+
+func (s *Service) handlePutUser(c *corehttp.Context) {
+	s.handleUpdateUser(c, true)
+}
+
+func (s *Service) handlePostUser(c *corehttp.Context) {
+	s.handleUpdateUser(c, false)
+}
+
+func (s *Service) handleUpdateUser(c *corehttp.Context, checkDuplicates bool) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	body := readJSONBody(c.Request)
+	updates := updateUserProfile(user, bodyMap(body, "profile"))
+	if checkDuplicates {
+		if login := stringValue(updates["login"]); login != "" && login != stringField(user, "login") && firstRecord(s.store.Users.FindBy("login", login)) != nil {
+			oktaError(c, http.StatusBadRequest, "E0000001", "A user with the same login or email already exists")
+			return
+		}
+		if email := stringValue(updates["email"]); email != "" && email != stringField(user, "email") && firstRecord(s.store.Users.FindBy("email", email)) != nil {
+			oktaError(c, http.StatusBadRequest, "E0000001", "A user with the same login or email already exists")
+			return
+		}
+	}
+	updated, _ := s.store.Users.Update(intField(user, "id"), updates)
+	c.JSON(http.StatusOK, userResponse(s.baseURL, updated))
+}
+
+func (s *Service) handleDeleteUser(c *corehttp.Context) {
+	if _, ok := s.requireManagementAuth(c); !ok {
+		return
+	}
+	user := s.findUser(c.Param("userId"))
+	if user == nil {
+		oktaError(c, http.StatusNotFound, "E0000007", "Not found: user")
+		return
+	}
+	if stringField(user, "status") != "DEPROVISIONED" {
+		s.updateUserLifecycle(user, "DEPROVISIONED")
+		writeNoContent(c)
+		return
+	}
+	for _, membership := range s.store.GroupMemberships.FindBy("user_okta_id", stringField(user, "okta_id")) {
+		s.store.GroupMemberships.Delete(intField(membership, "id"))
+	}
+	for _, assignment := range s.store.AppAssignments.FindBy("user_okta_id", stringField(user, "okta_id")) {
+		s.store.AppAssignments.Delete(intField(assignment, "id"))
+	}
+	s.store.Users.Delete(intField(user, "id"))
+	writeNoContent(c)
+}
+
+func updateUserProfile(user corestore.Record, profile map[string]any) corestore.Record {
+	firstName := firstNonEmpty(bodyString(profile, "firstName"), stringField(user, "first_name"))
+	lastName := firstNonEmpty(bodyString(profile, "lastName"), stringField(user, "last_name"))
+	displayName := firstNonEmpty(bodyString(profile, "displayName"), bodyString(profile, "nickName"), stringField(user, "display_name"))
+	if displayName == "" {
+		displayName = strings.TrimSpace(firstName + " " + lastName)
+	}
+	return corestore.Record{
+		"login":        firstNonEmpty(bodyString(profile, "login"), stringField(user, "login")),
+		"email":        firstNonEmpty(bodyString(profile, "email"), stringField(user, "email")),
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"display_name": displayName,
+		"locale":       firstNonEmpty(bodyString(profile, "locale"), stringField(user, "locale")),
+		"time_zone":    firstNonEmpty(bodyString(profile, "timeZone"), stringField(user, "time_zone")),
+	}
+}
+
+func (s *Service) updateUserLifecycle(user corestore.Record, target string) corestore.Record {
+	now := nowISO()
+	activatedAt := user["activated_at"]
+	if target == "ACTIVE" && activatedAt == nil {
+		activatedAt = now
+	}
+	updated, ok := s.store.Users.Update(intField(user, "id"), corestore.Record{
+		"status":                  target,
+		"transitioning_to_status": nil,
+		"status_changed_at":       now,
+		"activated_at":            activatedAt,
+	})
+	if !ok {
+		return user
+	}
+	return updated
+}
+
+func statusFilterValue(filter string) string {
+	filter = strings.TrimSpace(filter)
+	lower := strings.ToLower(filter)
+	marker := "status eq "
+	index := strings.Index(lower, marker)
+	if index < 0 {
+		return ""
+	}
+	value := strings.TrimSpace(filter[index+len(marker):])
+	value = strings.Trim(value, `" '`)
+	return strings.ToUpper(value)
+}

--- a/internal/services/okta/service.go
+++ b/internal/services/okta/service.go
@@ -1,0 +1,374 @@
+package okta
+
+import (
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const serviceLabel = "Okta"
+
+type Options struct {
+	Store   *corestore.Store
+	BaseURL string
+	Seed    *SeedConfig
+}
+
+type SeedConfig struct {
+	Users                []UserSeed                `json:"users"`
+	Groups               []GroupSeed               `json:"groups"`
+	Apps                 []AppSeed                 `json:"apps"`
+	OAuthClients         []OAuthClientSeed         `json:"oauth_clients"`
+	AuthorizationServers []AuthorizationServerSeed `json:"authorization_servers"`
+	GroupMemberships     []GroupMembershipSeed     `json:"group_memberships"`
+	AppAssignments       []AppAssignmentSeed       `json:"app_assignments"`
+}
+
+type UserSeed struct {
+	OktaID      string `json:"okta_id"`
+	Status      string `json:"status"`
+	Login       string `json:"login"`
+	Email       string `json:"email"`
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	DisplayName string `json:"display_name"`
+	Locale      string `json:"locale"`
+	TimeZone    string `json:"time_zone"`
+}
+
+type GroupSeed struct {
+	OktaID      string `json:"okta_id"`
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type AppSeed struct {
+	OktaID      string         `json:"okta_id"`
+	Name        string         `json:"name"`
+	Label       string         `json:"label"`
+	Status      string         `json:"status"`
+	SignOnMode  string         `json:"sign_on_mode"`
+	Settings    map[string]any `json:"settings"`
+	Credentials map[string]any `json:"credentials"`
+}
+
+type OAuthClientSeed struct {
+	ClientID                string   `json:"client_id"`
+	ClientSecret            string   `json:"client_secret"`
+	Name                    string   `json:"name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	ResponseTypes           []string `json:"response_types"`
+	GrantTypes              []string `json:"grant_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	AuthServerID            string   `json:"auth_server_id"`
+}
+
+type AuthorizationServerSeed struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Audiences   []string `json:"audiences"`
+	Status      string   `json:"status"`
+}
+
+type GroupMembershipSeed struct {
+	GroupOktaID string `json:"group_okta_id"`
+	UserOktaID  string `json:"user_okta_id"`
+}
+
+type AppAssignmentSeed struct {
+	AppOktaID  string `json:"app_okta_id"`
+	UserOktaID string `json:"user_okta_id"`
+}
+
+type Service struct {
+	store   Store
+	baseURL string
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	baseURL := strings.TrimRight(options.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:4000"
+	}
+	service := &Service{store: NewStore(runtimeStore), baseURL: baseURL}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, baseURL string, config SeedConfig) {
+	New(Options{Store: runtimeStore, BaseURL: baseURL, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerOAuthRoutes(router)
+	s.registerUserRoutes(router)
+	s.registerGroupRoutes(router)
+	s.registerAppRoutes(router)
+	s.registerAuthorizationServerRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if firstRecord(s.store.AuthorizationServers.FindBy("server_id", defaultAuthServerID)) == nil {
+		s.store.AuthorizationServers.Insert(corestore.Record{
+			"server_id":   defaultAuthServerID,
+			"name":        "default",
+			"description": "Default custom authorization server",
+			"audiences":   []string{defaultAudience},
+			"status":      "ACTIVE",
+		})
+	}
+	everyone := firstRecord(s.store.Groups.FindBy("okta_id", defaultEveryoneGroupID))
+	if everyone == nil {
+		everyone = s.store.Groups.Insert(corestore.Record{
+			"okta_id":     defaultEveryoneGroupID,
+			"type":        "BUILT_IN",
+			"name":        defaultEveryoneGroupName,
+			"description": "All users in the organization",
+		})
+	}
+	user := firstRecord(s.store.Users.FindBy("login", "testuser@okta.local"))
+	if user == nil {
+		now := nowISO()
+		user = s.store.Users.Insert(corestore.Record{
+			"okta_id":                 oktaID("00u"),
+			"status":                  "ACTIVE",
+			"activated_at":            now,
+			"status_changed_at":       now,
+			"last_login_at":           nil,
+			"password_changed_at":     nil,
+			"transitioning_to_status": nil,
+			"login":                   "testuser@okta.local",
+			"email":                   "testuser@okta.local",
+			"first_name":              "Test",
+			"last_name":               "User",
+			"display_name":            "Test User",
+			"locale":                  "en-US",
+			"time_zone":               "UTC",
+		})
+	}
+	if firstRecord(s.store.OAuthClients.FindBy("client_id", "okta-test-client")) == nil {
+		s.store.OAuthClients.Insert(corestore.Record{
+			"client_id":                  "okta-test-client",
+			"client_secret":              "okta-test-secret",
+			"name":                       "Sample OIDC Client",
+			"redirect_uris":              []string{"http://localhost:3000/callback"},
+			"response_types":             []string{"code"},
+			"grant_types":                []string{"authorization_code", "refresh_token", "client_credentials"},
+			"token_endpoint_auth_method": "client_secret_post",
+			"auth_server_id":             defaultAuthServerID,
+		})
+	}
+	if firstRecord(s.store.OAuthClients.FindBy("client_id", "okta-test-app")) == nil {
+		s.store.OAuthClients.Insert(corestore.Record{
+			"client_id":                  "okta-test-app",
+			"client_secret":              "",
+			"name":                       "Sample Public PKCE Client",
+			"redirect_uris":              []string{"http://localhost:3000/official-sdk/callback", "http://localhost:3000/official-sdk"},
+			"response_types":             []string{"code"},
+			"grant_types":                []string{"authorization_code", "refresh_token"},
+			"token_endpoint_auth_method": "none",
+			"auth_server_id":             defaultAuthServerID,
+		})
+	}
+	if s.store.Apps.Count() == 0 {
+		s.store.Apps.Insert(corestore.Record{
+			"okta_id":      oktaID("0oa"),
+			"name":         "oidc_client",
+			"label":        "Sample OIDC App",
+			"status":       "ACTIVE",
+			"sign_on_mode": "OPENID_CONNECT",
+			"settings":     map[string]any{"oauthClient": map[string]any{"redirect_uris": []string{"http://localhost:3000/callback"}}},
+			"credentials":  map[string]any{},
+		})
+	}
+	s.ensureMembership(stringField(everyone, "okta_id"), stringField(user, "okta_id"))
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	for _, server := range config.AuthorizationServers {
+		if server.ID == "" || firstRecord(s.store.AuthorizationServers.FindBy("server_id", server.ID)) != nil {
+			continue
+		}
+		audiences := server.Audiences
+		if len(audiences) == 0 {
+			audiences = []string{defaultAudience}
+		}
+		s.store.AuthorizationServers.Insert(corestore.Record{
+			"server_id":   server.ID,
+			"name":        server.Name,
+			"description": server.Description,
+			"audiences":   audiences,
+			"status":      normalizeActiveStatus(server.Status, "ACTIVE"),
+		})
+	}
+	for _, user := range config.Users {
+		if user.Login == "" || firstRecord(s.store.Users.FindBy("login", user.Login)) != nil {
+			continue
+		}
+		status := normalizeUserStatus(user.Status, "ACTIVE")
+		now := nowISO()
+		id := user.OktaID
+		if id == "" {
+			id = oktaID("00u")
+		}
+		email := user.Email
+		if email == "" {
+			email = user.Login
+		}
+		firstName := user.FirstName
+		if firstName == "" {
+			firstName = "Test"
+		}
+		lastName := user.LastName
+		if lastName == "" {
+			lastName = "User"
+		}
+		displayName := user.DisplayName
+		if displayName == "" {
+			displayName = strings.TrimSpace(firstName + " " + lastName)
+		}
+		activatedAt := stringOrNil("")
+		if status == "ACTIVE" {
+			activatedAt = now
+		}
+		s.store.Users.Insert(corestore.Record{
+			"okta_id":                 id,
+			"status":                  status,
+			"activated_at":            activatedAt,
+			"status_changed_at":       now,
+			"last_login_at":           nil,
+			"password_changed_at":     nil,
+			"transitioning_to_status": nil,
+			"login":                   user.Login,
+			"email":                   email,
+			"first_name":              firstName,
+			"last_name":               lastName,
+			"display_name":            displayName,
+			"locale":                  firstNonEmpty(user.Locale, "en-US"),
+			"time_zone":               firstNonEmpty(user.TimeZone, "UTC"),
+		})
+	}
+	for _, group := range config.Groups {
+		if group.Name == "" || firstRecord(s.store.Groups.FindBy("name", group.Name)) != nil {
+			continue
+		}
+		id := group.OktaID
+		if id == "" {
+			id = oktaID("00g")
+		}
+		s.store.Groups.Insert(corestore.Record{
+			"okta_id":     id,
+			"type":        normalizeGroupType(group.Type, "OKTA_GROUP"),
+			"name":        group.Name,
+			"description": stringOrNil(group.Description),
+		})
+	}
+	for _, app := range config.Apps {
+		if app.Name == "" || firstRecord(s.store.Apps.FindBy("name", app.Name)) != nil {
+			continue
+		}
+		id := app.OktaID
+		if id == "" {
+			id = oktaID("0oa")
+		}
+		s.store.Apps.Insert(corestore.Record{
+			"okta_id":      id,
+			"name":         app.Name,
+			"label":        firstNonEmpty(app.Label, app.Name),
+			"status":       normalizeActiveStatus(app.Status, "ACTIVE"),
+			"sign_on_mode": firstNonEmpty(app.SignOnMode, "OPENID_CONNECT"),
+			"settings":     firstMap(app.Settings),
+			"credentials":  firstMap(app.Credentials),
+		})
+	}
+	for _, client := range config.OAuthClients {
+		if client.ClientID == "" || firstRecord(s.store.OAuthClients.FindBy("client_id", client.ClientID)) != nil {
+			continue
+		}
+		responseTypes := client.ResponseTypes
+		if len(responseTypes) == 0 {
+			responseTypes = []string{"code"}
+		}
+		grantTypes := client.GrantTypes
+		if len(grantTypes) == 0 {
+			grantTypes = []string{"authorization_code", "refresh_token", "client_credentials"}
+		}
+		authMethod := client.TokenEndpointAuthMethod
+		if authMethod == "" {
+			authMethod = "client_secret_post"
+		}
+		authServerID := client.AuthServerID
+		if authServerID == "" {
+			authServerID = defaultAuthServerID
+		}
+		s.store.OAuthClients.Insert(corestore.Record{
+			"client_id":                  client.ClientID,
+			"client_secret":              client.ClientSecret,
+			"name":                       client.Name,
+			"redirect_uris":              client.RedirectURIs,
+			"response_types":             responseTypes,
+			"grant_types":                grantTypes,
+			"token_endpoint_auth_method": authMethod,
+			"auth_server_id":             authServerID,
+		})
+	}
+	for _, membership := range config.GroupMemberships {
+		if firstRecord(s.store.Groups.FindBy("okta_id", membership.GroupOktaID)) != nil && firstRecord(s.store.Users.FindBy("okta_id", membership.UserOktaID)) != nil {
+			s.ensureMembership(membership.GroupOktaID, membership.UserOktaID)
+		}
+	}
+	for _, assignment := range config.AppAssignments {
+		if firstRecord(s.store.Apps.FindBy("okta_id", assignment.AppOktaID)) != nil && firstRecord(s.store.Users.FindBy("okta_id", assignment.UserOktaID)) != nil {
+			s.ensureAppAssignment(assignment.AppOktaID, assignment.UserOktaID)
+		}
+	}
+}
+
+func (s *Service) ensureMembership(groupID string, userID string) {
+	for _, record := range s.store.GroupMemberships.FindBy("group_okta_id", groupID) {
+		if stringField(record, "user_okta_id") == userID {
+			return
+		}
+	}
+	s.store.GroupMemberships.Insert(corestore.Record{"group_okta_id": groupID, "user_okta_id": userID})
+}
+
+func (s *Service) ensureAppAssignment(appID string, userID string) {
+	for _, record := range s.store.AppAssignments.FindBy("app_okta_id", appID) {
+		if stringField(record, "user_okta_id") == userID {
+			return
+		}
+	}
+	s.store.AppAssignments.Insert(corestore.Record{"app_okta_id": appID, "user_okta_id": userID})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstMap(value map[string]any) map[string]any {
+	if value == nil {
+		return map[string]any{}
+	}
+	return value
+}

--- a/internal/services/okta/service_test.go
+++ b/internal/services/okta/service_test.go
@@ -1,0 +1,202 @@
+package okta
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func TestOAuthAuthorizationCodeFlow(t *testing.T) {
+	service, router := newTestService(t)
+	user := firstRecord(service.store.Users.FindBy("login", "testuser@okta.local"))
+	if user == nil {
+		t.Fatal("missing default user")
+	}
+
+	discovery := serveOkta(router, httptest.NewRequest(http.MethodGet, "/oauth2/default/.well-known/openid-configuration", nil))
+	if discovery.Code != http.StatusOK {
+		t.Fatalf("discovery status = %d, body = %s", discovery.Code, discovery.Body.String())
+	}
+	if !strings.Contains(discovery.Body.String(), `"issuer":"http://localhost:4016/oauth2/default"`) ||
+		!strings.Contains(discovery.Body.String(), `"introspection_endpoint"`) {
+		t.Fatalf("unexpected discovery body: %s", discovery.Body.String())
+	}
+
+	form := url.Values{
+		"user_ref":       {stringField(user, "okta_id")},
+		"redirect_uri":   {"http://localhost:3000/callback"},
+		"scope":          {"openid profile email groups"},
+		"client_id":      {"okta-test-client"},
+		"response_mode":  {"query"},
+		"auth_server_id": {"default"},
+		"state":          {"abc"},
+	}
+	callback := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/authorize/callback", strings.NewReader(form.Encode()))
+	callback.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRes := serveOkta(router, callback)
+	if callbackRes.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	location := callbackRes.Header().Get("Location")
+	redirect, err := url.Parse(location)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := redirect.Query().Get("code")
+	if code == "" || redirect.Query().Get("state") != "abc" {
+		t.Fatalf("unexpected redirect location: %s", location)
+	}
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"client_id":     {"okta-test-client"},
+		"client_secret": {"okta-test-secret"},
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/token", strings.NewReader(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRes := serveOkta(router, tokenReq)
+	if tokenRes.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	var tokenBody struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.Unmarshal(tokenRes.Body.Bytes(), &tokenBody); err != nil {
+		t.Fatal(err)
+	}
+	if tokenBody.AccessToken == "" || tokenBody.RefreshToken == "" || tokenBody.IDToken == "" || tokenBody.Scope != "openid profile email groups" {
+		t.Fatalf("unexpected token body: %#v", tokenBody)
+	}
+
+	userinfoReq := httptest.NewRequest(http.MethodGet, "/oauth2/default/v1/userinfo", nil)
+	userinfoReq.Header.Set("Authorization", "Bearer "+tokenBody.AccessToken)
+	userinfoRes := serveOkta(router, userinfoReq)
+	if userinfoRes.Code != http.StatusOK {
+		t.Fatalf("userinfo status = %d, body = %s", userinfoRes.Code, userinfoRes.Body.String())
+	}
+	if !strings.Contains(userinfoRes.Body.String(), `"preferred_username":"testuser@okta.local"`) || !strings.Contains(userinfoRes.Body.String(), `"groups":["Everyone"]`) {
+		t.Fatalf("unexpected userinfo body: %s", userinfoRes.Body.String())
+	}
+
+	introspectForm := url.Values{
+		"token":         {tokenBody.AccessToken},
+		"client_id":     {"okta-test-client"},
+		"client_secret": {"okta-test-secret"},
+	}
+	introspectReq := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/introspect", strings.NewReader(introspectForm.Encode()))
+	introspectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	introspectRes := serveOkta(router, introspectReq)
+	if introspectRes.Code != http.StatusOK {
+		t.Fatalf("introspect status = %d, body = %s", introspectRes.Code, introspectRes.Body.String())
+	}
+	if !strings.Contains(introspectRes.Body.String(), `"active":true`) || !strings.Contains(introspectRes.Body.String(), `"client_id":"okta-test-client"`) {
+		t.Fatalf("unexpected introspect body: %s", introspectRes.Body.String())
+	}
+}
+
+func TestManagementUsersGroupsAppsAndAuthorizationServers(t *testing.T) {
+	_, router := newTestService(t)
+
+	createUser := httptest.NewRequest(http.MethodPost, "/api/v1/users?activate=false", strings.NewReader(`{"profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Admin"}}`))
+	createUser.Header.Set("Content-Type", "application/json")
+	createUser.Header.Set("Authorization", "SSWS dev-token")
+	createUserRes := serveOkta(router, createUser)
+	if createUserRes.Code != http.StatusCreated {
+		t.Fatalf("create user status = %d, body = %s", createUserRes.Code, createUserRes.Body.String())
+	}
+	var user struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(createUserRes.Body.Bytes(), &user); err != nil {
+		t.Fatal(err)
+	}
+	if user.ID == "" || user.Status != "STAGED" {
+		t.Fatalf("unexpected user: %#v", user)
+	}
+
+	activate := httptest.NewRequest(http.MethodPost, "/api/v1/users/"+url.PathEscape(user.ID)+"/lifecycle/activate", nil)
+	activate.Header.Set("Authorization", "SSWS dev-token")
+	activateRes := serveOkta(router, activate)
+	if activateRes.Code != http.StatusOK || !strings.Contains(activateRes.Body.String(), `"status":"ACTIVE"`) {
+		t.Fatalf("activate status = %d, body = %s", activateRes.Code, activateRes.Body.String())
+	}
+
+	groupReq := httptest.NewRequest(http.MethodPost, "/api/v1/groups", strings.NewReader(`{"profile":{"name":"Admins","description":"Administrators"}}`))
+	groupReq.Header.Set("Content-Type", "application/json")
+	groupReq.Header.Set("Authorization", "SSWS dev-token")
+	groupRes := serveOkta(router, groupReq)
+	if groupRes.Code != http.StatusCreated {
+		t.Fatalf("create group status = %d, body = %s", groupRes.Code, groupRes.Body.String())
+	}
+	var group struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(groupRes.Body.Bytes(), &group); err != nil {
+		t.Fatal(err)
+	}
+
+	addMember := httptest.NewRequest(http.MethodPut, "/api/v1/groups/"+url.PathEscape(group.ID)+"/users/"+url.PathEscape(user.ID), nil)
+	addMember.Header.Set("Authorization", "SSWS dev-token")
+	addMemberRes := serveOkta(router, addMember)
+	if addMemberRes.Code != http.StatusNoContent {
+		t.Fatalf("add member status = %d, body = %s", addMemberRes.Code, addMemberRes.Body.String())
+	}
+
+	appReq := httptest.NewRequest(http.MethodPost, "/api/v1/apps", strings.NewReader(`{"name":"oidc_client","label":"Admin Console"}`))
+	appReq.Header.Set("Content-Type", "application/json")
+	appReq.Header.Set("Authorization", "SSWS dev-token")
+	appRes := serveOkta(router, appReq)
+	if appRes.Code != http.StatusCreated {
+		t.Fatalf("create app status = %d, body = %s", appRes.Code, appRes.Body.String())
+	}
+	var app struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(appRes.Body.Bytes(), &app); err != nil {
+		t.Fatal(err)
+	}
+
+	assign := httptest.NewRequest(http.MethodPut, "/api/v1/apps/"+url.PathEscape(app.ID)+"/users/"+url.PathEscape(user.ID), nil)
+	assign.Header.Set("Authorization", "SSWS dev-token")
+	assignRes := serveOkta(router, assign)
+	if assignRes.Code != http.StatusNoContent {
+		t.Fatalf("assign app status = %d, body = %s", assignRes.Code, assignRes.Body.String())
+	}
+
+	authServerReq := httptest.NewRequest(http.MethodPost, "/api/v1/authorizationServers", strings.NewReader(`{"name":"Partner API","audiences":["api://partner"]}`))
+	authServerReq.Header.Set("Content-Type", "application/json")
+	authServerReq.Header.Set("Authorization", "SSWS dev-token")
+	authServerRes := serveOkta(router, authServerReq)
+	if authServerRes.Code != http.StatusCreated {
+		t.Fatalf("create auth server status = %d, body = %s", authServerRes.Code, authServerRes.Body.String())
+	}
+	if !strings.Contains(authServerRes.Body.String(), `"id":"partner-api"`) || !strings.Contains(authServerRes.Body.String(), `"api://partner"`) {
+		t.Fatalf("unexpected auth server body: %s", authServerRes.Body.String())
+	}
+}
+
+func newTestService(t *testing.T) (*Service, *corehttp.Router) {
+	t.Helper()
+	service := New(Options{Store: corestore.New(), BaseURL: "http://localhost:4016"})
+	router := corehttp.NewRouter()
+	service.RegisterRoutes(router)
+	return service, router
+}
+
+func serveOkta(router *corehttp.Router, req *http.Request) *httptest.ResponseRecorder {
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	return res
+}

--- a/internal/services/okta/service_test.go
+++ b/internal/services/okta/service_test.go
@@ -126,6 +126,59 @@ func TestTokenRejectsGrantTypeNotAllowedForClient(t *testing.T) {
 	}
 }
 
+func TestTokenRejectsUnsupportedPKCEMethod(t *testing.T) {
+	service, router := newTestService(t)
+	user := firstRecord(service.store.Users.FindBy("login", "testuser@okta.local"))
+	if user == nil {
+		t.Fatal("missing default user")
+	}
+
+	form := url.Values{
+		"user_ref":              {stringField(user, "okta_id")},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"scope":                 {"openid profile email"},
+		"client_id":             {"okta-test-client"},
+		"response_mode":         {"query"},
+		"code_challenge":        {"same-secret"},
+		"code_challenge_method": {"unsupported"},
+	}
+	callback := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/authorize/callback", strings.NewReader(form.Encode()))
+	callback.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRes := serveOkta(router, callback)
+	if callbackRes.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	redirect, err := url.Parse(callbackRes.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := redirect.Query().Get("code")
+	if code == "" {
+		t.Fatalf("missing code in redirect: %s", callbackRes.Header().Get("Location"))
+	}
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"client_id":     {"okta-test-client"},
+		"client_secret": {"okta-test-secret"},
+		"code_verifier": {"same-secret"},
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/token", strings.NewReader(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRes := serveOkta(router, tokenReq)
+	if tokenRes.Code != http.StatusBadRequest {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	if !strings.Contains(tokenRes.Body.String(), `"error":"invalid_grant"`) || !strings.Contains(tokenRes.Body.String(), "PKCE verification failed") {
+		t.Fatalf("unexpected token body: %s", tokenRes.Body.String())
+	}
+	if service.store.AccessTokens.Count() != 0 {
+		t.Fatalf("access tokens were issued for unsupported PKCE method")
+	}
+}
+
 func TestAuthorizeRejectsInactiveUsers(t *testing.T) {
 	service, router := newTestService(t)
 	user := firstRecord(service.store.Users.FindBy("login", "testuser@okta.local"))
@@ -333,6 +386,45 @@ func TestManagementUsersGroupsAppsAndAuthorizationServers(t *testing.T) {
 	}
 	if !strings.Contains(authServerRes.Body.String(), `"id":"partner-api"`) || !strings.Contains(authServerRes.Body.String(), `"api://partner"`) {
 		t.Fatalf("unexpected auth server body: %s", authServerRes.Body.String())
+	}
+}
+
+func TestPartialUserUpdateRejectsDuplicateLogin(t *testing.T) {
+	service, router := newTestService(t)
+
+	createUser := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(`{"profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Admin"}}`))
+	createUser.Header.Set("Content-Type", "application/json")
+	createUser.Header.Set("Authorization", "SSWS dev-token")
+	createUserRes := serveOkta(router, createUser)
+	if createUserRes.Code != http.StatusCreated {
+		t.Fatalf("create user status = %d, body = %s", createUserRes.Code, createUserRes.Body.String())
+	}
+	var user struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(createUserRes.Body.Bytes(), &user); err != nil {
+		t.Fatal(err)
+	}
+	if user.ID == "" {
+		t.Fatalf("missing user id in create response: %s", createUserRes.Body.String())
+	}
+
+	updateUser := httptest.NewRequest(http.MethodPost, "/api/v1/users/"+url.PathEscape(user.ID), strings.NewReader(`{"profile":{"login":"testuser@okta.local"}}`))
+	updateUser.Header.Set("Content-Type", "application/json")
+	updateUser.Header.Set("Authorization", "SSWS dev-token")
+	updateUserRes := serveOkta(router, updateUser)
+	if updateUserRes.Code != http.StatusBadRequest {
+		t.Fatalf("update user status = %d, body = %s", updateUserRes.Code, updateUserRes.Body.String())
+	}
+	if !strings.Contains(updateUserRes.Body.String(), "A user with the same login or email already exists") {
+		t.Fatalf("unexpected update body: %s", updateUserRes.Body.String())
+	}
+	if got := len(service.store.Users.FindBy("login", "testuser@okta.local")); got != 1 {
+		t.Fatalf("duplicate login count = %d", got)
+	}
+	alice := firstRecord(service.store.Users.FindBy("okta_id", user.ID))
+	if alice == nil || stringField(alice, "login") != "alice@example.com" {
+		t.Fatalf("alice login changed after rejected update: %#v", alice)
 	}
 }
 

--- a/internal/services/okta/service_test.go
+++ b/internal/services/okta/service_test.go
@@ -105,6 +105,155 @@ func TestOAuthAuthorizationCodeFlow(t *testing.T) {
 	}
 }
 
+func TestTokenRejectsGrantTypeNotAllowedForClient(t *testing.T) {
+	service, router := newTestService(t)
+	form := url.Values{
+		"grant_type": {"client_credentials"},
+		"client_id":  {"okta-test-app"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res := serveOkta(router, req)
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("token status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"error":"unauthorized_client"`) {
+		t.Fatalf("unexpected token body: %s", res.Body.String())
+	}
+	if service.store.AccessTokens.Count() != 0 {
+		t.Fatalf("access tokens were minted for a disallowed grant")
+	}
+}
+
+func TestAuthorizeRejectsInactiveUsers(t *testing.T) {
+	service, router := newTestService(t)
+	user := firstRecord(service.store.Users.FindBy("login", "testuser@okta.local"))
+	if user == nil {
+		t.Fatal("missing default user")
+	}
+	if _, ok := service.store.Users.Update(intField(user, "id"), corestore.Record{"status": "SUSPENDED"}); !ok {
+		t.Fatal("failed to suspend user")
+	}
+
+	authorize := serveOkta(router, httptest.NewRequest(http.MethodGet, "/oauth2/default/v1/authorize?client_id=okta-test-client&redirect_uri="+url.QueryEscape("http://localhost:3000/callback")+"&response_type=code", nil))
+	if authorize.Code != http.StatusOK {
+		t.Fatalf("authorize status = %d, body = %s", authorize.Code, authorize.Body.String())
+	}
+	if strings.Contains(authorize.Body.String(), "testuser@okta.local") || !strings.Contains(authorize.Body.String(), "No active users") {
+		t.Fatalf("inactive user was shown in authorize body: %s", authorize.Body.String())
+	}
+
+	form := url.Values{
+		"user_ref":      {stringField(user, "okta_id")},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"scope":         {"openid profile email"},
+		"client_id":     {"okta-test-client"},
+		"response_mode": {"query"},
+	}
+	callback := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/authorize/callback", strings.NewReader(form.Encode()))
+	callback.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRes := serveOkta(router, callback)
+	if callbackRes.Code != http.StatusBadRequest {
+		t.Fatalf("callback status = %d, body = %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	if !strings.Contains(callbackRes.Body.String(), "User is not active") {
+		t.Fatalf("unexpected callback body: %s", callbackRes.Body.String())
+	}
+	if service.store.OAuthCodes.Count() != 0 {
+		t.Fatalf("oauth codes were issued for inactive user")
+	}
+}
+
+func TestTokenRejectsUserSuspendedAfterAuthorization(t *testing.T) {
+	service, router := newTestService(t)
+	user := firstRecord(service.store.Users.FindBy("login", "testuser@okta.local"))
+	if user == nil {
+		t.Fatal("missing default user")
+	}
+	code := authorizeOktaCode(t, service, router, "openid profile email")
+	if _, ok := service.store.Users.Update(intField(user, "id"), corestore.Record{"status": "SUSPENDED"}); !ok {
+		t.Fatal("failed to suspend user")
+	}
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"client_id":     {"okta-test-client"},
+		"client_secret": {"okta-test-secret"},
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/token", strings.NewReader(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRes := serveOkta(router, tokenReq)
+	if tokenRes.Code != http.StatusBadRequest {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	if !strings.Contains(tokenRes.Body.String(), `"error":"invalid_grant"`) || !strings.Contains(tokenRes.Body.String(), "User is not active") {
+		t.Fatalf("unexpected token body: %s", tokenRes.Body.String())
+	}
+	if service.store.AccessTokens.Count() != 0 {
+		t.Fatalf("access tokens were issued for inactive user")
+	}
+}
+
+func TestRefreshTokenRejectsScopeEscalation(t *testing.T) {
+	service, router := newTestService(t)
+	tokenBody := issueOktaToken(t, service, router, "openid email")
+
+	refreshForm := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {tokenBody.RefreshToken},
+		"client_id":     {"okta-test-client"},
+		"client_secret": {"okta-test-secret"},
+		"scope":         {"openid email groups"},
+	}
+	refreshReq := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/token", strings.NewReader(refreshForm.Encode()))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRes := serveOkta(router, refreshReq)
+	if refreshRes.Code != http.StatusBadRequest {
+		t.Fatalf("refresh status = %d, body = %s", refreshRes.Code, refreshRes.Body.String())
+	}
+	if !strings.Contains(refreshRes.Body.String(), `"error":"invalid_scope"`) {
+		t.Fatalf("unexpected refresh body: %s", refreshRes.Body.String())
+	}
+	if service.store.RefreshTokens.Count() != 1 {
+		t.Fatalf("refresh token was rotated after invalid scope")
+	}
+	if service.store.AccessTokens.Count() != 1 {
+		t.Fatalf("access token was minted after invalid scope")
+	}
+}
+
+func TestInactiveAuthorizationServerDoesNotServeOAuth(t *testing.T) {
+	service, router := newTestService(t)
+	server := firstRecord(service.store.AuthorizationServers.FindBy("server_id", "default"))
+	if server == nil {
+		t.Fatal("missing default authorization server")
+	}
+	if _, ok := service.store.AuthorizationServers.Update(intField(server, "id"), corestore.Record{"status": "INACTIVE"}); !ok {
+		t.Fatal("failed to deactivate authorization server")
+	}
+
+	management := httptest.NewRequest(http.MethodGet, "/api/v1/authorizationServers/default", nil)
+	management.Header.Set("Authorization", "SSWS dev-token")
+	managementRes := serveOkta(router, management)
+	if managementRes.Code != http.StatusOK || !strings.Contains(managementRes.Body.String(), `"status":"INACTIVE"`) {
+		t.Fatalf("management status = %d, body = %s", managementRes.Code, managementRes.Body.String())
+	}
+
+	discovery := serveOkta(router, httptest.NewRequest(http.MethodGet, "/oauth2/default/.well-known/openid-configuration", nil))
+	if discovery.Code != http.StatusNotFound {
+		t.Fatalf("discovery status = %d, body = %s", discovery.Code, discovery.Body.String())
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/token", strings.NewReader(url.Values{"grant_type": {"client_credentials"}, "client_id": {"okta-test-client"}, "client_secret": {"okta-test-secret"}}.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRes := serveOkta(router, tokenReq)
+	if tokenRes.Code != http.StatusNotFound {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+}
+
 func TestManagementUsersGroupsAppsAndAuthorizationServers(t *testing.T) {
 	_, router := newTestService(t)
 
@@ -185,6 +334,69 @@ func TestManagementUsersGroupsAppsAndAuthorizationServers(t *testing.T) {
 	if !strings.Contains(authServerRes.Body.String(), `"id":"partner-api"`) || !strings.Contains(authServerRes.Body.String(), `"api://partner"`) {
 		t.Fatalf("unexpected auth server body: %s", authServerRes.Body.String())
 	}
+}
+
+type oktaTokenBody struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	Scope        string `json:"scope"`
+}
+
+func authorizeOktaCode(t *testing.T, service *Service, router *corehttp.Router, scope string) string {
+	t.Helper()
+	user := firstRecord(service.store.Users.FindBy("login", "testuser@okta.local"))
+	if user == nil {
+		t.Fatal("missing default user")
+	}
+	form := url.Values{
+		"user_ref":      {stringField(user, "okta_id")},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"scope":         {scope},
+		"client_id":     {"okta-test-client"},
+		"response_mode": {"query"},
+	}
+	callback := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/authorize/callback", strings.NewReader(form.Encode()))
+	callback.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRes := serveOkta(router, callback)
+	if callbackRes.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	redirect, err := url.Parse(callbackRes.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := redirect.Query().Get("code")
+	if code == "" {
+		t.Fatalf("missing code in redirect: %s", callbackRes.Header().Get("Location"))
+	}
+	return code
+}
+
+func issueOktaToken(t *testing.T, service *Service, router *corehttp.Router, scope string) oktaTokenBody {
+	t.Helper()
+	code := authorizeOktaCode(t, service, router, scope)
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"client_id":     {"okta-test-client"},
+		"client_secret": {"okta-test-secret"},
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth2/default/v1/token", strings.NewReader(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRes := serveOkta(router, tokenReq)
+	if tokenRes.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	var body oktaTokenBody
+	if err := json.Unmarshal(tokenRes.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.AccessToken == "" || body.RefreshToken == "" {
+		t.Fatalf("unexpected token body: %#v", body)
+	}
+	return body
 }
 
 func newTestService(t *testing.T) (*Service, *corehttp.Router) {

--- a/internal/services/okta/store.go
+++ b/internal/services/okta/store.go
@@ -1,0 +1,31 @@
+package okta
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Users                *corestore.Collection
+	Groups               *corestore.Collection
+	Apps                 *corestore.Collection
+	OAuthClients         *corestore.Collection
+	AuthorizationServers *corestore.Collection
+	GroupMemberships     *corestore.Collection
+	AppAssignments       *corestore.Collection
+	OAuthCodes           *corestore.Collection
+	AccessTokens         *corestore.Collection
+	RefreshTokens        *corestore.Collection
+}
+
+func NewStore(store *corestore.Store) Store {
+	return Store{
+		Users:                store.MustCollection("okta.users", "okta_id", "login", "email"),
+		Groups:               store.MustCollection("okta.groups", "okta_id", "name"),
+		Apps:                 store.MustCollection("okta.apps", "okta_id", "name"),
+		OAuthClients:         store.MustCollection("okta.oauth_clients", "client_id", "auth_server_id"),
+		AuthorizationServers: store.MustCollection("okta.auth_servers", "server_id"),
+		GroupMemberships:     store.MustCollection("okta.group_memberships", "group_okta_id", "user_okta_id"),
+		AppAssignments:       store.MustCollection("okta.app_assignments", "app_okta_id", "user_okta_id"),
+		OAuthCodes:           store.MustCollection("okta.oauth_codes", "code", "auth_server_id", "client_id", "user_okta_id"),
+		AccessTokens:         store.MustCollection("okta.access_tokens", "token", "auth_server_id", "client_id", "user_okta_id"),
+		RefreshTokens:        store.MustCollection("okta.refresh_tokens", "token", "auth_server_id", "client_id", "user_okta_id"),
+	}
+}

--- a/packages/@emulators/okta/README.md
+++ b/packages/@emulators/okta/README.md
@@ -4,6 +4,8 @@ Okta identity provider emulation with OAuth 2.0 / OIDC, user management, groups,
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
+The native Go runtime implements the Okta OIDC and management API surface for local CLI runs and Vercel Go Function previews. Use `npx emulate vercel init --service okta` to expose Okta at `/emulate/okta/*` on Vercel previews.
+
 ## Install
 
 ```bash
@@ -79,8 +81,8 @@ okta:
   users:
     - login: testuser@example.com
       email: testuser@example.com
-      firstName: Test
-      lastName: User
+      first_name: Test
+      last_name: User
   groups:
     - name: Everyone
       description: All users

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,7 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
-      'Services: []string{"apple", "aws", "github", "google", "microsoft", "resend", "slack", "stripe", "vercel"}',
+      'Services: []string{"apple", "aws", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}',
     );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
@@ -35,7 +35,7 @@ describe("createVercelScaffold", () => {
   });
 
   it("includes google in the shared Vercel CLI service default", () => {
-    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe("apple,aws,github,google,microsoft,resend,slack,stripe,vercel");
+    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe("apple,aws,github,google,microsoft,okta,resend,slack,stripe,vercel");
   });
 
   it("merges the rewrite into an existing vercel.json", () => {
@@ -228,8 +228,8 @@ require (
   it("rejects services not available in the native Vercel scaffold", () => {
     const cwd = tempDir();
 
-    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "okta" })).toThrow(
-      "currently supports native services: apple, aws, github, google, microsoft, resend, slack, stripe, vercel",
+    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "clerk" })).toThrow(
+      "currently supports native services: apple, aws, github, google, microsoft, okta, resend, slack, stripe, vercel",
     );
   });
 

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -7,6 +7,7 @@ export const SUPPORTED_VERCEL_SERVICES = [
   "github",
   "google",
   "microsoft",
+  "okta",
   "resend",
   "slack",
   "stripe",

--- a/skills/apple/SKILL.md
+++ b/skills/apple/SKILL.md
@@ -117,7 +117,7 @@ PKCE is supported. Pass `code_challenge` and `code_challenge_method` on authoriz
 curl http://localhost:4004/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 Returns the standard OIDC discovery document with all endpoints pointing to the emulator:
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: emulate
-description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, scaffold Vercel Go Function previews, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", "npx emulate vercel init", or any task requiring local service emulation.
+description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, and Stripe. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, scaffold Vercel Go Function previews, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", "npx emulate vercel init", or any task requiring local service emulation.
 allowed-tools: Bash(npx emulate:*)
 ---
 
@@ -24,7 +24,10 @@ All services start with sensible defaults:
 | Slack     | 4003        |
 | Apple     | 4004        |
 | Microsoft | 4005        |
-| AWS       | 4006        |
+| Okta      | 4006        |
+| AWS       | 4007        |
+| Resend    | 4008        |
+| Stripe    | 4009        |
 
 ## CLI
 
@@ -93,7 +96,7 @@ await vercel.close()
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, or `'stripe'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -310,14 +313,17 @@ GOOGLE_EMULATOR_URL=http://localhost:4002
 SLACK_EMULATOR_URL=http://localhost:4003
 APPLE_EMULATOR_URL=http://localhost:4004
 MICROSOFT_EMULATOR_URL=http://localhost:4005
-AWS_EMULATOR_URL=http://localhost:4006
+OKTA_EMULATOR_URL=http://localhost:4006
+AWS_EMULATOR_URL=http://localhost:4007
+RESEND_EMULATOR_URL=http://localhost:4008
+STRIPE_EMULATOR_URL=http://localhost:4009
 ```
 
 Then use these in your app to construct API and OAuth URLs. See each service's skill for SDK-specific override instructions.
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, `stripe`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -195,7 +195,7 @@ To override the derived value, set `hd` on a seeded user. To suppress the claim 
 curl http://localhost:4002/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ### JWKS
 

--- a/skills/microsoft/SKILL.md
+++ b/skills/microsoft/SKILL.md
@@ -140,7 +140,7 @@ curl http://localhost:4005/.well-known/openid-configuration
 curl http://localhost:4005/common/v2.0/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, and Microsoft is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 Returns the standard OIDC discovery document:
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/skills/okta/SKILL.md
+++ b/skills/okta/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: okta
+description: Emulated Okta OAuth 2.0, OpenID Connect, and management APIs for local development and testing. Use when the user needs to test Okta sign-in locally, emulate Okta OIDC discovery, handle authorization code or token exchange, configure Okta users/groups/apps/authorization servers, use Okta SDKs against local endpoints, or scaffold Okta through npx emulate vercel init.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
+---
+
+# Okta Emulator
+
+Okta OAuth 2.0, OpenID Connect, users, groups, apps, and authorization server emulation with authorization code, refresh token, client credentials, PKCE, RS256 ID tokens, JWKS, userinfo, introspection, revocation, and management APIs.
+
+The native Go runtime implements this Okta OIDC and management API surface for local CLI runs and Vercel Go Function previews. To expose Okta on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service okta`; the generated route serves Okta at `/emulate/okta/*`.
+
+## Start
+
+```bash
+# Okta only
+npx emulate --service okta
+
+# Default port when all services run
+# http://localhost:4006
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const okta = await createEmulator({ service: 'okta', port: 4006 })
+// okta.url === 'http://localhost:4006'
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+OKTA_EMULATOR_URL=http://localhost:4006
+```
+
+### URL Mapping
+
+| Real Okta URL | Emulator URL |
+|---------------|-------------|
+| `https://{domain}/.well-known/openid-configuration` | `$OKTA_EMULATOR_URL/.well-known/openid-configuration` |
+| `https://{domain}/oauth2/{authServerId}/.well-known/openid-configuration` | `$OKTA_EMULATOR_URL/oauth2/{authServerId}/.well-known/openid-configuration` |
+| `https://{domain}/oauth2/v1/authorize` | `$OKTA_EMULATOR_URL/oauth2/v1/authorize` |
+| `https://{domain}/oauth2/{authServerId}/v1/authorize` | `$OKTA_EMULATOR_URL/oauth2/{authServerId}/v1/authorize` |
+| `https://{domain}/oauth2/v1/token` | `$OKTA_EMULATOR_URL/oauth2/v1/token` |
+| `https://{domain}/oauth2/{authServerId}/v1/token` | `$OKTA_EMULATOR_URL/oauth2/{authServerId}/v1/token` |
+| `https://{domain}/api/v1/users` | `$OKTA_EMULATOR_URL/api/v1/users` |
+| `https://{domain}/api/v1/groups` | `$OKTA_EMULATOR_URL/api/v1/groups` |
+| `https://{domain}/api/v1/apps` | `$OKTA_EMULATOR_URL/api/v1/apps` |
+| `https://{domain}/api/v1/authorizationServers` | `$OKTA_EMULATOR_URL/api/v1/authorizationServers` |
+
+## OIDC Routes
+
+- `GET /.well-known/openid-configuration`
+- `GET /oauth2/:authServerId/.well-known/openid-configuration`
+- `GET /oauth2/v1/keys`, `GET /oauth2/:authServerId/v1/keys`
+- `GET /oauth2/v1/authorize`, `GET /oauth2/:authServerId/v1/authorize`
+- `POST /oauth2/v1/token`, `POST /oauth2/:authServerId/v1/token`
+- `GET /oauth2/v1/userinfo`, `GET /oauth2/:authServerId/v1/userinfo`
+- `POST /oauth2/v1/revoke`, `POST /oauth2/:authServerId/v1/revoke`
+- `POST /oauth2/v1/introspect`, `POST /oauth2/:authServerId/v1/introspect`
+- `GET /oauth2/v1/logout`, `GET /oauth2/:authServerId/v1/logout`
+
+## Management Routes
+
+Management APIs accept `Authorization: SSWS <token>` in local development. Any non-empty SSWS token is accepted except `invalid-token`.
+
+- `/api/v1/users`
+- `/api/v1/groups`
+- `/api/v1/apps`
+- `/api/v1/authorizationServers`
+
+## Seed Config
+
+```yaml
+okta:
+  users:
+    - login: testuser@example.com
+      email: testuser@example.com
+      first_name: Test
+      last_name: User
+  groups:
+    - name: Everyone
+      description: All users
+      type: BUILT_IN
+      okta_id: 00g_everyone
+  authorization_servers:
+    - id: default
+      name: default
+      audiences: ["api://default"]
+  oauth_clients:
+    - client_id: okta-test-client
+      client_secret: okta-test-secret
+      name: Sample OIDC Client
+      redirect_uris:
+        - http://localhost:3000/callback
+      auth_server_id: default
+```
+
+## Multi-Service OIDC Discovery
+
+When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"apple", "aws", "github", "google", "microsoft", "resend", "slack", "stripe", "vercel"}
+var defaultServices = []string{"apple", "aws", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -35,7 +35,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "apple,aws,github,google,microsoft,resend,slack,stripe,vercel" {
+	if strings.Join(body.Services, ",") != "apple,aws,github,google,microsoft,okta,resend,slack,stripe,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -174,6 +174,23 @@ func TestHandlerForwardsGoogleService(t *testing.T) {
 	}
 }
 
+func TestHandlerForwardsOktaService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"okta"}})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/okta/oauth2/default/.well-known/openid-configuration", nil)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"https://preview.example.com/emulate/okta/oauth2/default"`) ||
+		!strings.Contains(res.Body.String(), `"authorization_endpoint":"https://preview.example.com/emulate/okta/oauth2/default/v1/authorize"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestHandlerForwardsSlackService(t *testing.T) {
 	handler := NewHandler(Options{Services: []string{"slack"}})
 	req := httptest.NewRequest(http.MethodPost, "https://preview.example.com/emulate/slack/api/auth.test", nil)
@@ -269,7 +286,7 @@ func TestHandlerRewritesHTMLRootPathsThroughPublicServicePrefix(t *testing.T) {
 
 func TestHandlerReturnsUnknownService(t *testing.T) {
 	handler := NewHandler(Options{})
-	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/okta/user", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/clerk/user", nil)
 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
@@ -277,7 +294,7 @@ func TestHandlerReturnsUnknownService(t *testing.T) {
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "Unknown service: okta") {
+	if !strings.Contains(res.Body.String(), "Unknown service: clerk") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }


### PR DESCRIPTION
- Adds native Okta OIDC, token, userinfo, introspection, revocation, and management API foundations in the Go runtime.
- Wires Okta into CLI seed loading, runtime routing, Vercel Go Function previews, docs, and skills.
- Covers OAuth, management APIs, native startup, and Vercel scaffold behavior with focused tests.