### PR TITLE
Add Go Clerk foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 The native Go runtime implements the OAuth/OIDC flow with RS256 ID tokens and JWKS, plus Gmail messages, drafts, threads, labels, history, settings filters, Calendar list/events/freebusy, and Drive file list/upload/download routes for local CLI runs and Vercel Go Function previews. To expose Google on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service google`. The generated route serves Google at `/emulate/google/*`.
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use the service specific discovery paths, for example `/google/.well-known/openid-configuration` or `/okta/.well-known/openid-configuration`, because those providers all use the root OIDC discovery path when run alone.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use the service specific discovery paths, for example `/google/.well-known/openid-configuration` or `/okta/.well-known/openid-configuration`, because those providers all use the root OIDC discovery path when run alone.
 
 - `GET /o/oauth2/v2/auth` - authorization endpoint
 - `POST /oauth2/token` - token exchange
@@ -698,6 +698,19 @@ The native Go runtime implements the Okta OIDC and management API routes below f
 - `GET /oauth2/v1/logout`, `GET /oauth2/:authServerId/v1/logout` - end session
 - `GET`, `POST`, `PUT`, `DELETE` under `/api/v1/users`, `/api/v1/groups`, `/api/v1/apps`, and `/api/v1/authorizationServers`
 
+## Clerk
+
+Clerk authentication and user management emulation with OAuth 2.0 / OIDC, RS256 ID tokens, JWKS, users, email addresses, organizations, memberships, invitations, and sessions.
+
+The native Go runtime implements the Clerk OIDC and management API routes below for local CLI runs and Vercel Go Function previews. To expose Clerk on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service clerk`. The generated route serves Clerk at `/emulate/clerk/*`.
+
+- `GET /.well-known/openid-configuration` - OIDC discovery document
+- `GET /v1/jwks` - JSON Web Key Set (JWKS)
+- `GET /oauth/authorize` - authorization endpoint (shows user picker)
+- `POST /oauth/token` - token exchange
+- `GET /oauth/userinfo` - OpenID Connect user info
+- `GET`, `POST`, `PATCH`, `DELETE` under `/v1/users`, `/v1/email_addresses`, `/v1/organizations`, `/v1/organizations/:orgId/memberships`, `/v1/organizations/:orgId/invitations`, and `/v1/sessions`
+
 ## AWS
 
 S3, SQS, SNS, DynamoDB, IAM, and STS emulation with AWS SDK-compatible S3 paths, AWS JSON RPC endpoints for SQS and DynamoDB, and AWS Query endpoints for SNS/SQS/IAM/STS. Query and REST XML operations return AWS-compatible XML. The native Go runtime is verified against current AWS SDK v3 clients for SQS, SNS, DynamoDB, IAM, and STS; SQS and DynamoDB use JSON target requests, and SNS/IAM/STS use AWS Query XML.
@@ -803,7 +816,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -844,7 +857,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/api/docs-chat/route.ts
+++ b/apps/web/app/api/docs-chat/route.ts
@@ -12,7 +12,7 @@ export const maxDuration = 60;
 
 const DEFAULT_MODEL = "anthropic/claude-haiku-4.5";
 
-const SYSTEM_PROMPT = `You are a helpful documentation assistant for emulate, a local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, MongoDB Atlas, Resend, and Stripe APIs used in CI and no-network sandboxes.
+const SYSTEM_PROMPT = `You are a helpful documentation assistant for emulate, a local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, Clerk, MongoDB Atlas, Resend, and Stripe APIs used in CI and no-network sandboxes.
 
 emulate provides fully stateful, production-fidelity API emulation, not mocks. The CLI is installed as the "emulate" npm package and run via "npx emulate". It also supports a programmatic API via createEmulator and a Next.js adapter (@emulators/adapter-next) for embedded emulators or native runtime proxy routes in your app.
 

--- a/apps/web/app/docs/apple/page.mdx
+++ b/apps/web/app/docs/apple/page.mdx
@@ -4,7 +4,7 @@ Sign in with Apple emulation with authorization code flow, PKCE support, RS256 I
 
 The native Go runtime implements the Apple OIDC flow below for local CLI runs and Vercel Go Function previews. To expose Apple on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service apple`. The generated route serves Apple at `/emulate/apple/*`.
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## Endpoints
 

--- a/apps/web/app/docs/architecture/page.mdx
+++ b/apps/web/app/docs/architecture/page.mdx
@@ -14,6 +14,7 @@ packages/
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
     okta/           # Okta identity provider / OIDC
+    clerk/          # Clerk authentication and user management
     mongoatlas/     # MongoDB Atlas Admin API + Data API
     resend/         # Resend email API
     stripe/         # Stripe billing and payments API

--- a/apps/web/app/docs/authentication/page.mdx
+++ b/apps/web/app/docs/authentication/page.mdx
@@ -60,7 +60,7 @@ The Google emulator uses the standard OAuth 2.0 authorization code flow. Configu
 curl http://localhost:4002/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/google/.well-known/openid-configuration`, `/apple/.well-known/openid-configuration`, `/microsoft/.well-known/openid-configuration`, or `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/google/.well-known/openid-configuration`, `/apple/.well-known/openid-configuration`, `/microsoft/.well-known/openid-configuration`, `/okta/.well-known/openid-configuration`, or `/clerk/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## Slack OAuth
 
@@ -95,6 +95,21 @@ curl http://localhost:4005/.well-known/openid-configuration
 ```
 
 Supports `Authorization: Basic` header with base64-encoded `client_id:client_secret` as an alternative to body parameters.
+
+## Clerk
+
+The Clerk emulator supports OIDC discovery, authorization code flow, PKCE, JWKS, ID tokens, userinfo, and session JWT creation.
+
+```bash
+curl http://localhost:4011/.well-known/openid-configuration
+```
+
+Management API routes require a Clerk-style secret key:
+
+```bash
+curl http://localhost:4011/v1/users \
+  -H "Authorization: Bearer sk_test_emulate"
+```
 
 ## AWS
 

--- a/apps/web/app/docs/clerk/layout.tsx
+++ b/apps/web/app/docs/clerk/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("clerk");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/clerk/page.mdx
+++ b/apps/web/app/docs/clerk/page.mdx
@@ -1,0 +1,64 @@
+# Clerk
+
+Clerk authentication and user management emulation with OAuth 2.0 / OIDC, users, email addresses, organizations, memberships, invitations, and sessions.
+
+The native Go runtime implements the Clerk OIDC and management API routes below for local CLI runs and Vercel Go Function previews. To expose Clerk on a Vercel preview without separate infrastructure, run:
+
+```bash
+npx emulate vercel init --service clerk
+```
+
+The generated route serves Clerk at `/emulate/clerk/*`.
+
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/clerk/.well-known/openid-configuration` to avoid the shared root discovery path.
+
+## OAuth / OIDC
+
+- `GET /.well-known/openid-configuration` — OIDC discovery
+- `GET /v1/jwks` — JSON Web Key Set (JWKS)
+- `GET /oauth/authorize` — authorization endpoint with seeded user picker
+- `POST /oauth/authorize/callback` — emulator form callback
+- `POST /oauth/token` — authorization code token exchange with optional PKCE
+- `GET /oauth/userinfo` — OpenID Connect user info
+
+## Management API
+
+Management routes accept `Authorization: Bearer sk_test_*` or `Authorization: Bearer sk_live_*`.
+
+- `GET /v1/users`, `GET /v1/users/count`, `POST /v1/users`
+- `GET /v1/users/:userId`, `PATCH /v1/users/:userId`, `DELETE /v1/users/:userId`
+- `POST /v1/users/:userId/ban`, `POST /v1/users/:userId/unban`
+- `POST /v1/users/:userId/lock`, `POST /v1/users/:userId/unlock`
+- `PATCH /v1/users/:userId/metadata`, `POST /v1/users/:userId/verify_password`
+- `GET /v1/email_addresses/:emailId`, `POST /v1/email_addresses`, `PATCH /v1/email_addresses/:emailId`, `DELETE /v1/email_addresses/:emailId`
+- `GET /v1/organizations`, `POST /v1/organizations`
+- `GET /v1/organizations/:orgId`, `PATCH /v1/organizations/:orgId`, `DELETE /v1/organizations/:orgId`
+- `GET /v1/organizations/:orgId/memberships`, `POST /v1/organizations/:orgId/memberships`
+- `PATCH /v1/organizations/:orgId/memberships/:userId`, `DELETE /v1/organizations/:orgId/memberships/:userId`
+- `GET /v1/organizations/:orgId/invitations`, `POST /v1/organizations/:orgId/invitations`, `POST /v1/organizations/:orgId/invitations/bulk`
+- `POST /v1/organizations/:orgId/invitations/:invitationId/revoke`
+- `GET /v1/sessions`, `POST /v1/sessions`, `GET /v1/sessions/:sessionId`
+- `POST /v1/sessions/:sessionId/revoke`, `POST /v1/sessions/:sessionId/tokens`
+
+## Seed Config
+
+```yaml
+clerk:
+  users:
+    - email_addresses: ["test@example.com"]
+      first_name: Test
+      last_name: User
+      password: clerk_test_password
+  organizations:
+    - name: My Company
+      slug: my-company
+      members:
+        - email: test@example.com
+          role: admin
+  oauth_applications:
+    - client_id: clerk_emulate_client
+      client_secret: clerk_emulate_secret
+      name: Emulate App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/clerk
+```

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -313,6 +313,29 @@ okta:
       audiences: ["api://default"]
 ```
 
+## Clerk Seed Config
+
+```yaml
+clerk:
+  users:
+    - email_addresses: ["test@example.com"]
+      first_name: Test
+      last_name: User
+      password: clerk_test_password
+  organizations:
+    - name: My Company
+      slug: my-company
+      members:
+        - email: test@example.com
+          role: admin
+  oauth_applications:
+    - client_id: clerk_emulate_client
+      client_secret: clerk_emulate_secret
+      name: Emulate App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/clerk
+```
+
 ## MongoDB Atlas Seed Config
 
 ```yaml

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -10,7 +10,7 @@ npx emulate vercel init --service google
 
 The generated route serves Google at `/emulate/google/*`.
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## OAuth & OpenID Connect
 

--- a/apps/web/app/docs/microsoft/page.mdx
+++ b/apps/web/app/docs/microsoft/page.mdx
@@ -4,7 +4,7 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 
 The native Go runtime implements the Microsoft OIDC, token, and Graph profile routes below for local CLI runs and Vercel Go Function previews. To expose Microsoft on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service microsoft`. The generated route serves Microsoft at `/emulate/microsoft/*`.
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## Endpoints
 

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/apps/web/app/docs/okta/page.mdx
+++ b/apps/web/app/docs/okta/page.mdx
@@ -4,7 +4,7 @@ Okta identity provider emulation with OAuth 2.0 / OIDC, user management, groups,
 
 The native Go runtime implements the Okta OIDC and management API routes below for local CLI runs and Vercel Go Function previews. To expose Okta on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service okta`. The generated route serves Okta at `/emulate/okta/*`.
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ## OAuth / OIDC
 

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -1,6 +1,6 @@
 # Getting Started
 
-Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, MongoDB Atlas, Resend, and Stripe APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
+Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, Clerk, MongoDB Atlas, Resend, and Stripe APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
 
 ## Quick Start
 

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -130,6 +130,7 @@ npm install @emulators/github @emulators/google @emulators/stripe
     <tr><td><code>@emulators/microsoft</code></td><td>Microsoft Entra ID, Graph API</td></tr>
     <tr><td><code>@emulators/aws</code></td><td>AWS S3, SQS, IAM, STS</td></tr>
     <tr><td><code>@emulators/okta</code></td><td>Okta identity provider / OIDC</td></tr>
+    <tr><td><code>@emulators/clerk</code></td><td>Clerk authentication and user management</td></tr>
     <tr><td><code>@emulators/mongoatlas</code></td><td>MongoDB Atlas Admin API + Data API</td></tr>
     <tr><td><code>@emulators/resend</code></td><td>Resend email API</td></tr>
     <tr><td><code>@emulators/stripe</code></td><td>Stripe billing and payments API</td></tr>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,7 @@ export default function LandingPage() {
           Local API emulation for dev and CI
         </h1>
         <p className="mb-8 max-w-xl text-base text-neutral-600 dark:text-neutral-400">
-          Stateful, production-fidelity replacements for Stripe, GitHub, Google, AWS, and 7 more services. No API keys.
+          Stateful, production-fidelity replacements for Stripe, GitHub, Google, AWS, and 8 more services. No API keys.
           No network. Not mocks.
         </p>
 

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -30,6 +30,7 @@ const sections: NavSection[] = [
       { href: "/docs/microsoft", label: "Microsoft Entra ID" },
       { href: "/docs/aws", label: "AWS" },
       { href: "/docs/okta", label: "Okta" },
+      { href: "/docs/clerk", label: "Clerk" },
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -28,6 +28,7 @@ const sections: NavSection[] = [
       { href: "/docs/microsoft", label: "Microsoft Entra ID" },
       { href: "/docs/aws", label: "AWS" },
       { href: "/docs/okta", label: "Okta" },
+      { href: "/docs/clerk", label: "Clerk" },
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -11,6 +11,7 @@ export const PAGE_TITLES: Record<string, string> = {
   microsoft: "Microsoft Entra ID",
   aws: "AWS",
   okta: "Okta",
+  clerk: "Clerk",
   mongoatlas: "MongoDB Atlas",
   resend: "Resend",
   stripe: "Stripe",

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,6 +14,7 @@ const oldDocsSlugs = [
   "microsoft",
   "aws",
   "okta",
+  "clerk",
   "mongoatlas",
   "resend",
   "stripe",

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -21,6 +21,7 @@ import (
 	coreconfig "github.com/vercel-labs/emulate/internal/core/config"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 	"github.com/vercel-labs/emulate/internal/services/apple"
+	"github.com/vercel-labs/emulate/internal/services/clerk"
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
@@ -112,6 +113,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 	}
 	var seedServices []string
 	var appleSeed *apple.SeedConfig
+	var clerkSeed *clerk.SeedConfig
 	var githubSeed *github.SeedConfig
 	var googleSeed *google.SeedConfig
 	var microsoftSeed *microsoft.SeedConfig
@@ -127,7 +129,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, github, google, microsoft, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, clerk, github, google, microsoft, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
@@ -170,6 +172,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 				return 1
 			}
 			appleSeed = &cfg
+		}
+		if raw, ok := loaded.Data["clerk"]; ok {
+			var cfg clerk.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse clerk seed config: %v\n", err)
+				return 1
+			}
+			clerkSeed = &cfg
 		}
 		if raw, ok := loaded.Data["microsoft"]; ok {
 			var cfg microsoft.SeedConfig
@@ -238,6 +248,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		BaseURL:       baseURL,
 		Services:      services,
 		AppleSeed:     appleSeed,
+		ClerkSeed:     clerkSeed,
 		GitHubSeed:    githubSeed,
 		GoogleSeed:    googleSeed,
 		MicrosoftSeed: microsoftSeed,
@@ -432,7 +443,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"apple", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
+	return []string{"apple", "clerk", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -370,6 +370,69 @@ func TestRunStartSeedsStripeFromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsClerkFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"clerk":{"users":[{"email_addresses":["alice@example.com"],"first_name":"Alice","password":"alice123"}],"organizations":[{"name":"Acme","slug":"acme","members":[{"email":"alice@example.com","role":"admin"}]}],"oauth_applications":[{"client_id":"test-client","client_secret":"test-secret","name":"Test App","redirect_uris":["http://localhost:3000/callback"]}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "clerk" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/v1/users?query=alice", port), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer sk_test_emulate")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("users status = %d", resp.StatusCode)
+	}
+	var users struct {
+		TotalCount int `json:"total_count"`
+		Data       []struct {
+			FirstName string `json:"first_name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&users); err != nil {
+		t.Fatal(err)
+	}
+	if users.TotalCount != 1 || len(users.Data) != 1 || users.Data[0].FirstName != "Alice" {
+		t.Fatalf("unexpected seeded users: %#v", users)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartSeedsAppleFromJSONConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.json")
@@ -550,7 +613,7 @@ func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
 				t.Fatal("start with unsupported seed service exited successfully")
 			}
 			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for apple, github, google, microsoft, okta, resend, slack, stripe, and vercel") || !strings.Contains(errText, "aws") {
+			if !strings.Contains(errText, "only supports --seed for apple, clerk, github, google, microsoft, okta, resend, slack, stripe, and vercel") || !strings.Contains(errText, "aws") {
 				t.Fatalf("unexpected stderr: %s", errText)
 			}
 		})

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/core/ui"
 	"github.com/vercel-labs/emulate/internal/services/apple"
 	"github.com/vercel-labs/emulate/internal/services/aws"
+	"github.com/vercel-labs/emulate/internal/services/clerk"
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
@@ -29,6 +30,7 @@ type ServerOptions struct {
 	Store         *store.Store
 	AssetStore    *coreassets.Store
 	AppleSeed     *apple.SeedConfig
+	ClerkSeed     *clerk.SeedConfig
 	GitHubSeed    *github.SeedConfig
 	GoogleSeed    *google.SeedConfig
 	MicrosoftSeed *microsoft.SeedConfig
@@ -201,6 +203,21 @@ func NewServer(options ServerOptions) *Server {
 			router.Mount("/okta", prefixed)
 		}
 	}
+	if serviceEnabled(services, "clerk") {
+		clerk.Register(router, clerk.Options{
+			Store:   runtimeStore,
+			BaseURL: options.BaseURL,
+			Seed:    options.ClerkSeed,
+		})
+		if len(ambiguousOIDCServices) > 1 {
+			prefixed := corehttp.NewRouter()
+			clerk.Register(prefixed, clerk.Options{
+				Store:   runtimeStore,
+				BaseURL: servicePrefixedBaseURL(options.BaseURL, "clerk"),
+			})
+			router.Mount("/clerk", prefixed)
+		}
+	}
 	router.NotFound(func(c *corehttp.Context) {
 		c.JSON(http.StatusNotFound, map[string]any{"message": "Not Found"})
 	})
@@ -226,7 +243,7 @@ func serviceEnabled(services []string, name string) bool {
 
 func enabledRootOIDCServices(services []string) []string {
 	names := []string{}
-	for _, name := range []string{"apple", "google", "microsoft", "okta"} {
+	for _, name := range []string{"apple", "google", "microsoft", "okta", "clerk"} {
 		if serviceEnabled(services, name) {
 			names = append(names, name)
 		}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -91,12 +91,17 @@ func NewServer(options ServerOptions) *Server {
 		})
 	})
 	ambiguousOIDCServices := enabledRootOIDCServices(services)
-	if len(ambiguousOIDCServices) > 1 {
+	clerkNeedsOAuthPrefix := serviceEnabled(services, "clerk") && serviceEnabled(services, "vercel")
+	if len(ambiguousOIDCServices) > 1 || clerkNeedsOAuthPrefix {
 		router.Get("/.well-known/openid-configuration", func(c *corehttp.Context) {
+			paths := oidcDiscoveryPaths(ambiguousOIDCServices)
+			if clerkNeedsOAuthPrefix {
+				paths["clerk"] = "/clerk/.well-known/openid-configuration"
+			}
 			c.JSON(http.StatusBadRequest, map[string]any{
-				"message":  "Multiple enabled services serve OIDC discovery at /.well-known/openid-configuration. Use a service specific discovery path.",
+				"message":  "Root OIDC discovery is ambiguous for the enabled services. Use a service specific discovery path.",
 				"services": ambiguousOIDCServices,
-				"paths":    oidcDiscoveryPaths(ambiguousOIDCServices),
+				"paths":    paths,
 			})
 		})
 	}
@@ -209,7 +214,7 @@ func NewServer(options ServerOptions) *Server {
 			BaseURL: options.BaseURL,
 			Seed:    options.ClerkSeed,
 		})
-		if len(ambiguousOIDCServices) > 1 {
+		if len(ambiguousOIDCServices) > 1 || clerkNeedsOAuthPrefix {
 			prefixed := corehttp.NewRouter()
 			clerk.Register(prefixed, clerk.Options{
 				Store:   runtimeStore,

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -410,6 +411,42 @@ func TestNewHandlerMultiServiceOIDCDiscoveryUsesServicePrefixes(t *testing.T) {
 				t.Fatalf("missing %s in %s", tc.want, res.Body.String())
 			}
 		})
+	}
+}
+
+func TestNewHandlerPrefixesClerkOIDCWhenVercelIsEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{
+		Services: []string{"vercel", "clerk"},
+		BaseURL:  "http://localhost:4010",
+	})
+
+	rootDiscovery := httptest.NewRecorder()
+	handler.ServeHTTP(rootDiscovery, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil))
+	if rootDiscovery.Code != http.StatusBadRequest {
+		t.Fatalf("root discovery status = %d, body = %s", rootDiscovery.Code, rootDiscovery.Body.String())
+	}
+	if !strings.Contains(rootDiscovery.Body.String(), "/clerk/.well-known/openid-configuration") {
+		t.Fatalf("unexpected root discovery body: %s", rootDiscovery.Body.String())
+	}
+
+	discovery := httptest.NewRecorder()
+	handler.ServeHTTP(discovery, httptest.NewRequest(http.MethodGet, "/clerk/.well-known/openid-configuration", nil))
+	if discovery.Code != http.StatusOK {
+		t.Fatalf("prefixed discovery status = %d, body = %s", discovery.Code, discovery.Body.String())
+	}
+	if !strings.Contains(discovery.Body.String(), `"issuer":"http://localhost:4010/clerk"`) ||
+		!strings.Contains(discovery.Body.String(), `"authorization_endpoint":"http://localhost:4010/clerk/oauth/authorize"`) {
+		t.Fatalf("unexpected prefixed discovery body: %s", discovery.Body.String())
+	}
+
+	authorizePath := "/clerk/oauth/authorize?client_id=clerk_emulate_client&response_type=code&redirect_uri=" + url.QueryEscape("http://localhost:3000/api/auth/callback/clerk")
+	authorize := httptest.NewRecorder()
+	handler.ServeHTTP(authorize, httptest.NewRequest(http.MethodGet, authorizePath, nil))
+	if authorize.Code != http.StatusOK {
+		t.Fatalf("authorize status = %d, body = %s", authorize.Code, authorize.Body.String())
+	}
+	if !strings.Contains(authorize.Body.String(), `action="/clerk/oauth/authorize/callback"`) {
+		t.Fatalf("authorize form did not use prefixed callback: %s", authorize.Body.String())
 	}
 }
 

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -360,9 +360,24 @@ func TestNewHandlerMountsOktaWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMountsClerkWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"clerk"}, BaseURL: "http://localhost:4017"})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"http://localhost:4017"`) ||
+		!strings.Contains(res.Body.String(), `"jwks_uri":"http://localhost:4017/v1/jwks"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestNewHandlerMultiServiceOIDCDiscoveryUsesServicePrefixes(t *testing.T) {
 	handler := NewHandler(ServerOptions{
-		Services: []string{"apple", "google", "microsoft", "okta"},
+		Services: []string{"apple", "google", "microsoft", "okta", "clerk"},
 		BaseURL:  "http://localhost:4010",
 	})
 
@@ -383,6 +398,7 @@ func TestNewHandlerMultiServiceOIDCDiscoveryUsesServicePrefixes(t *testing.T) {
 		{path: "/apple/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/apple"`},
 		{path: "/microsoft/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/microsoft/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"`},
 		{path: "/okta/oauth2/default/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/okta/oauth2/default"`},
+		{path: "/clerk/.well-known/openid-configuration", want: `"issuer":"http://localhost:4010/clerk"`},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			res := httptest.NewRecorder()
@@ -402,6 +418,17 @@ func TestNewHandlerDoesNotMountOktaWhenDisabled(t *testing.T) {
 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/oauth2/default/v1/keys", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountClerkWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/v1/jwks", nil))
 
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())

--- a/internal/services/clerk/helpers.go
+++ b/internal/services/clerk/helpers.go
@@ -331,12 +331,21 @@ func constantTimeEqual(left string, right string) bool {
 }
 
 func matchesRedirectURI(input string, allowed []string) bool {
+	normalized := normalizeRedirectURI(input)
 	for _, candidate := range allowed {
-		if input == candidate {
+		if normalized == normalizeRedirectURI(candidate) {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeRedirectURI(value string) string {
+	parsed, err := url.Parse(value)
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return parsed.Scheme + "://" + parsed.Host + strings.TrimRight(parsed.EscapedPath(), "/")
+	}
+	return strings.TrimRight(strings.Split(value, "?")[0], "/")
 }
 
 func slugify(value string) string {

--- a/internal/services/clerk/helpers.go
+++ b/internal/services/clerk/helpers.go
@@ -1,0 +1,377 @@
+package clerk
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func clerkID(prefix string) string {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return prefix + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return prefix + hex.EncodeToString(raw)[:24]
+}
+
+func clerkToken(prefix string) string {
+	raw := make([]byte, 20)
+	if _, err := rand.Read(raw); err != nil {
+		return prefix + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func nowUnix() int64 {
+	return time.Now().Unix()
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func stringField(record corestore.Record, field string) string {
+	if record == nil {
+		return ""
+	}
+	return stringValue(record[field])
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func intField(record corestore.Record, field string) int {
+	if record == nil {
+		return 0
+	}
+	return intValue(record[field])
+}
+
+func intValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return int(n)
+	case string:
+		n, _ := strconv.Atoi(v)
+		return n
+	default:
+		return 0
+	}
+}
+
+func int64Field(record corestore.Record, field string) int64 {
+	if record == nil {
+		return 0
+	}
+	return int64Value(record[field])
+}
+
+func int64Value(value any) int64 {
+	switch v := value.(type) {
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case float64:
+		return int64(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return n
+	case string:
+		n, _ := strconv.ParseInt(v, 10, 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+func boolField(record corestore.Record, field string) bool {
+	if record == nil {
+		return false
+	}
+	return boolValue(record[field])
+}
+
+func boolValue(value any) bool {
+	v, _ := value.(bool)
+	return v
+}
+
+func mapValue(value any) map[string]any {
+	if value == nil {
+		return map[string]any{}
+	}
+	if m, ok := value.(map[string]any); ok {
+		out := make(map[string]any, len(m))
+		for key, item := range m {
+			out[key] = item
+		}
+		return out
+	}
+	return map[string]any{}
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if text, ok := item.(string); ok {
+				out = append(out, text)
+			}
+		}
+		return out
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	default:
+		return nil
+	}
+}
+
+func readJSONBody(r *http.Request) map[string]any {
+	defer r.Body.Close()
+	raw, _ := io.ReadAll(r.Body)
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return map[string]any{}
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var body map[string]any
+	if err := decoder.Decode(&body); err != nil || body == nil {
+		return map[string]any{}
+	}
+	return body
+}
+
+func parseTokenBody(r *http.Request) map[string]string {
+	defer r.Body.Close()
+	raw, _ := io.ReadAll(r.Body)
+	if len(raw) == 0 {
+		return map[string]string{}
+	}
+	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			return map[string]string{}
+		}
+		out := map[string]string{}
+		for key, value := range body {
+			if text, ok := value.(string); ok {
+				out[key] = text
+			}
+		}
+		return out
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return map[string]string{}
+	}
+	out := map[string]string{}
+	for key, list := range values {
+		if len(list) > 0 {
+			out[key] = list[len(list)-1]
+		}
+	}
+	return out
+}
+
+func applyBasicCredentials(r *http.Request, clientID *string, clientSecret *string) {
+	header := strings.TrimSpace(r.Header.Get("Authorization"))
+	if !strings.HasPrefix(header, "Basic ") {
+		return
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(strings.TrimPrefix(header, "Basic ")))
+	if err != nil {
+		return
+	}
+	left, right, ok := strings.Cut(string(raw), ":")
+	if !ok {
+		return
+	}
+	if *clientID == "" {
+		*clientID, _ = url.QueryUnescape(left)
+	}
+	if *clientSecret == "" {
+		*clientSecret, _ = url.QueryUnescape(right)
+	}
+}
+
+func tokenFromRequest(r *http.Request) string {
+	header := strings.TrimSpace(r.Header.Get("Authorization"))
+	if strings.HasPrefix(strings.ToLower(header), "bearer ") {
+		return strings.TrimSpace(header[len("Bearer "):])
+	}
+	return ""
+}
+
+func requireSecretKey(c *corehttp.Context) bool {
+	token := tokenFromRequest(c.Request)
+	if strings.HasPrefix(token, "sk_test_") || strings.HasPrefix(token, "sk_live_") {
+		return true
+	}
+	clerkError(c, http.StatusUnauthorized, "UNAUTHORIZED", "Authentication failed", "Invalid or missing secret key")
+	return false
+}
+
+func clerkError(c *corehttp.Context, status int, code string, message string, longMessage ...string) {
+	long := message
+	if len(longMessage) > 0 && longMessage[0] != "" {
+		long = longMessage[0]
+	}
+	c.JSON(status, map[string]any{
+		"errors": []map[string]any{
+			{
+				"code":         code,
+				"message":      message,
+				"long_message": long,
+				"meta":         map[string]any{},
+			},
+		},
+	})
+}
+
+func oauthError(c *corehttp.Context, status int, code string, description string) {
+	c.JSON(status, map[string]any{"error": code, "error_description": description})
+}
+
+func deletedResponse(objectID string) map[string]any {
+	return map[string]any{
+		"object":  "deleted_object",
+		"id":      objectID,
+		"slug":    nil,
+		"deleted": true,
+	}
+}
+
+func paginatedResponse(data []map[string]any, totalCount int, limit int, offset int) map[string]any {
+	return map[string]any{
+		"data":        data,
+		"total_count": totalCount,
+		"has_more":    offset+limit < totalCount,
+	}
+}
+
+func parsePagination(c *corehttp.Context) (int, int) {
+	limit := intValue(c.Query("limit"))
+	if limit < 1 {
+		limit = 10
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	offset := intValue(c.Query("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
+func verifyPKCE(challenge string, method string, verifier string) bool {
+	if challenge == "" {
+		return true
+	}
+	if verifier == "" {
+		return false
+	}
+	switch strings.ToLower(method) {
+	case "", "plain":
+		return verifier == challenge
+	case "s256":
+		digest := sha256.Sum256([]byte(verifier))
+		return base64.RawURLEncoding.EncodeToString(digest[:]) == challenge
+	default:
+		return false
+	}
+}
+
+func constantTimeEqual(left string, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+}
+
+func matchesRedirectURI(input string, allowed []string) bool {
+	for _, candidate := range allowed {
+		if input == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func slugify(value string) string {
+	lower := strings.ToLower(value)
+	var b strings.Builder
+	lastDash := false
+	for _, r := range lower {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func sortNewestFirst(records []corestore.Record) []corestore.Record {
+	out := append([]corestore.Record(nil), records...)
+	sort.SliceStable(out, func(i int, j int) bool {
+		return int64Field(out[i], "created_at_unix") > int64Field(out[j], "created_at_unix")
+	})
+	return out
+}
+
+func sliceRecords(records []corestore.Record, limit int, offset int) []corestore.Record {
+	if offset > len(records) {
+		offset = len(records)
+	}
+	end := offset + limit
+	if end > len(records) {
+		end = len(records)
+	}
+	return records[offset:end]
+}

--- a/internal/services/clerk/jwt.go
+++ b/internal/services/clerk/jwt.go
@@ -45,7 +45,7 @@ func (s *jwtSigner) jwks() map[string]any {
 	}
 }
 
-func createIDToken(user corestore.Record, emails []corestore.Record, sessionID string, clientID string, issuer string) (string, error) {
+func createIDToken(user corestore.Record, emails []corestore.Record, sessionID string, clientID string, issuer string, nonce string) (string, error) {
 	now := time.Now().Unix()
 	primary := primaryEmail(emails)
 	claims := map[string]any{
@@ -62,6 +62,9 @@ func createIDToken(user corestore.Record, emails []corestore.Record, sessionID s
 	}
 	if name := userDisplayName(user); name != "" {
 		claims["name"] = name
+	}
+	if nonce != "" {
+		claims["nonce"] = nonce
 	}
 	return clerkSigner.sign(claims)
 }

--- a/internal/services/clerk/jwt.go
+++ b/internal/services/clerk/jwt.go
@@ -1,0 +1,127 @@
+package clerk
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const clerkKeyID = "emulate-clerk-1"
+
+var clerkSigner = mustClerkJWTSigner()
+
+type jwtSigner struct {
+	privateKey *rsa.PrivateKey
+}
+
+func mustClerkJWTSigner() *jwtSigner {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	return &jwtSigner{privateKey: privateKey}
+}
+
+func (s *jwtSigner) jwks() map[string]any {
+	publicKey := s.privateKey.Public().(*rsa.PublicKey)
+	return map[string]any{
+		"keys": []map[string]any{
+			{
+				"kty": "RSA",
+				"use": "sig",
+				"kid": clerkKeyID,
+				"alg": "RS256",
+				"n":   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+			},
+		},
+	}
+}
+
+func createIDToken(user corestore.Record, emails []corestore.Record, sessionID string, clientID string, issuer string) (string, error) {
+	now := time.Now().Unix()
+	primary := primaryEmail(emails)
+	claims := map[string]any{
+		"iss": issuer,
+		"sub": stringField(user, "clerk_id"),
+		"aud": firstNonEmpty(clientID, "default"),
+		"iat": now,
+		"exp": now + 3600,
+		"sid": sessionID,
+	}
+	if primary != nil {
+		claims["email"] = stringField(primary, "email_address")
+		claims["email_verified"] = stringField(primary, "verification_status") == "verified"
+	}
+	if name := userDisplayName(user); name != "" {
+		claims["name"] = name
+	}
+	return clerkSigner.sign(claims)
+}
+
+func createSessionToken(user corestore.Record, sessionID string, issuer string, org corestore.Record, membership corestore.Record) (string, error) {
+	now := time.Now().Unix()
+	claims := map[string]any{
+		"iss": issuer,
+		"sub": stringField(user, "clerk_id"),
+		"iat": now,
+		"nbf": now,
+		"exp": now + 3600,
+		"sid": sessionID,
+	}
+	if org != nil && membership != nil {
+		claims["org_id"] = stringField(org, "clerk_id")
+		claims["org_role"] = firstNonEmpty(stringField(membership, "role"), "org:member")
+		claims["org_slug"] = stringField(org, "slug")
+		claims["org_permissions"] = stringSliceValue(membership["permissions"])
+	}
+	metadata := mapValue(user["public_metadata"])
+	if len(metadata) > 0 {
+		claims["metadata"] = metadata
+	}
+	return clerkSigner.sign(claims)
+}
+
+func (s *jwtSigner) sign(claims map[string]any) (string, error) {
+	header := map[string]any{"alg": "RS256", "kid": clerkKeyID, "typ": "JWT"}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, s.privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func primaryEmail(emails []corestore.Record) corestore.Record {
+	for _, email := range emails {
+		if boolField(email, "is_primary") {
+			return email
+		}
+	}
+	return firstRecord(emails)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/services/clerk/responses.go
+++ b/internal/services/clerk/responses.go
@@ -1,0 +1,194 @@
+package clerk
+
+import (
+	"strings"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func userResponse(user corestore.Record, emailAddresses []corestore.Record) map[string]any {
+	imageURL := stringField(user, "image_url")
+	if imageURL == "" {
+		imageURL = "https://img.clerk.com/preview?seed=" + stringField(user, "clerk_id")
+	}
+	profileImageURL := stringField(user, "profile_image_url")
+	if profileImageURL == "" {
+		profileImageURL = "https://img.clerk.com/preview?seed=" + stringField(user, "clerk_id")
+	}
+	emails := make([]map[string]any, 0, len(emailAddresses))
+	for _, email := range emailAddresses {
+		emails = append(emails, emailAddressResponse(email))
+	}
+	return map[string]any{
+		"id":                       stringField(user, "clerk_id"),
+		"object":                   "user",
+		"username":                 nilString(user, "username"),
+		"first_name":               nilString(user, "first_name"),
+		"last_name":                nilString(user, "last_name"),
+		"image_url":                imageURL,
+		"profile_image_url":        profileImageURL,
+		"has_image":                stringField(user, "image_url") != "",
+		"primary_email_address_id": nilString(user, "primary_email_address_id"),
+		"primary_phone_number_id":  nilString(user, "primary_phone_number_id"),
+		"primary_web3_wallet_id":   nil,
+		"email_addresses":          emails,
+		"phone_numbers":            []any{},
+		"web3_wallets":             []any{},
+		"external_accounts":        []any{},
+		"saml_accounts":            []any{},
+		"passkeys":                 []any{},
+		"password_enabled":         boolField(user, "password_enabled"),
+		"totp_enabled":             boolField(user, "totp_enabled"),
+		"backup_code_enabled":      boolField(user, "backup_code_enabled"),
+		"two_factor_enabled":       boolField(user, "two_factor_enabled"),
+		"banned":                   boolField(user, "banned"),
+		"locked":                   boolField(user, "locked"),
+		"external_id":              nilString(user, "external_id"),
+		"public_metadata":          mapValue(user["public_metadata"]),
+		"private_metadata":         mapValue(user["private_metadata"]),
+		"unsafe_metadata":          mapValue(user["unsafe_metadata"]),
+		"last_sign_in_at":          nilInt64(user, "last_sign_in_at"),
+		"last_active_at":           nilInt64(user, "last_active_at"),
+		"created_at":               int64Field(user, "created_at_unix"),
+		"updated_at":               int64Field(user, "updated_at_unix"),
+	}
+}
+
+func emailAddressResponse(email corestore.Record) map[string]any {
+	return map[string]any{
+		"id":            stringField(email, "email_id"),
+		"object":        "email_address",
+		"email_address": stringField(email, "email_address"),
+		"reserved":      boolField(email, "reserved"),
+		"verification": map[string]any{
+			"status":   stringField(email, "verification_status"),
+			"strategy": stringField(email, "verification_strategy"),
+		},
+		"linked_to":  []any{},
+		"created_at": int64Field(email, "created_at_unix"),
+		"updated_at": int64Field(email, "updated_at_unix"),
+	}
+}
+
+func organizationResponse(org corestore.Record) map[string]any {
+	return map[string]any{
+		"id":                        stringField(org, "clerk_id"),
+		"object":                    "organization",
+		"name":                      stringField(org, "name"),
+		"slug":                      stringField(org, "slug"),
+		"image_url":                 nilString(org, "image_url"),
+		"has_image":                 stringField(org, "image_url") != "",
+		"members_count":             intField(org, "members_count"),
+		"pending_invitations_count": intField(org, "pending_invitations_count"),
+		"max_allowed_memberships":   nilInt(org, "max_allowed_memberships"),
+		"admin_delete_enabled":      boolField(org, "admin_delete_enabled"),
+		"public_metadata":           mapValue(org["public_metadata"]),
+		"private_metadata":          mapValue(org["private_metadata"]),
+		"created_at":                int64Field(org, "created_at_unix"),
+		"updated_at":                int64Field(org, "updated_at_unix"),
+	}
+}
+
+func membershipResponse(membership corestore.Record, org corestore.Record, user corestore.Record, emailAddresses []corestore.Record) map[string]any {
+	var organization any
+	if org != nil {
+		organization = organizationResponse(org)
+	}
+	var publicUserData any
+	if user != nil {
+		identifier := stringField(user, "username")
+		for _, email := range emailAddresses {
+			if boolField(email, "is_primary") {
+				identifier = stringField(email, "email_address")
+				break
+			}
+		}
+		if identifier == "" && len(emailAddresses) > 0 {
+			identifier = stringField(emailAddresses[0], "email_address")
+		}
+		if identifier == "" {
+			identifier = stringField(user, "clerk_id")
+		}
+		publicUserData = map[string]any{
+			"user_id":    stringField(user, "clerk_id"),
+			"first_name": nilString(user, "first_name"),
+			"last_name":  nilString(user, "last_name"),
+			"image_url":  nilString(user, "image_url"),
+			"has_image":  stringField(user, "image_url") != "",
+			"identifier": identifier,
+		}
+	}
+	return map[string]any{
+		"id":               stringField(membership, "membership_id"),
+		"object":           "organization_membership",
+		"role":             stringField(membership, "role"),
+		"permissions":      stringSliceValue(membership["permissions"]),
+		"public_metadata":  mapValue(membership["public_metadata"]),
+		"private_metadata": mapValue(membership["private_metadata"]),
+		"organization":     organization,
+		"public_user_data": publicUserData,
+		"created_at":       int64Field(membership, "created_at_unix"),
+		"updated_at":       int64Field(membership, "updated_at_unix"),
+	}
+}
+
+func invitationResponse(invitation corestore.Record) map[string]any {
+	return map[string]any{
+		"id":              stringField(invitation, "invitation_id"),
+		"object":          "organization_invitation",
+		"email_address":   stringField(invitation, "email_address"),
+		"role":            stringField(invitation, "role"),
+		"status":          stringField(invitation, "status"),
+		"organization_id": stringField(invitation, "org_id"),
+		"created_at":      int64Field(invitation, "created_at_unix"),
+		"updated_at":      int64Field(invitation, "updated_at_unix"),
+	}
+}
+
+func sessionResponse(session corestore.Record) map[string]any {
+	return map[string]any{
+		"id":             stringField(session, "clerk_id"),
+		"object":         "session",
+		"user_id":        stringField(session, "user_id"),
+		"client_id":      stringField(session, "client_id"),
+		"status":         stringField(session, "status"),
+		"last_active_at": nilInt64(session, "last_active_at"),
+		"expire_at":      int64Field(session, "expire_at"),
+		"abandon_at":     int64Field(session, "abandon_at"),
+		"created_at":     int64Field(session, "created_at_unix"),
+		"updated_at":     int64Field(session, "updated_at_unix"),
+	}
+}
+
+func nilString(record corestore.Record, field string) any {
+	value := stringField(record, field)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func nilInt(record corestore.Record, field string) any {
+	if record == nil || record[field] == nil {
+		return nil
+	}
+	return intValue(record[field])
+}
+
+func nilInt64(record corestore.Record, field string) any {
+	if record == nil || record[field] == nil {
+		return nil
+	}
+	return int64Value(record[field])
+}
+
+func userDisplayName(user corestore.Record) string {
+	name := strings.TrimSpace(stringField(user, "first_name") + " " + stringField(user, "last_name"))
+	if name != "" {
+		return name
+	}
+	if username := stringField(user, "username"); username != "" {
+		return username
+	}
+	return "User"
+}

--- a/internal/services/clerk/routes_email_addresses.go
+++ b/internal/services/clerk/routes_email_addresses.go
@@ -1,0 +1,133 @@
+package clerk
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerEmailAddressRoutes(router *corehttp.Router) {
+	router.Get("/v1/email_addresses/:emailId", s.handleGetEmailAddress)
+	router.Post("/v1/email_addresses", s.handleCreateEmailAddress)
+	router.Patch("/v1/email_addresses/:emailId", s.handlePatchEmailAddress)
+	router.Delete("/v1/email_addresses/:emailId", s.handleDeleteEmailAddress)
+}
+
+func (s *Service) handleGetEmailAddress(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	email := firstRecord(s.store.EmailAddresses.FindBy("email_id", c.Param("emailId")))
+	if email == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Email address not found")
+		return
+	}
+	c.JSON(http.StatusOK, emailAddressResponse(email))
+}
+
+func (s *Service) handleCreateEmailAddress(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	body := readJSONBody(c.Request)
+	userID := stringValue(body["user_id"])
+	emailAddress := stringValue(body["email_address"])
+	if userID == "" || emailAddress == "" {
+		clerkError(c, http.StatusUnprocessableEntity, "INVALID_REQUEST_BODY", "user_id and email_address are required")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	now := nowUnix()
+	primary := boolValue(body["primary"])
+	email := s.store.EmailAddresses.Insert(corestore.Record{
+		"email_id":              clerkID("idn_"),
+		"email_address":         emailAddress,
+		"user_id":               userID,
+		"verification_status":   verificationStatus(boolValue(body["verified"])),
+		"verification_strategy": "email_code",
+		"is_primary":            primary,
+		"reserved":              false,
+		"created_at_unix":       now,
+		"updated_at_unix":       now,
+	})
+	if primary {
+		s.makePrimaryEmail(user, email)
+	}
+	c.JSON(http.StatusOK, emailAddressResponse(email))
+}
+
+func (s *Service) handlePatchEmailAddress(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	emailID := c.Param("emailId")
+	email := firstRecord(s.store.EmailAddresses.FindBy("email_id", emailID))
+	if email == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Email address not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{"updated_at_unix": nowUnix()}
+	if _, ok := body["verified"]; ok {
+		patch["verification_status"] = verificationStatus(boolValue(body["verified"]))
+	}
+	if boolValue(body["primary"]) {
+		patch["is_primary"] = true
+		user := firstRecord(s.store.Users.FindBy("clerk_id", stringField(email, "user_id")))
+		if user != nil {
+			s.makePrimaryEmail(user, email)
+		}
+	}
+	s.store.EmailAddresses.Update(intField(email, "id"), patch)
+	updated := firstRecord(s.store.EmailAddresses.FindBy("email_id", emailID))
+	c.JSON(http.StatusOK, emailAddressResponse(updated))
+}
+
+func (s *Service) handleDeleteEmailAddress(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	emailID := c.Param("emailId")
+	email := firstRecord(s.store.EmailAddresses.FindBy("email_id", emailID))
+	if email == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Email address not found")
+		return
+	}
+	s.store.EmailAddresses.Delete(intField(email, "id"))
+	if boolField(email, "is_primary") {
+		remaining := s.store.EmailAddresses.FindBy("user_id", stringField(email, "user_id"))
+		user := firstRecord(s.store.Users.FindBy("clerk_id", stringField(email, "user_id")))
+		if user != nil {
+			if next := firstRecord(remaining); next != nil {
+				s.store.EmailAddresses.Update(intField(next, "id"), corestore.Record{"is_primary": true})
+				s.store.Users.Update(intField(user, "id"), corestore.Record{"primary_email_address_id": stringField(next, "email_id")})
+			} else {
+				s.store.Users.Update(intField(user, "id"), corestore.Record{"primary_email_address_id": nil})
+			}
+		}
+	}
+	c.JSON(http.StatusOK, deletedResponse(emailID))
+}
+
+func (s *Service) makePrimaryEmail(user corestore.Record, email corestore.Record) {
+	userID := stringField(user, "clerk_id")
+	emailID := stringField(email, "email_id")
+	for _, existing := range s.store.EmailAddresses.FindBy("user_id", userID) {
+		if stringField(existing, "email_id") != emailID && boolField(existing, "is_primary") {
+			s.store.EmailAddresses.Update(intField(existing, "id"), corestore.Record{"is_primary": false})
+		}
+	}
+	s.store.Users.Update(intField(user, "id"), corestore.Record{"primary_email_address_id": emailID, "updated_at_unix": nowUnix()})
+}
+
+func verificationStatus(verified bool) string {
+	if verified {
+		return "verified"
+	}
+	return "unverified"
+}

--- a/internal/services/clerk/routes_invitations.go
+++ b/internal/services/clerk/routes_invitations.go
@@ -1,0 +1,164 @@
+package clerk
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerInvitationRoutes(router *corehttp.Router) {
+	router.Get("/v1/organizations/:orgId/invitations", s.handleListInvitations)
+	router.Get("/v1/organizations/:orgId/invitations/:invitationId", s.handleGetInvitation)
+	router.Post("/v1/organizations/:orgId/invitations", s.handleCreateInvitation)
+	router.Post("/v1/organizations/:orgId/invitations/bulk", s.handleCreateBulkInvitations)
+	router.Post("/v1/organizations/:orgId/invitations/:invitationId/revoke", s.handleRevokeInvitation)
+}
+
+func (s *Service) handleListInvitations(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	limit, offset := parsePagination(c)
+	status := c.Query("status")
+	invitations := s.store.Invitations.FindBy("org_id", orgID)
+	filtered := make([]corestore.Record, 0, len(invitations))
+	for _, invitation := range invitations {
+		if status != "" && stringField(invitation, "status") != status {
+			continue
+		}
+		filtered = append(filtered, invitation)
+	}
+	paged := sliceRecords(filtered, limit, offset)
+	data := make([]map[string]any, 0, len(paged))
+	for _, invitation := range paged {
+		data = append(data, invitationResponse(invitation))
+	}
+	c.JSON(http.StatusOK, paginatedResponse(data, len(filtered), limit, offset))
+}
+
+func (s *Service) handleGetInvitation(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	invitation := firstRecord(s.store.Invitations.FindBy("invitation_id", c.Param("invitationId")))
+	if invitation == nil || stringField(invitation, "org_id") != orgID {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Invitation not found")
+		return
+	}
+	c.JSON(http.StatusOK, invitationResponse(invitation))
+}
+
+func (s *Service) handleCreateInvitation(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	emailAddress := stringValue(body["email_address"])
+	if emailAddress == "" {
+		clerkError(c, http.StatusUnprocessableEntity, "INVALID_REQUEST_BODY", "email_address is required")
+		return
+	}
+	invitation := s.createInvitation(org, emailAddress, firstNonEmpty(stringValue(body["role"]), "org:member"), expiresInDays(body["expires_in_days"]))
+	c.JSON(http.StatusOK, invitationResponse(invitation))
+}
+
+func (s *Service) handleCreateBulkInvitations(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	emailAddresses := stringSliceValue(body["email_addresses"])
+	if len(emailAddresses) == 0 {
+		clerkError(c, http.StatusUnprocessableEntity, "INVALID_REQUEST_BODY", "email_addresses array is required")
+		return
+	}
+	role := firstNonEmpty(stringValue(body["role"]), "org:member")
+	expires := expiresInDays(body["expires_in_days"])
+	data := make([]map[string]any, 0, len(emailAddresses))
+	for _, emailAddress := range emailAddresses {
+		data = append(data, invitationResponse(s.createInvitation(org, emailAddress, role, expires)))
+	}
+	c.JSON(http.StatusOK, data)
+}
+
+func (s *Service) handleRevokeInvitation(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	invitation := firstRecord(s.store.Invitations.FindBy("invitation_id", c.Param("invitationId")))
+	if invitation == nil || stringField(invitation, "org_id") != orgID {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Invitation not found")
+		return
+	}
+	if stringField(invitation, "status") != "pending" {
+		clerkError(c, http.StatusUnprocessableEntity, "INVALID_REQUEST_BODY", "Only pending invitations can be revoked")
+		return
+	}
+	now := nowUnix()
+	s.store.Invitations.Update(intField(invitation, "id"), corestore.Record{"status": "revoked", "updated_at_unix": now})
+	s.store.Organizations.Update(intField(org, "id"), corestore.Record{"pending_invitations_count": max(0, intField(org, "pending_invitations_count")-1), "updated_at_unix": now})
+	updated := firstRecord(s.store.Invitations.FindBy("invitation_id", c.Param("invitationId")))
+	c.JSON(http.StatusOK, invitationResponse(updated))
+}
+
+func (s *Service) createInvitation(org corestore.Record, emailAddress string, role string, expiresDays int) corestore.Record {
+	now := nowUnix()
+	orgID := stringField(org, "clerk_id")
+	invitation := s.store.Invitations.Insert(corestore.Record{
+		"invitation_id":   clerkID("orginv_"),
+		"email_address":   emailAddress,
+		"org_id":          orgID,
+		"role":            role,
+		"status":          "pending",
+		"expires_at":      now + int64(expiresDays)*86400,
+		"created_at_unix": now,
+		"updated_at_unix": now,
+	})
+	if latest := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID)); latest != nil {
+		org = latest
+	}
+	s.store.Organizations.Update(intField(org, "id"), corestore.Record{
+		"pending_invitations_count": intField(org, "pending_invitations_count") + 1,
+		"updated_at_unix":           now,
+	})
+	return invitation
+}
+
+func expiresInDays(value any) int {
+	days := intValue(value)
+	if days <= 0 {
+		return 30
+	}
+	return days
+}

--- a/internal/services/clerk/routes_memberships.go
+++ b/internal/services/clerk/routes_memberships.go
@@ -1,0 +1,204 @@
+package clerk
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerMembershipRoutes(router *corehttp.Router) {
+	router.Get("/v1/organizations/:orgId/memberships", s.handleListMemberships)
+	router.Post("/v1/organizations/:orgId/memberships", s.handleCreateMembership)
+	router.Patch("/v1/organizations/:orgId/memberships/:userId", s.handlePatchMembership)
+	router.Delete("/v1/organizations/:orgId/memberships/:userId", s.handleDeleteMembership)
+	router.Patch("/v1/organizations/:orgId/memberships/:userId/metadata", s.handlePatchMembershipMetadata)
+}
+
+func (s *Service) handleListMemberships(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	limit, offset := parsePagination(c)
+	role := c.Query("role")
+	memberships := s.store.Memberships.FindBy("org_id", orgID)
+	filtered := make([]corestore.Record, 0, len(memberships))
+	for _, membership := range memberships {
+		if role != "" && stringField(membership, "role") != role {
+			continue
+		}
+		filtered = append(filtered, membership)
+	}
+	paged := sliceRecords(filtered, limit, offset)
+	data := make([]map[string]any, 0, len(paged))
+	for _, membership := range paged {
+		user := firstRecord(s.store.Users.FindBy("clerk_id", stringField(membership, "user_id")))
+		emails := []corestore.Record{}
+		if user != nil {
+			emails = s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+		}
+		data = append(data, membershipResponse(membership, org, user, emails))
+	}
+	c.JSON(http.StatusOK, paginatedResponse(data, len(filtered), limit, offset))
+}
+
+func (s *Service) handleCreateMembership(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	userID := stringValue(body["user_id"])
+	if userID == "" {
+		clerkError(c, http.StatusUnprocessableEntity, "INVALID_REQUEST_BODY", "user_id is required")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	if membershipForUser(s.store.Memberships.FindBy("org_id", orgID), userID) != nil {
+		clerkError(c, http.StatusUnprocessableEntity, "DUPLICATE_RECORD", "User is already a member of this organization")
+		return
+	}
+	role := firstNonEmpty(stringValue(body["role"]), "org:member")
+	now := nowUnix()
+	membership := s.store.Memberships.Insert(corestore.Record{
+		"membership_id":    clerkID("orgmem_"),
+		"org_id":           orgID,
+		"user_id":          userID,
+		"role":             role,
+		"permissions":      defaultPermissions(role),
+		"public_metadata":  map[string]any{},
+		"private_metadata": map[string]any{},
+		"created_at_unix":  now,
+		"updated_at_unix":  now,
+	})
+	s.store.Organizations.Update(intField(org, "id"), corestore.Record{"members_count": intField(org, "members_count") + 1, "updated_at_unix": now})
+	updatedOrg := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	emails := s.store.EmailAddresses.FindBy("user_id", userID)
+	c.JSON(http.StatusOK, membershipResponse(membership, updatedOrg, user, emails))
+}
+
+func (s *Service) handlePatchMembership(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	userID := c.Param("userId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	membership := membershipForUser(s.store.Memberships.FindBy("org_id", orgID), userID)
+	if membership == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Membership not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{"updated_at_unix": nowUnix()}
+	if body["role"] != nil {
+		role := stringValue(body["role"])
+		patch["role"] = role
+		patch["permissions"] = defaultPermissions(role)
+	}
+	s.store.Memberships.Update(intField(membership, "id"), patch)
+	updated := membershipForUser(s.store.Memberships.FindBy("org_id", orgID), userID)
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	emails := []corestore.Record{}
+	if user != nil {
+		emails = s.store.EmailAddresses.FindBy("user_id", userID)
+	}
+	c.JSON(http.StatusOK, membershipResponse(updated, org, user, emails))
+}
+
+func (s *Service) handleDeleteMembership(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	userID := c.Param("userId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	membership := membershipForUser(s.store.Memberships.FindBy("org_id", orgID), userID)
+	if membership == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Membership not found")
+		return
+	}
+	s.store.Memberships.Delete(intField(membership, "id"))
+	s.store.Organizations.Update(intField(org, "id"), corestore.Record{"members_count": max(0, intField(org, "members_count")-1), "updated_at_unix": nowUnix()})
+	c.JSON(http.StatusOK, deletedResponse(stringField(membership, "membership_id")))
+}
+
+func (s *Service) handlePatchMembershipMetadata(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	userID := c.Param("userId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	membership := membershipForUser(s.store.Memberships.FindBy("org_id", orgID), userID)
+	if membership == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Membership not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{"updated_at_unix": nowUnix()}
+	if body["public_metadata"] != nil {
+		patch["public_metadata"] = mergeMaps(mapValue(membership["public_metadata"]), mapValue(body["public_metadata"]))
+	}
+	if body["private_metadata"] != nil {
+		patch["private_metadata"] = mergeMaps(mapValue(membership["private_metadata"]), mapValue(body["private_metadata"]))
+	}
+	s.store.Memberships.Update(intField(membership, "id"), patch)
+	updated := membershipForUser(s.store.Memberships.FindBy("org_id", orgID), userID)
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	emails := []corestore.Record{}
+	if user != nil {
+		emails = s.store.EmailAddresses.FindBy("user_id", userID)
+	}
+	c.JSON(http.StatusOK, membershipResponse(updated, org, user, emails))
+}
+
+func membershipForUser(memberships []corestore.Record, userID string) corestore.Record {
+	for _, membership := range memberships {
+		if stringField(membership, "user_id") == userID {
+			return membership
+		}
+	}
+	return nil
+}
+
+func defaultPermissions(role string) []string {
+	if role == "org:admin" {
+		return []string{
+			"org:sys_profile:manage",
+			"org:sys_profile:delete",
+			"org:sys_memberships:read",
+			"org:sys_memberships:manage",
+			"org:sys_domains:read",
+			"org:sys_domains:manage",
+		}
+	}
+	return []string{"org:sys_memberships:read"}
+}

--- a/internal/services/clerk/routes_oauth.go
+++ b/internal/services/clerk/routes_oauth.go
@@ -255,7 +255,7 @@ func (s *Service) handleToken(c *corehttp.Context) {
 		"expires_at":      now + 3600,
 	})
 	emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
-	idToken, err := createIDToken(user, emails, sessionID, firstNonEmpty(clientID, "default"), s.baseURL)
+	idToken, err := createIDToken(user, emails, sessionID, firstNonEmpty(clientID, "default"), s.baseURL, stringField(pending, "nonce"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, map[string]any{"message": "Failed to sign ID token"})
 		return

--- a/internal/services/clerk/routes_oauth.go
+++ b/internal/services/clerk/routes_oauth.go
@@ -1,0 +1,299 @@
+package clerk
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/core/ui"
+)
+
+const pendingCodeTTL = 10 * time.Minute
+
+func (s *Service) registerOAuthRoutes(router *corehttp.Router) {
+	router.Get("/.well-known/openid-configuration", s.handleOpenIDConfiguration)
+	router.Get("/v1/jwks", s.handleJWKS)
+	router.Get("/oauth/authorize", s.handleAuthorize)
+	router.Post("/oauth/authorize/callback", s.handleAuthorizeCallback)
+	router.Post("/oauth/token", s.handleToken)
+	router.Get("/oauth/userinfo", s.handleUserinfo)
+}
+
+func (s *Service) handleOpenIDConfiguration(c *corehttp.Context) {
+	c.JSON(http.StatusOK, map[string]any{
+		"issuer":                                s.baseURL,
+		"authorization_endpoint":                s.baseURL + "/oauth/authorize",
+		"token_endpoint":                        s.baseURL + "/oauth/token",
+		"userinfo_endpoint":                     s.baseURL + "/oauth/userinfo",
+		"jwks_uri":                              s.baseURL + "/v1/jwks",
+		"response_types_supported":              []string{"code"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"scopes_supported":                      []string{"openid", "profile", "email"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_post", "client_secret_basic"},
+		"claims_supported":                      []string{"sub", "iss", "aud", "exp", "iat", "nbf", "azp", "sid", "org_id", "org_role", "org_slug", "org_permissions"},
+		"code_challenge_methods_supported":      []string{"plain", "S256"},
+	})
+}
+
+func (s *Service) handleJWKS(c *corehttp.Context) {
+	c.JSON(http.StatusOK, clerkSigner.jwks())
+}
+
+func (s *Service) handleAuthorize(c *corehttp.Context) {
+	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
+	scope := firstNonEmpty(c.Query("scope"), "openid profile email")
+	state := c.Query("state")
+	nonce := c.Query("nonce")
+	responseType := firstNonEmpty(c.Query("response_type"), "code")
+	codeChallenge := c.Query("code_challenge")
+	codeChallengeMethod := c.Query("code_challenge_method")
+
+	if responseType != "code" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Unsupported response_type", "Only response_type=code is supported.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	if redirectURI == "" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Missing redirect URI", "The redirect_uri parameter is required.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+
+	appName := ""
+	if s.store.OAuthApps.Count() > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if !matchesRedirectURI(redirectURI, stringSliceValue(app["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		appName = stringField(app, "name")
+	}
+
+	users := s.store.Users.All()
+	var body strings.Builder
+	if len(users) == 0 {
+		body.WriteString(`<p class="empty">No users in the emulator store.</p>`)
+	} else {
+		for _, user := range users {
+			emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+			primary := primaryEmail(emails)
+			login := firstNonEmpty(stringField(primary, "email_address"), stringField(user, "username"), stringField(user, "clerk_id"))
+			letter := "?"
+			if source := firstNonEmpty(stringField(user, "first_name"), stringField(user, "username"), login); source != "" {
+				letter = strings.ToUpper(source[:1])
+			}
+			body.WriteString(ui.RenderUserButton(ui.UserButtonOptions{
+				Letter:     letter,
+				Login:      login,
+				Name:       userDisplayName(user),
+				Email:      stringField(primary, "email_address"),
+				FormAction: "/oauth/authorize/callback",
+				HiddenFields: map[string]string{
+					"user_ref":              stringField(user, "clerk_id"),
+					"redirect_uri":          redirectURI,
+					"scope":                 scope,
+					"state":                 state,
+					"nonce":                 nonce,
+					"client_id":             clientID,
+					"code_challenge":        codeChallenge,
+					"code_challenge_method": codeChallengeMethod,
+				},
+			}))
+		}
+	}
+
+	subtitle := "Choose a seeded user to continue."
+	if appName != "" {
+		subtitle = "Sign in to <strong>" + ui.EscapeHTML(appName) + "</strong> with your Clerk account."
+	}
+	c.HTML(http.StatusOK, ui.RenderCardPage("Sign in with Clerk", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+}
+
+func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {
+	if err := c.Request.ParseForm(); err != nil {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Invalid request", "The authorization form body is invalid.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	userRef := c.Request.Form.Get("user_ref")
+	redirectURI := c.Request.Form.Get("redirect_uri")
+	scope := firstNonEmpty(c.Request.Form.Get("scope"), "openid profile email")
+	state := c.Request.Form.Get("state")
+	nonce := c.Request.Form.Get("nonce")
+	clientID := c.Request.Form.Get("client_id")
+	codeChallenge := c.Request.Form.Get("code_challenge")
+	codeChallengeMethod := c.Request.Form.Get("code_challenge_method")
+
+	if redirectURI == "" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Missing redirect URI", "The redirect_uri parameter is required.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userRef))
+	if user == nil {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Unknown user", "The selected user is not available.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	if s.store.OAuthApps.Count() > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Application not found", "The client_id '"+clientID+"' is not registered.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+		if !matchesRedirectURI(redirectURI, stringSliceValue(app["redirect_uris"])) {
+			c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this application.", ui.PageOptions{Service: serviceLabel}))
+			return
+		}
+	}
+	target, err := url.Parse(redirectURI)
+	if err != nil || target == nil || target.Scheme == "" {
+		c.HTML(http.StatusBadRequest, ui.RenderErrorPage("Invalid redirect URI", "The redirect_uri parameter is invalid.", ui.PageOptions{Service: serviceLabel}))
+		return
+	}
+	code := clerkToken("")
+	s.store.OAuthCodes.Insert(corestore.Record{
+		"code":                  code,
+		"user_id":               stringField(user, "clerk_id"),
+		"scope":                 scope,
+		"redirect_uri":          redirectURI,
+		"client_id":             clientID,
+		"nonce":                 nonce,
+		"code_challenge":        codeChallenge,
+		"code_challenge_method": codeChallengeMethod,
+		"created_at_ms":         time.Now().UnixMilli(),
+	})
+
+	query := target.Query()
+	query.Set("code", code)
+	if state != "" {
+		query.Set("state", state)
+	}
+	target.RawQuery = query.Encode()
+	c.Redirect(http.StatusFound, target.String())
+}
+
+func (s *Service) handleToken(c *corehttp.Context) {
+	body := parseTokenBody(c.Request)
+	grantType := body["grant_type"]
+	code := body["code"]
+	redirectURI := body["redirect_uri"]
+	codeVerifier := body["code_verifier"]
+	clientID := body["client_id"]
+	clientSecret := body["client_secret"]
+	applyBasicCredentials(c.Request, &clientID, &clientSecret)
+
+	if grantType != "authorization_code" {
+		oauthError(c, http.StatusBadRequest, "unsupported_grant_type", "Only authorization_code is supported.")
+		return
+	}
+
+	pending := firstRecord(s.store.OAuthCodes.FindBy("code", code))
+	if pending == nil || time.Since(time.UnixMilli(int64Field(pending, "created_at_ms"))) > pendingCodeTTL {
+		if pending != nil {
+			s.deleteOAuthCode(code)
+		}
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Authorization code is invalid or expired.")
+		return
+	}
+	if redirectURI != "" && redirectURI != stringField(pending, "redirect_uri") {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match.")
+		return
+	}
+	if pendingClient := stringField(pending, "client_id"); pendingClient != "" && clientID != "" && clientID != pendingClient {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "client_id does not match.")
+		return
+	}
+	if s.store.OAuthApps.Count() > 0 {
+		app := firstRecord(s.store.OAuthApps.FindBy("client_id", clientID))
+		if app == nil {
+			oauthError(c, http.StatusUnauthorized, "invalid_client", "Unknown client.")
+			return
+		}
+		if !boolField(app, "is_public") && !constantTimeEqual(stringField(app, "client_secret"), clientSecret) {
+			oauthError(c, http.StatusUnauthorized, "invalid_client", "Invalid client credentials.")
+			return
+		}
+	}
+	if !verifyPKCE(stringField(pending, "code_challenge"), stringField(pending, "code_challenge_method"), codeVerifier) {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "PKCE verification failed.")
+		return
+	}
+
+	user := firstRecord(s.store.Users.FindBy("clerk_id", stringField(pending, "user_id")))
+	if user == nil {
+		oauthError(c, http.StatusBadRequest, "invalid_grant", "Unknown user.")
+		return
+	}
+	s.deleteOAuthCode(code)
+	now := nowUnix()
+	sessionID := clerkID("sess_")
+	s.store.Sessions.Insert(corestore.Record{
+		"clerk_id":        sessionID,
+		"user_id":         stringField(user, "clerk_id"),
+		"client_id":       firstNonEmpty(clientID, "default"),
+		"status":          "active",
+		"last_active_at":  now,
+		"expire_at":       now + 86400,
+		"abandon_at":      now + 604800,
+		"created_at_unix": now,
+		"updated_at_unix": now,
+	})
+	accessToken := clerkToken("clerk_")
+	scope := stringField(pending, "scope")
+	s.store.AccessTokens.Insert(corestore.Record{
+		"token":           accessToken,
+		"user_id":         stringField(user, "clerk_id"),
+		"session_id":      sessionID,
+		"client_id":       firstNonEmpty(clientID, "default"),
+		"scope":           scope,
+		"created_at_unix": now,
+		"expires_at":      now + 3600,
+	})
+	emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+	idToken, err := createIDToken(user, emails, sessionID, firstNonEmpty(clientID, "default"), s.baseURL)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]any{"message": "Failed to sign ID token"})
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"access_token": accessToken,
+		"id_token":     idToken,
+		"scope":        scope,
+	})
+}
+
+func (s *Service) handleUserinfo(c *corehttp.Context) {
+	token := tokenFromRequest(c.Request)
+	accessToken := firstRecord(s.store.AccessTokens.FindBy("token", token))
+	if accessToken == nil {
+		oauthError(c, http.StatusUnauthorized, "invalid_token", "The access token is invalid.")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", stringField(accessToken, "user_id")))
+	if user == nil {
+		oauthError(c, http.StatusUnauthorized, "invalid_token", "User not found.")
+		return
+	}
+	emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+	primary := primaryEmail(emails)
+	c.JSON(http.StatusOK, map[string]any{
+		"sub":            stringField(user, "clerk_id"),
+		"name":           userDisplayName(user),
+		"email":          nilString(primary, "email_address"),
+		"email_verified": stringField(primary, "verification_status") == "verified",
+		"picture":        nilString(user, "image_url"),
+	})
+}
+
+func (s *Service) deleteOAuthCode(code string) {
+	for _, row := range s.store.OAuthCodes.FindBy("code", code) {
+		s.store.OAuthCodes.Delete(intField(row, "id"))
+	}
+}

--- a/internal/services/clerk/routes_oauth.go
+++ b/internal/services/clerk/routes_oauth.go
@@ -94,7 +94,7 @@ func (s *Service) handleAuthorize(c *corehttp.Context) {
 				Login:      login,
 				Name:       userDisplayName(user),
 				Email:      stringField(primary, "email_address"),
-				FormAction: "/oauth/authorize/callback",
+				FormAction: s.oauthCallbackPath(),
 				HiddenFields: map[string]string{
 					"user_ref":              stringField(user, "clerk_id"),
 					"redirect_uri":          redirectURI,
@@ -114,6 +114,19 @@ func (s *Service) handleAuthorize(c *corehttp.Context) {
 		subtitle = "Sign in to <strong>" + ui.EscapeHTML(appName) + "</strong> with your Clerk account."
 	}
 	c.HTML(http.StatusOK, ui.RenderCardPage("Sign in with Clerk", subtitle, body.String(), ui.PageOptions{Service: serviceLabel}))
+}
+
+func (s *Service) oauthCallbackPath() string {
+	callbackPath := "/oauth/authorize/callback"
+	parsed, err := url.Parse(s.baseURL)
+	if err != nil {
+		return callbackPath
+	}
+	prefix := strings.TrimRight(parsed.Path, "/")
+	if prefix == "" {
+		return callbackPath
+	}
+	return prefix + callbackPath
 }
 
 func (s *Service) handleAuthorizeCallback(c *corehttp.Context) {

--- a/internal/services/clerk/routes_organizations.go
+++ b/internal/services/clerk/routes_organizations.go
@@ -1,0 +1,197 @@
+package clerk
+
+import (
+	"net/http"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerOrganizationRoutes(router *corehttp.Router) {
+	router.Get("/v1/organizations", s.handleListOrganizations)
+	router.Get("/v1/organizations/:orgId", s.handleGetOrganization)
+	router.Post("/v1/organizations", s.handleCreateOrganization)
+	router.Patch("/v1/organizations/:orgId", s.handlePatchOrganization)
+	router.Delete("/v1/organizations/:orgId", s.handleDeleteOrganization)
+	router.Patch("/v1/organizations/:orgId/metadata", s.handlePatchOrganizationMetadata)
+}
+
+func (s *Service) handleListOrganizations(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	limit, offset := parsePagination(c)
+	query := strings.ToLower(c.Query("query"))
+	orgs := sortNewestFirst(s.store.Organizations.All())
+	filtered := make([]corestore.Record, 0, len(orgs))
+	for _, org := range orgs {
+		if query != "" &&
+			!strings.Contains(strings.ToLower(stringField(org, "name")), query) &&
+			!strings.Contains(strings.ToLower(stringField(org, "slug")), query) {
+			continue
+		}
+		filtered = append(filtered, org)
+	}
+	paged := sliceRecords(filtered, limit, offset)
+	data := make([]map[string]any, 0, len(paged))
+	for _, org := range paged {
+		data = append(data, organizationResponse(org))
+	}
+	c.JSON(http.StatusOK, paginatedResponse(data, len(filtered), limit, offset))
+}
+
+func (s *Service) handleGetOrganization(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	org := s.findOrg(c.Param("orgId"))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	c.JSON(http.StatusOK, organizationResponse(org))
+}
+
+func (s *Service) handleCreateOrganization(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	body := readJSONBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		clerkError(c, http.StatusUnprocessableEntity, "INVALID_REQUEST_BODY", "name is required")
+		return
+	}
+	now := nowUnix()
+	slug := firstNonEmpty(stringValue(body["slug"]), slugify(name))
+	org := s.store.Organizations.Insert(corestore.Record{
+		"clerk_id":                  clerkID("org_"),
+		"name":                      name,
+		"slug":                      slug,
+		"image_url":                 nil,
+		"has_logo":                  false,
+		"members_count":             0,
+		"pending_invitations_count": 0,
+		"public_metadata":           mapValue(body["public_metadata"]),
+		"private_metadata":          mapValue(body["private_metadata"]),
+		"max_allowed_memberships":   numberOrNil(body["max_allowed_memberships"]),
+		"admin_delete_enabled":      boolOrDefault(body["admin_delete_enabled"], true),
+		"created_at_unix":           now,
+		"updated_at_unix":           now,
+	})
+	if createdBy := stringValue(body["created_by"]); createdBy != "" {
+		user := firstRecord(s.store.Users.FindBy("clerk_id", createdBy))
+		if user != nil {
+			s.store.Memberships.Insert(corestore.Record{
+				"membership_id":    clerkID("orgmem_"),
+				"org_id":           stringField(org, "clerk_id"),
+				"user_id":          createdBy,
+				"role":             "org:admin",
+				"permissions":      defaultPermissions("org:admin"),
+				"public_metadata":  map[string]any{},
+				"private_metadata": map[string]any{},
+				"created_at_unix":  now,
+				"updated_at_unix":  now,
+			})
+			s.store.Organizations.Update(intField(org, "id"), corestore.Record{"members_count": 1})
+			org = firstRecord(s.store.Organizations.FindBy("clerk_id", stringField(org, "clerk_id")))
+		}
+	}
+	c.JSON(http.StatusOK, organizationResponse(org))
+}
+
+func (s *Service) handlePatchOrganization(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{"updated_at_unix": nowUnix()}
+	assignStringPatch(patch, body, "name")
+	assignStringPatch(patch, body, "slug")
+	if body["public_metadata"] != nil {
+		patch["public_metadata"] = mapValue(body["public_metadata"])
+	}
+	if body["private_metadata"] != nil {
+		patch["private_metadata"] = mapValue(body["private_metadata"])
+	}
+	if _, ok := body["max_allowed_memberships"]; ok {
+		patch["max_allowed_memberships"] = numberOrNil(body["max_allowed_memberships"])
+	}
+	if _, ok := body["admin_delete_enabled"]; ok {
+		patch["admin_delete_enabled"] = boolValue(body["admin_delete_enabled"])
+	}
+	s.store.Organizations.Update(intField(org, "id"), patch)
+	updated := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	c.JSON(http.StatusOK, organizationResponse(updated))
+}
+
+func (s *Service) handleDeleteOrganization(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	for _, membership := range s.store.Memberships.FindBy("org_id", orgID) {
+		s.store.Memberships.Delete(intField(membership, "id"))
+	}
+	for _, invitation := range s.store.Invitations.FindBy("org_id", orgID) {
+		s.store.Invitations.Delete(intField(invitation, "id"))
+	}
+	s.store.Organizations.Delete(intField(org, "id"))
+	c.JSON(http.StatusOK, deletedResponse(orgID))
+}
+
+func (s *Service) handlePatchOrganizationMetadata(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	orgID := c.Param("orgId")
+	org := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	if org == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Organization not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{"updated_at_unix": nowUnix()}
+	if body["public_metadata"] != nil {
+		patch["public_metadata"] = mergeMaps(mapValue(org["public_metadata"]), mapValue(body["public_metadata"]))
+	}
+	if body["private_metadata"] != nil {
+		patch["private_metadata"] = mergeMaps(mapValue(org["private_metadata"]), mapValue(body["private_metadata"]))
+	}
+	s.store.Organizations.Update(intField(org, "id"), patch)
+	updated := firstRecord(s.store.Organizations.FindBy("clerk_id", orgID))
+	c.JSON(http.StatusOK, organizationResponse(updated))
+}
+
+func (s *Service) findOrg(ref string) corestore.Record {
+	if org := firstRecord(s.store.Organizations.FindBy("clerk_id", ref)); org != nil {
+		return org
+	}
+	return firstRecord(s.store.Organizations.FindBy("slug", ref))
+}
+
+func boolOrDefault(value any, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return boolValue(value)
+}
+
+func numberOrNil(value any) any {
+	if value == nil {
+		return nil
+	}
+	return intValue(value)
+}

--- a/internal/services/clerk/routes_sessions.go
+++ b/internal/services/clerk/routes_sessions.go
@@ -1,0 +1,131 @@
+package clerk
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerSessionRoutes(router *corehttp.Router) {
+	router.Get("/v1/sessions", s.handleListSessions)
+	router.Get("/v1/sessions/:sessionId", s.handleGetSession)
+	router.Post("/v1/sessions", s.handleCreateSession)
+	router.Post("/v1/sessions/:sessionId/revoke", s.handleRevokeSession)
+	router.Post("/v1/sessions/:sessionId/tokens", s.handleCreateSessionToken)
+	router.Post("/v1/sessions/:sessionId/tokens/:template", s.handleCreateSessionToken)
+}
+
+func (s *Service) handleListSessions(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	limit, offset := parsePagination(c)
+	userID := c.Query("user_id")
+	sessions := sortNewestFirst(s.store.Sessions.All())
+	filtered := make([]corestore.Record, 0, len(sessions))
+	for _, session := range sessions {
+		if userID != "" && stringField(session, "user_id") != userID {
+			continue
+		}
+		filtered = append(filtered, session)
+	}
+	paged := sliceRecords(filtered, limit, offset)
+	data := make([]map[string]any, 0, len(paged))
+	for _, session := range paged {
+		data = append(data, sessionResponse(session))
+	}
+	c.JSON(http.StatusOK, paginatedResponse(data, len(filtered), limit, offset))
+}
+
+func (s *Service) handleGetSession(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	session := firstRecord(s.store.Sessions.FindBy("clerk_id", c.Param("sessionId")))
+	if session == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Session not found")
+		return
+	}
+	c.JSON(http.StatusOK, sessionResponse(session))
+}
+
+func (s *Service) handleCreateSession(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	body := readJSONBody(c.Request)
+	userID := stringValue(body["user_id"])
+	if userID == "" {
+		clerkError(c, http.StatusUnprocessableEntity, "INVALID_REQUEST_BODY", "user_id is required")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	now := nowUnix()
+	session := s.store.Sessions.Insert(corestore.Record{
+		"clerk_id":        clerkID("sess_"),
+		"user_id":         userID,
+		"client_id":       firstNonEmpty(stringValue(body["client_id"]), "client_emulate"),
+		"status":          "active",
+		"last_active_at":  now,
+		"expire_at":       now + 86400,
+		"abandon_at":      now + 604800,
+		"created_at_unix": now,
+		"updated_at_unix": now,
+	})
+	s.store.Users.Update(intField(user, "id"), corestore.Record{"last_active_at": now, "last_sign_in_at": now, "updated_at_unix": now})
+	c.JSON(http.StatusOK, sessionResponse(session))
+}
+
+func (s *Service) handleRevokeSession(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	sessionID := c.Param("sessionId")
+	session := firstRecord(s.store.Sessions.FindBy("clerk_id", sessionID))
+	if session == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Session not found")
+		return
+	}
+	s.store.Sessions.Update(intField(session, "id"), corestore.Record{"status": "revoked", "updated_at_unix": nowUnix()})
+	updated := firstRecord(s.store.Sessions.FindBy("clerk_id", sessionID))
+	c.JSON(http.StatusOK, sessionResponse(updated))
+}
+
+func (s *Service) handleCreateSessionToken(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	sessionID := c.Param("sessionId")
+	session := firstRecord(s.store.Sessions.FindBy("clerk_id", sessionID))
+	if session == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "Session not found")
+		return
+	}
+	if stringField(session, "status") != "active" {
+		clerkError(c, http.StatusUnprocessableEntity, "SESSION_NOT_ACTIVE", "Session is not active")
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", stringField(session, "user_id")))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	var org corestore.Record
+	var membership corestore.Record
+	if memberships := s.store.Memberships.FindBy("user_id", stringField(user, "clerk_id")); len(memberships) > 0 {
+		membership = memberships[0]
+		org = firstRecord(s.store.Organizations.FindBy("clerk_id", stringField(membership, "org_id")))
+	}
+	jwt, err := createSessionToken(user, sessionID, s.baseURL, org, membership)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]any{"message": "Failed to sign session token"})
+		return
+	}
+	s.store.Sessions.Update(intField(session, "id"), corestore.Record{"last_active_at": nowUnix()})
+	c.JSON(http.StatusOK, map[string]any{"object": "token", "jwt": jwt})
+}

--- a/internal/services/clerk/routes_sessions.go
+++ b/internal/services/clerk/routes_sessions.go
@@ -117,9 +117,11 @@ func (s *Service) handleCreateSessionToken(c *corehttp.Context) {
 	}
 	var org corestore.Record
 	var membership corestore.Record
-	if memberships := s.store.Memberships.FindBy("user_id", stringField(user, "clerk_id")); len(memberships) > 0 {
-		membership = memberships[0]
-		org = firstRecord(s.store.Organizations.FindBy("clerk_id", stringField(membership, "org_id")))
+	if c.Param("template") == "" {
+		if memberships := s.store.Memberships.FindBy("user_id", stringField(user, "clerk_id")); len(memberships) > 0 {
+			membership = memberships[0]
+			org = firstRecord(s.store.Organizations.FindBy("clerk_id", stringField(membership, "org_id")))
+		}
 	}
 	jwt, err := createSessionToken(user, sessionID, s.baseURL, org, membership)
 	if err != nil {

--- a/internal/services/clerk/routes_users.go
+++ b/internal/services/clerk/routes_users.go
@@ -29,25 +29,8 @@ func (s *Service) handleListUsers(c *corehttp.Context) {
 		return
 	}
 	limit, offset := parsePagination(c)
-	query := strings.ToLower(c.Query("query"))
 	orderBy := firstNonEmpty(c.Query("order_by"), "-created_at")
-	emailFilters := c.Request.URL.Query()["email_address"]
-	emailSet := map[string]bool{}
-	for _, email := range emailFilters {
-		emailSet[strings.ToLower(email)] = true
-	}
-	users := s.store.Users.All()
-	filtered := make([]corestore.Record, 0, len(users))
-	for _, user := range users {
-		emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
-		if query != "" && !userMatchesQuery(user, emails, query) {
-			continue
-		}
-		if len(emailSet) > 0 && !userHasEmail(emails, emailSet) {
-			continue
-		}
-		filtered = append(filtered, user)
-	}
+	filtered := s.filteredUsers(c)
 	desc := strings.HasPrefix(orderBy, "-")
 	field := strings.TrimPrefix(orderBy, "-")
 	sort.SliceStable(filtered, func(i int, j int) bool {
@@ -75,7 +58,7 @@ func (s *Service) handleCountUsers(c *corehttp.Context) {
 	if !requireSecretKey(c) {
 		return
 	}
-	c.JSON(http.StatusOK, map[string]any{"object": "total_count", "total_count": s.store.Users.Count()})
+	c.JSON(http.StatusOK, map[string]any{"object": "total_count", "total_count": len(s.filteredUsers(c))})
 }
 
 func (s *Service) handleGetUser(c *corehttp.Context) {
@@ -288,7 +271,9 @@ func (s *Service) handleVerifyPassword(c *corehttp.Context) {
 func userMatchesQuery(user corestore.Record, emails []corestore.Record, query string) bool {
 	if strings.Contains(strings.ToLower(stringField(user, "first_name")), query) ||
 		strings.Contains(strings.ToLower(stringField(user, "last_name")), query) ||
-		strings.Contains(strings.ToLower(stringField(user, "username")), query) {
+		strings.Contains(strings.ToLower(stringField(user, "username")), query) ||
+		strings.Contains(strings.ToLower(stringField(user, "clerk_id")), query) ||
+		strings.Contains(strings.ToLower(stringField(user, "external_id")), query) {
 		return true
 	}
 	for _, email := range emails {
@@ -297,6 +282,28 @@ func userMatchesQuery(user corestore.Record, emails []corestore.Record, query st
 		}
 	}
 	return false
+}
+
+func (s *Service) filteredUsers(c *corehttp.Context) []corestore.Record {
+	query := strings.ToLower(c.Query("query"))
+	emailFilters := c.Request.URL.Query()["email_address"]
+	emailSet := map[string]bool{}
+	for _, email := range emailFilters {
+		emailSet[strings.ToLower(email)] = true
+	}
+	users := s.store.Users.All()
+	filtered := make([]corestore.Record, 0, len(users))
+	for _, user := range users {
+		emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+		if query != "" && !userMatchesQuery(user, emails, query) {
+			continue
+		}
+		if len(emailSet) > 0 && !userHasEmail(emails, emailSet) {
+			continue
+		}
+		filtered = append(filtered, user)
+	}
+	return filtered
 }
 
 func userHasEmail(emails []corestore.Record, emailSet map[string]bool) bool {

--- a/internal/services/clerk/routes_users.go
+++ b/internal/services/clerk/routes_users.go
@@ -1,0 +1,330 @@
+package clerk
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerUserRoutes(router *corehttp.Router) {
+	router.Get("/v1/users", s.handleListUsers)
+	router.Get("/v1/users/count", s.handleCountUsers)
+	router.Get("/v1/users/:userId", s.handleGetUser)
+	router.Post("/v1/users", s.handleCreateUser)
+	router.Patch("/v1/users/:userId", s.handlePatchUser)
+	router.Delete("/v1/users/:userId", s.handleDeleteUser)
+	router.Post("/v1/users/:userId/ban", s.handleBanUser)
+	router.Post("/v1/users/:userId/unban", s.handleUnbanUser)
+	router.Post("/v1/users/:userId/lock", s.handleLockUser)
+	router.Post("/v1/users/:userId/unlock", s.handleUnlockUser)
+	router.Patch("/v1/users/:userId/metadata", s.handlePatchUserMetadata)
+	router.Post("/v1/users/:userId/verify_password", s.handleVerifyPassword)
+}
+
+func (s *Service) handleListUsers(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	limit, offset := parsePagination(c)
+	query := strings.ToLower(c.Query("query"))
+	orderBy := firstNonEmpty(c.Query("order_by"), "-created_at")
+	emailFilters := c.Request.URL.Query()["email_address"]
+	emailSet := map[string]bool{}
+	for _, email := range emailFilters {
+		emailSet[strings.ToLower(email)] = true
+	}
+	users := s.store.Users.All()
+	filtered := make([]corestore.Record, 0, len(users))
+	for _, user := range users {
+		emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+		if query != "" && !userMatchesQuery(user, emails, query) {
+			continue
+		}
+		if len(emailSet) > 0 && !userHasEmail(emails, emailSet) {
+			continue
+		}
+		filtered = append(filtered, user)
+	}
+	desc := strings.HasPrefix(orderBy, "-")
+	field := strings.TrimPrefix(orderBy, "-")
+	sort.SliceStable(filtered, func(i int, j int) bool {
+		left := int64Field(filtered[i], "updated_at_unix")
+		right := int64Field(filtered[j], "updated_at_unix")
+		if field == "created_at" {
+			left = int64Field(filtered[i], "created_at_unix")
+			right = int64Field(filtered[j], "created_at_unix")
+		}
+		if desc {
+			return left > right
+		}
+		return left < right
+	})
+	paged := sliceRecords(filtered, limit, offset)
+	data := make([]map[string]any, 0, len(paged))
+	for _, user := range paged {
+		emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+		data = append(data, userResponse(user, emails))
+	}
+	c.JSON(http.StatusOK, paginatedResponse(data, len(filtered), limit, offset))
+}
+
+func (s *Service) handleCountUsers(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	c.JSON(http.StatusOK, map[string]any{"object": "total_count", "total_count": s.store.Users.Count()})
+}
+
+func (s *Service) handleGetUser(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", c.Param("userId")))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	emails := s.store.EmailAddresses.FindBy("user_id", stringField(user, "clerk_id"))
+	c.JSON(http.StatusOK, userResponse(user, emails))
+}
+
+func (s *Service) handleCreateUser(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	body := readJSONBody(c.Request)
+	now := nowUnix()
+	userID := clerkID("user_")
+	user := s.store.Users.Insert(corestore.Record{
+		"clerk_id":                 userID,
+		"username":                 nilStringValue(stringValue(body["username"])),
+		"first_name":               nilStringValue(stringValue(body["first_name"])),
+		"last_name":                nilStringValue(stringValue(body["last_name"])),
+		"image_url":                nil,
+		"profile_image_url":        nil,
+		"external_id":              nilStringValue(stringValue(body["external_id"])),
+		"primary_email_address_id": nil,
+		"primary_phone_number_id":  nil,
+		"password_enabled":         stringValue(body["password"]) != "",
+		"password_hash":            nilStringValue(stringValue(body["password"])),
+		"totp_enabled":             false,
+		"backup_code_enabled":      false,
+		"two_factor_enabled":       false,
+		"banned":                   false,
+		"locked":                   false,
+		"public_metadata":          mapValue(body["public_metadata"]),
+		"private_metadata":         mapValue(body["private_metadata"]),
+		"unsafe_metadata":          mapValue(body["unsafe_metadata"]),
+		"last_active_at":           nil,
+		"last_sign_in_at":          nil,
+		"created_at_unix":          now,
+		"updated_at_unix":          now,
+	})
+	emailList := stringSliceValue(body["email_address"])
+	primaryEmailID := ""
+	for index, value := range emailList {
+		email := s.store.EmailAddresses.Insert(corestore.Record{
+			"email_id":              clerkID("idn_"),
+			"email_address":         value,
+			"user_id":               userID,
+			"verification_status":   "verified",
+			"verification_strategy": "email_code",
+			"is_primary":            index == 0,
+			"reserved":              false,
+			"created_at_unix":       now,
+			"updated_at_unix":       now,
+		})
+		if index == 0 {
+			primaryEmailID = stringField(email, "email_id")
+		}
+	}
+	if primaryEmailID != "" {
+		s.store.Users.Update(intField(user, "id"), corestore.Record{"primary_email_address_id": primaryEmailID})
+	}
+	created := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	emails := s.store.EmailAddresses.FindBy("user_id", userID)
+	c.JSON(http.StatusOK, userResponse(created, emails))
+}
+
+func (s *Service) handlePatchUser(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	userID := c.Param("userId")
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{"updated_at_unix": nowUnix()}
+	assignStringPatch(patch, body, "first_name")
+	assignStringPatch(patch, body, "last_name")
+	assignStringPatch(patch, body, "username")
+	assignStringPatch(patch, body, "external_id")
+	assignStringPatch(patch, body, "primary_email_address_id")
+	assignStringPatch(patch, body, "primary_phone_number_id")
+	if body["public_metadata"] != nil {
+		patch["public_metadata"] = mapValue(body["public_metadata"])
+	}
+	if body["private_metadata"] != nil {
+		patch["private_metadata"] = mapValue(body["private_metadata"])
+	}
+	if body["unsafe_metadata"] != nil {
+		patch["unsafe_metadata"] = mapValue(body["unsafe_metadata"])
+	}
+	if password, ok := body["password"].(string); ok {
+		patch["password_enabled"] = password != ""
+		patch["password_hash"] = nilStringValue(password)
+	}
+	s.store.Users.Update(intField(user, "id"), patch)
+	updated := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	emails := s.store.EmailAddresses.FindBy("user_id", userID)
+	c.JSON(http.StatusOK, userResponse(updated, emails))
+}
+
+func (s *Service) handleDeleteUser(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	userID := c.Param("userId")
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	for _, email := range s.store.EmailAddresses.FindBy("user_id", userID) {
+		s.store.EmailAddresses.Delete(intField(email, "id"))
+	}
+	for _, membership := range s.store.Memberships.FindBy("user_id", userID) {
+		s.store.Memberships.Delete(intField(membership, "id"))
+		org := firstRecord(s.store.Organizations.FindBy("clerk_id", stringField(membership, "org_id")))
+		if org != nil {
+			s.store.Organizations.Update(intField(org, "id"), corestore.Record{"members_count": max(0, intField(org, "members_count")-1)})
+		}
+	}
+	for _, session := range s.store.Sessions.FindBy("user_id", userID) {
+		s.store.Sessions.Delete(intField(session, "id"))
+	}
+	s.store.Users.Delete(intField(user, "id"))
+	c.JSON(http.StatusOK, deletedResponse(userID))
+}
+
+func (s *Service) handleBanUser(c *corehttp.Context) {
+	s.setUserFlag(c, "banned", true)
+}
+
+func (s *Service) handleUnbanUser(c *corehttp.Context) {
+	s.setUserFlag(c, "banned", false)
+}
+
+func (s *Service) handleLockUser(c *corehttp.Context) {
+	s.setUserFlag(c, "locked", true)
+}
+
+func (s *Service) handleUnlockUser(c *corehttp.Context) {
+	s.setUserFlag(c, "locked", false)
+}
+
+func (s *Service) setUserFlag(c *corehttp.Context, field string, value bool) {
+	if !requireSecretKey(c) {
+		return
+	}
+	userID := c.Param("userId")
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	s.store.Users.Update(intField(user, "id"), corestore.Record{field: value, "updated_at_unix": nowUnix()})
+	updated := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	emails := s.store.EmailAddresses.FindBy("user_id", userID)
+	c.JSON(http.StatusOK, userResponse(updated, emails))
+}
+
+func (s *Service) handlePatchUserMetadata(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	userID := c.Param("userId")
+	user := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{"updated_at_unix": nowUnix()}
+	if body["public_metadata"] != nil {
+		patch["public_metadata"] = mergeMaps(mapValue(user["public_metadata"]), mapValue(body["public_metadata"]))
+	}
+	if body["private_metadata"] != nil {
+		patch["private_metadata"] = mergeMaps(mapValue(user["private_metadata"]), mapValue(body["private_metadata"]))
+	}
+	if body["unsafe_metadata"] != nil {
+		patch["unsafe_metadata"] = mergeMaps(mapValue(user["unsafe_metadata"]), mapValue(body["unsafe_metadata"]))
+	}
+	s.store.Users.Update(intField(user, "id"), patch)
+	updated := firstRecord(s.store.Users.FindBy("clerk_id", userID))
+	emails := s.store.EmailAddresses.FindBy("user_id", userID)
+	c.JSON(http.StatusOK, userResponse(updated, emails))
+}
+
+func (s *Service) handleVerifyPassword(c *corehttp.Context) {
+	if !requireSecretKey(c) {
+		return
+	}
+	user := firstRecord(s.store.Users.FindBy("clerk_id", c.Param("userId")))
+	if user == nil {
+		clerkError(c, http.StatusNotFound, "RESOURCE_NOT_FOUND", "User not found")
+		return
+	}
+	body := readJSONBody(c.Request)
+	c.JSON(http.StatusOK, map[string]any{"object": "verification", "verified": stringField(user, "password_hash") == stringValue(body["password"])})
+}
+
+func userMatchesQuery(user corestore.Record, emails []corestore.Record, query string) bool {
+	if strings.Contains(strings.ToLower(stringField(user, "first_name")), query) ||
+		strings.Contains(strings.ToLower(stringField(user, "last_name")), query) ||
+		strings.Contains(strings.ToLower(stringField(user, "username")), query) {
+		return true
+	}
+	for _, email := range emails {
+		if strings.Contains(strings.ToLower(stringField(email, "email_address")), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func userHasEmail(emails []corestore.Record, emailSet map[string]bool) bool {
+	for _, email := range emails {
+		if emailSet[strings.ToLower(stringField(email, "email_address"))] {
+			return true
+		}
+	}
+	return false
+}
+
+func assignStringPatch(patch corestore.Record, body map[string]any, field string) {
+	if value, ok := body[field]; ok {
+		if value == nil {
+			patch[field] = nil
+			return
+		}
+		patch[field] = stringValue(value)
+	}
+}
+
+func mergeMaps(left map[string]any, right map[string]any) map[string]any {
+	out := make(map[string]any, len(left)+len(right))
+	for key, value := range left {
+		out[key] = value
+	}
+	for key, value := range right {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/services/clerk/service.go
+++ b/internal/services/clerk/service.go
@@ -1,0 +1,340 @@
+package clerk
+
+import (
+	"strings"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const serviceLabel = "Clerk"
+
+type Options struct {
+	Store   *corestore.Store
+	BaseURL string
+	Seed    *SeedConfig
+}
+
+type SeedConfig struct {
+	Users             []UserSeed             `json:"users"`
+	Organizations     []OrganizationSeed     `json:"organizations"`
+	OAuthApplications []OAuthApplicationSeed `json:"oauth_applications"`
+}
+
+type UserSeed struct {
+	ClerkID         string         `json:"clerk_id"`
+	EmailAddresses  []string       `json:"email_addresses"`
+	FirstName       string         `json:"first_name"`
+	LastName        string         `json:"last_name"`
+	Username        string         `json:"username"`
+	Password        string         `json:"password"`
+	ExternalID      string         `json:"external_id"`
+	PublicMetadata  map[string]any `json:"public_metadata"`
+	PrivateMetadata map[string]any `json:"private_metadata"`
+	UnsafeMetadata  map[string]any `json:"unsafe_metadata"`
+}
+
+type OrganizationSeed struct {
+	ClerkID               string             `json:"clerk_id"`
+	Name                  string             `json:"name"`
+	Slug                  string             `json:"slug"`
+	MaxAllowedMemberships *int               `json:"max_allowed_memberships"`
+	PublicMetadata        map[string]any     `json:"public_metadata"`
+	PrivateMetadata       map[string]any     `json:"private_metadata"`
+	Members               []OrganizationUser `json:"members"`
+}
+
+type OrganizationUser struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+type OAuthApplicationSeed struct {
+	ClientID     string   `json:"client_id"`
+	ClientSecret string   `json:"client_secret"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris"`
+	Scopes       []string `json:"scopes"`
+	Public       bool     `json:"public"`
+}
+
+type Service struct {
+	store   Store
+	baseURL string
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	baseURL := strings.TrimRight(options.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:4000"
+	}
+	service := &Service{store: NewStore(runtimeStore), baseURL: baseURL}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, baseURL string, config SeedConfig) {
+	New(Options{Store: runtimeStore, BaseURL: baseURL, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerOAuthRoutes(router)
+	s.registerUserRoutes(router)
+	s.registerEmailAddressRoutes(router)
+	s.registerOrganizationRoutes(router)
+	s.registerMembershipRoutes(router)
+	s.registerInvitationRoutes(router)
+	s.registerSessionRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if s.store.Users.Count() > 0 {
+		return
+	}
+	user := s.store.Users.Insert(defaultUser("test_password"))
+	email := s.store.EmailAddresses.Insert(defaultEmailAddress(stringField(user, "clerk_id"), "test@example.com", true))
+	s.store.Users.Update(intField(user, "id"), corestore.Record{"primary_email_address_id": stringField(email, "email_id")})
+	if firstRecord(s.store.OAuthApps.FindBy("client_id", "clerk_emulate_client")) == nil {
+		now := nowUnix()
+		s.store.OAuthApps.Insert(corestore.Record{
+			"app_id":          clerkID("oauth_app_"),
+			"name":            "Emulate App",
+			"client_id":       "clerk_emulate_client",
+			"client_secret":   "clerk_emulate_secret",
+			"is_public":       false,
+			"scopes":          []string{"openid", "profile", "email"},
+			"redirect_uris":   []string{"http://localhost:3000/api/auth/callback/clerk"},
+			"created_at_unix": now,
+			"updated_at_unix": now,
+		})
+	}
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	for _, seed := range config.Users {
+		existingEmail := ""
+		if len(seed.EmailAddresses) > 0 {
+			existingEmail = seed.EmailAddresses[0]
+		}
+		if existingEmail != "" && firstRecord(s.store.EmailAddresses.FindBy("email_address", existingEmail)) != nil {
+			continue
+		}
+		clerkIDValue := seed.ClerkID
+		if clerkIDValue == "" {
+			clerkIDValue = clerkID("user_")
+		}
+		firstName := firstNonEmpty(seed.FirstName, "Test")
+		lastName := firstNonEmpty(seed.LastName, "User")
+		now := nowUnix()
+		user := s.store.Users.Insert(corestore.Record{
+			"clerk_id":                 clerkIDValue,
+			"username":                 nilStringValue(seed.Username),
+			"first_name":               firstName,
+			"last_name":                lastName,
+			"image_url":                nil,
+			"profile_image_url":        nil,
+			"external_id":              nilStringValue(seed.ExternalID),
+			"primary_email_address_id": nil,
+			"primary_phone_number_id":  nil,
+			"password_enabled":         seed.Password != "",
+			"password_hash":            nilStringValue(seed.Password),
+			"totp_enabled":             false,
+			"backup_code_enabled":      false,
+			"two_factor_enabled":       false,
+			"banned":                   false,
+			"locked":                   false,
+			"public_metadata":          cloneMap(seed.PublicMetadata),
+			"private_metadata":         cloneMap(seed.PrivateMetadata),
+			"unsafe_metadata":          cloneMap(seed.UnsafeMetadata),
+			"last_active_at":           nil,
+			"last_sign_in_at":          nil,
+			"created_at_unix":          now,
+			"updated_at_unix":          now,
+		})
+		primaryEmailID := ""
+		for index, emailAddress := range seed.EmailAddresses {
+			email := s.store.EmailAddresses.Insert(defaultEmailAddress(clerkIDValue, emailAddress, index == 0))
+			if index == 0 {
+				primaryEmailID = stringField(email, "email_id")
+			}
+		}
+		if primaryEmailID != "" {
+			s.store.Users.Update(intField(user, "id"), corestore.Record{"primary_email_address_id": primaryEmailID})
+		}
+	}
+
+	for _, seed := range config.Organizations {
+		name := seed.Name
+		if name == "" {
+			continue
+		}
+		slug := seed.Slug
+		if slug == "" {
+			slug = slugify(name)
+		}
+		if firstRecord(s.store.Organizations.FindBy("slug", slug)) != nil {
+			continue
+		}
+		orgID := seed.ClerkID
+		if orgID == "" {
+			orgID = clerkID("org_")
+		}
+		now := nowUnix()
+		maxAllowed := any(nil)
+		if seed.MaxAllowedMemberships != nil {
+			maxAllowed = *seed.MaxAllowedMemberships
+		}
+		org := s.store.Organizations.Insert(corestore.Record{
+			"clerk_id":                  orgID,
+			"name":                      name,
+			"slug":                      slug,
+			"image_url":                 nil,
+			"has_logo":                  false,
+			"members_count":             0,
+			"pending_invitations_count": 0,
+			"public_metadata":           cloneMap(seed.PublicMetadata),
+			"private_metadata":          cloneMap(seed.PrivateMetadata),
+			"max_allowed_memberships":   maxAllowed,
+			"admin_delete_enabled":      true,
+			"created_at_unix":           now,
+			"updated_at_unix":           now,
+		})
+		memberCount := 0
+		for _, member := range seed.Members {
+			email := firstRecord(s.store.EmailAddresses.FindBy("email_address", member.Email))
+			if email == nil {
+				continue
+			}
+			user := firstRecord(s.store.Users.FindBy("clerk_id", stringField(email, "user_id")))
+			if user == nil {
+				continue
+			}
+			userID := stringField(user, "clerk_id")
+			if membershipForUser(s.store.Memberships.FindBy("org_id", orgID), userID) != nil {
+				continue
+			}
+			role := normalizeOrgRole(member.Role)
+			s.store.Memberships.Insert(corestore.Record{
+				"membership_id":    clerkID("orgmem_"),
+				"org_id":           orgID,
+				"user_id":          userID,
+				"role":             role,
+				"permissions":      defaultPermissions(role),
+				"public_metadata":  map[string]any{},
+				"private_metadata": map[string]any{},
+				"created_at_unix":  now,
+				"updated_at_unix":  now,
+			})
+			memberCount++
+		}
+		if memberCount > 0 {
+			s.store.Organizations.Update(intField(org, "id"), corestore.Record{"members_count": memberCount})
+		}
+	}
+
+	for _, seed := range config.OAuthApplications {
+		if seed.ClientID == "" || firstRecord(s.store.OAuthApps.FindBy("client_id", seed.ClientID)) != nil {
+			continue
+		}
+		scopes := seed.Scopes
+		if len(scopes) == 0 {
+			scopes = []string{"openid", "profile", "email"}
+		}
+		now := nowUnix()
+		s.store.OAuthApps.Insert(corestore.Record{
+			"app_id":          clerkID("oauth_app_"),
+			"name":            seed.Name,
+			"client_id":       seed.ClientID,
+			"client_secret":   seed.ClientSecret,
+			"is_public":       seed.Public,
+			"scopes":          scopes,
+			"redirect_uris":   seed.RedirectURIs,
+			"created_at_unix": now,
+			"updated_at_unix": now,
+		})
+	}
+}
+
+func defaultUser(password string) corestore.Record {
+	now := nowUnix()
+	return corestore.Record{
+		"clerk_id":                 clerkID("user_"),
+		"username":                 nil,
+		"first_name":               "Test",
+		"last_name":                "User",
+		"image_url":                nil,
+		"profile_image_url":        nil,
+		"external_id":              nil,
+		"primary_email_address_id": nil,
+		"primary_phone_number_id":  nil,
+		"password_enabled":         password != "",
+		"password_hash":            nilStringValue(password),
+		"totp_enabled":             false,
+		"backup_code_enabled":      false,
+		"two_factor_enabled":       false,
+		"banned":                   false,
+		"locked":                   false,
+		"public_metadata":          map[string]any{},
+		"private_metadata":         map[string]any{},
+		"unsafe_metadata":          map[string]any{},
+		"last_active_at":           nil,
+		"last_sign_in_at":          nil,
+		"created_at_unix":          now,
+		"updated_at_unix":          now,
+	}
+}
+
+func defaultEmailAddress(userID string, emailAddress string, primary bool) corestore.Record {
+	now := nowUnix()
+	return corestore.Record{
+		"email_id":              clerkID("idn_"),
+		"email_address":         emailAddress,
+		"user_id":               userID,
+		"verification_status":   "verified",
+		"verification_strategy": "email_code",
+		"is_primary":            primary,
+		"reserved":              false,
+		"created_at_unix":       now,
+		"updated_at_unix":       now,
+	}
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func nilStringValue(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func normalizeOrgRole(role string) string {
+	if role == "" {
+		return "org:member"
+	}
+	if strings.HasPrefix(role, "org:") {
+		return role
+	}
+	return "org:" + role
+}

--- a/internal/services/clerk/service_test.go
+++ b/internal/services/clerk/service_test.go
@@ -80,7 +80,7 @@ func TestOAuthAuthorizationCodeFlow(t *testing.T) {
 		t.Fatalf("unexpected token body: %#v", tokenBody)
 	}
 	claims := decodeJWTClaims(t, tokenBody.IDToken)
-	if claims["iss"] != testBaseURL || claims["sub"] != stringField(alice, "clerk_id") || claims["sid"] == "" {
+	if claims["iss"] != testBaseURL || claims["sub"] != stringField(alice, "clerk_id") || claims["sid"] == "" || claims["nonce"] != "nonce-1" {
 		t.Fatalf("unexpected id token claims: %#v", claims)
 	}
 
@@ -178,6 +178,19 @@ func TestManagementAPIsAndSessionTokens(t *testing.T) {
 	listUsers := clerkJSON(router, http.MethodGet, "/v1/users?query=alice", "")
 	if listUsers.Code != http.StatusOK || !strings.Contains(listUsers.Body.String(), `"total_count":1`) {
 		t.Fatalf("list users status = %d, body = %s", listUsers.Code, listUsers.Body.String())
+	}
+	countUsers := clerkJSON(router, http.MethodGet, "/v1/users/count?query=alice", "")
+	if countUsers.Code != http.StatusOK {
+		t.Fatalf("count users status = %d, body = %s", countUsers.Code, countUsers.Body.String())
+	}
+	var countBody struct {
+		TotalCount int `json:"total_count"`
+	}
+	if err := json.Unmarshal(countUsers.Body.Bytes(), &countBody); err != nil {
+		t.Fatal(err)
+	}
+	if countBody.TotalCount != 1 {
+		t.Fatalf("filtered count = %d, body = %s", countBody.TotalCount, countUsers.Body.String())
 	}
 
 	createUser := clerkJSON(router, http.MethodPost, "/v1/users", `{"email_address":["new@example.com"],"first_name":"New","password":"secret"}`)

--- a/internal/services/clerk/service_test.go
+++ b/internal/services/clerk/service_test.go
@@ -100,6 +100,38 @@ func TestOAuthAuthorizationCodeFlow(t *testing.T) {
 	}
 }
 
+func TestOAuthAcceptsNormalizedRedirectURI(t *testing.T) {
+	service, router := newTestService(t)
+	aliceID := userIDByEmail(t, service, "alice@example.com")
+	redirectURI := "http://localhost:3000/callback/?next=dashboard"
+
+	authorize := serveClerk(router, httptest.NewRequest(http.MethodGet, "/oauth/authorize?client_id=test-client&response_type=code&redirect_uri="+url.QueryEscape(redirectURI), nil))
+	if authorize.Code != http.StatusOK {
+		t.Fatalf("authorize status = %d, body = %s", authorize.Code, authorize.Body.String())
+	}
+
+	form := url.Values{
+		"user_ref":     {aliceID},
+		"redirect_uri": {redirectURI},
+		"scope":        {"openid profile email"},
+		"client_id":    {"test-client"},
+		"state":        {"state-1"},
+	}
+	callback := httptest.NewRequest(http.MethodPost, "/oauth/authorize/callback", strings.NewReader(form.Encode()))
+	callback.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRes := serveClerk(router, callback)
+	if callbackRes.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	redirect, err := url.Parse(callbackRes.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if redirect.Query().Get("code") == "" || redirect.Query().Get("next") != "dashboard" || redirect.Query().Get("state") != "state-1" {
+		t.Fatalf("unexpected redirect: %s", callbackRes.Header().Get("Location"))
+	}
+}
+
 func TestOAuthRejectsInvalidPKCEVerifier(t *testing.T) {
 	service, router := newTestService(t)
 	aliceID := userIDByEmail(t, service, "alice@example.com")
@@ -186,6 +218,24 @@ func TestManagementAPIsAndSessionTokens(t *testing.T) {
 	claims := decodeJWTClaims(t, tokenBody.JWT)
 	if claims["sub"] != aliceID || claims["org_role"] != "org:admin" || claims["org_slug"] != "acme" {
 		t.Fatalf("unexpected session token claims: %#v", claims)
+	}
+
+	templateTokenRes := clerkJSON(router, http.MethodPost, "/v1/sessions/"+session.ID+"/tokens/custom", `{}`)
+	if templateTokenRes.Code != http.StatusOK {
+		t.Fatalf("template session token status = %d, body = %s", templateTokenRes.Code, templateTokenRes.Body.String())
+	}
+	var templateTokenBody struct {
+		JWT string `json:"jwt"`
+	}
+	if err := json.Unmarshal(templateTokenRes.Body.Bytes(), &templateTokenBody); err != nil {
+		t.Fatal(err)
+	}
+	templateClaims := decodeJWTClaims(t, templateTokenBody.JWT)
+	if templateClaims["sub"] != aliceID || templateClaims["sid"] != session.ID {
+		t.Fatalf("unexpected template session token claims: %#v", templateClaims)
+	}
+	if _, ok := templateClaims["org_role"]; ok {
+		t.Fatalf("template session token included org claims: %#v", templateClaims)
 	}
 }
 

--- a/internal/services/clerk/service_test.go
+++ b/internal/services/clerk/service_test.go
@@ -1,0 +1,282 @@
+package clerk
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+const testBaseURL = "http://localhost:4017"
+
+func TestOAuthAuthorizationCodeFlow(t *testing.T) {
+	service, router := newTestService(t)
+	alice := firstRecord(service.store.Users.FindBy("clerk_id", userIDByEmail(t, service, "alice@example.com")))
+	if alice == nil {
+		t.Fatal("missing alice")
+	}
+
+	discovery := serveClerk(router, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil))
+	if discovery.Code != http.StatusOK {
+		t.Fatalf("discovery status = %d, body = %s", discovery.Code, discovery.Body.String())
+	}
+	if !strings.Contains(discovery.Body.String(), `"issuer":"`+testBaseURL+`"`) ||
+		!strings.Contains(discovery.Body.String(), `"jwks_uri":"`+testBaseURL+`/v1/jwks"`) {
+		t.Fatalf("unexpected discovery body: %s", discovery.Body.String())
+	}
+
+	form := url.Values{
+		"user_ref":     {stringField(alice, "clerk_id")},
+		"redirect_uri": {"http://localhost:3000/callback"},
+		"scope":        {"openid profile email"},
+		"client_id":    {"test-client"},
+		"state":        {"state-1"},
+		"nonce":        {"nonce-1"},
+	}
+	callback := httptest.NewRequest(http.MethodPost, "/oauth/authorize/callback", strings.NewReader(form.Encode()))
+	callback.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRes := serveClerk(router, callback)
+	if callbackRes.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	redirect, err := url.Parse(callbackRes.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := redirect.Query().Get("code")
+	if code == "" || redirect.Query().Get("state") != "state-1" {
+		t.Fatalf("unexpected redirect: %s", callbackRes.Header().Get("Location"))
+	}
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRes := serveClerk(router, tokenReq)
+	if tokenRes.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	var tokenBody struct {
+		AccessToken string `json:"access_token"`
+		IDToken     string `json:"id_token"`
+		TokenType   string `json:"token_type"`
+		Scope       string `json:"scope"`
+	}
+	if err := json.Unmarshal(tokenRes.Body.Bytes(), &tokenBody); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(tokenBody.AccessToken, "clerk_") || tokenBody.TokenType != "Bearer" || tokenBody.IDToken == "" || tokenBody.Scope != "openid profile email" {
+		t.Fatalf("unexpected token body: %#v", tokenBody)
+	}
+	claims := decodeJWTClaims(t, tokenBody.IDToken)
+	if claims["iss"] != testBaseURL || claims["sub"] != stringField(alice, "clerk_id") || claims["sid"] == "" {
+		t.Fatalf("unexpected id token claims: %#v", claims)
+	}
+
+	secondUse := serveClerk(router, tokenReqWithForm(tokenForm))
+	if secondUse.Code != http.StatusBadRequest || !strings.Contains(secondUse.Body.String(), `"error":"invalid_grant"`) {
+		t.Fatalf("second token status = %d, body = %s", secondUse.Code, secondUse.Body.String())
+	}
+
+	userinfoReq := httptest.NewRequest(http.MethodGet, "/oauth/userinfo", nil)
+	userinfoReq.Header.Set("Authorization", "Bearer "+tokenBody.AccessToken)
+	userinfoRes := serveClerk(router, userinfoReq)
+	if userinfoRes.Code != http.StatusOK {
+		t.Fatalf("userinfo status = %d, body = %s", userinfoRes.Code, userinfoRes.Body.String())
+	}
+	if !strings.Contains(userinfoRes.Body.String(), `"email":"alice@example.com"`) {
+		t.Fatalf("unexpected userinfo body: %s", userinfoRes.Body.String())
+	}
+}
+
+func TestOAuthRejectsInvalidPKCEVerifier(t *testing.T) {
+	service, router := newTestService(t)
+	aliceID := userIDByEmail(t, service, "alice@example.com")
+	form := url.Values{
+		"user_ref":              {aliceID},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"scope":                 {"openid profile email"},
+		"client_id":             {"test-client"},
+		"code_challenge":        {"expected"},
+		"code_challenge_method": {"plain"},
+	}
+	callback := httptest.NewRequest(http.MethodPost, "/oauth/authorize/callback", strings.NewReader(form.Encode()))
+	callback.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRes := serveClerk(router, callback)
+	redirect, err := url.Parse(callbackRes.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {redirect.Query().Get("code")},
+		"redirect_uri":  {"http://localhost:3000/callback"},
+		"client_id":     {"test-client"},
+		"client_secret": {"test-secret"},
+		"code_verifier": {"wrong"},
+	}
+	tokenRes := serveClerk(router, tokenReqWithForm(tokenForm))
+	if tokenRes.Code != http.StatusBadRequest || !strings.Contains(tokenRes.Body.String(), "PKCE verification failed") {
+		t.Fatalf("token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	if service.store.AccessTokens.Count() != 0 {
+		t.Fatal("access token was issued for invalid PKCE verifier")
+	}
+}
+
+func TestManagementAPIsAndSessionTokens(t *testing.T) {
+	service, router := newTestService(t)
+
+	unauthorized := serveClerk(router, httptest.NewRequest(http.MethodGet, "/v1/users", nil))
+	if unauthorized.Code != http.StatusUnauthorized || !strings.Contains(unauthorized.Body.String(), "UNAUTHORIZED") {
+		t.Fatalf("unauthorized status = %d, body = %s", unauthorized.Code, unauthorized.Body.String())
+	}
+
+	listUsers := clerkJSON(router, http.MethodGet, "/v1/users?query=alice", "")
+	if listUsers.Code != http.StatusOK || !strings.Contains(listUsers.Body.String(), `"total_count":1`) {
+		t.Fatalf("list users status = %d, body = %s", listUsers.Code, listUsers.Body.String())
+	}
+
+	createUser := clerkJSON(router, http.MethodPost, "/v1/users", `{"email_address":["new@example.com"],"first_name":"New","password":"secret"}`)
+	if createUser.Code != http.StatusOK || !strings.Contains(createUser.Body.String(), `"first_name":"New"`) || !strings.Contains(createUser.Body.String(), `"password_enabled":true`) {
+		t.Fatalf("create user status = %d, body = %s", createUser.Code, createUser.Body.String())
+	}
+
+	acme := firstRecord(service.store.Organizations.FindBy("slug", "acme"))
+	if acme == nil || intField(acme, "members_count") != 2 {
+		t.Fatalf("unexpected seeded org: %#v", acme)
+	}
+	aliceID := userIDByEmail(t, service, "alice@example.com")
+	duplicate := clerkJSON(router, http.MethodPost, "/v1/organizations/"+stringField(acme, "clerk_id")+"/memberships", `{"user_id":"`+aliceID+`","role":"org:member"}`)
+	if duplicate.Code != http.StatusUnprocessableEntity || !strings.Contains(duplicate.Body.String(), "DUPLICATE_RECORD") {
+		t.Fatalf("duplicate membership status = %d, body = %s", duplicate.Code, duplicate.Body.String())
+	}
+
+	sessionRes := clerkJSON(router, http.MethodPost, "/v1/sessions", `{"user_id":"`+aliceID+`"}`)
+	if sessionRes.Code != http.StatusOK {
+		t.Fatalf("session status = %d, body = %s", sessionRes.Code, sessionRes.Body.String())
+	}
+	var session struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(sessionRes.Body.Bytes(), &session); err != nil {
+		t.Fatal(err)
+	}
+	tokenRes := clerkJSON(router, http.MethodPost, "/v1/sessions/"+session.ID+"/tokens", `{}`)
+	if tokenRes.Code != http.StatusOK {
+		t.Fatalf("session token status = %d, body = %s", tokenRes.Code, tokenRes.Body.String())
+	}
+	var tokenBody struct {
+		JWT string `json:"jwt"`
+	}
+	if err := json.Unmarshal(tokenRes.Body.Bytes(), &tokenBody); err != nil {
+		t.Fatal(err)
+	}
+	claims := decodeJWTClaims(t, tokenBody.JWT)
+	if claims["sub"] != aliceID || claims["org_role"] != "org:admin" || claims["org_slug"] != "acme" {
+		t.Fatalf("unexpected session token claims: %#v", claims)
+	}
+}
+
+func TestSeedFromConfigDoesNotDuplicateUsers(t *testing.T) {
+	service, _ := newTestService(t)
+	before := service.store.Users.Count()
+	service.SeedFromConfig(SeedConfig{
+		Users: []UserSeed{{EmailAddresses: []string{"alice@example.com"}, FirstName: "Alice"}},
+	})
+	if service.store.Users.Count() != before {
+		t.Fatalf("seed duplicated user: before %d after %d", before, service.store.Users.Count())
+	}
+}
+
+func newTestService(t *testing.T) (*Service, *corehttp.Router) {
+	t.Helper()
+	runtimeStore := corestore.New()
+	service := New(Options{
+		Store:   runtimeStore,
+		BaseURL: testBaseURL,
+		Seed: &SeedConfig{
+			Users: []UserSeed{
+				{EmailAddresses: []string{"alice@example.com"}, FirstName: "Alice", LastName: "Smith", Password: "alice123"},
+				{EmailAddresses: []string{"bob@example.com"}, FirstName: "Bob", LastName: "Jones"},
+			},
+			Organizations: []OrganizationSeed{
+				{
+					Name: "Acme Corp",
+					Slug: "acme",
+					Members: []OrganizationUser{
+						{Email: "alice@example.com", Role: "admin"},
+						{Email: "bob@example.com", Role: "member"},
+					},
+				},
+			},
+			OAuthApplications: []OAuthApplicationSeed{
+				{
+					ClientID:     "test-client",
+					ClientSecret: "test-secret",
+					Name:         "Test App",
+					RedirectURIs: []string{"http://localhost:3000/callback"},
+				},
+			},
+		},
+	})
+	router := corehttp.NewRouter()
+	service.RegisterRoutes(router)
+	return service, router
+}
+
+func serveClerk(router *corehttp.Router, req *http.Request) *httptest.ResponseRecorder {
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	return res
+}
+
+func clerkJSON(router *corehttp.Router, method string, path string, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk_test_emulate")
+	req.Header.Set("Content-Type", "application/json")
+	return serveClerk(router, req)
+}
+
+func tokenReqWithForm(form url.Values) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req
+}
+
+func userIDByEmail(t *testing.T, service *Service, emailAddress string) string {
+	t.Helper()
+	email := firstRecord(service.store.EmailAddresses.FindBy("email_address", emailAddress))
+	if email == nil {
+		t.Fatalf("missing email %s", emailAddress)
+	}
+	return stringField(email, "user_id")
+}
+
+func decodeJWTClaims(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("invalid jwt: %s", token)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		t.Fatal(err)
+	}
+	return claims
+}

--- a/internal/services/clerk/store.go
+++ b/internal/services/clerk/store.go
@@ -1,0 +1,29 @@
+package clerk
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Users          *corestore.Collection
+	EmailAddresses *corestore.Collection
+	Organizations  *corestore.Collection
+	Memberships    *corestore.Collection
+	Invitations    *corestore.Collection
+	Sessions       *corestore.Collection
+	OAuthApps      *corestore.Collection
+	OAuthCodes     *corestore.Collection
+	AccessTokens   *corestore.Collection
+}
+
+func NewStore(store *corestore.Store) Store {
+	return Store{
+		Users:          store.MustCollection("clerk.users", "clerk_id", "username"),
+		EmailAddresses: store.MustCollection("clerk.emails", "email_id", "user_id", "email_address"),
+		Organizations:  store.MustCollection("clerk.orgs", "clerk_id", "slug"),
+		Memberships:    store.MustCollection("clerk.memberships", "membership_id", "org_id", "user_id"),
+		Invitations:    store.MustCollection("clerk.invitations", "invitation_id", "org_id"),
+		Sessions:       store.MustCollection("clerk.sessions", "clerk_id", "user_id"),
+		OAuthApps:      store.MustCollection("clerk.oauth_apps", "app_id", "client_id"),
+		OAuthCodes:     store.MustCollection("clerk.oauth_codes", "code", "client_id", "user_id"),
+		AccessTokens:   store.MustCollection("clerk.access_tokens", "token", "user_id", "session_id"),
+	}
+}

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,7 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
-      'Services: []string{"apple", "aws", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}',
+      'Services: []string{"apple", "aws", "clerk", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}',
     );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
@@ -35,7 +35,7 @@ describe("createVercelScaffold", () => {
   });
 
   it("includes google in the shared Vercel CLI service default", () => {
-    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe("apple,aws,github,google,microsoft,okta,resend,slack,stripe,vercel");
+    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe("apple,aws,clerk,github,google,microsoft,okta,resend,slack,stripe,vercel");
   });
 
   it("merges the rewrite into an existing vercel.json", () => {
@@ -228,8 +228,8 @@ require (
   it("rejects services not available in the native Vercel scaffold", () => {
     const cwd = tempDir();
 
-    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "clerk" })).toThrow(
-      "currently supports native services: apple, aws, github, google, microsoft, okta, resend, slack, stripe, vercel",
+    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "mongoatlas" })).toThrow(
+      "currently supports native services: apple, aws, clerk, github, google, microsoft, okta, resend, slack, stripe, vercel",
     );
   });
 

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -35,7 +35,9 @@ describe("createVercelScaffold", () => {
   });
 
   it("includes google in the shared Vercel CLI service default", () => {
-    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe("apple,aws,clerk,github,google,microsoft,okta,resend,slack,stripe,vercel");
+    expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe(
+      "apple,aws,clerk,github,google,microsoft,okta,resend,slack,stripe,vercel",
+    );
   });
 
   it("merges the rewrite into an existing vercel.json", () => {

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 export const SUPPORTED_VERCEL_SERVICES = [
   "apple",
   "aws",
+  "clerk",
   "github",
   "google",
   "microsoft",

--- a/skills/apple/SKILL.md
+++ b/skills/apple/SKILL.md
@@ -117,7 +117,7 @@ PKCE is supported. Pass `code_challenge` and `code_challenge_method` on authoriz
 curl http://localhost:4004/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 Returns the standard OIDC discovery document with all endpoints pointing to the emulator:
 

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: clerk
+description: Emulated Clerk authentication, OIDC, users, organizations, invitations, sessions, and session JWTs for local development, testing, and native Vercel preview functions. Use when the user needs to test Clerk OAuth/OIDC locally, manage Clerk users or organizations without network calls, scaffold Clerk through npx emulate vercel init, or point Clerk SDK-style requests at a local API. Triggers include "Clerk", "emulate Clerk", "Clerk OIDC", "Clerk user", "Clerk organization", "session token", "sk_test", or any task requiring local Clerk service emulation.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# Clerk Emulator
+
+The native Go runtime implements Clerk OIDC discovery, JWKS, authorization code flow, token exchange, userinfo, users, email addresses, organizations, memberships, invitations, sessions, and session JWTs.
+
+## Start
+
+```bash
+npx emulate --service clerk
+```
+
+Default URL: `http://localhost:4000` when started alone. In the all-services default layout, Clerk is on `http://localhost:4011`.
+
+## Vercel Go Function Preview
+
+```bash
+npx emulate vercel init --service clerk
+```
+
+Deploy the generated app to expose Clerk at `/emulate/clerk/*`.
+
+## OIDC
+
+- Discovery: `GET /.well-known/openid-configuration`
+- JWKS: `GET /v1/jwks`
+- Authorize: `GET /oauth/authorize`
+- Token: `POST /oauth/token`
+- Userinfo: `GET /oauth/userinfo`
+
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/clerk/.well-known/openid-configuration` to avoid the shared root discovery path.
+
+## Management API
+
+Management routes accept Clerk-style secret keys:
+
+```bash
+curl http://localhost:4011/v1/users \
+  -H "Authorization: Bearer sk_test_emulate"
+```
+
+Core routes:
+
+- `GET /v1/users`, `POST /v1/users`, `GET /v1/users/:userId`, `PATCH /v1/users/:userId`, `DELETE /v1/users/:userId`
+- `GET /v1/email_addresses/:emailId`, `POST /v1/email_addresses`, `PATCH /v1/email_addresses/:emailId`, `DELETE /v1/email_addresses/:emailId`
+- `GET /v1/organizations`, `POST /v1/organizations`, `GET /v1/organizations/:orgId`, `PATCH /v1/organizations/:orgId`, `DELETE /v1/organizations/:orgId`
+- `GET /v1/organizations/:orgId/memberships`, `POST /v1/organizations/:orgId/memberships`, `PATCH /v1/organizations/:orgId/memberships/:userId`, `DELETE /v1/organizations/:orgId/memberships/:userId`
+- `GET /v1/organizations/:orgId/invitations`, `POST /v1/organizations/:orgId/invitations`, `POST /v1/organizations/:orgId/invitations/bulk`, `POST /v1/organizations/:orgId/invitations/:invitationId/revoke`
+- `GET /v1/sessions`, `POST /v1/sessions`, `POST /v1/sessions/:sessionId/revoke`, `POST /v1/sessions/:sessionId/tokens`
+
+## Seed Config
+
+```yaml
+clerk:
+  users:
+    - email_addresses: ["test@example.com"]
+      first_name: Test
+      last_name: User
+      password: clerk_test_password
+  organizations:
+    - name: My Company
+      slug: my-company
+      members:
+        - email: test@example.com
+          role: admin
+  oauth_applications:
+    - client_id: clerk_emulate_client
+      client_secret: clerk_emulate_secret
+      name: Emulate App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/clerk
+```

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: emulate
-description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, and Stripe. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, scaffold Vercel Go Function previews, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", "npx emulate vercel init", or any task requiring local service emulation.
+description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, Clerk, AWS, MongoDB Atlas, Resend, and Stripe. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, scaffold Vercel Go Function previews, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", "npx emulate vercel init", or any task requiring local service emulation.
 allowed-tools: Bash(npx emulate:*)
 ---
 
@@ -28,6 +28,8 @@ All services start with sensible defaults:
 | AWS       | 4007        |
 | Resend    | 4008        |
 | Stripe    | 4009        |
+| MongoDB Atlas | 4010   |
+| Clerk    | 4011        |
 
 ## CLI
 
@@ -96,7 +98,7 @@ await vercel.close()
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, or `'stripe'` |
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, or `'clerk'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -323,7 +325,7 @@ Then use these in your app to construct API and OAuth URLs. See each service's s
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -195,7 +195,7 @@ To override the derived value, set `hd` on a seeded user. To suppress the claim 
 curl http://localhost:4002/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 ### JWKS
 

--- a/skills/microsoft/SKILL.md
+++ b/skills/microsoft/SKILL.md
@@ -140,7 +140,7 @@ curl http://localhost:4005/.well-known/openid-configuration
 curl http://localhost:4005/common/v2.0/.well-known/openid-configuration
 ```
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
 
 Returns the standard OIDC discovery document:
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/skills/okta/SKILL.md
+++ b/skills/okta/SKILL.md
@@ -102,4 +102,4 @@ okta:
 
 ## Multi-Service OIDC Discovery
 
-When more than one of Apple, Google, Microsoft, and Okta is enabled on one native Go server, use `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.
+When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/okta/.well-known/openid-configuration` to avoid the shared root discovery path.

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"apple", "aws", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
+var defaultServices = []string{"apple", "aws", "clerk", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -35,7 +35,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "apple,aws,github,google,microsoft,okta,resend,slack,stripe,vercel" {
+	if strings.Join(body.Services, ",") != "apple,aws,clerk,github,google,microsoft,okta,resend,slack,stripe,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -191,6 +191,23 @@ func TestHandlerForwardsOktaService(t *testing.T) {
 	}
 }
 
+func TestHandlerForwardsClerkService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"clerk"}})
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/clerk/.well-known/openid-configuration", nil)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"issuer":"https://preview.example.com/emulate/clerk"`) ||
+		!strings.Contains(res.Body.String(), `"jwks_uri":"https://preview.example.com/emulate/clerk/v1/jwks"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestHandlerForwardsSlackService(t *testing.T) {
 	handler := NewHandler(Options{Services: []string{"slack"}})
 	req := httptest.NewRequest(http.MethodPost, "https://preview.example.com/emulate/slack/api/auth.test", nil)
@@ -286,7 +303,7 @@ func TestHandlerRewritesHTMLRootPathsThroughPublicServicePrefix(t *testing.T) {
 
 func TestHandlerReturnsUnknownService(t *testing.T) {
 	handler := NewHandler(Options{})
-	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/clerk/user", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/mongoatlas/user", nil)
 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
@@ -294,7 +311,7 @@ func TestHandlerReturnsUnknownService(t *testing.T) {
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "Unknown service: clerk") {
+	if !strings.Contains(res.Body.String(), "Unknown service: mongoatlas") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }


### PR DESCRIPTION
- Adds a dependency-free native Clerk service with OIDC, JWKS, OAuth token/userinfo, management resources, session JWTs, and seedable state.
- Wires Clerk into the native runtime, CLI seed parsing, Vercel Go Function defaults, and scaffold service lists.
- Updates docs, skills, and focused Go/TypeScript coverage for native Clerk support.