### PR TITLE
Add Go MongoDB Atlas foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,17 @@ The native Go runtime implements the current high-value Stripe API and checkout 
 - `POST /v1/checkout/sessions`, `GET /v1/checkout/sessions`, `GET /v1/checkout/sessions/:id`, `POST /v1/checkout/sessions/:id/expire`
 - `GET /checkout/:id`, `POST /checkout/:id/complete`
 
+## MongoDB Atlas
+
+MongoDB Atlas emulation with Atlas Admin API v2 and Atlas Data API v1. The native Go runtime stores projects, clusters, database users, databases, collections, and documents in memory for local CLI runs and Vercel Go Function previews. To expose MongoDB Atlas on a Vercel preview without separate infrastructure, run `npx emulate vercel init --service mongoatlas`. The generated route serves MongoDB Atlas at `/emulate/mongoatlas/*`.
+
+- `GET /api/atlas/v2/groups`, `GET /api/atlas/v2/groups/:groupId`, `POST /api/atlas/v2/groups`, `DELETE /api/atlas/v2/groups/:groupId`
+- `GET /api/atlas/v2/groups/:groupId/clusters`, `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName`, `POST /api/atlas/v2/groups/:groupId/clusters`, `PATCH /api/atlas/v2/groups/:groupId/clusters/:clusterName`, `DELETE /api/atlas/v2/groups/:groupId/clusters/:clusterName`
+- `GET /api/atlas/v2/groups/:groupId/databaseUsers`, `GET /api/atlas/v2/groups/:groupId/databaseUsers/admin/:username`, `POST /api/atlas/v2/groups/:groupId/databaseUsers`, `DELETE /api/atlas/v2/groups/:groupId/databaseUsers/admin/:username`
+- `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName/databases`, `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName/databases/:databaseName/collections`
+- `POST /app/data-api/v1/action/findOne`, `POST /app/data-api/v1/action/find`, `POST /app/data-api/v1/action/insertOne`, `POST /app/data-api/v1/action/insertMany`
+- `POST /app/data-api/v1/action/updateOne`, `POST /app/data-api/v1/action/updateMany`, `POST /app/data-api/v1/action/deleteOne`, `POST /app/data-api/v1/action/deleteMany`, `POST /app/data-api/v1/action/aggregate`
+
 ## Next.js Integration
 
 Use `@emulators/adapter-next` to run emulator routes on the same origin as your Next.js app. Embedded mode runs JavaScript emulators directly in the app. Proxy mode forwards to a separately running native runtime.
@@ -816,7 +827,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `mongoatlas`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -857,7 +868,7 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 })
 ```
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `mongoatlas`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ### Native runtime proxy
 

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -348,6 +348,14 @@ mongoatlas:
   database_users:
     - project: my-project
       username: app-user
+      roles:
+        - database_name: mydb
+          role_name: readWrite
+  databases:
+    - cluster: my-cluster
+      name: mydb
+      collections:
+        - items
 ```
 
 ## Resend Seed Config

--- a/apps/web/app/docs/mongoatlas/page.mdx
+++ b/apps/web/app/docs/mongoatlas/page.mdx
@@ -1,6 +1,14 @@
 # MongoDB Atlas
 
-MongoDB Atlas emulation with Atlas Admin API v2 and Atlas Data API v1. In-memory document storage with CRUD, filtering, and aggregation.
+MongoDB Atlas emulation with Atlas Admin API v2 and Atlas Data API v1. The native Go runtime stores projects, clusters, database users, databases, collections, and documents in memory for local CLI runs and Vercel Go Function previews.
+
+To expose MongoDB Atlas on a Vercel preview without separate infrastructure, scaffold the Go Function route:
+
+```bash
+npx emulate vercel init --service mongoatlas
+```
+
+The generated route serves MongoDB Atlas at `/emulate/mongoatlas/*`.
 
 ## Admin API
 
@@ -39,7 +47,7 @@ All operations via `POST` with JSON body specifying `dataSource`, `database`, an
 - `POST /app/data-api/v1/action/find` — find many (filter, projection, sort, limit, skip)
 - `POST /app/data-api/v1/action/insertOne` — insert one document
 - `POST /app/data-api/v1/action/insertMany` — insert many documents
-- `POST /app/data-api/v1/action/updateOne` — update one document (`$set`, upsert)
+- `POST /app/data-api/v1/action/updateOne` — update one document (`$set`, `$unset`, `$inc`, `$push`, `$pull`, `$rename`, replacement updates, upsert)
 - `POST /app/data-api/v1/action/updateMany` — update many documents
 - `POST /app/data-api/v1/action/deleteOne` — delete one document
 - `POST /app/data-api/v1/action/deleteMany` — delete many documents

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -16,7 +16,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `mongoatlas`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -62,7 +62,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `mongoatlas`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/apps/web/components/hero-terminal.tsx
+++ b/apps/web/components/hero-terminal.tsx
@@ -9,11 +9,12 @@ const services = [
   { name: "Slack", port: 4003, slug: "slack" },
   { name: "Apple", port: 4004, slug: "apple" },
   { name: "Microsoft", port: 4005, slug: "microsoft" },
-  { name: "AWS", port: 4006, slug: "aws" },
-  { name: "Okta", port: 4007, slug: "okta" },
-  { name: "MongoDB Atlas", port: 4008, slug: "mongoatlas" },
-  { name: "Resend", port: 4009, slug: "resend" },
-  { name: "Stripe", port: 4010, slug: "stripe" },
+  { name: "Okta", port: 4006, slug: "okta" },
+  { name: "AWS", port: 4007, slug: "aws" },
+  { name: "Resend", port: 4008, slug: "resend" },
+  { name: "Stripe", port: 4009, slug: "stripe" },
+  { name: "MongoDB Atlas", port: 4010, slug: "mongoatlas" },
+  { name: "Clerk", port: 4011, slug: "clerk" },
 ];
 
 export function HeroTerminal({ pixelFont }: { pixelFont: string }) {

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
+	"github.com/vercel-labs/emulate/internal/services/mongoatlas"
 	"github.com/vercel-labs/emulate/internal/services/okta"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/slack"
@@ -117,6 +118,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 	var githubSeed *github.SeedConfig
 	var googleSeed *google.SeedConfig
 	var microsoftSeed *microsoft.SeedConfig
+	var mongoAtlasSeed *mongoatlas.SeedConfig
 	var oktaSeed *okta.SeedConfig
 	var resendSeed *resend.SeedConfig
 	var slackSeed *slack.SeedConfig
@@ -129,7 +131,7 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, clerk, github, google, microsoft, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, clerk, github, google, microsoft, mongoatlas, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
@@ -189,6 +191,14 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			}
 			microsoftSeed = &cfg
 		}
+		if raw, ok := loaded.Data["mongoatlas"]; ok {
+			var cfg mongoatlas.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse mongoatlas seed config: %v\n", err)
+				return 1
+			}
+			mongoAtlasSeed = &cfg
+		}
 		if raw, ok := loaded.Data["okta"]; ok {
 			var cfg okta.SeedConfig
 			if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -244,19 +254,20 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		baseURL = fmt.Sprintf("http://localhost:%d", port)
 	}
 	server := emuruntime.NewServer(emuruntime.ServerOptions{
-		Version:       version,
-		BaseURL:       baseURL,
-		Services:      services,
-		AppleSeed:     appleSeed,
-		ClerkSeed:     clerkSeed,
-		GitHubSeed:    githubSeed,
-		GoogleSeed:    googleSeed,
-		MicrosoftSeed: microsoftSeed,
-		OktaSeed:      oktaSeed,
-		ResendSeed:    resendSeed,
-		SlackSeed:     slackSeed,
-		StripeSeed:    stripeSeed,
-		VercelSeed:    vercelSeed,
+		Version:        version,
+		BaseURL:        baseURL,
+		Services:       services,
+		AppleSeed:      appleSeed,
+		ClerkSeed:      clerkSeed,
+		GitHubSeed:     githubSeed,
+		GoogleSeed:     googleSeed,
+		MicrosoftSeed:  microsoftSeed,
+		MongoAtlasSeed: mongoAtlasSeed,
+		OktaSeed:       oktaSeed,
+		ResendSeed:     resendSeed,
+		SlackSeed:      slackSeed,
+		StripeSeed:     stripeSeed,
+		VercelSeed:     vercelSeed,
 	})
 	httpServer := &nethttp.Server{
 		Handler:           server.Handler,
@@ -443,7 +454,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"apple", "clerk", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
+	return []string{"apple", "clerk", "github", "google", "microsoft", "mongoatlas", "okta", "resend", "slack", "stripe", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -433,6 +433,69 @@ func TestRunStartSeedsClerkFromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRunStartSeedsMongoAtlasFromJSONConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"mongoatlas":{"projects":[{"name":"CustomProject"}],"clusters":[{"name":"CustomCluster","project":"CustomProject"}],"database_users":[{"username":"appuser","project":"CustomProject","roles":[{"database_name":"mydb","role_name":"readWrite"}]}],"databases":[{"cluster":"CustomCluster","name":"mydb","collections":["items"]}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "mongoatlas" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	var projects struct {
+		Results []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"results"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d/api/atlas/v2/groups", port), &projects)
+	if len(projects.Results) != 2 || projects.Results[1].Name != "CustomProject" {
+		t.Fatalf("unexpected projects: %#v", projects)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/app/data-api/v1/action/insertOne", port), strings.NewReader(`{"dataSource":"CustomCluster","database":"mydb","collection":"items","document":{"name":"Widget"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("insert status = %d, body = %s", resp.StatusCode, string(raw))
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartSeedsAppleFromJSONConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.json")
@@ -613,7 +676,7 @@ func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
 				t.Fatal("start with unsupported seed service exited successfully")
 			}
 			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for apple, clerk, github, google, microsoft, okta, resend, slack, stripe, and vercel") || !strings.Contains(errText, "aws") {
+			if !strings.Contains(errText, "only supports --seed for apple, clerk, github, google, microsoft, mongoatlas, okta, resend, slack, stripe, and vercel") || !strings.Contains(errText, "aws") {
 				t.Fatalf("unexpected stderr: %s", errText)
 			}
 		})

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/google"
 	"github.com/vercel-labs/emulate/internal/services/microsoft"
+	"github.com/vercel-labs/emulate/internal/services/mongoatlas"
 	"github.com/vercel-labs/emulate/internal/services/okta"
 	"github.com/vercel-labs/emulate/internal/services/resend"
 	"github.com/vercel-labs/emulate/internal/services/slack"
@@ -24,21 +25,22 @@ import (
 const HealthPath = "/_emulate/health"
 
 type ServerOptions struct {
-	Version       string
-	BaseURL       string
-	Services      []string
-	Store         *store.Store
-	AssetStore    *coreassets.Store
-	AppleSeed     *apple.SeedConfig
-	ClerkSeed     *clerk.SeedConfig
-	GitHubSeed    *github.SeedConfig
-	GoogleSeed    *google.SeedConfig
-	MicrosoftSeed *microsoft.SeedConfig
-	OktaSeed      *okta.SeedConfig
-	ResendSeed    *resend.SeedConfig
-	SlackSeed     *slack.SeedConfig
-	StripeSeed    *stripe.SeedConfig
-	VercelSeed    *vercel.SeedConfig
+	Version        string
+	BaseURL        string
+	Services       []string
+	Store          *store.Store
+	AssetStore     *coreassets.Store
+	AppleSeed      *apple.SeedConfig
+	ClerkSeed      *clerk.SeedConfig
+	GitHubSeed     *github.SeedConfig
+	GoogleSeed     *google.SeedConfig
+	MicrosoftSeed  *microsoft.SeedConfig
+	MongoAtlasSeed *mongoatlas.SeedConfig
+	OktaSeed       *okta.SeedConfig
+	ResendSeed     *resend.SeedConfig
+	SlackSeed      *slack.SeedConfig
+	StripeSeed     *stripe.SeedConfig
+	VercelSeed     *vercel.SeedConfig
 }
 
 type Server struct {
@@ -139,6 +141,12 @@ func NewServer(options ServerOptions) *Server {
 			Store:   runtimeStore,
 			BaseURL: options.BaseURL,
 			Seed:    options.VercelSeed,
+		})
+	}
+	if serviceEnabled(services, "mongoatlas") {
+		mongoatlas.Register(router, mongoatlas.Options{
+			Store: runtimeStore,
+			Seed:  options.MongoAtlasSeed,
 		})
 	}
 	if serviceEnabled(services, "github") {

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -199,6 +199,33 @@ func TestNewHandlerDoesNotMountResendWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestNewHandlerMountsMongoAtlasWhenEnabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"mongoatlas"}})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/app/data-api/v1/action/insertOne", strings.NewReader(`{"dataSource":"Cluster0","database":"test","collection":"items","document":{"name":"Widget"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"insertedId"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
+func TestNewHandlerDoesNotMountMongoAtlasWhenDisabled(t *testing.T) {
+	handler := NewHandler(ServerOptions{Services: []string{"resend"}})
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/api/atlas/v2/groups", nil))
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func TestNewHandlerMountsSlackWhenEnabled(t *testing.T) {
 	handler := NewHandler(ServerOptions{Services: []string{"slack"}})
 

--- a/internal/services/mongoatlas/helpers.go
+++ b/internal/services/mongoatlas/helpers.go
@@ -34,18 +34,97 @@ func generateHexID() string {
 }
 
 func readJSONBody(r *http.Request) map[string]any {
+	return readJSONBodyWithOrder(r).Values
+}
+
+type orderedJSONBody struct {
+	Values map[string]any
+	Orders map[string][]string
+}
+
+func (body orderedJSONBody) Order(path string) []string {
+	return append([]string(nil), body.Orders[path]...)
+}
+
+func readJSONBodyWithOrder(r *http.Request) orderedJSONBody {
 	defer r.Body.Close()
 	raw, _ := io.ReadAll(r.Body)
 	if len(strings.TrimSpace(string(raw))) == 0 {
-		return map[string]any{}
+		return orderedJSONBody{Values: map[string]any{}, Orders: map[string][]string{}}
 	}
 	decoder := json.NewDecoder(strings.NewReader(string(raw)))
 	decoder.UseNumber()
-	var body map[string]any
-	if err := decoder.Decode(&body); err != nil || body == nil {
-		return map[string]any{}
+	orders := map[string][]string{}
+	value, err := readOrderedJSONValue(decoder, "", orders)
+	if err != nil {
+		return orderedJSONBody{Values: map[string]any{}, Orders: map[string][]string{}}
 	}
-	return body
+	body, ok := value.(map[string]any)
+	if !ok || body == nil {
+		return orderedJSONBody{Values: map[string]any{}, Orders: map[string][]string{}}
+	}
+	return orderedJSONBody{Values: body, Orders: orders}
+}
+
+func readOrderedJSONValue(decoder *json.Decoder, path string, orders map[string][]string) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return token, nil
+	}
+
+	switch delimiter {
+	case '{':
+		object := map[string]any{}
+		keys := make([]string, 0)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid JSON object key")
+			}
+			value, err := readOrderedJSONValue(decoder, joinJSONPath(path, key), orders)
+			if err != nil {
+				return nil, err
+			}
+			object[key] = value
+			keys = append(keys, key)
+		}
+		if _, err := decoder.Token(); err != nil {
+			return nil, err
+		}
+		orders[path] = keys
+		return object, nil
+	case '[':
+		items := make([]any, 0)
+		for i := 0; decoder.More(); i++ {
+			value, err := readOrderedJSONValue(decoder, joinJSONPath(path, strconv.Itoa(i)), orders)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, value)
+		}
+		if _, err := decoder.Token(); err != nil {
+			return nil, err
+		}
+		return items, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+}
+
+func joinJSONPath(parent string, child string) string {
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
 }
 
 func mongoOK(c *corehttp.Context, status int, value map[string]any) {
@@ -260,7 +339,7 @@ func matchesFilter(data map[string]any, filter map[string]any) bool {
 		}
 
 		docValue, exists := nestedValue(data, key)
-		if operators, ok := value.(map[string]any); ok && value != nil {
+		if operators, ok := value.(map[string]any); ok && value != nil && hasOperatorKey(operators) {
 			for op, opValue := range operators {
 				switch op {
 				case "$eq":
@@ -276,11 +355,11 @@ func matchesFilter(data map[string]any, filter map[string]any) bool {
 						return false
 					}
 				case "$in":
-					if !arrayContains(opValue, docValue) {
+					if !matchesAnyValue(opValue, docValue) {
 						return false
 					}
 				case "$nin":
-					if arrayContains(opValue, docValue) {
+					if matchesAnyValue(opValue, docValue) {
 						return false
 					}
 				case "$exists":
@@ -302,7 +381,11 @@ func matchesFilter(data map[string]any, filter map[string]any) bool {
 						return false
 					}
 				case "$options":
+					if operators["$regex"] == nil {
+						return false
+					}
 				default:
+					return false
 				}
 			}
 			continue
@@ -503,10 +586,12 @@ func applyUpdate(data map[string]any, update map[string]any) map[string]any {
 	return out
 }
 
-func sortRecords(records []corestore.Record, spec map[string]any) []corestore.Record {
+func sortRecords(records []corestore.Record, spec map[string]any, order []string) []corestore.Record {
 	out := append([]corestore.Record(nil), records...)
+	keys := orderedSpecKeys(spec, order)
 	sort.SliceStable(out, func(i int, j int) bool {
-		for key, directionValue := range spec {
+		for _, key := range keys {
+			directionValue := spec[key]
 			direction := intValue(directionValue)
 			if direction == 0 {
 				direction = 1
@@ -529,10 +614,12 @@ func sortRecords(records []corestore.Record, spec map[string]any) []corestore.Re
 	return out
 }
 
-func sortMaps(records []map[string]any, spec map[string]any) []map[string]any {
+func sortMaps(records []map[string]any, spec map[string]any, order []string) []map[string]any {
 	out := append([]map[string]any(nil), records...)
+	keys := orderedSpecKeys(spec, order)
 	sort.SliceStable(out, func(i int, j int) bool {
-		for key, directionValue := range spec {
+		for _, key := range keys {
+			directionValue := spec[key]
 			direction := intValue(directionValue)
 			if direction == 0 {
 				direction = 1
@@ -553,6 +640,25 @@ func sortMaps(records []map[string]any, spec map[string]any) []map[string]any {
 		return false
 	})
 	return out
+}
+
+func orderedSpecKeys(spec map[string]any, order []string) []string {
+	keys := make([]string, 0, len(spec))
+	seen := map[string]bool{}
+	for _, key := range order {
+		if _, ok := spec[key]; ok {
+			keys = append(keys, key)
+			seen[key] = true
+		}
+	}
+	remaining := make([]string, 0)
+	for key := range spec {
+		if !seen[key] {
+			remaining = append(remaining, key)
+		}
+	}
+	sort.Strings(remaining)
+	return append(keys, remaining...)
 }
 
 func compareNumber(left any, right any, op string) bool {
@@ -611,17 +717,47 @@ func valuesEqual(left any, right any) bool {
 	return string(leftJSON) == string(rightJSON)
 }
 
-func arrayContains(value any, target any) bool {
-	items, ok := value.([]any)
+func matchesAnyValue(options any, docValue any) bool {
+	items, ok := arrayItems(options)
 	if !ok {
 		return false
 	}
 	for _, item := range items {
-		if valuesEqual(item, target) {
+		if valuesEqual(item, docValue) {
 			return true
+		}
+		docItems, ok := arrayItems(docValue)
+		if !ok {
+			continue
+		}
+		for _, docItem := range docItems {
+			if valuesEqual(item, docItem) {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+func arrayItems(value any) ([]any, bool) {
+	switch v := value.(type) {
+	case []any:
+		return append([]any(nil), v...), true
+	case []string:
+		items := make([]any, 0, len(v))
+		for _, item := range v {
+			items = append(items, item)
+		}
+		return items, true
+	case []int:
+		items := make([]any, 0, len(v))
+		for _, item := range v {
+			items = append(items, item)
+		}
+		return items, true
+	default:
+		return nil, false
+	}
 }
 
 func boolValue(value any) bool {
@@ -655,6 +791,15 @@ var dangerousKeys = map[string]bool{"__proto__": true, "constructor": true, "pro
 func hasDangerousKey(parts []string) bool {
 	for _, part := range parts {
 		if dangerousKeys[part] {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOperatorKey(values map[string]any) bool {
+	for key := range values {
+		if strings.HasPrefix(key, "$") {
 			return true
 		}
 	}

--- a/internal/services/mongoatlas/helpers.go
+++ b/internal/services/mongoatlas/helpers.go
@@ -1,0 +1,711 @@
+package mongoatlas
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func generateObjectID() string {
+	raw := make([]byte, 8)
+	if _, err := rand.Read(raw); err != nil {
+		return fmt.Sprintf("%08x%s", time.Now().Unix(), strconv.FormatInt(time.Now().UnixNano(), 16))[:24]
+	}
+	return fmt.Sprintf("%08x%s", time.Now().Unix(), hex.EncodeToString(raw))[:24]
+}
+
+func generateHexID() string {
+	raw := make([]byte, 12)
+	if _, err := rand.Read(raw); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	return hex.EncodeToString(raw)
+}
+
+func readJSONBody(r *http.Request) map[string]any {
+	defer r.Body.Close()
+	raw, _ := io.ReadAll(r.Body)
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return map[string]any{}
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var body map[string]any
+	if err := decoder.Decode(&body); err != nil || body == nil {
+		return map[string]any{}
+	}
+	return body
+}
+
+func mongoOK(c *corehttp.Context, status int, value map[string]any) {
+	c.JSON(status, value)
+}
+
+func mongoError(c *corehttp.Context, status int, code string, detail string) {
+	c.JSON(status, map[string]any{"error": status, "errorCode": code, "detail": detail})
+}
+
+func firstRecord(records []corestore.Record) corestore.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+func stringField(record corestore.Record, field string) string {
+	if record == nil {
+		return ""
+	}
+	return stringValue(record[field])
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func intField(record corestore.Record, field string) int {
+	if record == nil {
+		return 0
+	}
+	return intValue(record[field])
+}
+
+func intValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return int(n)
+	case string:
+		n, _ := strconv.Atoi(v)
+		return n
+	default:
+		return 0
+	}
+}
+
+func floatValue(value any) (float64, bool) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case float64:
+		return v, true
+	case json.Number:
+		n, err := v.Float64()
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func mapValue(value any) map[string]any {
+	if m, ok := objectValue(value); ok {
+		return m
+	}
+	return map[string]any{}
+}
+
+func objectValue(value any) (map[string]any, bool) {
+	if value == nil {
+		return nil, false
+	}
+	if m, ok := value.(map[string]any); ok {
+		return cloneMap(m), true
+	}
+	return nil, false
+}
+
+func mapSliceValue(value any) []map[string]any {
+	if maps, ok := value.([]map[string]any); ok {
+		out := make([]map[string]any, 0, len(maps))
+		for _, item := range maps {
+			out = append(out, cloneMap(item))
+		}
+		return out
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			out = append(out, cloneMap(m))
+		}
+	}
+	return out
+}
+
+func stringSliceValue(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if text, ok := item.(string); ok {
+				out = append(out, text)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneValue(value)
+	}
+	return out
+}
+
+func cloneValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return cloneMap(v)
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = cloneValue(item)
+		}
+		return out
+	case []string:
+		return append([]string(nil), v...)
+	case []map[string]any:
+		out := make([]map[string]any, len(v))
+		for i, item := range v {
+			out[i] = cloneMap(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func recordData(record corestore.Record) map[string]any {
+	return mapValue(record["data"])
+}
+
+func recordsForCollection(store Store, clusterID string, database string, collection string) []corestore.Record {
+	records := store.Documents.FindBy("cluster_id", clusterID)
+	filtered := make([]corestore.Record, 0, len(records))
+	for _, record := range records {
+		if stringField(record, "database") == database && stringField(record, "collection") == collection {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered
+}
+
+func matchesFilter(data map[string]any, filter map[string]any) bool {
+	for key, value := range filter {
+		switch key {
+		case "$and":
+			conditions := mapSliceValue(value)
+			for _, condition := range conditions {
+				if !matchesFilter(data, condition) {
+					return false
+				}
+			}
+			continue
+		case "$or":
+			conditions := mapSliceValue(value)
+			matched := false
+			for _, condition := range conditions {
+				if matchesFilter(data, condition) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+			continue
+		case "$nor":
+			for _, condition := range mapSliceValue(value) {
+				if matchesFilter(data, condition) {
+					return false
+				}
+			}
+			continue
+		}
+
+		docValue, exists := nestedValue(data, key)
+		if operators, ok := value.(map[string]any); ok && value != nil {
+			for op, opValue := range operators {
+				switch op {
+				case "$eq":
+					if !valuesEqual(docValue, opValue) {
+						return false
+					}
+				case "$ne":
+					if valuesEqual(docValue, opValue) {
+						return false
+					}
+				case "$gt", "$gte", "$lt", "$lte":
+					if !compareNumber(docValue, opValue, op) {
+						return false
+					}
+				case "$in":
+					if !arrayContains(opValue, docValue) {
+						return false
+					}
+				case "$nin":
+					if arrayContains(opValue, docValue) {
+						return false
+					}
+				case "$exists":
+					want := boolValue(opValue)
+					if want != exists {
+						return false
+					}
+				case "$regex":
+					pattern := stringValue(opValue)
+					if len(pattern) > 1000 {
+						return false
+					}
+					flags := stringValue(operators["$options"])
+					if strings.Contains(flags, "i") {
+						pattern = "(?i)" + pattern
+					}
+					re, err := regexp.Compile(pattern)
+					if err != nil || !re.MatchString(stringValue(docValue)) {
+						return false
+					}
+				case "$options":
+				default:
+				}
+			}
+			continue
+		}
+		if !valuesEqual(docValue, value) {
+			return false
+		}
+	}
+	return true
+}
+
+func filterRecords(records []corestore.Record, filter map[string]any) []corestore.Record {
+	if len(filter) == 0 {
+		return records
+	}
+	out := make([]corestore.Record, 0, len(records))
+	for _, record := range records {
+		if matchesFilter(recordData(record), filter) {
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+func nestedValue(data map[string]any, path string) (any, bool) {
+	parts := strings.Split(path, ".")
+	if hasDangerousKey(parts) {
+		return nil, false
+	}
+	var current any = data
+	for _, part := range parts {
+		m, ok := current.(map[string]any)
+		if !ok || m == nil {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func setNestedValue(data map[string]any, path string, value any) {
+	parts := strings.Split(path, ".")
+	if hasDangerousKey(parts) || len(parts) == 0 {
+		return
+	}
+	current := data
+	for i := 0; i < len(parts)-1; i++ {
+		next, ok := current[parts[i]].(map[string]any)
+		if !ok || next == nil {
+			next = map[string]any{}
+			current[parts[i]] = next
+		}
+		current = next
+	}
+	current[parts[len(parts)-1]] = cloneValue(value)
+}
+
+func unsetNestedValue(data map[string]any, path string) {
+	parts := strings.Split(path, ".")
+	if hasDangerousKey(parts) || len(parts) == 0 {
+		return
+	}
+	if len(parts) == 1 {
+		delete(data, path)
+		return
+	}
+	current := data
+	for i := 0; i < len(parts)-1; i++ {
+		next, ok := current[parts[i]].(map[string]any)
+		if !ok || next == nil {
+			return
+		}
+		current = next
+	}
+	delete(current, parts[len(parts)-1])
+}
+
+func applyProjection(data map[string]any, projection map[string]any) map[string]any {
+	if len(projection) == 0 {
+		return cloneMap(data)
+	}
+	hasInclusions := false
+	for _, value := range projection {
+		if projectionEnabled(value) {
+			hasInclusions = true
+			break
+		}
+	}
+	if hasInclusions {
+		out := map[string]any{}
+		if !projectionDisabled(projection["_id"]) {
+			if value, ok := data["_id"]; ok {
+				out["_id"] = cloneValue(value)
+			}
+		}
+		for key, value := range projection {
+			if key == "_id" {
+				continue
+			}
+			if projectionEnabled(value) {
+				if item, ok := nestedValue(data, key); ok {
+					setNestedValue(out, key, item)
+				}
+			}
+		}
+		return out
+	}
+	out := cloneMap(data)
+	for key, value := range projection {
+		if projectionDisabled(value) {
+			unsetNestedValue(out, key)
+		}
+	}
+	return out
+}
+
+func applyUpdate(data map[string]any, update map[string]any) map[string]any {
+	out := cloneMap(data)
+	hasOperators := false
+	for key := range update {
+		if strings.HasPrefix(key, "$") {
+			hasOperators = true
+			break
+		}
+	}
+	if !hasOperators {
+		id := out["_id"]
+		out = cloneMap(update)
+		out["_id"] = id
+		return out
+	}
+
+	if fields := mapValue(update["$set"]); len(fields) > 0 {
+		for key, value := range fields {
+			setNestedValue(out, key, value)
+		}
+	}
+	if fields := mapValue(update["$unset"]); len(fields) > 0 {
+		for key := range fields {
+			unsetNestedValue(out, key)
+		}
+	}
+	if fields := mapValue(update["$inc"]); len(fields) > 0 {
+		for key, value := range fields {
+			current, _ := nestedValue(out, key)
+			left, _ := floatValue(current)
+			right, ok := floatValue(value)
+			if !ok {
+				continue
+			}
+			next := left + right
+			if isWhole(next) {
+				setNestedValue(out, key, int(next))
+			} else {
+				setNestedValue(out, key, next)
+			}
+		}
+	}
+	if fields := mapValue(update["$push"]); len(fields) > 0 {
+		for key, value := range fields {
+			current, _ := nestedValue(out, key)
+			items, _ := current.([]any)
+			items = append(append([]any(nil), items...), cloneValue(value))
+			setNestedValue(out, key, items)
+		}
+	}
+	if fields := mapValue(update["$pull"]); len(fields) > 0 {
+		for key, value := range fields {
+			current, _ := nestedValue(out, key)
+			items, ok := current.([]any)
+			if !ok {
+				continue
+			}
+			next := make([]any, 0, len(items))
+			for _, item := range items {
+				if !valuesEqual(item, value) {
+					next = append(next, item)
+				}
+			}
+			setNestedValue(out, key, next)
+		}
+	}
+	if fields := mapValue(update["$rename"]); len(fields) > 0 {
+		for oldKey, newKeyValue := range fields {
+			newKey := stringValue(newKeyValue)
+			if newKey == "" {
+				continue
+			}
+			if value, ok := nestedValue(out, oldKey); ok {
+				setNestedValue(out, newKey, value)
+				unsetNestedValue(out, oldKey)
+			}
+		}
+	}
+	return out
+}
+
+func sortRecords(records []corestore.Record, spec map[string]any) []corestore.Record {
+	out := append([]corestore.Record(nil), records...)
+	sort.SliceStable(out, func(i int, j int) bool {
+		for key, directionValue := range spec {
+			direction := intValue(directionValue)
+			if direction == 0 {
+				direction = 1
+			}
+			left, leftOK := nestedValue(recordData(out[i]), key)
+			right, rightOK := nestedValue(recordData(out[j]), key)
+			if valuesEqual(left, right) {
+				continue
+			}
+			if !leftOK {
+				return direction > 0
+			}
+			if !rightOK {
+				return direction < 0
+			}
+			return compareValues(left, right) < 0 == (direction > 0)
+		}
+		return false
+	})
+	return out
+}
+
+func sortMaps(records []map[string]any, spec map[string]any) []map[string]any {
+	out := append([]map[string]any(nil), records...)
+	sort.SliceStable(out, func(i int, j int) bool {
+		for key, directionValue := range spec {
+			direction := intValue(directionValue)
+			if direction == 0 {
+				direction = 1
+			}
+			left, leftOK := nestedValue(out[i], key)
+			right, rightOK := nestedValue(out[j], key)
+			if valuesEqual(left, right) {
+				continue
+			}
+			if !leftOK {
+				return direction > 0
+			}
+			if !rightOK {
+				return direction < 0
+			}
+			return compareValues(left, right) < 0 == (direction > 0)
+		}
+		return false
+	})
+	return out
+}
+
+func compareNumber(left any, right any, op string) bool {
+	leftNumber, leftOK := floatValue(left)
+	rightNumber, rightOK := floatValue(right)
+	if !leftOK || !rightOK {
+		return false
+	}
+	switch op {
+	case "$gt":
+		return leftNumber > rightNumber
+	case "$gte":
+		return leftNumber >= rightNumber
+	case "$lt":
+		return leftNumber < rightNumber
+	case "$lte":
+		return leftNumber <= rightNumber
+	default:
+		return false
+	}
+}
+
+func compareValues(left any, right any) int {
+	if leftNumber, leftOK := floatValue(left); leftOK {
+		if rightNumber, rightOK := floatValue(right); rightOK {
+			switch {
+			case leftNumber < rightNumber:
+				return -1
+			case leftNumber > rightNumber:
+				return 1
+			default:
+				return 0
+			}
+		}
+	}
+	leftText := stringValue(left)
+	rightText := stringValue(right)
+	switch {
+	case leftText < rightText:
+		return -1
+	case leftText > rightText:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func valuesEqual(left any, right any) bool {
+	if leftNumber, leftOK := floatValue(left); leftOK {
+		if rightNumber, rightOK := floatValue(right); rightOK {
+			return leftNumber == rightNumber
+		}
+	}
+	leftJSON, _ := json.Marshal(left)
+	rightJSON, _ := json.Marshal(right)
+	return string(leftJSON) == string(rightJSON)
+}
+
+func arrayContains(value any, target any) bool {
+	items, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if valuesEqual(item, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func boolValue(value any) bool {
+	v, _ := value.(bool)
+	return v
+}
+
+func projectionEnabled(value any) bool {
+	if boolValue(value) {
+		return true
+	}
+	return intValue(value) == 1
+}
+
+func projectionDisabled(value any) bool {
+	if value == nil {
+		return false
+	}
+	if v, ok := value.(bool); ok {
+		return !v
+	}
+	return intValue(value) == 0
+}
+
+func isWhole(value float64) bool {
+	return value == float64(int(value))
+}
+
+var dangerousKeys = map[string]bool{"__proto__": true, "constructor": true, "prototype": true}
+
+func hasDangerousKey(parts []string) bool {
+	for _, part := range parts {
+		if dangerousKeys[part] {
+			return true
+		}
+	}
+	return false
+}
+
+func extractEqualityFields(filter map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range filter {
+		if strings.HasPrefix(key, "$") {
+			continue
+		}
+		if operators, ok := value.(map[string]any); ok && value != nil {
+			hasOperator := false
+			for op := range operators {
+				if strings.HasPrefix(op, "$") {
+					hasOperator = true
+					break
+				}
+			}
+			if hasOperator {
+				continue
+			}
+		}
+		out[key] = cloneValue(value)
+	}
+	return out
+}
+
+func roleRecords(value any) []map[string]any {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if role, ok := item.(map[string]any); ok {
+			out = append(out, map[string]any{
+				"database_name": firstNonEmpty(stringValue(role["databaseName"]), stringValue(role["database_name"])),
+				"role_name":     firstNonEmpty(stringValue(role["roleName"]), stringValue(role["role_name"])),
+			})
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/services/mongoatlas/routes_admin.go
+++ b/internal/services/mongoatlas/routes_admin.go
@@ -1,0 +1,365 @@
+package mongoatlas
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerAdminRoutes(router *corehttp.Router) {
+	router.Get("/api/atlas/v2/groups", s.handleListProjects)
+	router.Get("/api/atlas/v2/groups/:groupId", s.handleGetProject)
+	router.Post("/api/atlas/v2/groups", s.handleCreateProject)
+	router.Delete("/api/atlas/v2/groups/:groupId", s.handleDeleteProject)
+
+	router.Get("/api/atlas/v2/groups/:groupId/clusters", s.handleListClusters)
+	router.Get("/api/atlas/v2/groups/:groupId/clusters/:clusterName", s.handleGetCluster)
+	router.Post("/api/atlas/v2/groups/:groupId/clusters", s.handleCreateCluster)
+	router.Patch("/api/atlas/v2/groups/:groupId/clusters/:clusterName", s.handlePatchCluster)
+	router.Delete("/api/atlas/v2/groups/:groupId/clusters/:clusterName", s.handleDeleteCluster)
+
+	router.Get("/api/atlas/v2/groups/:groupId/databaseUsers", s.handleListDatabaseUsers)
+	router.Get("/api/atlas/v2/groups/:groupId/databaseUsers/admin/:username", s.handleGetDatabaseUser)
+	router.Post("/api/atlas/v2/groups/:groupId/databaseUsers", s.handleCreateDatabaseUser)
+	router.Delete("/api/atlas/v2/groups/:groupId/databaseUsers/admin/:username", s.handleDeleteDatabaseUser)
+
+	router.Get("/api/atlas/v2/groups/:groupId/clusters/:clusterName/databases", s.handleListDatabases)
+	router.Get("/api/atlas/v2/groups/:groupId/clusters/:clusterName/databases/:databaseName/collections", s.handleListCollections)
+}
+
+func (s *Service) handleListProjects(c *corehttp.Context) {
+	projects := s.store.Projects.All()
+	results := make([]map[string]any, 0, len(projects))
+	for _, project := range projects {
+		results = append(results, formatProject(project))
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"results": results, "totalCount": len(results)})
+}
+
+func (s *Service) handleGetProject(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	project := firstRecord(s.store.Projects.FindBy("group_id", groupID))
+	if project == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
+	mongoOK(c, http.StatusOK, formatProject(project))
+}
+
+func (s *Service) handleCreateProject(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		mongoError(c, http.StatusBadRequest, "INVALID_PARAMETER", "name is required")
+		return
+	}
+	if s.projectByName(name) != nil {
+		mongoError(c, http.StatusConflict, "DUPLICATE_GROUP_NAME", "Group name '"+name+"' already exists.")
+		return
+	}
+	project := s.store.Projects.Insert(corestore.Record{
+		"group_id":      generateHexID(),
+		"name":          name,
+		"org_id":        firstNonEmpty(stringValue(body["orgId"]), "default_org"),
+		"cluster_count": 0,
+	})
+	mongoOK(c, http.StatusCreated, formatProject(project))
+}
+
+func (s *Service) handleDeleteProject(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	project := firstRecord(s.store.Projects.FindBy("group_id", groupID))
+	if project == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
+	for _, cluster := range s.store.Clusters.FindBy("group_id", groupID) {
+		s.deleteClusterData(stringField(cluster, "cluster_id"))
+		s.store.Clusters.Delete(intField(cluster, "id"))
+	}
+	s.store.Projects.Delete(intField(project, "id"))
+	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) handleListClusters(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	if firstRecord(s.store.Projects.FindBy("group_id", groupID)) == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
+	clusters := s.store.Clusters.FindBy("group_id", groupID)
+	results := make([]map[string]any, 0, len(clusters))
+	for _, cluster := range clusters {
+		results = append(results, formatCluster(cluster))
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"results": results, "totalCount": len(results)})
+}
+
+func (s *Service) handleGetCluster(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	clusterName := c.Param("clusterName")
+	cluster := s.clusterByName(groupID, clusterName)
+	if cluster == nil {
+		mongoError(c, http.StatusNotFound, "CLUSTER_NOT_FOUND", "Cluster '"+clusterName+"' not found.")
+		return
+	}
+	mongoOK(c, http.StatusOK, formatCluster(cluster))
+}
+
+func (s *Service) handleCreateCluster(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	project := firstRecord(s.store.Projects.FindBy("group_id", groupID))
+	if project == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
+	body := readJSONBody(c.Request)
+	name := stringValue(body["name"])
+	if name == "" {
+		mongoError(c, http.StatusBadRequest, "INVALID_PARAMETER", "name is required")
+		return
+	}
+	if s.clusterByName(groupID, name) != nil {
+		mongoError(c, http.StatusConflict, "DUPLICATE_CLUSTER_NAME", "Cluster '"+name+"' already exists.")
+		return
+	}
+	provider := mapValue(body["providerSettings"])
+	clusterType := firstNonEmpty(stringValue(body["clusterType"]), "REPLICASET")
+	record := clusterRecord(
+		generateHexID(),
+		name,
+		groupID,
+		firstNonEmpty(stringValue(provider["providerName"]), "AWS"),
+		firstNonEmpty(stringValue(provider["instanceSizeName"]), "M10"),
+		firstNonEmpty(stringValue(provider["regionName"]), "US_EAST_1"),
+		firstNonZeroFloat(body["diskSizeGB"], 10),
+		firstNonEmpty(stringValue(body["mongoDBMajorVersion"]), "8.0"),
+	)
+	record["cluster_type"] = clusterType
+	cluster := s.store.Clusters.Insert(record)
+	s.store.Projects.Update(intField(project, "id"), corestore.Record{"cluster_count": intField(project, "cluster_count") + 1})
+	mongoOK(c, http.StatusCreated, formatCluster(cluster))
+}
+
+func (s *Service) handlePatchCluster(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	clusterName := c.Param("clusterName")
+	cluster := s.clusterByName(groupID, clusterName)
+	if cluster == nil {
+		mongoError(c, http.StatusNotFound, "CLUSTER_NOT_FOUND", "Cluster '"+clusterName+"' not found.")
+		return
+	}
+	body := readJSONBody(c.Request)
+	patch := corestore.Record{}
+	if provider := mapValue(body["providerSettings"]); len(provider) > 0 {
+		current := mapValue(cluster["provider_settings"])
+		if value := stringValue(provider["instanceSizeName"]); value != "" {
+			current["instance_size_name"] = value
+		}
+		if value := stringValue(provider["regionName"]); value != "" {
+			current["region_name"] = value
+		}
+		patch["provider_settings"] = current
+	}
+	if _, ok := body["diskSizeGB"]; ok {
+		patch["disk_size_gb"] = firstNonZeroFloat(body["diskSizeGB"], 0)
+	}
+	updated, _ := s.store.Clusters.Update(intField(cluster, "id"), patch)
+	mongoOK(c, http.StatusOK, formatCluster(updated))
+}
+
+func (s *Service) handleDeleteCluster(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	clusterName := c.Param("clusterName")
+	cluster := s.clusterByName(groupID, clusterName)
+	if cluster == nil {
+		mongoError(c, http.StatusNotFound, "CLUSTER_NOT_FOUND", "Cluster '"+clusterName+"' not found.")
+		return
+	}
+	s.deleteClusterData(stringField(cluster, "cluster_id"))
+	s.store.Clusters.Delete(intField(cluster, "id"))
+	if project := firstRecord(s.store.Projects.FindBy("group_id", groupID)); project != nil {
+		count := intField(project, "cluster_count") - 1
+		if count < 0 {
+			count = 0
+		}
+		s.store.Projects.Update(intField(project, "id"), corestore.Record{"cluster_count": count})
+	}
+	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) handleListDatabaseUsers(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	users := s.store.Users.FindBy("group_id", groupID)
+	results := make([]map[string]any, 0, len(users))
+	for _, user := range users {
+		results = append(results, formatUser(user))
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"results": results, "totalCount": len(results)})
+}
+
+func (s *Service) handleGetDatabaseUser(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	username := c.Param("username")
+	user := s.userByName(groupID, username)
+	if user == nil {
+		mongoError(c, http.StatusNotFound, "USER_NOT_FOUND", "Database user '"+username+"' not found.")
+		return
+	}
+	mongoOK(c, http.StatusOK, formatUser(user))
+}
+
+func (s *Service) handleCreateDatabaseUser(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	body := readJSONBody(c.Request)
+	username := stringValue(body["username"])
+	if username == "" {
+		mongoError(c, http.StatusBadRequest, "INVALID_PARAMETER", "username is required")
+		return
+	}
+	if s.userByName(groupID, username) != nil {
+		mongoError(c, http.StatusConflict, "DUPLICATE_USER", "User '"+username+"' already exists.")
+		return
+	}
+	roles := roleRecords(body["roles"])
+	user := s.store.Users.Insert(corestore.Record{"user_id": generateHexID(), "username": username, "group_id": groupID, "roles": roles})
+	mongoOK(c, http.StatusCreated, formatUser(user))
+}
+
+func (s *Service) handleDeleteDatabaseUser(c *corehttp.Context) {
+	groupID := c.Param("groupId")
+	username := c.Param("username")
+	user := s.userByName(groupID, username)
+	if user == nil {
+		mongoError(c, http.StatusNotFound, "USER_NOT_FOUND", "Database user '"+username+"' not found.")
+		return
+	}
+	s.store.Users.Delete(intField(user, "id"))
+	c.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) handleListDatabases(c *corehttp.Context) {
+	cluster := s.clusterByName(c.Param("groupId"), c.Param("clusterName"))
+	if cluster == nil {
+		mongoError(c, http.StatusNotFound, "CLUSTER_NOT_FOUND", "Cluster '"+c.Param("clusterName")+"' not found.")
+		return
+	}
+	databases := s.store.Databases.FindBy("cluster_id", stringField(cluster, "cluster_id"))
+	results := make([]map[string]any, 0, len(databases))
+	for _, db := range databases {
+		results = append(results, map[string]any{"databaseName": stringField(db, "name")})
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"results": results, "totalCount": len(results)})
+}
+
+func (s *Service) handleListCollections(c *corehttp.Context) {
+	cluster := s.clusterByName(c.Param("groupId"), c.Param("clusterName"))
+	if cluster == nil {
+		mongoError(c, http.StatusNotFound, "CLUSTER_NOT_FOUND", "Cluster '"+c.Param("clusterName")+"' not found.")
+		return
+	}
+	databaseName := c.Param("databaseName")
+	collections := s.store.Collections.FindBy("cluster_id", stringField(cluster, "cluster_id"))
+	results := make([]map[string]any, 0)
+	for _, collection := range collections {
+		if stringField(collection, "database") == databaseName {
+			results = append(results, map[string]any{"collectionName": stringField(collection, "name"), "databaseName": databaseName})
+		}
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"results": results, "totalCount": len(results)})
+}
+
+func (s *Service) projectByName(name string) corestore.Record {
+	for _, project := range s.store.Projects.All() {
+		if stringField(project, "name") == name {
+			return project
+		}
+	}
+	return nil
+}
+
+func (s *Service) clusterByName(groupID string, name string) corestore.Record {
+	for _, cluster := range s.store.Clusters.FindBy("group_id", groupID) {
+		if stringField(cluster, "name") == name {
+			return cluster
+		}
+	}
+	return nil
+}
+
+func (s *Service) userByName(groupID string, username string) corestore.Record {
+	for _, user := range s.store.Users.FindBy("group_id", groupID) {
+		if stringField(user, "username") == username {
+			return user
+		}
+	}
+	return nil
+}
+
+func (s *Service) deleteClusterData(clusterID string) {
+	for _, doc := range s.store.Documents.FindBy("cluster_id", clusterID) {
+		s.store.Documents.Delete(intField(doc, "id"))
+	}
+	for _, collection := range s.store.Collections.FindBy("cluster_id", clusterID) {
+		s.store.Collections.Delete(intField(collection, "id"))
+	}
+	for _, db := range s.store.Databases.FindBy("cluster_id", clusterID) {
+		s.store.Databases.Delete(intField(db, "id"))
+	}
+}
+
+func formatProject(project corestore.Record) map[string]any {
+	return map[string]any{
+		"id":           stringField(project, "group_id"),
+		"name":         stringField(project, "name"),
+		"orgId":        stringField(project, "org_id"),
+		"clusterCount": intField(project, "cluster_count"),
+		"created":      stringField(project, "created_at"),
+	}
+}
+
+func formatCluster(cluster corestore.Record) map[string]any {
+	connection := mapValue(cluster["connection_strings"])
+	provider := mapValue(cluster["provider_settings"])
+	return map[string]any{
+		"id":        stringField(cluster, "cluster_id"),
+		"name":      stringField(cluster, "name"),
+		"groupId":   stringField(cluster, "group_id"),
+		"stateName": stringField(cluster, "state"),
+		"mongoURI":  stringField(cluster, "mongo_uri"),
+		"connectionStrings": map[string]any{
+			"standard":    stringValue(connection["standard"]),
+			"standardSrv": stringValue(connection["standard_srv"]),
+		},
+		"providerSettings": map[string]any{
+			"providerName":     stringValue(provider["provider_name"]),
+			"instanceSizeName": stringValue(provider["instance_size_name"]),
+			"regionName":       stringValue(provider["region_name"]),
+		},
+		"clusterType":    stringField(cluster, "cluster_type"),
+		"diskSizeGB":     cluster["disk_size_gb"],
+		"mongoDBVersion": stringField(cluster, "mongodb_version"),
+		"created":        stringField(cluster, "created_at"),
+	}
+}
+
+func formatUser(user corestore.Record) map[string]any {
+	roles := make([]map[string]any, 0)
+	for _, role := range mapSliceValue(user["roles"]) {
+		roles = append(roles, map[string]any{"databaseName": stringValue(role["database_name"]), "roleName": stringValue(role["role_name"])})
+	}
+	return map[string]any{
+		"username":     stringField(user, "username"),
+		"groupId":      stringField(user, "group_id"),
+		"databaseName": "admin",
+		"roles":        roles,
+	}
+}
+
+func firstNonZeroFloat(value any, fallback float64) float64 {
+	if number, ok := floatValue(value); ok && number != 0 {
+		return number
+	}
+	return fallback
+}

--- a/internal/services/mongoatlas/routes_admin.go
+++ b/internal/services/mongoatlas/routes_admin.go
@@ -78,6 +78,9 @@ func (s *Service) handleDeleteProject(c *corehttp.Context) {
 		s.deleteClusterData(stringField(cluster, "cluster_id"))
 		s.store.Clusters.Delete(intField(cluster, "id"))
 	}
+	for _, user := range s.store.Users.FindBy("group_id", groupID) {
+		s.store.Users.Delete(intField(user, "id"))
+	}
 	s.store.Projects.Delete(intField(project, "id"))
 	c.Writer.WriteHeader(http.StatusNoContent)
 }
@@ -191,6 +194,10 @@ func (s *Service) handleDeleteCluster(c *corehttp.Context) {
 
 func (s *Service) handleListDatabaseUsers(c *corehttp.Context) {
 	groupID := c.Param("groupId")
+	if firstRecord(s.store.Projects.FindBy("group_id", groupID)) == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
 	users := s.store.Users.FindBy("group_id", groupID)
 	results := make([]map[string]any, 0, len(users))
 	for _, user := range users {
@@ -202,6 +209,10 @@ func (s *Service) handleListDatabaseUsers(c *corehttp.Context) {
 func (s *Service) handleGetDatabaseUser(c *corehttp.Context) {
 	groupID := c.Param("groupId")
 	username := c.Param("username")
+	if firstRecord(s.store.Projects.FindBy("group_id", groupID)) == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
 	user := s.userByName(groupID, username)
 	if user == nil {
 		mongoError(c, http.StatusNotFound, "USER_NOT_FOUND", "Database user '"+username+"' not found.")
@@ -212,6 +223,10 @@ func (s *Service) handleGetDatabaseUser(c *corehttp.Context) {
 
 func (s *Service) handleCreateDatabaseUser(c *corehttp.Context) {
 	groupID := c.Param("groupId")
+	if firstRecord(s.store.Projects.FindBy("group_id", groupID)) == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
 	body := readJSONBody(c.Request)
 	username := stringValue(body["username"])
 	if username == "" {
@@ -230,6 +245,10 @@ func (s *Service) handleCreateDatabaseUser(c *corehttp.Context) {
 func (s *Service) handleDeleteDatabaseUser(c *corehttp.Context) {
 	groupID := c.Param("groupId")
 	username := c.Param("username")
+	if firstRecord(s.store.Projects.FindBy("group_id", groupID)) == nil {
+		mongoError(c, http.StatusNotFound, "GROUP_NOT_FOUND", "Group '"+groupID+"' not found.")
+		return
+	}
 	user := s.userByName(groupID, username)
 	if user == nil {
 		mongoError(c, http.StatusNotFound, "USER_NOT_FOUND", "Database user '"+username+"' not found.")

--- a/internal/services/mongoatlas/routes_data_api.go
+++ b/internal/services/mongoatlas/routes_data_api.go
@@ -2,6 +2,7 @@ package mongoatlas
 
 import (
 	"net/http"
+	"strconv"
 
 	corehttp "github.com/vercel-labs/emulate/internal/core/http"
 	corestore "github.com/vercel-labs/emulate/internal/core/store"
@@ -34,14 +35,15 @@ func (s *Service) handleFindOne(c *corehttp.Context) {
 }
 
 func (s *Service) handleFind(c *corehttp.Context) {
-	body := readJSONBody(c.Request)
+	parsed := readJSONBodyWithOrder(c.Request)
+	body := parsed.Values
 	cluster, ok := s.resolveDataRequest(c, body, true)
 	if !ok {
 		return
 	}
 	records := filterRecords(recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"])), mapValue(body["filter"]))
 	if sortSpec := mapValue(body["sort"]); len(sortSpec) > 0 {
-		records = sortRecords(records, sortSpec)
+		records = sortRecords(records, sortSpec, parsed.Order("sort"))
 	}
 	skip := intValue(body["skip"])
 	if skip < 0 {
@@ -206,7 +208,8 @@ func (s *Service) handleDeleteMany(c *corehttp.Context) {
 }
 
 func (s *Service) handleAggregate(c *corehttp.Context) {
-	body := readJSONBody(c.Request)
+	parsed := readJSONBodyWithOrder(c.Request)
+	body := parsed.Values
 	cluster, ok := s.resolveDataRequest(c, body, true)
 	if !ok {
 		return
@@ -216,7 +219,7 @@ func (s *Service) handleAggregate(c *corehttp.Context) {
 	for _, record := range records {
 		results = append(results, recordData(record))
 	}
-	for _, stage := range mapSliceValue(body["pipeline"]) {
+	for index, stage := range mapSliceValue(body["pipeline"]) {
 		switch {
 		case stage["$match"] != nil:
 			filter := mapValue(stage["$match"])
@@ -247,7 +250,7 @@ func (s *Service) handleAggregate(c *corehttp.Context) {
 			}
 			results = results[skip:]
 		case stage["$sort"] != nil:
-			results = sortMaps(results, mapValue(stage["$sort"]))
+			results = sortMaps(results, mapValue(stage["$sort"]), parsed.Order("pipeline."+strconv.Itoa(index)+".$sort"))
 		case stage["$project"] != nil:
 			projection := mapValue(stage["$project"])
 			for i, result := range results {

--- a/internal/services/mongoatlas/routes_data_api.go
+++ b/internal/services/mongoatlas/routes_data_api.go
@@ -44,11 +44,19 @@ func (s *Service) handleFind(c *corehttp.Context) {
 		records = sortRecords(records, sortSpec)
 	}
 	skip := intValue(body["skip"])
+	if skip < 0 {
+		mongoError(c, http.StatusBadRequest, "InvalidParameter", "skip must be zero or greater")
+		return
+	}
 	if skip > len(records) {
 		skip = len(records)
 	}
 	records = records[skip:]
 	limit := intValue(body["limit"])
+	if limit < 0 {
+		mongoError(c, http.StatusBadRequest, "InvalidParameter", "limit must be zero or greater")
+		return
+	}
 	if limit > 0 && limit < len(records) {
 		records = records[:limit]
 	}
@@ -221,11 +229,19 @@ func (s *Service) handleAggregate(c *corehttp.Context) {
 			results = next
 		case stage["$limit"] != nil:
 			limit := intValue(stage["$limit"])
+			if limit < 0 {
+				mongoError(c, http.StatusBadRequest, "InvalidParameter", "$limit must be zero or greater")
+				return
+			}
 			if limit < len(results) {
 				results = results[:limit]
 			}
 		case stage["$skip"] != nil:
 			skip := intValue(stage["$skip"])
+			if skip < 0 {
+				mongoError(c, http.StatusBadRequest, "InvalidParameter", "$skip must be zero or greater")
+				return
+			}
 			if skip > len(results) {
 				skip = len(results)
 			}

--- a/internal/services/mongoatlas/routes_data_api.go
+++ b/internal/services/mongoatlas/routes_data_api.go
@@ -1,0 +1,293 @@
+package mongoatlas
+
+import (
+	"net/http"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func (s *Service) registerDataAPIRoutes(router *corehttp.Router) {
+	router.Post("/app/data-api/v1/action/findOne", s.handleFindOne)
+	router.Post("/app/data-api/v1/action/find", s.handleFind)
+	router.Post("/app/data-api/v1/action/insertOne", s.handleInsertOne)
+	router.Post("/app/data-api/v1/action/insertMany", s.handleInsertMany)
+	router.Post("/app/data-api/v1/action/updateOne", s.handleUpdateOne)
+	router.Post("/app/data-api/v1/action/updateMany", s.handleUpdateMany)
+	router.Post("/app/data-api/v1/action/deleteOne", s.handleDeleteOne)
+	router.Post("/app/data-api/v1/action/deleteMany", s.handleDeleteMany)
+	router.Post("/app/data-api/v1/action/aggregate", s.handleAggregate)
+}
+
+func (s *Service) handleFindOne(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	records := filterRecords(recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"])), mapValue(body["filter"]))
+	var document any
+	if len(records) > 0 {
+		document = applyProjection(recordData(records[0]), mapValue(body["projection"]))
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"document": document})
+}
+
+func (s *Service) handleFind(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	records := filterRecords(recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"])), mapValue(body["filter"]))
+	if sortSpec := mapValue(body["sort"]); len(sortSpec) > 0 {
+		records = sortRecords(records, sortSpec)
+	}
+	skip := intValue(body["skip"])
+	if skip > len(records) {
+		skip = len(records)
+	}
+	records = records[skip:]
+	limit := intValue(body["limit"])
+	if limit > 0 && limit < len(records) {
+		records = records[:limit]
+	}
+	documents := make([]map[string]any, 0, len(records))
+	projection := mapValue(body["projection"])
+	for _, record := range records {
+		documents = append(documents, applyProjection(recordData(record), projection))
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"documents": documents})
+}
+
+func (s *Service) handleInsertOne(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	document, ok := objectValue(body["document"])
+	if !ok {
+		mongoError(c, http.StatusBadRequest, "InvalidParameter", "dataSource, database, collection, and document are required")
+		return
+	}
+	s.ensureCollection(stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"]))
+	docID := firstNonEmpty(stringValue(document["_id"]), generateObjectID())
+	document["_id"] = docID
+	s.store.Documents.Insert(corestore.Record{
+		"cluster_id": stringField(cluster, "cluster_id"),
+		"database":   stringValue(body["database"]),
+		"collection": stringValue(body["collection"]),
+		"doc_id":     docID,
+		"data":       document,
+	})
+	mongoOK(c, http.StatusCreated, map[string]any{"insertedId": docID})
+}
+
+func (s *Service) handleInsertMany(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	documents := mapSliceValue(body["documents"])
+	if documents == nil {
+		mongoError(c, http.StatusBadRequest, "InvalidParameter", "dataSource, database, collection, and documents are required")
+		return
+	}
+	s.ensureCollection(stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"]))
+	insertedIDs := make([]string, 0, len(documents))
+	for _, document := range documents {
+		docID := firstNonEmpty(stringValue(document["_id"]), generateObjectID())
+		document["_id"] = docID
+		s.store.Documents.Insert(corestore.Record{
+			"cluster_id": stringField(cluster, "cluster_id"),
+			"database":   stringValue(body["database"]),
+			"collection": stringValue(body["collection"]),
+			"doc_id":     docID,
+			"data":       document,
+		})
+		insertedIDs = append(insertedIDs, docID)
+	}
+	mongoOK(c, http.StatusCreated, map[string]any{"insertedIds": insertedIDs})
+}
+
+func (s *Service) handleUpdateOne(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	update, ok := objectValue(body["update"])
+	if !ok {
+		mongoError(c, http.StatusBadRequest, "InvalidParameter", "dataSource, database, collection, and update are required")
+		return
+	}
+	records := filterRecords(recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"])), mapValue(body["filter"]))
+	if len(records) > 0 {
+		data := applyUpdate(recordData(records[0]), update)
+		s.store.Documents.Update(intField(records[0], "id"), corestore.Record{"data": data})
+		mongoOK(c, http.StatusOK, map[string]any{"matchedCount": 1, "modifiedCount": 1})
+		return
+	}
+	if boolValue(body["upsert"]) {
+		docID := generateObjectID()
+		data := applyUpdate(mapWithID(docID, extractEqualityFields(mapValue(body["filter"]))), update)
+		s.ensureCollection(stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"]))
+		s.store.Documents.Insert(corestore.Record{"cluster_id": stringField(cluster, "cluster_id"), "database": stringValue(body["database"]), "collection": stringValue(body["collection"]), "doc_id": docID, "data": data})
+		mongoOK(c, http.StatusOK, map[string]any{"matchedCount": 0, "modifiedCount": 0, "upsertedId": docID})
+		return
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"matchedCount": 0, "modifiedCount": 0})
+}
+
+func (s *Service) handleUpdateMany(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	update, ok := objectValue(body["update"])
+	if !ok {
+		mongoError(c, http.StatusBadRequest, "InvalidParameter", "dataSource, database, collection, and update are required")
+		return
+	}
+	records := filterRecords(recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"])), mapValue(body["filter"]))
+	modified := 0
+	for _, record := range records {
+		s.store.Documents.Update(intField(record, "id"), corestore.Record{"data": applyUpdate(recordData(record), update)})
+		modified++
+	}
+	if len(records) == 0 && boolValue(body["upsert"]) {
+		docID := generateObjectID()
+		data := applyUpdate(mapWithID(docID, extractEqualityFields(mapValue(body["filter"]))), update)
+		s.ensureCollection(stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"]))
+		s.store.Documents.Insert(corestore.Record{"cluster_id": stringField(cluster, "cluster_id"), "database": stringValue(body["database"]), "collection": stringValue(body["collection"]), "doc_id": docID, "data": data})
+		mongoOK(c, http.StatusOK, map[string]any{"matchedCount": 0, "modifiedCount": 0, "upsertedId": docID})
+		return
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"matchedCount": len(records), "modifiedCount": modified})
+}
+
+func (s *Service) handleDeleteOne(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	records := filterRecords(recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"])), mapValue(body["filter"]))
+	if len(records) > 0 {
+		s.store.Documents.Delete(intField(records[0], "id"))
+		mongoOK(c, http.StatusOK, map[string]any{"deletedCount": 1})
+		return
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"deletedCount": 0})
+}
+
+func (s *Service) handleDeleteMany(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	records := filterRecords(recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"])), mapValue(body["filter"]))
+	for _, record := range records {
+		s.store.Documents.Delete(intField(record, "id"))
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"deletedCount": len(records)})
+}
+
+func (s *Service) handleAggregate(c *corehttp.Context) {
+	body := readJSONBody(c.Request)
+	cluster, ok := s.resolveDataRequest(c, body, true)
+	if !ok {
+		return
+	}
+	records := recordsForCollection(s.store, stringField(cluster, "cluster_id"), stringValue(body["database"]), stringValue(body["collection"]))
+	results := make([]map[string]any, 0, len(records))
+	for _, record := range records {
+		results = append(results, recordData(record))
+	}
+	for _, stage := range mapSliceValue(body["pipeline"]) {
+		switch {
+		case stage["$match"] != nil:
+			filter := mapValue(stage["$match"])
+			next := make([]map[string]any, 0, len(results))
+			for _, result := range results {
+				if matchesFilter(result, filter) {
+					next = append(next, result)
+				}
+			}
+			results = next
+		case stage["$limit"] != nil:
+			limit := intValue(stage["$limit"])
+			if limit < len(results) {
+				results = results[:limit]
+			}
+		case stage["$skip"] != nil:
+			skip := intValue(stage["$skip"])
+			if skip > len(results) {
+				skip = len(results)
+			}
+			results = results[skip:]
+		case stage["$sort"] != nil:
+			results = sortMaps(results, mapValue(stage["$sort"]))
+		case stage["$project"] != nil:
+			projection := mapValue(stage["$project"])
+			for i, result := range results {
+				results[i] = applyProjection(result, projection)
+			}
+		case stage["$count"] != nil:
+			results = []map[string]any{{stringValue(stage["$count"]): len(results)}}
+		}
+	}
+	mongoOK(c, http.StatusOK, map[string]any{"documents": results})
+}
+
+func (s *Service) resolveDataRequest(c *corehttp.Context, body map[string]any, requireCollection bool) (corestore.Record, bool) {
+	if stringValue(body["dataSource"]) == "" || stringValue(body["database"]) == "" || (requireCollection && stringValue(body["collection"]) == "") {
+		mongoError(c, http.StatusBadRequest, "InvalidParameter", "dataSource, database, and collection are required")
+		return nil, false
+	}
+	cluster := firstRecord(s.store.Clusters.FindBy("name", stringValue(body["dataSource"])))
+	if cluster == nil {
+		mongoError(c, http.StatusNotFound, "ClusterNotFound", "Cluster '"+stringValue(body["dataSource"])+"' not found")
+		return nil, false
+	}
+	return cluster, true
+}
+
+func (s *Service) ensureCollection(clusterID string, database string, collection string) {
+	if database != "" && s.databaseByName(clusterID, database) == nil {
+		s.store.Databases.Insert(corestore.Record{"cluster_id": clusterID, "name": database})
+	}
+	if collection != "" && s.collectionByName(clusterID, database, collection) == nil {
+		s.store.Collections.Insert(corestore.Record{"cluster_id": clusterID, "database": database, "name": collection})
+	}
+}
+
+func (s *Service) databaseByName(clusterID string, name string) corestore.Record {
+	for _, db := range s.store.Databases.FindBy("cluster_id", clusterID) {
+		if stringField(db, "name") == name {
+			return db
+		}
+	}
+	return nil
+}
+
+func (s *Service) collectionByName(clusterID string, database string, name string) corestore.Record {
+	for _, collection := range s.store.Collections.FindBy("cluster_id", clusterID) {
+		if stringField(collection, "database") == database && stringField(collection, "name") == name {
+			return collection
+		}
+	}
+	return nil
+}
+
+func mapWithID(id string, values map[string]any) map[string]any {
+	out := map[string]any{"_id": id}
+	for key, value := range values {
+		out[key] = cloneValue(value)
+	}
+	return out
+}

--- a/internal/services/mongoatlas/service.go
+++ b/internal/services/mongoatlas/service.go
@@ -1,0 +1,205 @@
+package mongoatlas
+
+import (
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+type Options struct {
+	Store *corestore.Store
+	Seed  *SeedConfig
+}
+
+type SeedConfig struct {
+	Port          int                `json:"port,omitempty"`
+	Projects      []ProjectSeed      `json:"projects"`
+	Clusters      []ClusterSeed      `json:"clusters"`
+	DatabaseUsers []DatabaseUserSeed `json:"database_users"`
+	Databases     []DatabaseSeed     `json:"databases"`
+}
+
+type ProjectSeed struct {
+	Name  string `json:"name"`
+	OrgID string `json:"org_id"`
+}
+
+type ClusterSeed struct {
+	Name           string  `json:"name"`
+	Project        string  `json:"project"`
+	Provider       string  `json:"provider"`
+	InstanceSize   string  `json:"instance_size"`
+	Region         string  `json:"region"`
+	DiskSizeGB     float64 `json:"disk_size_gb"`
+	MongoDBVersion string  `json:"mongodb_version"`
+}
+
+type DatabaseUserSeed struct {
+	Username string     `json:"username"`
+	Project  string     `json:"project"`
+	Roles    []RoleSeed `json:"roles"`
+}
+
+type RoleSeed struct {
+	DatabaseName string `json:"database_name"`
+	RoleName     string `json:"role_name"`
+}
+
+type DatabaseSeed struct {
+	Cluster     string   `json:"cluster"`
+	Name        string   `json:"name"`
+	Collections []string `json:"collections"`
+}
+
+type Service struct {
+	store Store
+}
+
+func Register(router *corehttp.Router, options Options) {
+	service := New(options)
+	service.RegisterRoutes(router)
+}
+
+func New(options Options) *Service {
+	runtimeStore := options.Store
+	if runtimeStore == nil {
+		runtimeStore = corestore.New()
+	}
+	service := &Service{store: NewStore(runtimeStore)}
+	service.SeedDefaults()
+	if options.Seed != nil {
+		service.SeedFromConfig(*options.Seed)
+	}
+	return service
+}
+
+func SeedFromConfig(runtimeStore *corestore.Store, config SeedConfig) {
+	New(Options{Store: runtimeStore, Seed: &config})
+}
+
+func (s *Service) RegisterRoutes(router *corehttp.Router) {
+	s.registerAdminRoutes(router)
+	s.registerDataAPIRoutes(router)
+}
+
+func (s *Service) SeedDefaults() {
+	if s.store.Projects.Count() > 0 {
+		return
+	}
+	groupID := generateHexID()
+	s.store.Projects.Insert(corestore.Record{
+		"group_id":      groupID,
+		"name":          "Project0",
+		"org_id":        "default_org",
+		"cluster_count": 1,
+	})
+	clusterID := generateHexID()
+	s.store.Clusters.Insert(clusterRecord(clusterID, "Cluster0", groupID, "AWS", "M10", "US_EAST_1", 10, "8.0"))
+	s.store.Users.Insert(corestore.Record{
+		"user_id":  generateHexID(),
+		"username": "admin",
+		"group_id": groupID,
+		"roles": []map[string]any{{
+			"database_name": "admin",
+			"role_name":     "atlasAdmin",
+		}},
+	})
+	s.store.Databases.Insert(corestore.Record{"cluster_id": clusterID, "name": "test"})
+	s.store.Collections.Insert(corestore.Record{"cluster_id": clusterID, "database": "test", "name": "items"})
+}
+
+func (s *Service) SeedFromConfig(config SeedConfig) {
+	projectIDs := map[string]string{}
+	for _, project := range s.store.Projects.All() {
+		projectIDs[stringField(project, "name")] = stringField(project, "group_id")
+	}
+	for _, seed := range config.Projects {
+		if seed.Name == "" {
+			continue
+		}
+		if existing := s.projectByName(seed.Name); existing != nil {
+			projectIDs[seed.Name] = stringField(existing, "group_id")
+			continue
+		}
+		groupID := generateHexID()
+		s.store.Projects.Insert(corestore.Record{
+			"group_id":      groupID,
+			"name":          seed.Name,
+			"org_id":        firstNonEmpty(seed.OrgID, "default_org"),
+			"cluster_count": 0,
+		})
+		projectIDs[seed.Name] = groupID
+	}
+
+	clusterIDs := map[string]string{}
+	for _, cluster := range s.store.Clusters.All() {
+		clusterIDs[stringField(cluster, "name")] = stringField(cluster, "cluster_id")
+	}
+	for _, seed := range config.Clusters {
+		groupID := projectIDs[seed.Project]
+		if seed.Name == "" || groupID == "" {
+			continue
+		}
+		if existing := s.clusterByName(groupID, seed.Name); existing != nil {
+			clusterIDs[seed.Name] = stringField(existing, "cluster_id")
+			continue
+		}
+		disk := seed.DiskSizeGB
+		if disk == 0 {
+			disk = 10
+		}
+		clusterID := generateHexID()
+		s.store.Clusters.Insert(clusterRecord(clusterID, seed.Name, groupID, firstNonEmpty(seed.Provider, "AWS"), firstNonEmpty(seed.InstanceSize, "M10"), firstNonEmpty(seed.Region, "US_EAST_1"), disk, firstNonEmpty(seed.MongoDBVersion, "8.0")))
+		clusterIDs[seed.Name] = clusterID
+		if project := firstRecord(s.store.Projects.FindBy("group_id", groupID)); project != nil {
+			s.store.Projects.Update(intField(project, "id"), corestore.Record{"cluster_count": intField(project, "cluster_count") + 1})
+		}
+	}
+
+	for _, seed := range config.DatabaseUsers {
+		groupID := projectIDs[seed.Project]
+		if seed.Username == "" || groupID == "" || s.userByName(groupID, seed.Username) != nil {
+			continue
+		}
+		roles := make([]map[string]any, 0, len(seed.Roles))
+		for _, role := range seed.Roles {
+			roles = append(roles, map[string]any{"database_name": role.DatabaseName, "role_name": role.RoleName})
+		}
+		if len(roles) == 0 {
+			roles = []map[string]any{{"database_name": "admin", "role_name": "readWriteAnyDatabase"}}
+		}
+		s.store.Users.Insert(corestore.Record{"user_id": generateHexID(), "username": seed.Username, "group_id": groupID, "roles": roles})
+	}
+
+	for _, seed := range config.Databases {
+		clusterID := clusterIDs[seed.Cluster]
+		if seed.Name == "" || clusterID == "" {
+			continue
+		}
+		s.ensureCollection(clusterID, seed.Name, "")
+		for _, collection := range seed.Collections {
+			s.ensureCollection(clusterID, seed.Name, collection)
+		}
+	}
+}
+
+func clusterRecord(clusterID string, name string, groupID string, provider string, size string, region string, disk float64, version string) corestore.Record {
+	return corestore.Record{
+		"cluster_id": clusterID,
+		"name":       name,
+		"group_id":   groupID,
+		"state":      "IDLE",
+		"mongo_uri":  "mongodb+srv://" + name + ".emulate.mongodb.net",
+		"connection_strings": map[string]any{
+			"standard":     "mongodb://" + name + ".emulate.mongodb.net:27017",
+			"standard_srv": "mongodb+srv://" + name + ".emulate.mongodb.net",
+		},
+		"provider_settings": map[string]any{
+			"provider_name":      provider,
+			"instance_size_name": size,
+			"region_name":        region,
+		},
+		"cluster_type":    "REPLICASET",
+		"disk_size_gb":    disk,
+		"mongodb_version": version,
+	}
+}

--- a/internal/services/mongoatlas/service_test.go
+++ b/internal/services/mongoatlas/service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAdminAPIs(t *testing.T) {
-	_, router := newTestService(t)
+	service, router := newTestService(t)
 
 	projects := mongoJSON(router, http.MethodGet, "/api/atlas/v2/groups", "")
 	if projects.Code != http.StatusOK || !strings.Contains(projects.Body.String(), `"name":"Project0"`) {
@@ -39,6 +39,33 @@ func TestAdminAPIs(t *testing.T) {
 	user := mongoJSON(router, http.MethodPost, "/api/atlas/v2/groups/"+groupID+"/databaseUsers", `{"username":"app","roles":[{"databaseName":"test","roleName":"readWrite"}]}`)
 	if user.Code != http.StatusCreated || !strings.Contains(user.Body.String(), `"username":"app"`) || !strings.Contains(user.Body.String(), `"roleName":"readWrite"`) {
 		t.Fatalf("create user status = %d, body = %s", user.Code, user.Body.String())
+	}
+
+	missingUsers := mongoJSON(router, http.MethodGet, "/api/atlas/v2/groups/missing/databaseUsers", "")
+	if missingUsers.Code != http.StatusNotFound || !strings.Contains(missingUsers.Body.String(), "GROUP_NOT_FOUND") {
+		t.Fatalf("missing group users status = %d, body = %s", missingUsers.Code, missingUsers.Body.String())
+	}
+
+	missingUserCreate := mongoJSON(router, http.MethodPost, "/api/atlas/v2/groups/missing/databaseUsers", `{"username":"ghost"}`)
+	if missingUserCreate.Code != http.StatusNotFound || !strings.Contains(missingUserCreate.Body.String(), "GROUP_NOT_FOUND") {
+		t.Fatalf("missing group user create status = %d, body = %s", missingUserCreate.Code, missingUserCreate.Body.String())
+	}
+
+	deleteProject := mongoJSON(router, http.MethodPost, "/api/atlas/v2/groups", `{"name":"DeleteMe"}`)
+	if deleteProject.Code != http.StatusCreated {
+		t.Fatalf("delete project create status = %d, body = %s", deleteProject.Code, deleteProject.Body.String())
+	}
+	deleteGroupID := stringFromJSON(t, deleteProject.Body.Bytes(), "id")
+	deleteProjectUser := mongoJSON(router, http.MethodPost, "/api/atlas/v2/groups/"+deleteGroupID+"/databaseUsers", `{"username":"delete-me"}`)
+	if deleteProjectUser.Code != http.StatusCreated {
+		t.Fatalf("delete project user create status = %d, body = %s", deleteProjectUser.Code, deleteProjectUser.Body.String())
+	}
+	deletedProject := mongoJSON(router, http.MethodDelete, "/api/atlas/v2/groups/"+deleteGroupID, "")
+	if deletedProject.Code != http.StatusNoContent {
+		t.Fatalf("delete project status = %d, body = %s", deletedProject.Code, deletedProject.Body.String())
+	}
+	if users := service.store.Users.FindBy("group_id", deleteGroupID); len(users) != 0 {
+		t.Fatalf("expected project delete to remove database users, got %#v", users)
 	}
 
 	databases := mongoJSON(router, http.MethodGet, "/api/atlas/v2/groups/"+groupID+"/clusters/Cluster0/databases", "")
@@ -76,6 +103,16 @@ func TestDataAPIs(t *testing.T) {
 		t.Fatalf("find status = %d, body = %s", find.Code, find.Body.String())
 	}
 
+	negativeSkip := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/find", `{"dataSource":"Cluster0","database":"test","collection":"items","skip":-1}`)
+	if negativeSkip.Code != http.StatusBadRequest || !strings.Contains(negativeSkip.Body.String(), "skip must be zero or greater") {
+		t.Fatalf("negative skip status = %d, body = %s", negativeSkip.Code, negativeSkip.Body.String())
+	}
+
+	negativeLimit := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/find", `{"dataSource":"Cluster0","database":"test","collection":"items","limit":-1}`)
+	if negativeLimit.Code != http.StatusBadRequest || !strings.Contains(negativeLimit.Body.String(), "limit must be zero or greater") {
+		t.Fatalf("negative limit status = %d, body = %s", negativeLimit.Code, negativeLimit.Body.String())
+	}
+
 	update := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/updateOne", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"name":"A"},"update":{"$inc":{"price":5}}}`)
 	if update.Code != http.StatusOK || !strings.Contains(update.Body.String(), `"matchedCount":1`) {
 		t.Fatalf("update status = %d, body = %s", update.Code, update.Body.String())
@@ -94,6 +131,16 @@ func TestDataAPIs(t *testing.T) {
 	aggregate := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/aggregate", `{"dataSource":"Cluster0","database":"test","collection":"items","pipeline":[{"$match":{"price":{"$gte":20}}},{"$count":"total"}]}`)
 	if aggregate.Code != http.StatusOK || !strings.Contains(aggregate.Body.String(), `"total":2`) {
 		t.Fatalf("aggregate status = %d, body = %s", aggregate.Code, aggregate.Body.String())
+	}
+
+	negativeAggregateLimit := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/aggregate", `{"dataSource":"Cluster0","database":"test","collection":"items","pipeline":[{"$limit":-1}]}`)
+	if negativeAggregateLimit.Code != http.StatusBadRequest || !strings.Contains(negativeAggregateLimit.Body.String(), "$limit must be zero or greater") {
+		t.Fatalf("negative aggregate limit status = %d, body = %s", negativeAggregateLimit.Code, negativeAggregateLimit.Body.String())
+	}
+
+	negativeAggregateSkip := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/aggregate", `{"dataSource":"Cluster0","database":"test","collection":"items","pipeline":[{"$skip":-1}]}`)
+	if negativeAggregateSkip.Code != http.StatusBadRequest || !strings.Contains(negativeAggregateSkip.Body.String(), "$skip must be zero or greater") {
+		t.Fatalf("negative aggregate skip status = %d, body = %s", negativeAggregateSkip.Code, negativeAggregateSkip.Body.String())
 	}
 
 	deleteMany := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/deleteMany", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"price":{"$gte":20}}}`)

--- a/internal/services/mongoatlas/service_test.go
+++ b/internal/services/mongoatlas/service_test.go
@@ -149,6 +149,56 @@ func TestDataAPIs(t *testing.T) {
 	}
 }
 
+func TestDataAPIFilterTreatsNestedObjectAsEquality(t *testing.T) {
+	_, router := newTestService(t)
+
+	mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/insertOne", `{"dataSource":"Cluster0","database":"test","collection":"object_filters","document":{"name":"NestedA","metadata":{"tenant":"a"}}}`)
+	mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/insertOne", `{"dataSource":"Cluster0","database":"test","collection":"object_filters","document":{"name":"NestedB","metadata":{"tenant":"b"}}}`)
+
+	deleteMany := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/deleteMany", `{"dataSource":"Cluster0","database":"test","collection":"object_filters","filter":{"metadata":{"tenant":"a"}}}`)
+	if deleteMany.Code != http.StatusOK || !strings.Contains(deleteMany.Body.String(), `"deletedCount":1`) {
+		t.Fatalf("deleteMany status = %d, body = %s", deleteMany.Code, deleteMany.Body.String())
+	}
+
+	remaining := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/find", `{"dataSource":"Cluster0","database":"test","collection":"object_filters","projection":{"name":1,"_id":0}}`)
+	if remaining.Code != http.StatusOK || strings.Contains(remaining.Body.String(), "NestedA") || !strings.Contains(remaining.Body.String(), "NestedB") {
+		t.Fatalf("remaining documents status = %d, body = %s", remaining.Code, remaining.Body.String())
+	}
+
+	unsupported := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/find", `{"dataSource":"Cluster0","database":"test","collection":"object_filters","filter":{"metadata":{"$unsupported":"b"}}}`)
+	if unsupported.Code != http.StatusOK || !strings.Contains(unsupported.Body.String(), `"documents":[]`) {
+		t.Fatalf("unsupported operator status = %d, body = %s", unsupported.Code, unsupported.Body.String())
+	}
+}
+
+func TestDataAPIInMatchesArrayFields(t *testing.T) {
+	_, router := newTestService(t)
+
+	mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/insertOne", `{"dataSource":"Cluster0","database":"test","collection":"array_filters","document":{"name":"Tagged","tags":["urgent","billing"]}}`)
+
+	find := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/find", `{"dataSource":"Cluster0","database":"test","collection":"array_filters","filter":{"tags":{"$in":["urgent"]}},"projection":{"name":1,"_id":0}}`)
+	if find.Code != http.StatusOK || !strings.Contains(find.Body.String(), `"documents":[{"name":"Tagged"}]`) {
+		t.Fatalf("find status = %d, body = %s", find.Code, find.Body.String())
+	}
+}
+
+func TestDataAPIMultiKeySortUsesRequestOrder(t *testing.T) {
+	_, router := newTestService(t)
+
+	mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/insertMany", `{"dataSource":"Cluster0","database":"test","collection":"sort_items","documents":[{"name":"a1","group":"a","score":1},{"name":"b3","group":"b","score":3},{"name":"a2","group":"a","score":2},{"name":"b1","group":"b","score":1}]}`)
+
+	want := `"documents":[{"name":"b3"},{"name":"a2"},{"name":"a1"},{"name":"b1"}]`
+	find := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/find", `{"dataSource":"Cluster0","database":"test","collection":"sort_items","sort":{"score":-1,"group":1},"projection":{"name":1,"_id":0}}`)
+	if find.Code != http.StatusOK || !strings.Contains(find.Body.String(), want) {
+		t.Fatalf("find sort status = %d, body = %s", find.Code, find.Body.String())
+	}
+
+	aggregate := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/aggregate", `{"dataSource":"Cluster0","database":"test","collection":"sort_items","pipeline":[{"$sort":{"score":-1,"group":1}},{"$project":{"name":1,"_id":0}}]}`)
+	if aggregate.Code != http.StatusOK || !strings.Contains(aggregate.Body.String(), want) {
+		t.Fatalf("aggregate sort status = %d, body = %s", aggregate.Code, aggregate.Body.String())
+	}
+}
+
 func TestSeedFromConfig(t *testing.T) {
 	service, _ := newTestService(t)
 	service.SeedFromConfig(SeedConfig{

--- a/internal/services/mongoatlas/service_test.go
+++ b/internal/services/mongoatlas/service_test.go
@@ -1,0 +1,166 @@
+package mongoatlas
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	corehttp "github.com/vercel-labs/emulate/internal/core/http"
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+)
+
+func TestAdminAPIs(t *testing.T) {
+	_, router := newTestService(t)
+
+	projects := mongoJSON(router, http.MethodGet, "/api/atlas/v2/groups", "")
+	if projects.Code != http.StatusOK || !strings.Contains(projects.Body.String(), `"name":"Project0"`) {
+		t.Fatalf("projects status = %d, body = %s", projects.Code, projects.Body.String())
+	}
+	groupID := stringFromJSON(t, projects.Body.Bytes(), "results.0.id")
+
+	duplicate := mongoJSON(router, http.MethodPost, "/api/atlas/v2/groups", `{"name":"Project0"}`)
+	if duplicate.Code != http.StatusConflict || !strings.Contains(duplicate.Body.String(), "DUPLICATE_GROUP_NAME") {
+		t.Fatalf("duplicate project status = %d, body = %s", duplicate.Code, duplicate.Body.String())
+	}
+
+	cluster := mongoJSON(router, http.MethodGet, "/api/atlas/v2/groups/"+groupID+"/clusters/Cluster0", "")
+	if cluster.Code != http.StatusOK || !strings.Contains(cluster.Body.String(), `"stateName":"IDLE"`) || !strings.Contains(cluster.Body.String(), `"connectionStrings"`) {
+		t.Fatalf("cluster status = %d, body = %s", cluster.Code, cluster.Body.String())
+	}
+
+	createCluster := mongoJSON(router, http.MethodPost, "/api/atlas/v2/groups/"+groupID+"/clusters", `{"name":"NewCluster","clusterType":"REPLICASET"}`)
+	if createCluster.Code != http.StatusCreated || !strings.Contains(createCluster.Body.String(), `"name":"NewCluster"`) {
+		t.Fatalf("create cluster status = %d, body = %s", createCluster.Code, createCluster.Body.String())
+	}
+
+	user := mongoJSON(router, http.MethodPost, "/api/atlas/v2/groups/"+groupID+"/databaseUsers", `{"username":"app","roles":[{"databaseName":"test","roleName":"readWrite"}]}`)
+	if user.Code != http.StatusCreated || !strings.Contains(user.Body.String(), `"username":"app"`) || !strings.Contains(user.Body.String(), `"roleName":"readWrite"`) {
+		t.Fatalf("create user status = %d, body = %s", user.Code, user.Body.String())
+	}
+
+	databases := mongoJSON(router, http.MethodGet, "/api/atlas/v2/groups/"+groupID+"/clusters/Cluster0/databases", "")
+	if databases.Code != http.StatusOK || !strings.Contains(databases.Body.String(), `"databaseName":"test"`) {
+		t.Fatalf("databases status = %d, body = %s", databases.Code, databases.Body.String())
+	}
+
+	collections := mongoJSON(router, http.MethodGet, "/api/atlas/v2/groups/"+groupID+"/clusters/Cluster0/databases/test/collections", "")
+	if collections.Code != http.StatusOK || !strings.Contains(collections.Body.String(), `"collectionName":"items"`) {
+		t.Fatalf("collections status = %d, body = %s", collections.Code, collections.Body.String())
+	}
+}
+
+func TestDataAPIs(t *testing.T) {
+	_, router := newTestService(t)
+
+	emptyDocument := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/insertOne", `{"dataSource":"Cluster0","database":"test","collection":"items","document":{}}`)
+	if emptyDocument.Code != http.StatusCreated || !strings.Contains(emptyDocument.Body.String(), `"insertedId"`) {
+		t.Fatalf("empty document insert status = %d, body = %s", emptyDocument.Code, emptyDocument.Body.String())
+	}
+
+	insert := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/insertOne", `{"dataSource":"Cluster0","database":"test","collection":"items","document":{"name":"Widget","price":9.99,"nested":{"tag":"a"}}}`)
+	if insert.Code != http.StatusCreated || !strings.Contains(insert.Body.String(), `"insertedId"`) {
+		t.Fatalf("insert status = %d, body = %s", insert.Code, insert.Body.String())
+	}
+
+	findOne := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/findOne", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"nested.tag":"a"}}`)
+	if findOne.Code != http.StatusOK || !strings.Contains(findOne.Body.String(), `"name":"Widget"`) {
+		t.Fatalf("findOne status = %d, body = %s", findOne.Code, findOne.Body.String())
+	}
+
+	mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/insertMany", `{"dataSource":"Cluster0","database":"test","collection":"items","documents":[{"name":"A","price":10},{"name":"B","price":20},{"name":"C","price":30}]}`)
+	find := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/find", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"price":{"$gte":20}},"sort":{"price":-1},"projection":{"name":1,"_id":0}}`)
+	if find.Code != http.StatusOK || !strings.Contains(find.Body.String(), `"documents":[{"name":"C"},{"name":"B"}]`) {
+		t.Fatalf("find status = %d, body = %s", find.Code, find.Body.String())
+	}
+
+	update := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/updateOne", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"name":"A"},"update":{"$inc":{"price":5}}}`)
+	if update.Code != http.StatusOK || !strings.Contains(update.Body.String(), `"matchedCount":1`) {
+		t.Fatalf("update status = %d, body = %s", update.Code, update.Body.String())
+	}
+
+	emptyUpdate := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/updateOne", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"name":"A"},"update":{}}`)
+	if emptyUpdate.Code != http.StatusOK || !strings.Contains(emptyUpdate.Body.String(), `"matchedCount":1`) {
+		t.Fatalf("empty update status = %d, body = %s", emptyUpdate.Code, emptyUpdate.Body.String())
+	}
+
+	upsert := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/updateOne", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"name":"Upserted"},"update":{"$set":{"value":42}},"upsert":true}`)
+	if upsert.Code != http.StatusOK || !strings.Contains(upsert.Body.String(), `"upsertedId"`) {
+		t.Fatalf("upsert status = %d, body = %s", upsert.Code, upsert.Body.String())
+	}
+
+	aggregate := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/aggregate", `{"dataSource":"Cluster0","database":"test","collection":"items","pipeline":[{"$match":{"price":{"$gte":20}}},{"$count":"total"}]}`)
+	if aggregate.Code != http.StatusOK || !strings.Contains(aggregate.Body.String(), `"total":2`) {
+		t.Fatalf("aggregate status = %d, body = %s", aggregate.Code, aggregate.Body.String())
+	}
+
+	deleteMany := mongoJSON(router, http.MethodPost, "/app/data-api/v1/action/deleteMany", `{"dataSource":"Cluster0","database":"test","collection":"items","filter":{"price":{"$gte":20}}}`)
+	if deleteMany.Code != http.StatusOK || !strings.Contains(deleteMany.Body.String(), `"deletedCount":2`) {
+		t.Fatalf("deleteMany status = %d, body = %s", deleteMany.Code, deleteMany.Body.String())
+	}
+}
+
+func TestSeedFromConfig(t *testing.T) {
+	service, _ := newTestService(t)
+	service.SeedFromConfig(SeedConfig{
+		Projects: []ProjectSeed{{Name: "CustomProject"}},
+		Clusters: []ClusterSeed{{Name: "CustomCluster", Project: "CustomProject"}},
+		DatabaseUsers: []DatabaseUserSeed{{
+			Username: "appuser",
+			Project:  "CustomProject",
+			Roles:    []RoleSeed{{DatabaseName: "mydb", RoleName: "readWrite"}},
+		}},
+		Databases: []DatabaseSeed{{Cluster: "CustomCluster", Name: "mydb", Collections: []string{"users", "orders"}}},
+	})
+	if service.projectByName("CustomProject") == nil || firstRecord(service.store.Clusters.FindBy("name", "CustomCluster")) == nil {
+		t.Fatal("seed did not create project and cluster")
+	}
+	cluster := firstRecord(service.store.Clusters.FindBy("name", "CustomCluster"))
+	if service.collectionByName(stringField(cluster, "cluster_id"), "mydb", "orders") == nil {
+		t.Fatal("seed did not create collection")
+	}
+}
+
+func newTestService(t *testing.T) (*Service, *corehttp.Router) {
+	t.Helper()
+	service := New(Options{Store: corestore.New()})
+	router := corehttp.NewRouter()
+	service.RegisterRoutes(router)
+	return service, router
+}
+
+func mongoJSON(router *corehttp.Router, method string, path string, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	return res
+}
+
+func stringFromJSON(t *testing.T, raw []byte, path string) string {
+	t.Helper()
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	current := value
+	for _, part := range strings.Split(path, ".") {
+		if index, err := strconv.Atoi(part); err == nil {
+			items, ok := current.([]any)
+			if !ok || index >= len(items) {
+				t.Fatalf("missing JSON path %s", path)
+			}
+			current = items[index]
+			continue
+		}
+		object, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("missing JSON path %s", path)
+		}
+		current = object[part]
+	}
+	return stringValue(current)
+}

--- a/internal/services/mongoatlas/store.go
+++ b/internal/services/mongoatlas/store.go
@@ -1,0 +1,23 @@
+package mongoatlas
+
+import corestore "github.com/vercel-labs/emulate/internal/core/store"
+
+type Store struct {
+	Clusters    *corestore.Collection
+	Databases   *corestore.Collection
+	Collections *corestore.Collection
+	Documents   *corestore.Collection
+	Projects    *corestore.Collection
+	Users       *corestore.Collection
+}
+
+func NewStore(store *corestore.Store) Store {
+	return Store{
+		Clusters:    store.MustCollection("mongoatlas.clusters", "cluster_id", "name"),
+		Databases:   store.MustCollection("mongoatlas.databases", "cluster_id", "name"),
+		Collections: store.MustCollection("mongoatlas.collections", "cluster_id", "database", "name"),
+		Documents:   store.MustCollection("mongoatlas.documents", "cluster_id", "doc_id"),
+		Projects:    store.MustCollection("mongoatlas.projects", "group_id"),
+		Users:       store.MustCollection("mongoatlas.users", "user_id", "username"),
+	}
+}

--- a/packages/@emulators/mongoatlas/README.md
+++ b/packages/@emulators/mongoatlas/README.md
@@ -1,6 +1,6 @@
 # @emulators/mongoatlas
 
-MongoDB Atlas emulation with Atlas Admin API v2 and Atlas Data API v1 for local development and testing. In-memory document storage with CRUD, filtering, and aggregation.
+MongoDB Atlas emulation with Atlas Admin API v2 and Atlas Data API v1 for local development and testing. The JavaScript package can be embedded through `@emulators/adapter-next`, and the native Go runtime serves the same core routes for local CLI runs and Vercel Go Function previews.
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
@@ -45,7 +45,7 @@ All operations via `POST` with JSON body specifying `dataSource`, `database`, an
 - `POST /app/data-api/v1/action/find` — find many (filter, projection, sort, limit, skip)
 - `POST /app/data-api/v1/action/insertOne` — insert one document
 - `POST /app/data-api/v1/action/insertMany` — insert many documents
-- `POST /app/data-api/v1/action/updateOne` — update one document (`$set`, upsert)
+- `POST /app/data-api/v1/action/updateOne` — update one document (`$set`, `$unset`, `$inc`, `$push`, `$pull`, `$rename`, replacement updates, upsert)
 - `POST /app/data-api/v1/action/updateMany` — update many documents
 - `POST /app/data-api/v1/action/deleteOne` — delete one document
 - `POST /app/data-api/v1/action/deleteMany` — delete many documents
@@ -63,6 +63,14 @@ mongoatlas:
   database_users:
     - project: my-project
       username: app-user
+      roles:
+        - database_name: mydb
+          role_name: readWrite
+  databases:
+    - cluster: my-cluster
+      name: mydb
+      collections:
+        - items
 ```
 
 ## Links

--- a/packages/emulate/src/__tests__/vercel.test.ts
+++ b/packages/emulate/src/__tests__/vercel.test.ts
@@ -22,7 +22,7 @@ describe("createVercelScaffold", () => {
       'emulate "github.com/vercel-labs/emulate/vercel"',
     );
     expect(readFileSync(join(cwd, "api/emulate.go"), "utf-8")).toContain(
-      'Services: []string{"apple", "aws", "clerk", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}',
+      'Services: []string{"apple", "aws", "clerk", "github", "google", "microsoft", "mongoatlas", "okta", "resend", "slack", "stripe", "vercel"}',
     );
     expect(readFileSync(join(cwd, "go.mod"), "utf-8")).toContain("require github.com/vercel-labs/emulate v0.5.0");
     const vercelConfig = JSON.parse(readFileSync(join(cwd, "vercel.json"), "utf-8")) as {
@@ -36,7 +36,7 @@ describe("createVercelScaffold", () => {
 
   it("includes google in the shared Vercel CLI service default", () => {
     expect(DEFAULT_VERCEL_SERVICE_OPTION).toBe(
-      "apple,aws,clerk,github,google,microsoft,okta,resend,slack,stripe,vercel",
+      "apple,aws,clerk,github,google,microsoft,mongoatlas,okta,resend,slack,stripe,vercel",
     );
   });
 
@@ -230,8 +230,8 @@ require (
   it("rejects services not available in the native Vercel scaffold", () => {
     const cwd = tempDir();
 
-    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "mongoatlas" })).toThrow(
-      "currently supports native services: apple, aws, clerk, github, google, microsoft, okta, resend, slack, stripe, vercel",
+    expect(() => createVercelScaffold({ cwd, version: "0.5.0", service: "linear" })).toThrow(
+      "currently supports native services: apple, aws, clerk, github, google, microsoft, mongoatlas, okta, resend, slack, stripe, vercel",
     );
   });
 

--- a/packages/emulate/src/commands/vercel.ts
+++ b/packages/emulate/src/commands/vercel.ts
@@ -8,6 +8,7 @@ export const SUPPORTED_VERCEL_SERVICES = [
   "github",
   "google",
   "microsoft",
+  "mongoatlas",
   "okta",
   "resend",
   "slack",

--- a/skills/aws/SKILL.md
+++ b/skills/aws/SKILL.md
@@ -42,7 +42,7 @@ const aws = await createEmulator({ service: 'aws', port: 4006 })
 Pass tokens as `Authorization: Bearer <token>`. Scoped permissions use `s3:*`, `sqs:*`, `sns:*`, `dynamodb:*`, `iam:*`, `sts:*` patterns.
 
 ```bash
-curl http://localhost:4006/ \
+curl http://localhost:4007/ \
   -H "Authorization: Bearer test_token_admin"
 ```
 
@@ -51,7 +51,7 @@ curl http://localhost:4006/ \
 ### Environment Variable
 
 ```bash
-AWS_EMULATOR_URL=http://localhost:4006
+AWS_EMULATOR_URL=http://localhost:4007
 ```
 
 ### AWS SDK v3

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -319,13 +319,14 @@ OKTA_EMULATOR_URL=http://localhost:4006
 AWS_EMULATOR_URL=http://localhost:4007
 RESEND_EMULATOR_URL=http://localhost:4008
 STRIPE_EMULATOR_URL=http://localhost:4009
+MONGOATLAS_EMULATOR_URL=http://localhost:4010
 ```
 
 Then use these in your app to construct API and OAuth URLs. See each service's skill for SDK-specific override instructions.
 
 ## Next.js Integration
 
-The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
+The `@emulators/adapter-next` package supports embedded JavaScript emulators and native runtime proxy routes on the same Next.js origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `mongoatlas`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews on Vercel, run `npx emulate vercel init` to generate `api/emulate.go`, `vercel.json`, and `go.mod`. See the **next** skill (`skills/next/SKILL.md`) for full setup, Auth.js configuration, Vercel Go Function state behavior, persistence, font tracing, and `createEmulateProxy` details.
 
 ## Persistence
 

--- a/skills/mongoatlas/SKILL.md
+++ b/skills/mongoatlas/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: mongoatlas
+description: Emulated MongoDB Atlas Admin API v2 and Data API v1 for local development, testing, and native Vercel preview functions. Use when the user needs to manage Atlas projects, clusters, database users, databases, collections, Data API documents, seed MongoDB Atlas state, scaffold MongoDB Atlas through npx emulate vercel init, or point Atlas SDK-style HTTP requests at a local API. Triggers include "MongoDB Atlas", "Atlas Admin API", "Atlas Data API", "emulate MongoDB", "mongoatlas", "dataSource", or any task requiring local MongoDB Atlas service emulation.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# MongoDB Atlas Emulator
+
+Use the MongoDB Atlas emulator for Atlas Admin API v2 and Data API v1 flows in local development, CI, and Vercel preview functions.
+
+## Start
+
+```bash
+npx emulate --service mongoatlas
+```
+
+Default base URL:
+
+```bash
+http://localhost:4010
+```
+
+## Vercel Preview
+
+To expose MongoDB Atlas in a zero infra Vercel preview, scaffold the Go Function route:
+
+```bash
+npx emulate vercel init --service mongoatlas
+```
+
+The generated route serves MongoDB Atlas at `/emulate/mongoatlas/*`.
+
+## Admin API
+
+- `GET /api/atlas/v2/groups` lists projects.
+- `GET /api/atlas/v2/groups/:groupId` gets a project.
+- `POST /api/atlas/v2/groups` creates a project.
+- `DELETE /api/atlas/v2/groups/:groupId` deletes a project and cascades clusters and data.
+- `GET /api/atlas/v2/groups/:groupId/clusters` lists clusters.
+- `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName` gets a cluster.
+- `POST /api/atlas/v2/groups/:groupId/clusters` creates a cluster.
+- `PATCH /api/atlas/v2/groups/:groupId/clusters/:clusterName` updates a cluster.
+- `DELETE /api/atlas/v2/groups/:groupId/clusters/:clusterName` deletes a cluster.
+- `GET /api/atlas/v2/groups/:groupId/databaseUsers` lists database users.
+- `GET /api/atlas/v2/groups/:groupId/databaseUsers/admin/:username` gets a database user.
+- `POST /api/atlas/v2/groups/:groupId/databaseUsers` creates a database user.
+- `DELETE /api/atlas/v2/groups/:groupId/databaseUsers/admin/:username` deletes a database user.
+- `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName/databases` lists databases.
+- `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName/databases/:databaseName/collections` lists collections.
+
+## Data API
+
+All Data API routes accept JSON bodies with `dataSource`, `database`, and `collection`.
+
+- `POST /app/data-api/v1/action/findOne`
+- `POST /app/data-api/v1/action/find`
+- `POST /app/data-api/v1/action/insertOne`
+- `POST /app/data-api/v1/action/insertMany`
+- `POST /app/data-api/v1/action/updateOne`
+- `POST /app/data-api/v1/action/updateMany`
+- `POST /app/data-api/v1/action/deleteOne`
+- `POST /app/data-api/v1/action/deleteMany`
+- `POST /app/data-api/v1/action/aggregate`
+
+Supported document filters include equality, dotted paths, `$and`, `$or`, `$nor`, `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, and `$regex`. Supported updates include `$set`, `$unset`, `$inc`, `$push`, `$pull`, `$rename`, replacement updates, and upserts.
+
+## Seed Config
+
+```yaml
+mongoatlas:
+  projects:
+    - name: my-project
+  clusters:
+    - project: my-project
+      name: my-cluster
+  database_users:
+    - project: my-project
+      username: app-user
+      roles:
+        - database_name: mydb
+          role_name: readWrite
+  databases:
+    - cluster: my-cluster
+      name: mydb
+      collections:
+        - items
+```

--- a/skills/mongoatlas/SKILL.md
+++ b/skills/mongoatlas/SKILL.md
@@ -14,11 +14,13 @@ Use the MongoDB Atlas emulator for Atlas Admin API v2 and Data API v1 flows in l
 npx emulate --service mongoatlas
 ```
 
-Default base URL:
+When run alone, the default base URL is:
 
 ```bash
-http://localhost:4010
+http://localhost:4000
 ```
+
+When all services run together from the default base port, MongoDB Atlas is available at `http://localhost:4010`.
 
 ## Vercel Preview
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -22,7 +22,7 @@ This creates:
 - `vercel.json`, with `/emulate/:path*` rewritten to `/api/emulate?path=:path*`
 - `go.mod`, pinned to the installed `emulate` package version
 
-The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
+The scaffold currently enables the native `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `mongoatlas`, `okta`, `resend`, `slack`, `stripe`, and `vercel` handlers. Use `npx emulate vercel init --service github` to limit the function to one service.
 
 State uses warm memory by default: cold starts reset to a fresh store, warm invocations reuse mutations, and concurrent function instances can diverge. For snapshots across cold starts, implement `vercel.Persistence` in `api/emulate.go` and pass it to `emulate.NewHandler`.
 
@@ -68,7 +68,7 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
-Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
+Embedded mode is the broadest zero infra path for JavaScript emulator packages on Vercel preview deployments. The emulator code runs in the Next.js function, so OAuth callback URLs can point at the preview origin. For native Go `apple`, `aws`, `clerk`, `github`, `google`, `microsoft`, `mongoatlas`, `okta`, `resend`, `slack`, `stripe`, and `vercel` previews, use `npx emulate vercel init`.
 
 ## Native Runtime Proxy
 

--- a/vercel/handler.go
+++ b/vercel/handler.go
@@ -18,7 +18,7 @@ import (
 
 const DefaultRoutePrefix = "/emulate"
 
-var defaultServices = []string{"apple", "aws", "clerk", "github", "google", "microsoft", "okta", "resend", "slack", "stripe", "vercel"}
+var defaultServices = []string{"apple", "aws", "clerk", "github", "google", "microsoft", "mongoatlas", "okta", "resend", "slack", "stripe", "vercel"}
 
 var mutatingMethods = map[string]struct{}{
 	http.MethodPost:   {},

--- a/vercel/handler_test.go
+++ b/vercel/handler_test.go
@@ -35,7 +35,7 @@ func TestHandlerServesPreviewHealth(t *testing.T) {
 	if !body.OK || body.Adapter != "vercel" || body.Runtime != "go" || body.Version != "test" || body.RoutePrefix != "/emulate" {
 		t.Fatalf("unexpected body: %#v", body)
 	}
-	if strings.Join(body.Services, ",") != "apple,aws,clerk,github,google,microsoft,okta,resend,slack,stripe,vercel" {
+	if strings.Join(body.Services, ",") != "apple,aws,clerk,github,google,microsoft,mongoatlas,okta,resend,slack,stripe,vercel" {
 		t.Fatalf("services = %#v", body.Services)
 	}
 }
@@ -208,6 +208,22 @@ func TestHandlerForwardsClerkService(t *testing.T) {
 	}
 }
 
+func TestHandlerForwardsMongoAtlasService(t *testing.T) {
+	handler := NewHandler(Options{Services: []string{"mongoatlas"}})
+	req := newJSONRequest(http.MethodPost, "https://preview.example.com/emulate/mongoatlas/app/data-api/v1/action/insertOne", `{"dataSource":"Cluster0","database":"test","collection":"items","document":{"name":"Preview"}}`)
+	req.Host = "preview.example.com"
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"insertedId"`) {
+		t.Fatalf("unexpected body: %s", res.Body.String())
+	}
+}
+
 func TestHandlerForwardsSlackService(t *testing.T) {
 	handler := NewHandler(Options{Services: []string{"slack"}})
 	req := httptest.NewRequest(http.MethodPost, "https://preview.example.com/emulate/slack/api/auth.test", nil)
@@ -303,7 +319,7 @@ func TestHandlerRewritesHTMLRootPathsThroughPublicServicePrefix(t *testing.T) {
 
 func TestHandlerReturnsUnknownService(t *testing.T) {
 	handler := NewHandler(Options{})
-	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/mongoatlas/user", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://preview.example.com/emulate/linear/user", nil)
 
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
@@ -311,7 +327,7 @@ func TestHandlerReturnsUnknownService(t *testing.T) {
 	if res.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %s", res.Code, res.Body.String())
 	}
-	if !strings.Contains(res.Body.String(), "Unknown service: mongoatlas") {
+	if !strings.Contains(res.Body.String(), "Unknown service: linear") {
 		t.Fatalf("unexpected body: %s", res.Body.String())
 	}
 }


### PR DESCRIPTION
- Adds native Atlas Admin API and Data API handlers with in-memory project, cluster, user, database, collection, and document state.

- Wires mongoatlas into native CLI seed parsing, runtime registration, and Vercel Go Function scaffolding.

- Updates docs, skills, and tests for native MongoDB Atlas support.