### PR TITLE
Use native Go engine for npm CLI distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
 
       - run: go build ./cmd/emulate
 
+      - run: node scripts/build-native-packages.mjs
+
       - name: Native AWS SDK E2E
         run: |
           go build -o /tmp/emulate-native ./cmd/emulate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   EMULATOR_PACKAGES: adapter-next apple aws clerk core github google microsoft mongoatlas okta resend slack stripe vercel
+  NATIVE_BINARY_PACKAGES: emulate-darwin-arm64 emulate-darwin-x64 emulate-linux-arm64 emulate-linux-x64 emulate-win32-arm64 emulate-win32-x64
 
 jobs:
   check-release:
@@ -45,6 +46,14 @@ jobs:
           fi
 
           for pkg in $EMULATOR_PACKAGES; do
+            REGISTRY_VERSION=$(npm view "@emulators/$pkg" version 2>/dev/null || echo "0.0.0")
+            echo "@emulators/$pkg — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
+            if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
+              SHOULD_RELEASE=true
+            fi
+          done
+
+          for pkg in $NATIVE_BINARY_PACKAGES; do
             REGISTRY_VERSION=$(npm view "@emulators/$pkg" version 2>/dev/null || echo "0.0.0")
             echo "@emulators/$pkg — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
             if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
@@ -85,11 +94,20 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
+
+      - name: Build native binary packages
+        run: node scripts/build-native-packages.mjs
 
       - name: Publish packages
         run: |
@@ -111,6 +129,10 @@ jobs:
               FAILED="$FAILED $name"
             fi
           }
+
+          for pkg in $NATIVE_BINARY_PACKAGES; do
+            publish_pkg "packages/@emulators/$pkg" "@emulators/$pkg"
+          done
 
           publish_pkg packages/emulate emulate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,6 @@ jobs:
             fi
           done
 
-          for pkg in $NATIVE_BINARY_PACKAGES; do
-            REGISTRY_VERSION=$(npm view "@emulators/$pkg" version 2>/dev/null || echo "0.0.0")
-            echo "@emulators/$pkg — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
-            if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
-              SHOULD_RELEASE=true
-            fi
-          done
-
           echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
           echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
 
@@ -133,6 +125,11 @@ jobs:
           for pkg in $NATIVE_BINARY_PACKAGES; do
             publish_pkg "packages/@emulators/$pkg" "@emulators/$pkg"
           done
+
+          if [ -n "$FAILED" ]; then
+            echo "Failed to publish native packages:$FAILED"
+            exit 1
+          fi
 
           publish_pkg packages/emulate emulate
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ emulate.config.yml
 
 # emulate CLI README is copied from root by prepack
 packages/emulate/README.md
+packages/@emulators/emulate-*/bin/
 
 # opensrc - source code for packages
 opensrc/

--- a/README.md
+++ b/README.md
@@ -8,20 +8,11 @@ Local drop-in replacement services for CI and no-network sandboxes. Fully statef
 npx emulate
 ```
 
-All services start with sensible defaults. No config file needed:
+The npm CLI launches the native Go engine. All services start on one local server with sensible defaults. No config file needed:
 
-- **Vercel** on `http://localhost:4000`
-- **GitHub** on `http://localhost:4001`
-- **Google** on `http://localhost:4002`
-- **Slack** on `http://localhost:4003`
-- **Apple** on `http://localhost:4004`
-- **Microsoft** on `http://localhost:4005`
-- **Okta** on `http://localhost:4006`
-- **AWS** on `http://localhost:4007`
-- **Resend** on `http://localhost:4008`
-- **Stripe** on `http://localhost:4009`
-- **MongoDB Atlas** on `http://localhost:4010`
-- **Clerk** on `http://localhost:4011`
+```
+http://localhost:4000
+```
 
 ## CLI
 
@@ -55,13 +46,15 @@ npx emulate list
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-p, --port` | `4000` | Base port (auto-increments per service) |
+| `-p, --port` | `4000` | Port for the native server |
 | `-s, --service` | all | Comma-separated services to enable |
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
-| `--base-url` | none | Override advertised base URL (supports `{service}` template) |
+| `--base-url` | none | Override advertised base URL |
 | `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+
+The `emulate` npm package installs a small JavaScript launcher plus an optional native binary package for your OS and CPU. Supported native packages cover macOS, Linux, and Windows on x64 and arm64.
 
 ## HTTPS with portless
 
@@ -83,17 +76,17 @@ google  https://google.emulate.localhost
 slack   https://slack.emulate.localhost
 ```
 
-If portless is not installed, emulate will prompt to install it (`npm i -g portless`).
+If portless is not installed, install it with `npm i -g portless`.
 
 The `--portless` flag overwrites any existing portless aliases matching `*.emulate`. Aliases are removed automatically when emulate shuts down.
 
 For a custom base URL without portless (any reverse proxy), use `--base-url` or the `EMULATE_BASE_URL` env var:
 
 ```bash
-npx emulate start --base-url "https://{service}.myproxy.test"
+npx emulate start --base-url "https://emulate.myproxy.test"
 ```
 
-The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`), typically to a value like `https://{service}.emulate.localhost`. It supports `{service}` interpolation, just like `--base-url` and `EMULATE_BASE_URL`. When no explicit `baseUrl` is provided, it is used as a fallback.
+The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it. When no explicit `baseUrl` is provided, it is used as a fallback. `{service}` templates are supported when exactly one service is enabled; use `--portless` for per-service aliases.
 
 Per-service overrides are also supported in the seed config (these take highest priority over all other base URL sources):
 
@@ -781,7 +774,7 @@ Manual STS requests can use `POST /sts/` with an `Action` form parameter. In the
 
 Resend email API emulation with local capture for sent emails, domains, API keys, audiences, contacts, and an inbox UI. Set `RESEND_BASE_URL` before importing the official Resend Node.js SDK and the SDK will send to the emulator.
 
-The native Go runtime serves the same current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime serves the same current Resend routes, supports YAML and JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 To expose the native Resend emulator in a Vercel preview without separate infrastructure, run `npx emulate vercel init --service resend`. The generated route serves Resend at `/emulate/resend/*`.
 
@@ -994,7 +987,7 @@ The persistence adapter is called on cold start (load) and after every mutating 
 
 ```
 packages/
-  emulate/          # CLI entry point (commander)
+  emulate/          # npm CLI shim and programmatic API
   @emulators/
     core/           # HTTP server, in-memory store, plugin interface, middleware
     adapter-next/   # Next.js App Router integration
@@ -1009,7 +1002,7 @@ apps/
   web/              # Documentation site (Next.js)
 ```
 
-The core provides a generic `Store` with typed `Collection<T>` instances supporting CRUD, indexing, filtering, and pagination. Each service plugin registers its routes with the shared internal app and uses the store for state.
+The native Go runtime is the default CLI engine and is distributed through npm as platform-specific optional binary packages. The TypeScript packages remain available for the programmatic API, framework adapters, and SDK conformance tests.
 
 ## Auth
 

--- a/apps/web/app/docs/architecture/page.mdx
+++ b/apps/web/app/docs/architecture/page.mdx
@@ -2,7 +2,7 @@
 
 ```
 packages/
-  emulate/          # CLI entry point (commander)
+  emulate/          # npm CLI shim and programmatic API
   @emulators/
     core/           # HTTP server, in-memory store, plugin interface, middleware
     adapter-next/   # Next.js App Router integration
@@ -35,7 +35,7 @@ Each service is a plugin that:
 3. Provides a seed function to populate initial state from config
 4. Uses shared middleware for auth, error handling, and pagination
 
-Multiple services can run simultaneously, each on its own port (auto-incremented from the base port).
+The native Go runtime is the default CLI engine and serves selected services from one local server. `--portless` starts service-specific native listeners so each service can keep a named HTTPS alias.
 
 ## In-Memory State
 

--- a/apps/web/app/docs/authentication/page.mdx
+++ b/apps/web/app/docs/authentication/page.mdx
@@ -35,7 +35,7 @@ Use the token in requests:
 
 ```bash
 curl -H "Authorization: Bearer gho_test_token_admin" \
-  http://localhost:4001/user
+  http://localhost:4000/user
 ```
 
 ## GitHub Apps (JWT)
@@ -47,7 +47,7 @@ Then create an installation access token:
 ```bash
 curl -X POST \
   -H "Authorization: Bearer <jwt>" \
-  http://localhost:4001/app/installations/100/access_tokens
+  http://localhost:4000/app/installations/100/access_tokens
 ```
 
 The returned token can be used for API calls scoped to that installation's permissions.
@@ -57,7 +57,7 @@ The returned token can be used for API calls scoped to that installation's permi
 The Google emulator uses the standard OAuth 2.0 authorization code flow. Configure clients in the seed config and use them with your OAuth library of choice. The OIDC discovery document is available at `/.well-known/openid-configuration`.
 
 ```bash
-curl http://localhost:4002/.well-known/openid-configuration
+curl http://localhost:4000/.well-known/openid-configuration
 ```
 
 When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/google/.well-known/openid-configuration`, `/apple/.well-known/openid-configuration`, `/microsoft/.well-known/openid-configuration`, `/okta/.well-known/openid-configuration`, or `/clerk/.well-known/openid-configuration` to avoid the shared root discovery path.
@@ -70,7 +70,7 @@ The Slack emulator supports OAuth v2 with a user picker UI. Configure OAuth apps
 import { WebClient } from '@slack/web-api'
 
 const client = new WebClient(token, {
-  slackApiUrl: 'http://localhost:4003/api/',
+  slackApiUrl: 'http://localhost:4000/api/',
 })
 ```
 
@@ -81,7 +81,7 @@ All Web API endpoints require `Authorization: Bearer <token>`.
 The Apple emulator provides OIDC discovery, JWKS, and a full authorization code flow with RS256 ID tokens. Point your app at the emulator's endpoints:
 
 ```bash
-curl http://localhost:4004/.well-known/openid-configuration
+curl http://localhost:4000/.well-known/openid-configuration
 ```
 
 On first authorization per user/client pair, a `user` JSON blob is included in the callback (matching real Apple behavior).
@@ -91,7 +91,7 @@ On first authorization per user/client pair, a `user` JSON blob is included in t
 The Microsoft emulator supports OIDC discovery, authorization code flow, PKCE, and client credentials grants. It also provides a Microsoft Graph `/v1.0/me` endpoint.
 
 ```bash
-curl http://localhost:4005/.well-known/openid-configuration
+curl http://localhost:4000/.well-known/openid-configuration
 ```
 
 Supports `Authorization: Basic` header with base64-encoded `client_id:client_secret` as an alternative to body parameters.
@@ -101,13 +101,13 @@ Supports `Authorization: Basic` header with base64-encoded `client_id:client_sec
 The Clerk emulator supports OIDC discovery, authorization code flow, PKCE, JWKS, ID tokens, userinfo, and session JWT creation.
 
 ```bash
-curl http://localhost:4011/.well-known/openid-configuration
+curl http://localhost:4000/.well-known/openid-configuration
 ```
 
 Management API routes require a Clerk-style secret key:
 
 ```bash
-curl http://localhost:4011/v1/users \
+curl http://localhost:4000/v1/users \
   -H "Authorization: Bearer sk_test_emulate"
 ```
 
@@ -116,7 +116,7 @@ curl http://localhost:4011/v1/users \
 Pass tokens as `Authorization: Bearer <token>`. Scoped permissions use `s3:*`, `sqs:*`, `sns:*`, `events:*`, `dynamodb:*`, `iam:*`, `sts:*` patterns.
 
 ```bash
-curl http://localhost:4006/s3/ \
+curl http://localhost:4000/s3/ \
   -H "Authorization: Bearer test_token_admin"
 ```
 

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -8,20 +8,11 @@ Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, A
 npx emulate
 ```
 
-All services start with sensible defaults. No config file needed:
+The npm CLI launches the native Go engine. All services start on one local server with sensible defaults:
 
-- **Vercel** on `http://localhost:4000`
-- **GitHub** on `http://localhost:4001`
-- **Google** on `http://localhost:4002`
-- **Slack** on `http://localhost:4003`
-- **Apple** on `http://localhost:4004`
-- **Microsoft** on `http://localhost:4005`
-- **Okta** on `http://localhost:4006`
-- **AWS** on `http://localhost:4007`
-- **Resend** on `http://localhost:4008`
-- **Stripe** on `http://localhost:4009`
-- **MongoDB Atlas** on `http://localhost:4010`
-- **Clerk** on `http://localhost:4011`
+```bash
+http://localhost:4000
+```
 
 ## CLI
 
@@ -32,7 +23,7 @@ npx emulate
 # Start specific services
 npx emulate --service vercel,github
 
-# Custom port
+# Custom native server port
 npx emulate --port 3000
 
 # Use a seed config file
@@ -43,6 +34,9 @@ npx emulate init
 
 # Generate config for a specific service
 npx emulate init --service github
+
+# Scaffold a Vercel Go Function preview route
+npx emulate vercel init
 
 # List available services
 npx emulate list
@@ -62,7 +56,7 @@ npx emulate list
     <tr>
       <td><code>-p, --port</code></td>
       <td><code>4000</code></td>
-      <td>Base port (auto-increments per service)</td>
+      <td>Port for the native server</td>
     </tr>
     <tr>
       <td><code>-s, --service</code></td>
@@ -78,6 +72,8 @@ npx emulate list
 </table>
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+
+The `emulate` npm package installs a small JavaScript launcher plus an optional native binary package for your OS and CPU. Supported native packages cover macOS, Linux, and Windows on x64 and arm64.
 
 ## Programmatic API
 

--- a/apps/web/app/docs/resend/page.mdx
+++ b/apps/web/app/docs/resend/page.mdx
@@ -4,7 +4,7 @@ Resend email API emulation with email sending, domain management, API keys, audi
 
 Set `RESEND_BASE_URL` before importing the official `resend` Node.js SDK and the SDK will call the emulator without code changes.
 
-The native Go runtime implements the current Resend routes below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime implements the current Resend routes below, supports YAML and JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 ## Vercel Preview
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -62,7 +62,7 @@ export default function LandingPage() {
               <h3 className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">Zero config</h3>
               <p className="text-sm text-neutral-600 dark:text-neutral-400">
                 Run <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">npx emulate</code>{" "}
-                and all 11 services start with sensible defaults. Seed data via YAML when you need it.
+                and all 12 services start with sensible defaults. Seed data via YAML when you need it.
               </p>
             </div>
             <div>

--- a/apps/web/components/hero-terminal.tsx
+++ b/apps/web/components/hero-terminal.tsx
@@ -4,17 +4,17 @@ import { useState } from "react";
 
 const services = [
   { name: "Vercel", port: 4000, slug: "vercel" },
-  { name: "GitHub", port: 4001, slug: "github" },
-  { name: "Google", port: 4002, slug: "google" },
-  { name: "Slack", port: 4003, slug: "slack" },
-  { name: "Apple", port: 4004, slug: "apple" },
-  { name: "Microsoft", port: 4005, slug: "microsoft" },
-  { name: "Okta", port: 4006, slug: "okta" },
-  { name: "AWS", port: 4007, slug: "aws" },
-  { name: "Resend", port: 4008, slug: "resend" },
-  { name: "Stripe", port: 4009, slug: "stripe" },
-  { name: "MongoDB Atlas", port: 4010, slug: "mongoatlas" },
-  { name: "Clerk", port: 4011, slug: "clerk" },
+  { name: "GitHub", port: 4000, slug: "github" },
+  { name: "Google", port: 4000, slug: "google" },
+  { name: "Slack", port: 4000, slug: "slack" },
+  { name: "Apple", port: 4000, slug: "apple" },
+  { name: "Microsoft", port: 4000, slug: "microsoft" },
+  { name: "Okta", port: 4000, slug: "okta" },
+  { name: "AWS", port: 4000, slug: "aws" },
+  { name: "Resend", port: 4000, slug: "resend" },
+  { name: "Stripe", port: 4000, slug: "stripe" },
+  { name: "MongoDB Atlas", port: 4000, slug: "mongoatlas" },
+  { name: "Clerk", port: 4000, slug: "clerk" },
 ];
 
 export function HeroTerminal({ pixelFont }: { pixelFont: string }) {

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -49,6 +49,7 @@ type nativeSeedOptions struct {
 	Slack      *slack.SeedConfig
 	Stripe     *stripe.SeedConfig
 	Vercel     *vercel.SeedConfig
+	BaseURLs   map[string]string
 }
 
 func main() {
@@ -139,17 +140,19 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 	var slackSeed *slack.SeedConfig
 	var stripeSeed *stripe.SeedConfig
 	var vercelSeed *vercel.SeedConfig
-	if *seedValue != "" {
-		loaded, err := coreconfig.Load(coreconfig.LoadOptions{Path: *seedValue})
-		if err != nil {
-			fmt.Fprintf(stderr, "Failed to load seed config: %v\n", err)
-			return 1
-		}
+	seedBaseURLs := map[string]string{}
+	loaded, err := loadNativeSeedConfig(*seedValue)
+	if err != nil {
+		fmt.Fprintf(stderr, "Failed to load seed config: %v\n", err)
+		return 1
+	}
+	if loaded != nil {
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
 			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, aws, clerk, github, google, microsoft, mongoatlas, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
+		seedBaseURLs = nativeSeedBaseURLs(loaded.Data)
 		if raw, ok := loaded.Data["aws"]; ok {
 			var cfg aws.SeedConfig
 			if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -285,24 +288,21 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		Slack:      slackSeed,
 		Stripe:     stripeSeed,
 		Vercel:     vercelSeed,
+		BaseURLs:   seedBaseURLs,
 	}
 	if *portlessValue {
 		return runPortlessStart(ctx, stdout, stderr, port, services, seeds)
 	}
 
-	baseURL := *baseURLValue
-	if baseURL == "" {
-		baseURL = getenv("EMULATE_BASE_URL", getenv("PORTLESS_URL", ""))
+	fallbackBaseURL, err := nativeCommandBaseURL(*baseURLValue, services, port)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
 	}
-	if baseURL != "" && strings.Contains(baseURL, "{service}") {
-		if len(services) != 1 {
-			fmt.Fprintln(stderr, "Base URL templates with {service} require exactly one service in native single-server mode. Use --portless for per-service aliases.")
-			return 1
-		}
-		baseURL = strings.ReplaceAll(baseURL, "{service}", services[0])
-	}
-	if baseURL == "" {
-		baseURL = fmt.Sprintf("http://localhost:%d", port)
+	baseURL, err := nativeSingleServerBaseURL(services, seeds.BaseURLs, fallbackBaseURL)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
 	}
 	server := emuruntime.NewServer(serverOptions(baseURL, services, seeds))
 	httpServer := &nethttp.Server{
@@ -344,6 +344,107 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		}
 		return 0
 	}
+}
+
+func loadNativeSeedConfig(seedPath string) (*coreconfig.LoadResult, error) {
+	if seedPath != "" {
+		return coreconfig.Load(coreconfig.LoadOptions{Path: seedPath})
+	}
+	loaded, err := coreconfig.Load(coreconfig.LoadOptions{})
+	if errors.Is(err, coreconfig.ErrNotFound) {
+		return nil, nil
+	}
+	return loaded, err
+}
+
+func nativeSeedBaseURLs(data map[string]json.RawMessage) map[string]string {
+	baseURLs := map[string]string{}
+	for _, service := range nativeSeedServiceNames() {
+		raw, ok := data[service]
+		if !ok {
+			continue
+		}
+		var config struct {
+			BaseURL string `json:"baseUrl"`
+		}
+		if err := json.Unmarshal(raw, &config); err != nil {
+			continue
+		}
+		baseURL := strings.TrimRight(strings.TrimSpace(config.BaseURL), "/")
+		if baseURL != "" {
+			baseURLs[service] = baseURL
+		}
+	}
+	return baseURLs
+}
+
+func nativeCommandBaseURL(baseURL string, services []string, port int) (string, error) {
+	if baseURL == "" {
+		baseURL = getenv("EMULATE_BASE_URL", getenv("PORTLESS_URL", ""))
+	}
+	if baseURL != "" && strings.Contains(baseURL, "{service}") {
+		if len(services) != 1 {
+			return "", fmt.Errorf("Base URL templates with {service} require exactly one service in native single-server mode. Use --portless for per-service aliases.")
+		}
+		baseURL = strings.ReplaceAll(baseURL, "{service}", services[0])
+	}
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("http://localhost:%d", port)
+	}
+	return baseURL, nil
+}
+
+func nativeSingleServerBaseURL(services []string, seedBaseURLs map[string]string, fallback string) (string, error) {
+	if len(seedBaseURLs) == 0 {
+		return fallback, nil
+	}
+	selected := map[string]string{}
+	for _, service := range services {
+		if baseURL := seedBaseURLForService(service, seedBaseURLs); baseURL != "" {
+			selected[service] = baseURL
+		}
+	}
+	if len(selected) == 0 {
+		return fallback, nil
+	}
+	if len(services) == 1 {
+		return selected[services[0]], nil
+	}
+
+	var shared string
+	allSelectedHaveSameBaseURL := len(selected) == len(services)
+	for _, service := range services {
+		baseURL, ok := selected[service]
+		if !ok {
+			allSelectedHaveSameBaseURL = false
+			continue
+		}
+		if shared == "" {
+			shared = baseURL
+			continue
+		}
+		if baseURL != shared {
+			allSelectedHaveSameBaseURL = false
+		}
+	}
+	if allSelectedHaveSameBaseURL {
+		return shared, nil
+	}
+
+	names := make([]string, 0, len(selected))
+	for service := range selected {
+		names = append(names, service)
+	}
+	sort.Strings(names)
+	return "", fmt.Errorf("Per-service baseUrl seed overrides require exactly one selected service or the same baseUrl for every selected service in native single-server mode. Use --portless for per-service URLs. Overrides found for: %s", strings.Join(names, ", "))
+}
+
+func seedBaseURLForService(service string, seedBaseURLs map[string]string) string {
+	baseURL := seedBaseURLs[service]
+	if baseURL == "" {
+		return ""
+	}
+	return strings.ReplaceAll(baseURL, "{service}", service)
 }
 
 func serverOptions(baseURL string, services []string, seeds nativeSeedOptions) emuruntime.ServerOptions {

--- a/cmd/emulate/main.go
+++ b/cmd/emulate/main.go
@@ -21,6 +21,7 @@ import (
 	coreconfig "github.com/vercel-labs/emulate/internal/core/config"
 	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
 	"github.com/vercel-labs/emulate/internal/services/apple"
+	"github.com/vercel-labs/emulate/internal/services/aws"
 	"github.com/vercel-labs/emulate/internal/services/clerk"
 	"github.com/vercel-labs/emulate/internal/services/github"
 	"github.com/vercel-labs/emulate/internal/services/google"
@@ -34,6 +35,21 @@ import (
 )
 
 var version = "dev"
+
+type nativeSeedOptions struct {
+	Apple      *apple.SeedConfig
+	AWS        *aws.SeedConfig
+	Clerk      *clerk.SeedConfig
+	GitHub     *github.SeedConfig
+	Google     *google.SeedConfig
+	Microsoft  *microsoft.SeedConfig
+	MongoAtlas *mongoatlas.SeedConfig
+	Okta       *okta.SeedConfig
+	Resend     *resend.SeedConfig
+	Slack      *slack.SeedConfig
+	Stripe     *stripe.SeedConfig
+	Vercel     *vercel.SeedConfig
+}
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -63,6 +79,8 @@ func runWithContext(ctx context.Context, args []string, stdout io.Writer, stderr
 		return runInit(args[1:], stdout, stderr)
 	case "list", "list-services":
 		return runList(args[1:], stdout, stderr)
+	case "vercel":
+		return runVercel(args[1:], stdout, stderr)
 	default:
 		if strings.HasPrefix(args[0], "-") {
 			return runStart(ctx, args, stdout, stderr)
@@ -81,8 +99,8 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		printStartHelp(stderr)
 	}
 
-	portValue := fs.String("port", defaultPort, "Base port")
-	fs.StringVar(portValue, "p", defaultPort, "Base port")
+	portValue := fs.String("port", defaultPort, "Port")
+	fs.StringVar(portValue, "p", defaultPort, "Port")
 	serviceValue := fs.String("service", "", "Comma-separated services to enable")
 	fs.StringVar(serviceValue, "s", "", "Comma-separated services to enable")
 	seedValue := fs.String("seed", "", "Path to seed config file")
@@ -108,12 +126,9 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		fmt.Fprintln(stderr, "--portless and --base-url are mutually exclusive.")
 		return 1
 	}
-	if *portlessValue {
-		fmt.Fprintln(stderr, "The native Go runtime does not support --portless yet.")
-		return 1
-	}
 	var seedServices []string
 	var appleSeed *apple.SeedConfig
+	var awsSeed *aws.SeedConfig
 	var clerkSeed *clerk.SeedConfig
 	var githubSeed *github.SeedConfig
 	var googleSeed *google.SeedConfig
@@ -131,10 +146,18 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		if unsupported := unsupportedNativeSeedServices(loaded.Data); len(unsupported) > 0 {
-			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, clerk, github, google, microsoft, mongoatlas, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
+			fmt.Fprintf(stderr, "The native Go runtime only supports --seed for apple, aws, clerk, github, google, microsoft, mongoatlas, okta, resend, slack, stripe, and vercel. Unsupported seed config services: %s\n", strings.Join(unsupported, ", "))
 			return 1
 		}
 		seedServices = coreconfig.InferServices(loaded.Data, nativeSeedServiceNames())
+		if raw, ok := loaded.Data["aws"]; ok {
+			var cfg aws.SeedConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				fmt.Fprintf(stderr, "Failed to parse aws seed config: %v\n", err)
+				return 1
+			}
+			awsSeed = &cfg
+		}
 		if raw, ok := loaded.Data["github"]; ok {
 			var cfg github.SeedConfig
 			if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -249,26 +272,39 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		services = seedServices
 	}
 
+	seeds := nativeSeedOptions{
+		Apple:      appleSeed,
+		AWS:        awsSeed,
+		Clerk:      clerkSeed,
+		GitHub:     githubSeed,
+		Google:     googleSeed,
+		Microsoft:  microsoftSeed,
+		MongoAtlas: mongoAtlasSeed,
+		Okta:       oktaSeed,
+		Resend:     resendSeed,
+		Slack:      slackSeed,
+		Stripe:     stripeSeed,
+		Vercel:     vercelSeed,
+	}
+	if *portlessValue {
+		return runPortlessStart(ctx, stdout, stderr, port, services, seeds)
+	}
+
 	baseURL := *baseURLValue
+	if baseURL == "" {
+		baseURL = getenv("EMULATE_BASE_URL", getenv("PORTLESS_URL", ""))
+	}
+	if baseURL != "" && strings.Contains(baseURL, "{service}") {
+		if len(services) != 1 {
+			fmt.Fprintln(stderr, "Base URL templates with {service} require exactly one service in native single-server mode. Use --portless for per-service aliases.")
+			return 1
+		}
+		baseURL = strings.ReplaceAll(baseURL, "{service}", services[0])
+	}
 	if baseURL == "" {
 		baseURL = fmt.Sprintf("http://localhost:%d", port)
 	}
-	server := emuruntime.NewServer(emuruntime.ServerOptions{
-		Version:        version,
-		BaseURL:        baseURL,
-		Services:       services,
-		AppleSeed:      appleSeed,
-		ClerkSeed:      clerkSeed,
-		GitHubSeed:     githubSeed,
-		GoogleSeed:     googleSeed,
-		MicrosoftSeed:  microsoftSeed,
-		MongoAtlasSeed: mongoAtlasSeed,
-		OktaSeed:       oktaSeed,
-		ResendSeed:     resendSeed,
-		SlackSeed:      slackSeed,
-		StripeSeed:     stripeSeed,
-		VercelSeed:     vercelSeed,
-	})
+	server := emuruntime.NewServer(serverOptions(baseURL, services, seeds))
 	httpServer := &nethttp.Server{
 		Handler:           server.Handler,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -307,6 +343,26 @@ func runStart(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 			return 1
 		}
 		return 0
+	}
+}
+
+func serverOptions(baseURL string, services []string, seeds nativeSeedOptions) emuruntime.ServerOptions {
+	return emuruntime.ServerOptions{
+		Version:        version,
+		BaseURL:        baseURL,
+		Services:       services,
+		AppleSeed:      seeds.Apple,
+		AWSSeed:        seeds.AWS,
+		ClerkSeed:      seeds.Clerk,
+		GitHubSeed:     seeds.GitHub,
+		GoogleSeed:     seeds.Google,
+		MicrosoftSeed:  seeds.Microsoft,
+		MongoAtlasSeed: seeds.MongoAtlas,
+		OktaSeed:       seeds.Okta,
+		ResendSeed:     seeds.Resend,
+		SlackSeed:      seeds.Slack,
+		StripeSeed:     seeds.Stripe,
+		VercelSeed:     seeds.Vercel,
 	}
 }
 
@@ -399,23 +455,24 @@ func printHelp(w io.Writer) {
 	fmt.Fprintln(w, "  npx emulate [start] [options]")
 	fmt.Fprintln(w, "  npx emulate init [--service <service>]")
 	fmt.Fprintln(w, "  npx emulate list")
+	fmt.Fprintln(w, "  npx emulate vercel init [--service <services>]")
 	fmt.Fprintln(w, "\nStart options:")
-	fmt.Fprintln(w, "  -p, --port <port>          Base port")
+	fmt.Fprintln(w, "  -p, --port <port>          Port")
 	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
-	fmt.Fprintln(w, "      --seed <file>          Path to JSON seed config file (YAML not supported in native Go yet)")
+	fmt.Fprintln(w, "      --seed <file>          Path to YAML or JSON seed config file")
 	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
-	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless (not supported in native Go yet)")
+	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless")
 }
 
 func printStartHelp(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  npx emulate [start] [options]")
 	fmt.Fprintln(w, "\nOptions:")
-	fmt.Fprintln(w, "  -p, --port <port>          Base port")
+	fmt.Fprintln(w, "  -p, --port <port>          Port")
 	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated services to enable")
-	fmt.Fprintln(w, "      --seed <file>          Path to JSON seed config file (YAML not supported in native Go yet)")
+	fmt.Fprintln(w, "      --seed <file>          Path to YAML or JSON seed config file")
 	fmt.Fprintln(w, "      --base-url <url>       Override advertised base URL")
-	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless (not supported in native Go yet)")
+	fmt.Fprintln(w, "      --portless             Serve over HTTPS via portless")
 }
 
 func printInitHelp(w io.Writer) {
@@ -454,7 +511,7 @@ func parseServices(value string) ([]string, error) {
 }
 
 func nativeSeedServiceNames() []string {
-	return []string{"apple", "clerk", "github", "google", "microsoft", "mongoatlas", "okta", "resend", "slack", "stripe", "vercel"}
+	return []string{"apple", "aws", "clerk", "github", "google", "microsoft", "mongoatlas", "okta", "resend", "slack", "stripe", "vercel"}
 }
 
 func unsupportedNativeSeedServices(data map[string]json.RawMessage) []string {

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -243,6 +243,55 @@ func TestRunStartPortlessRegistersServiceAliases(t *testing.T) {
 	}
 }
 
+func TestRunStartPortlessUsesSeedBaseURL(t *testing.T) {
+	original := runPortlessCommand
+	runPortlessCommand = func(args []string, stdout io.Writer, stderr io.Writer) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		runPortlessCommand = original
+	})
+
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"github":{"baseUrl":"https://custom-github.example.test"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--service", "github", "--port", strconv.Itoa(port), "--seed", seedPath, "--portless"}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK      bool   `json:"ok"`
+		Runtime string `json:"runtime"`
+		BaseURL string `json:"base_url"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || health.Runtime != "go" || health.BaseURL != "https://custom-github.example.test" {
+		t.Fatalf("unexpected health: %#v", health)
+	}
+	if !strings.Contains(stdout.String(), "https://custom-github.example.test") {
+		t.Fatalf("stdout missing seed base URL:\n%s", stdout.String())
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
 func TestRunStartSeedsResendFromJSONConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.json")
@@ -769,6 +818,119 @@ func TestRunStartSeedsResendFromYAMLConfig(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
+func TestRunStartAutoDetectsYAMLConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if err := os.WriteFile(filepath.Join(tempDir, "emulate.config.yaml"), []byte("resend:\n  domains:\n    - name: autodetect.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port)}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "resend" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	var domains struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d/domains", port), &domains)
+	if len(domains.Data) != 1 || domains.Data[0].Name != "autodetect.example" {
+		t.Fatalf("unexpected seeded domains: %#v", domains)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
+func TestRunStartUsesSeedBaseURL(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"github":{"baseUrl":"https://github.seed.example.test"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		BaseURL  string   `json:"base_url"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || health.BaseURL != "https://github.seed.example.test" || len(health.Services) != 1 || health.Services[0] != "github" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+}
+
+func TestRunStartRejectsConflictingSeedBaseURLsForMultipleServices(t *testing.T) {
+	tempDir := t.TempDir()
+	seedPath := filepath.Join(tempDir, "emulate.config.json")
+	if err := os.WriteFile(seedPath, []byte(`{"github":{"baseUrl":"https://github.seed.example.test"},"google":{"baseUrl":"https://google.seed.example.test"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"start", "--service", "github,google", "--port", strconv.Itoa(freePort(t)), "--seed", seedPath}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("start with conflicting seed base URLs exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "baseUrl seed overrides require exactly one selected service") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
 	}
 }
 

--- a/cmd/emulate/main_test.go
+++ b/cmd/emulate/main_test.go
@@ -88,6 +88,17 @@ func TestRunStartRejectsUnexpectedArgument(t *testing.T) {
 	}
 }
 
+func TestRunStartRejectsBaseURLTemplateForMultipleServices(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"start", "--service", "github,resend", "--base-url", "https://{service}.example.test"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("start with multi-service base URL template exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "require exactly one service") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
 func TestRunStartHelpExitsSuccessfully(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"start", "--help"}, &stdout, &stderr)
@@ -156,6 +167,79 @@ func TestRunStartServesHealthEndpoint(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestRunStartPortlessRequiresPortless(t *testing.T) {
+	original := runPortlessCommand
+	runPortlessCommand = func(args []string, stdout io.Writer, stderr io.Writer) error {
+		return fmt.Errorf("missing")
+	}
+	t.Cleanup(func() {
+		runPortlessCommand = original
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"start", "--service", "github", "--portless"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("portless start exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "portless is required but not installed") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestRunStartPortlessRegistersServiceAliases(t *testing.T) {
+	original := runPortlessCommand
+	calls := [][]string{}
+	runPortlessCommand = func(args []string, stdout io.Writer, stderr io.Writer) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		runPortlessCommand = original
+	})
+
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--service", "github", "--port", strconv.Itoa(port), "--portless"}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK      bool   `json:"ok"`
+		Runtime string `json:"runtime"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || health.Runtime != "go" {
+		t.Fatalf("unexpected health: %#v", health)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
+	}
+
+	wantCalls := [][]string{
+		{"--version"},
+		{"list"},
+		{"alias", "github.emulate", strconv.Itoa(port), "--force"},
+		{"alias", "--remove", "github.emulate"},
+	}
+	if fmt.Sprint(calls) != fmt.Sprint(wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+	if !strings.Contains(stdout.String(), "https://github.emulate.localhost") {
+		t.Fatalf("stdout missing portless URL:\n%s", stdout.String())
 	}
 }
 
@@ -641,45 +725,113 @@ func TestRunStartSeedsOktaFromJSONConfig(t *testing.T) {
 	}
 }
 
-func TestRunStartRejectsYAMLSeedConfig(t *testing.T) {
+func TestRunStartSeedsResendFromYAMLConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.yaml")
 	if err := os.WriteFile(seedPath, []byte("resend:\n  domains:\n    - name: example.com\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"start", "--seed", seedPath}, &stdout, &stderr)
-	if code == 0 {
-		t.Fatal("start with YAML seed exited successfully")
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
 	}
-	if !strings.Contains(stderr.String(), "YAML config loading is not implemented") {
-		t.Fatalf("unexpected stderr: %s", stderr.String())
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "resend" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	var domains struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d/domains", port), &domains)
+	if len(domains.Data) != 1 || domains.Data[0].Name != "example.com" {
+		t.Fatalf("unexpected seeded domains: %#v", domains)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
 	}
 }
 
-func TestRunStartRejectsUnsupportedNativeSeedServices(t *testing.T) {
+func TestRunStartSeedsAWSFromJSONConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	seedPath := filepath.Join(tempDir, "emulate.config.json")
-	if err := os.WriteFile(seedPath, []byte(`{"aws":{"s3":{"buckets":[{"name":"example"}]}}}`), 0o644); err != nil {
+	if err := os.WriteFile(seedPath, []byte(`{"aws":{"region":"us-west-2","account_id":"999999999999","s3":{"buckets":[{"name":"example","region":"eu-west-1"}]},"sqs":{"queues":[{"name":"seeded-queue","visibility_timeout":45}]},"iam":{"users":[{"user_name":"developer","create_access_key":true}],"roles":[{"role_name":"lambda-execution-role","description":"Role for Lambda function execution"}]}}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	for _, args := range [][]string{
-		{"start", "--seed", seedPath},
-		{"start", "--service", "aws", "--seed", seedPath},
-	} {
-		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
-			var stdout, stderr bytes.Buffer
-			code := run(args, &stdout, &stderr)
-			if code == 0 {
-				t.Fatal("start with unsupported seed service exited successfully")
-			}
-			errText := stderr.String()
-			if !strings.Contains(errText, "only supports --seed for apple, clerk, github, google, microsoft, mongoatlas, okta, resend, slack, stripe, and vercel") || !strings.Contains(errText, "aws") {
-				t.Fatalf("unexpected stderr: %s", errText)
-			}
-		})
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithContext(ctx, []string{"start", "--port", strconv.Itoa(port), "--seed", seedPath}, &stdout, &stderr)
+	}()
+
+	var health struct {
+		OK       bool     `json:"ok"`
+		Services []string `json:"services"`
+	}
+	waitForJSON(t, fmt.Sprintf("http://127.0.0.1:%d%s", port, emuruntime.HealthPath), &health)
+	if !health.OK || len(health.Services) != 1 || health.Services[0] != "aws" {
+		t.Fatalf("unexpected health body: %#v", health)
+	}
+
+	req, err := http.NewRequest(http.MethodHead, fmt.Sprintf("http://127.0.0.1:%d/example", port), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("x-amz-bucket-region") != "eu-west-1" {
+		t.Fatalf("head bucket status = %d, region = %q", resp.StatusCode, resp.Header.Get("x-amz-bucket-region"))
+	}
+
+	resp, err = http.Post(fmt.Sprintf("http://127.0.0.1:%d/sqs/", port), "application/x-www-form-urlencoded", strings.NewReader("Action=GetQueueUrl&QueueName=seeded-queue"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(raw), "999999999999/seeded-queue") {
+		t.Fatalf("get seeded queue status = %d, body = %s", resp.StatusCode, string(raw))
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("start exited with %d, stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("start did not shut down after context cancellation")
 	}
 }
 
@@ -850,6 +1002,120 @@ func TestRunInitRejectsExistingAutoDetectedConfig(t *testing.T) {
 		t.Fatal("init with existing config exited successfully")
 	}
 	if !strings.Contains(stderr.String(), "Config file already exists: emulate.config.yaml") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestRunVercelInitWritesScaffold(t *testing.T) {
+	tempDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"vercel", "init", "--service", "resend,aws"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("vercel init exited with %d, stderr: %s", code, stderr.String())
+	}
+	handler, err := os.ReadFile(filepath.Join(tempDir, "api", "emulate.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(handler), `Services: []string{"resend", "aws"}`) {
+		t.Fatalf("unexpected handler:\n%s", string(handler))
+	}
+	goMod, err := os.ReadFile(filepath.Join(tempDir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(goMod), "go 1.24") || !strings.Contains(string(goMod), "github.com/vercel-labs/emulate vdev") {
+		t.Fatalf("unexpected go.mod:\n%s", string(goMod))
+	}
+	config, err := os.ReadFile(filepath.Join(tempDir, "vercel.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), `"/emulate/:path*"`) || !strings.Contains(stdout.String(), "Vercel Go Function scaffold ready for: resend, aws") {
+		t.Fatalf("unexpected scaffold stdout = %s config = %s", stdout.String(), string(config))
+	}
+}
+
+func TestRunVercelInitPreservesExistingRewriteFields(t *testing.T) {
+	tempDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	existingConfig := `{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "/api/:path*",
+      "has": [{ "type": "host", "value": "example.com" }]
+    },
+    {
+      "source": "/:path*",
+      "destination": "/index"
+    }
+  ]
+}
+`
+	if err := os.WriteFile(filepath.Join(tempDir, "vercel.json"), []byte(existingConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"vercel", "init", "--service", "resend"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("vercel init exited with %d, stderr: %s", code, stderr.String())
+	}
+	raw, err := os.ReadFile(filepath.Join(tempDir, "vercel.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		Rewrites []map[string]any `json:"rewrites"`
+	}
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Rewrites) != 3 {
+		t.Fatalf("rewrites = %#v", config.Rewrites)
+	}
+	if config.Rewrites[1]["source"] != "/emulate/:path*" || config.Rewrites[2]["source"] != "/:path*" {
+		t.Fatalf("unexpected rewrite order: %#v", config.Rewrites)
+	}
+	has, ok := config.Rewrites[0]["has"].([]any)
+	if !ok || len(has) != 1 {
+		t.Fatalf("existing rewrite metadata was not preserved: %#v", config.Rewrites[0])
+	}
+}
+
+func TestRunVercelInitRejectsUnsupportedService(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"vercel", "init", "--service", "linear"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("vercel init exited successfully")
+	}
+	if !strings.Contains(stderr.String(), "currently supports native services") {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
 	}
 }

--- a/cmd/emulate/portless.go
+++ b/cmd/emulate/portless.go
@@ -45,6 +45,9 @@ func runPortlessStart(ctx context.Context, stdout io.Writer, stderr io.Writer, b
 	for index, service := range services {
 		port := basePort + index
 		baseURL := portlessBaseURL(service)
+		if seedBaseURL := seedBaseURLForService(service, seeds.BaseURLs); seedBaseURL != "" {
+			baseURL = seedBaseURL
+		}
 		server := emuruntime.NewServer(serverOptions(baseURL, []string{service}, seeds))
 		httpServer := &nethttp.Server{
 			Handler:           server.Handler,

--- a/cmd/emulate/portless.go
+++ b/cmd/emulate/portless.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	nethttp "net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	emuruntime "github.com/vercel-labs/emulate/internal/runtime"
+)
+
+type portlessAlias struct {
+	Name string
+	Port int
+}
+
+type runningPortlessServer struct {
+	Service  string
+	BaseURL  string
+	Port     int
+	Server   *nethttp.Server
+	Listener net.Listener
+}
+
+var runPortlessCommand = func(args []string, stdout io.Writer, stderr io.Writer) error {
+	cmd := exec.Command("portless", args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func runPortlessStart(ctx context.Context, stdout io.Writer, stderr io.Writer, basePort int, services []string, seeds nativeSeedOptions) int {
+	if err := ensurePortless(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+
+	running := make([]runningPortlessServer, 0, len(services))
+	for index, service := range services {
+		port := basePort + index
+		baseURL := portlessBaseURL(service)
+		server := emuruntime.NewServer(serverOptions(baseURL, []string{service}, seeds))
+		httpServer := &nethttp.Server{
+			Handler:           server.Handler,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			closePortlessListeners(running)
+			fmt.Fprintf(stderr, "Failed to listen on port %d for %s: %v\n", port, service, err)
+			return 1
+		}
+		running = append(running, runningPortlessServer{
+			Service:  service,
+			BaseURL:  baseURL,
+			Port:     port,
+			Server:   httpServer,
+			Listener: listener,
+		})
+	}
+
+	aliases := make([]portlessAlias, 0, len(running))
+	for _, server := range running {
+		aliases = append(aliases, portlessAlias{Name: server.Service + ".emulate", Port: server.Port})
+	}
+	if err := registerPortlessAliases(aliases, stdout, stderr); err != nil {
+		closePortlessListeners(running)
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "emulate %s native Go runtime.\n", version)
+	fmt.Fprintln(stdout, "Listening with portless:")
+	for _, server := range running {
+		fmt.Fprintf(stdout, "  %s  %s\n", server.Service, server.BaseURL)
+	}
+	fmt.Fprintf(stdout, "Health check: %s%s\n", strings.TrimRight(running[0].BaseURL, "/"), emuruntime.HealthPath)
+
+	errCh := make(chan error, len(running))
+	for _, server := range running {
+		server := server
+		go func() {
+			errCh <- server.Server.Serve(server.Listener)
+		}()
+	}
+
+	var exitCode int
+	select {
+	case <-ctx.Done():
+		exitCode = shutdownPortlessServers(running, stderr)
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, nethttp.ErrServerClosed) {
+			fmt.Fprintf(stderr, "Server stopped unexpectedly: %v\n", err)
+			exitCode = 1
+		}
+		if shutdownCode := shutdownPortlessServers(running, stderr); exitCode == 0 {
+			exitCode = shutdownCode
+		}
+	}
+	removePortlessAliases(aliases, stderr)
+	return exitCode
+}
+
+func ensurePortless() error {
+	if err := runPortlessCommand([]string{"--version"}, nil, nil); err != nil {
+		return fmt.Errorf("portless is required but not installed. Run: npm i -g portless")
+	}
+	if err := runPortlessCommand([]string{"list"}, nil, nil); err != nil {
+		return fmt.Errorf("portless proxy is not running. Start it with: portless proxy start")
+	}
+	return nil
+}
+
+func registerPortlessAliases(aliases []portlessAlias, stdout io.Writer, stderr io.Writer) error {
+	registered := []portlessAlias{}
+	for _, alias := range aliases {
+		err := runPortlessCommand([]string{"alias", alias.Name, strconv.Itoa(alias.Port), "--force"}, stdout, stderr)
+		if err != nil {
+			removePortlessAliases(registered, stderr)
+			return fmt.Errorf("failed to register portless alias: %s -> %d", alias.Name, alias.Port)
+		}
+		registered = append(registered, alias)
+	}
+	return nil
+}
+
+func removePortlessAliases(aliases []portlessAlias, stderr io.Writer) {
+	for _, alias := range aliases {
+		if err := runPortlessCommand([]string{"alias", "--remove", alias.Name}, nil, nil); err != nil {
+			fmt.Fprintf(stderr, "Warning: failed to remove portless alias: %s\n", alias.Name)
+		}
+	}
+}
+
+func portlessBaseURL(service string) string {
+	return "https://" + service + ".emulate.localhost"
+}
+
+func closePortlessListeners(servers []runningPortlessServer) {
+	for _, server := range servers {
+		_ = server.Listener.Close()
+	}
+}
+
+func shutdownPortlessServers(servers []runningPortlessServer, stderr io.Writer) int {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	exitCode := 0
+	for _, server := range servers {
+		if err := server.Server.Shutdown(shutdownCtx); err != nil {
+			fmt.Fprintf(stderr, "Failed to shut down %s server: %v\n", server.Service, err)
+			exitCode = 1
+		}
+	}
+	return exitCode
+}

--- a/cmd/emulate/vercel.go
+++ b/cmd/emulate/vercel.go
@@ -1,0 +1,532 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const requiredVercelGoVersion = "1.24"
+
+var defaultVercelRewrite = map[string]string{
+	"source":      "/emulate/:path*",
+	"destination": "/api/emulate?path=:path*",
+}
+
+var supportedVercelServices = []string{"apple", "aws", "clerk", "github", "google", "microsoft", "mongoatlas", "okta", "resend", "slack", "stripe", "vercel"}
+
+type vercelScaffoldResult struct {
+	Created   []string
+	Updated   []string
+	Unchanged []string
+	Services  []string
+}
+
+type preparedVercelConfig struct {
+	RelativePath string
+	Target       string
+	Existed      bool
+	Changed      bool
+	Content      string
+}
+
+func runVercel(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		printVercelHelp(stderr)
+		return 1
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		printVercelHelp(stdout)
+		return 0
+	case "init":
+		return runVercelInit(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "Unknown vercel command: %s\n", args[0])
+		printVercelHelp(stderr)
+		return 1
+	}
+}
+
+func runVercelInit(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("vercel init", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		printVercelInitHelp(stderr)
+	}
+	serviceValue := fs.String("service", strings.Join(supportedVercelServices, ","), "Comma-separated native services to enable")
+	fs.StringVar(serviceValue, "s", strings.Join(supportedVercelServices, ","), "Comma-separated native services to enable")
+	forceValue := fs.Bool("force", false, "Overwrite generated files")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 1
+	}
+	if hasUnexpectedArg(fs, stderr) {
+		return 1
+	}
+
+	result, err := createVercelScaffold(".", *serviceValue, *forceValue, version)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	for _, file := range result.Created {
+		fmt.Fprintf(stdout, "Created %s\n", file)
+	}
+	for _, file := range result.Updated {
+		fmt.Fprintf(stdout, "Updated %s\n", file)
+	}
+	for _, file := range result.Unchanged {
+		fmt.Fprintf(stdout, "Skipped existing %s\n", file)
+	}
+	fmt.Fprintf(stdout, "\nVercel Go Function scaffold ready for: %s\n", strings.Join(result.Services, ", "))
+	fmt.Fprintln(stdout, "State uses warm in-memory stores by default. Cold starts reset state, and concurrent instances can diverge.")
+	fmt.Fprintln(stdout, "Add a vercel.Persistence implementation in api/emulate.go when snapshots need to survive cold starts.")
+	return 0
+}
+
+func printVercelHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  npx emulate vercel init [--service <services>] [--force]")
+}
+
+func printVercelInitHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  npx emulate vercel init [--service <services>] [--force]")
+	fmt.Fprintln(w, "\nOptions:")
+	fmt.Fprintln(w, "  -s, --service <services>   Comma-separated native services to enable")
+	fmt.Fprintln(w, "      --force                Overwrite generated files")
+}
+
+func createVercelScaffold(cwd string, serviceValue string, force bool, versionValue string) (vercelScaffoldResult, error) {
+	root, err := filepath.Abs(cwd)
+	if err != nil {
+		return vercelScaffoldResult{}, err
+	}
+	services, err := parseVercelServices(serviceValue)
+	if err != nil {
+		return vercelScaffoldResult{}, err
+	}
+	prepared, err := prepareVercelConfig(root, force)
+	if err != nil {
+		return vercelScaffoldResult{}, err
+	}
+	result := vercelScaffoldResult{Services: services}
+	if err := os.MkdirAll(filepath.Join(root, "api"), 0o755); err != nil {
+		return result, err
+	}
+	if err := writeFileIfAllowed(root, "api/emulate.go", renderVercelHandler(services), force, &result); err != nil {
+		return result, err
+	}
+	if err := updateVercelGoMod(root, versionValue, &result); err != nil {
+		return result, err
+	}
+	if err := writePreparedVercelConfig(prepared, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func parseVercelServices(value string) ([]string, error) {
+	if strings.TrimSpace(value) == "" || strings.EqualFold(strings.TrimSpace(value), "all") {
+		return append([]string(nil), supportedVercelServices...), nil
+	}
+	supported := map[string]bool{}
+	for _, service := range supportedVercelServices {
+		supported[service] = true
+	}
+	services := []string{}
+	seen := map[string]bool{}
+	for _, part := range strings.Split(value, ",") {
+		name := strings.ToLower(strings.TrimSpace(part))
+		if name == "" || seen[name] {
+			continue
+		}
+		if !supported[name] {
+			return nil, fmt.Errorf("The Vercel Go Function scaffold currently supports native services: %s", strings.Join(supportedVercelServices, ", "))
+		}
+		seen[name] = true
+		services = append(services, name)
+	}
+	if len(services) == 0 {
+		return append([]string(nil), supportedVercelServices...), nil
+	}
+	return services, nil
+}
+
+func writeFileIfAllowed(root string, relativePath string, content string, force bool, result *vercelScaffoldResult) error {
+	target := filepath.Join(root, relativePath)
+	_, statErr := os.Stat(target)
+	if statErr == nil && !force {
+		result.Unchanged = append(result.Unchanged, relativePath)
+		return nil
+	}
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return statErr
+	}
+	existed := statErr == nil
+	if err := os.WriteFile(target, []byte(content), 0o644); err != nil {
+		return err
+	}
+	if existed {
+		result.Updated = append(result.Updated, relativePath)
+	} else {
+		result.Created = append(result.Created, relativePath)
+	}
+	return nil
+}
+
+func updateVercelGoMod(root string, versionValue string, result *vercelScaffoldResult) error {
+	relativePath := "go.mod"
+	target := filepath.Join(root, relativePath)
+	moduleVersion := normalizeGoModuleVersion(versionValue)
+	raw, err := os.ReadFile(target)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.WriteFile(target, []byte(renderVercelGoMod(moduleVersion)), 0o644); err != nil {
+			return err
+		}
+		result.Created = append(result.Created, relativePath)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	content := string(raw)
+	next := content
+	if existing := getEmulateRequirementVersion(content); existing != moduleVersion {
+		if existing == "" {
+			next = addEmulateRequirement(next, moduleVersion)
+		} else {
+			next = updateEmulateRequirement(next, moduleVersion)
+		}
+	}
+	next = ensureGoDirective(next, requiredVercelGoVersion)
+	if next == content {
+		result.Unchanged = append(result.Unchanged, relativePath)
+		return nil
+	}
+	if err := os.WriteFile(target, []byte(next), 0o644); err != nil {
+		return err
+	}
+	result.Updated = append(result.Updated, relativePath)
+	return nil
+}
+
+func getEmulateRequirementVersion(content string) string {
+	match := regexp.MustCompile(`(?m)^[ \t]*(?:require[ \t]+)?github\.com/vercel-labs/emulate[ \t]+(v\S+)`).FindStringSubmatch(content)
+	if len(match) == 0 {
+		return ""
+	}
+	return match[1]
+}
+
+func updateEmulateRequirement(content string, moduleVersion string) string {
+	re := regexp.MustCompile(`(?m)^([ \t]*(?:require[ \t]+)?github\.com/vercel-labs/emulate[ \t]+)v\S+([ \t]*(?://.*)?$)`)
+	return re.ReplaceAllString(content, "${1}"+moduleVersion+"${2}")
+}
+
+func addEmulateRequirement(content string, moduleVersion string) string {
+	dependency := "github.com/vercel-labs/emulate " + moduleVersion
+	if regexp.MustCompile(`(?m)^require\s*\(`).MatchString(content) {
+		re := regexp.MustCompile(`(?m)^require\s*\(\s*\n`)
+		return re.ReplaceAllStringFunc(content, func(match string) string {
+			return match + "\t" + dependency + "\n"
+		})
+	}
+	suffix := ""
+	if !strings.HasSuffix(content, "\n") {
+		suffix = "\n"
+	}
+	return content + suffix + "\nrequire " + dependency + "\n"
+}
+
+func ensureGoDirective(content string, requiredVersion string) string {
+	re := regexp.MustCompile(`(?m)^([ \t]*go[ \t]+)(\S+)([ \t]*(?://.*)?$)`)
+	match := re.FindStringSubmatch(content)
+	if len(match) > 0 {
+		if compareGoVersions(match[2], requiredVersion) >= 0 {
+			return content
+		}
+		return re.ReplaceAllString(content, "${1}"+requiredVersion+"${3}")
+	}
+	moduleRe := regexp.MustCompile(`(?m)^(module[ \t]+\S+[ \t]*(?://.*)?)(?:\r?\n)+`)
+	if moduleRe.MatchString(content) {
+		return moduleRe.ReplaceAllString(content, "$1\n\ngo "+requiredVersion+"\n\n")
+	}
+	suffix := ""
+	if !strings.HasSuffix(content, "\n") {
+		suffix = "\n"
+	}
+	return content + suffix + "\ngo " + requiredVersion + "\n"
+}
+
+func compareGoVersions(left string, right string) int {
+	leftParts := parseGoVersion(left)
+	rightParts := parseGoVersion(right)
+	if leftParts == nil || rightParts == nil {
+		if left == right {
+			return 0
+		}
+		return -1
+	}
+	for index := 0; index < 3; index++ {
+		if leftParts[index] != rightParts[index] {
+			return leftParts[index] - rightParts[index]
+		}
+	}
+	return 0
+}
+
+func parseGoVersion(value string) []int {
+	match := regexp.MustCompile(`^(\d+)\.(\d+)(?:\.(\d+))?(?:rc\d+)?$`).FindStringSubmatch(value)
+	if len(match) == 0 {
+		return nil
+	}
+	patch := 0
+	if match[3] != "" {
+		patch, _ = strconv.Atoi(match[3])
+	}
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	return []int{major, minor, patch}
+}
+
+func prepareVercelConfig(root string, force bool) (preparedVercelConfig, error) {
+	relativePath := "vercel.json"
+	target := filepath.Join(root, relativePath)
+	config := map[string]any{"$schema": "https://openapi.vercel.sh/vercel.json"}
+	existed := false
+	raw, err := os.ReadFile(target)
+	if err == nil {
+		existed = true
+		if err := json.Unmarshal(raw, &config); err != nil {
+			return preparedVercelConfig{}, fmt.Errorf("Failed to parse %s: %v", relativePath, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return preparedVercelConfig{}, err
+	}
+	rewriteList, err := vercelRewriteList(config)
+	if err != nil {
+		return preparedVercelConfig{}, err
+	}
+	for _, rewrite := range rewriteList {
+		if isRewrite(rewrite) && stringField(rewrite, "source") == defaultVercelRewrite["source"] && stringField(rewrite, "destination") != defaultVercelRewrite["destination"] {
+			return preparedVercelConfig{}, fmt.Errorf("%s already has a rewrite for %s", relativePath, defaultVercelRewrite["source"])
+		}
+	}
+	hasRewrite := false
+	for _, rewrite := range rewriteList {
+		if isDefaultVercelRewrite(rewrite) {
+			hasRewrite = true
+			break
+		}
+	}
+	next := rewriteList
+	if !hasRewrite {
+		next = insertVercelRewrite(next)
+	}
+	next = moveVercelRewriteBeforeCatchAll(next)
+	if hasRewrite && !force && rewriteListsEqual(next, rewriteList) {
+		return preparedVercelConfig{RelativePath: relativePath, Target: target, Existed: existed}, nil
+	}
+	config["rewrites"] = recordsToInterfaces(next)
+	if _, ok := config["$schema"]; !ok {
+		config["$schema"] = "https://openapi.vercel.sh/vercel.json"
+	}
+	content, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return preparedVercelConfig{}, err
+	}
+	return preparedVercelConfig{
+		RelativePath: relativePath,
+		Target:       target,
+		Existed:      existed,
+		Changed:      true,
+		Content:      string(content) + "\n",
+	}, nil
+}
+
+func vercelRewriteList(config map[string]any) ([]map[string]any, error) {
+	raw, ok := config["rewrites"]
+	if !ok {
+		return []map[string]any{}, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("vercel.json rewrites must be an array to add the emulate preview route")
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		object, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("vercel.json rewrites must contain objects to add the emulate preview route")
+		}
+		out = append(out, cloneInterfaceMap(object))
+	}
+	return out, nil
+}
+
+func writePreparedVercelConfig(prepared preparedVercelConfig, result *vercelScaffoldResult) error {
+	if !prepared.Changed {
+		result.Unchanged = append(result.Unchanged, prepared.RelativePath)
+		return nil
+	}
+	if err := os.WriteFile(prepared.Target, []byte(prepared.Content), 0o644); err != nil {
+		return err
+	}
+	if prepared.Existed {
+		result.Updated = append(result.Updated, prepared.RelativePath)
+	} else {
+		result.Created = append(result.Created, prepared.RelativePath)
+	}
+	return nil
+}
+
+func insertVercelRewrite(rewrites []map[string]any) []map[string]any {
+	catchAll := -1
+	for index, rewrite := range rewrites {
+		if isCatchAllSource(stringField(rewrite, "source")) {
+			catchAll = index
+			break
+		}
+	}
+	next := cloneRewriteList(rewrites)
+	rewrite := defaultVercelRewriteRecord()
+	if catchAll < 0 {
+		return append(next, rewrite)
+	}
+	next = append(next[:catchAll], append([]map[string]any{rewrite}, next[catchAll:]...)...)
+	return next
+}
+
+func moveVercelRewriteBeforeCatchAll(rewrites []map[string]any) []map[string]any {
+	rewriteIndex := -1
+	catchAllIndex := -1
+	for index, rewrite := range rewrites {
+		if rewriteIndex < 0 && isDefaultVercelRewrite(rewrite) {
+			rewriteIndex = index
+		}
+		if catchAllIndex < 0 && isCatchAllSource(stringField(rewrite, "source")) {
+			catchAllIndex = index
+		}
+	}
+	if rewriteIndex < 0 || catchAllIndex < 0 || rewriteIndex < catchAllIndex {
+		return rewrites
+	}
+	next := cloneRewriteList(rewrites)
+	rewrite := next[rewriteIndex]
+	next = append(next[:rewriteIndex], next[rewriteIndex+1:]...)
+	catchAllIndex = -1
+	for index, candidate := range next {
+		if isCatchAllSource(stringField(candidate, "source")) {
+			catchAllIndex = index
+			break
+		}
+	}
+	return append(next[:catchAllIndex], append([]map[string]any{rewrite}, next[catchAllIndex:]...)...)
+}
+
+func isDefaultVercelRewrite(value map[string]any) bool {
+	return stringField(value, "source") == defaultVercelRewrite["source"] && stringField(value, "destination") == defaultVercelRewrite["destination"]
+}
+
+func isRewrite(value map[string]any) bool {
+	return stringField(value, "source") != "" && stringField(value, "destination") != ""
+}
+
+func isCatchAllSource(source string) bool {
+	value := strings.TrimSpace(source)
+	if value == "/(.*)" {
+		return true
+	}
+	return regexp.MustCompile(`^/:[A-Za-z_][\w-]*(?:\*|\(\.\*\))$`).MatchString(value)
+}
+
+func rewriteListsEqual(left []map[string]any, right []map[string]any) bool {
+	return reflect.DeepEqual(left, right)
+}
+
+func recordsToInterfaces(records []map[string]any) []any {
+	out := make([]any, 0, len(records))
+	for _, record := range records {
+		out = append(out, cloneInterfaceMap(record))
+	}
+	return out
+}
+
+func cloneInterfaceMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneRewriteList(in []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(in))
+	for _, rewrite := range in {
+		out = append(out, cloneInterfaceMap(rewrite))
+	}
+	return out
+}
+
+func defaultVercelRewriteRecord() map[string]any {
+	return map[string]any{
+		"source":      defaultVercelRewrite["source"],
+		"destination": defaultVercelRewrite["destination"],
+	}
+}
+
+func stringField(value map[string]any, key string) string {
+	str, _ := value[key].(string)
+	return str
+}
+
+func renderVercelHandler(services []string) string {
+	quoted := make([]string, 0, len(services))
+	for _, service := range services {
+		quoted = append(quoted, strconv.Quote(service))
+	}
+	return `package handler
+
+import (
+	"net/http"
+
+	emulate "github.com/vercel-labs/emulate/vercel"
+)
+
+var emulateHandler = emulate.NewHandler(emulate.Options{
+	Services: []string{` + strings.Join(quoted, ", ") + `},
+})
+
+func Handler(w http.ResponseWriter, r *http.Request) {
+	emulateHandler.ServeHTTP(w, r)
+}
+`
+}
+
+func normalizeGoModuleVersion(value string) string {
+	if strings.HasPrefix(value, "v") {
+		return value
+	}
+	return "v" + value
+}
+
+func renderVercelGoMod(moduleVersion string) string {
+	return `module emulate-vercel-preview
+
+go ` + requiredVercelGoVersion + `
+
+require github.com/vercel-labs/emulate ` + moduleVersion + `
+`
+}

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -34,9 +34,6 @@ type UnsupportedFormatError struct {
 }
 
 func (e *UnsupportedFormatError) Error() string {
-	if e.Format == FormatYAML {
-		return fmt.Sprintf("unsupported config format for %s: YAML config loading is not implemented in the native Go runtime yet; use JSON config or the current TypeScript runtime", e.Path)
-	}
 	return fmt.Sprintf("unsupported config format for %s", e.Path)
 }
 
@@ -108,10 +105,6 @@ func loadFile(fullPath string, sourceName string) (*LoadResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if format != FormatJSON {
-		return nil, &UnsupportedFormatError{Path: sourceName, Format: format}
-	}
-
 	raw, err := os.ReadFile(fullPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -121,8 +114,19 @@ func loadFile(fullPath string, sourceName string) (*LoadResult, error) {
 	}
 
 	data := map[string]json.RawMessage{}
-	if err := json.Unmarshal(raw, &data); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", sourceName, err)
+	switch format {
+	case FormatJSON:
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", sourceName, err)
+		}
+	case FormatYAML:
+		parsed, err := parseYAMLDocument(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", sourceName, err)
+		}
+		data = parsed
+	default:
+		return nil, &UnsupportedFormatError{Path: sourceName, Format: format}
 	}
 	return &LoadResult{
 		Path:     fullPath,

--- a/internal/core/config/config_test.go
+++ b/internal/core/config/config_test.go
@@ -51,18 +51,88 @@ func TestLoadDiscoversCurrentConfigNamesInOrder(t *testing.T) {
 	}
 }
 
-func TestLoadReportsYAMLAsUnsupportedForThisPhase(t *testing.T) {
+func TestLoadExplicitYAMLConfig(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "emulate.config.yaml"), []byte("github: {}\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "emulate.config.yaml"), []byte(`
+tokens:
+  dev_token:
+    login: octocat
+    scopes: [repo, user]
+github:
+  app:
+    private_key: |
+      -----BEGIN PRIVATE KEY-----
+      abc123
+      -----END PRIVATE KEY-----
+  users:
+    - login: octocat
+      email: octocat@example.com
+      site_admin: true
+aws:
+  region: us-west-2
+  s3:
+    buckets:
+      - name: docs
+        region: eu-west-1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(LoadOptions{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Format != FormatYAML {
+		t.Fatalf("format = %s", loaded.Format)
+	}
+	var github struct {
+		App struct {
+			PrivateKey string `json:"private_key"`
+		} `json:"app"`
+		Users []struct {
+			Login     string `json:"login"`
+			Email     string `json:"email"`
+			SiteAdmin bool   `json:"site_admin"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(loaded.Data["github"], &github); err != nil {
+		t.Fatal(err)
+	}
+	if len(github.Users) != 1 || github.Users[0].Login != "octocat" || !github.Users[0].SiteAdmin {
+		t.Fatalf("github = %#v", github)
+	}
+	if github.App.PrivateKey != "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----\n" {
+		t.Fatalf("private key = %q", github.App.PrivateKey)
+	}
+	var aws struct {
+		Region string `json:"region"`
+		S3     struct {
+			Buckets []struct {
+				Name   string `json:"name"`
+				Region string `json:"region"`
+			} `json:"buckets"`
+		} `json:"s3"`
+	}
+	if err := json.Unmarshal(loaded.Data["aws"], &aws); err != nil {
+		t.Fatal(err)
+	}
+	if aws.Region != "us-west-2" || len(aws.S3.Buckets) != 1 || aws.S3.Buckets[0].Region != "eu-west-1" {
+		t.Fatalf("aws = %#v", aws)
+	}
+}
+
+func TestLoadRejectsInvalidYAMLConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "emulate.config.yaml"), []byte("github:\n   users: []\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	_, err := Load(LoadOptions{Dir: dir})
 	if err == nil {
-		t.Fatal("expected unsupported format error")
+		t.Fatal("expected YAML parse error")
 	}
-	if !IsUnsupportedFormat(err) {
-		t.Fatalf("expected unsupported format, got %v", err)
+	if IsUnsupportedFormat(err) {
+		t.Fatalf("expected parse error, got %v", err)
 	}
 }
 

--- a/internal/core/config/yaml.go
+++ b/internal/core/config/yaml.go
@@ -1,0 +1,432 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type yamlLine struct {
+	indent int
+	text   string
+	line   int
+}
+
+type yamlParser struct {
+	lines []yamlLine
+	pos   int
+}
+
+func parseYAMLDocument(raw []byte) (map[string]json.RawMessage, error) {
+	lines, err := tokenizeYAML(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(lines) == 0 {
+		return map[string]json.RawMessage{}, nil
+	}
+	parser := yamlParser{lines: lines}
+	value, err := parser.parseBlock(lines[0].indent)
+	if err != nil {
+		return nil, err
+	}
+	if parser.pos != len(lines) {
+		line := parser.lines[parser.pos]
+		return nil, fmt.Errorf("unexpected YAML content on line %d", line.line)
+	}
+	top, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("top-level YAML config must be a mapping")
+	}
+	out := make(map[string]json.RawMessage, len(top))
+	for key, value := range top {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("encode %s: %w", key, err)
+		}
+		out[key] = raw
+	}
+	return out, nil
+}
+
+func tokenizeYAML(raw []byte) ([]yamlLine, error) {
+	normalized := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	sourceLines := strings.Split(normalized, "\n")
+	lines := make([]yamlLine, 0, len(sourceLines))
+	for index, source := range sourceLines {
+		if strings.TrimSpace(source) == "" {
+			continue
+		}
+		withoutComment := stripYAMLComment(source)
+		if strings.TrimSpace(withoutComment) == "" {
+			continue
+		}
+		indent := leadingSpaces(withoutComment)
+		if strings.Contains(withoutComment[:indent], "\t") || (indent < len(withoutComment) && withoutComment[indent] == '\t') {
+			return nil, fmt.Errorf("tabs are not supported for indentation on line %d", index+1)
+		}
+		if indent%2 != 0 {
+			return nil, fmt.Errorf("indentation must use multiples of two spaces on line %d", index+1)
+		}
+		lines = append(lines, yamlLine{
+			indent: indent,
+			text:   strings.TrimSpace(withoutComment),
+			line:   index + 1,
+		})
+	}
+	return lines, nil
+}
+
+func (p *yamlParser) parseBlock(indent int) (any, error) {
+	if p.pos >= len(p.lines) {
+		return map[string]any{}, nil
+	}
+	line := p.lines[p.pos]
+	if line.indent < indent {
+		return map[string]any{}, nil
+	}
+	if line.indent != indent {
+		return nil, fmt.Errorf("unexpected indentation on line %d", line.line)
+	}
+	if strings.HasPrefix(line.text, "- ") {
+		return p.parseSequence(indent)
+	}
+	return p.parseMap(indent)
+}
+
+func (p *yamlParser) parseMap(indent int) (map[string]any, error) {
+	out := map[string]any{}
+	for p.pos < len(p.lines) {
+		line := p.lines[p.pos]
+		if line.indent < indent {
+			break
+		}
+		if line.indent != indent {
+			return nil, fmt.Errorf("unexpected indentation on line %d", line.line)
+		}
+		if strings.HasPrefix(line.text, "- ") {
+			break
+		}
+		key, rawValue, ok := splitYAMLKeyValue(line.text)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("expected mapping entry on line %d", line.line)
+		}
+		p.pos++
+		value, err := p.parseMapValue(rawValue, indent, line.line)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+func (p *yamlParser) parseSequence(indent int) ([]any, error) {
+	values := []any{}
+	for p.pos < len(p.lines) {
+		line := p.lines[p.pos]
+		if line.indent < indent {
+			break
+		}
+		if line.indent != indent {
+			return nil, fmt.Errorf("unexpected indentation on line %d", line.line)
+		}
+		if !strings.HasPrefix(line.text, "- ") {
+			break
+		}
+		itemText := strings.TrimSpace(strings.TrimPrefix(line.text, "- "))
+		p.pos++
+		if itemText == "" {
+			value, err := p.parseNestedValue(indent, line.line)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+			continue
+		}
+		if key, rawValue, ok := splitYAMLKeyValue(itemText); ok {
+			item := map[string]any{}
+			value, err := p.parseMapValue(rawValue, indent, line.line)
+			if err != nil {
+				return nil, err
+			}
+			item[key] = value
+			if err := p.parseMapFieldsInto(item, indent+2); err != nil {
+				return nil, err
+			}
+			values = append(values, item)
+			continue
+		}
+		value, err := parseYAMLScalar(itemText)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", line.line, err)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func (p *yamlParser) parseMapFieldsInto(out map[string]any, indent int) error {
+	for p.pos < len(p.lines) {
+		line := p.lines[p.pos]
+		if line.indent < indent {
+			return nil
+		}
+		if line.indent != indent {
+			return fmt.Errorf("unexpected indentation on line %d", line.line)
+		}
+		if strings.HasPrefix(line.text, "- ") {
+			return nil
+		}
+		key, rawValue, ok := splitYAMLKeyValue(line.text)
+		if !ok || key == "" {
+			return fmt.Errorf("expected mapping entry on line %d", line.line)
+		}
+		p.pos++
+		value, err := p.parseMapValue(rawValue, indent, line.line)
+		if err != nil {
+			return err
+		}
+		out[key] = value
+	}
+	return nil
+}
+
+func (p *yamlParser) parseMapValue(rawValue string, indent int, lineNumber int) (any, error) {
+	if strings.TrimSpace(rawValue) == "" {
+		return p.parseNestedValue(indent, lineNumber)
+	}
+	if isYAMLBlockScalar(rawValue) {
+		return p.parseBlockScalar(rawValue, indent)
+	}
+	value, err := parseYAMLScalar(rawValue)
+	if err != nil {
+		return nil, fmt.Errorf("line %d: %w", lineNumber, err)
+	}
+	return value, nil
+}
+
+func (p *yamlParser) parseBlockScalar(marker string, parentIndent int) (string, error) {
+	chomp := byte(0)
+	if strings.HasSuffix(marker, "-") || strings.HasSuffix(marker, "+") {
+		chomp = marker[len(marker)-1]
+	}
+	if p.pos >= len(p.lines) || p.lines[p.pos].indent <= parentIndent {
+		return "", nil
+	}
+	contentIndent := p.lines[p.pos].indent
+	parts := []string{}
+	for p.pos < len(p.lines) {
+		line := p.lines[p.pos]
+		if line.indent < contentIndent {
+			break
+		}
+		if line.indent > contentIndent {
+			parts = append(parts, strings.Repeat(" ", line.indent-contentIndent)+line.text)
+		} else {
+			parts = append(parts, line.text)
+		}
+		p.pos++
+	}
+
+	var value string
+	if strings.HasPrefix(marker, ">") {
+		value = strings.Join(parts, " ")
+	} else {
+		value = strings.Join(parts, "\n")
+	}
+	if chomp != '-' && value != "" {
+		value += "\n"
+	}
+	return value, nil
+}
+
+func (p *yamlParser) parseNestedValue(parentIndent int, lineNumber int) (any, error) {
+	if p.pos >= len(p.lines) || p.lines[p.pos].indent <= parentIndent {
+		return map[string]any{}, nil
+	}
+	return p.parseBlock(p.lines[p.pos].indent)
+}
+
+func splitYAMLKeyValue(text string) (string, string, bool) {
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for index, r := range text {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inDouble && r == '\\' {
+			escaped = true
+			continue
+		}
+		switch r {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case ':':
+			if inSingle || inDouble {
+				continue
+			}
+			if index == len(text)-1 || text[index+1] == ' ' || text[index+1] == '\t' {
+				return strings.TrimSpace(text[:index]), strings.TrimSpace(text[index+1:]), true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func parseYAMLScalar(raw string) (any, error) {
+	value := strings.TrimSpace(raw)
+	switch value {
+	case "":
+		return "", nil
+	case "null", "Null", "NULL", "~":
+		return nil, nil
+	case "true", "True", "TRUE":
+		return true, nil
+	case "false", "False", "FALSE":
+		return false, nil
+	case "{}":
+		return map[string]any{}, nil
+	case "[]":
+		return []any{}, nil
+	}
+	if strings.HasPrefix(value, `"`) {
+		unquoted, err := strconv.Unquote(value)
+		if err != nil {
+			return nil, err
+		}
+		return unquoted, nil
+	}
+	if strings.HasPrefix(value, `'`) && strings.HasSuffix(value, `'`) && len(value) >= 2 {
+		return strings.ReplaceAll(value[1:len(value)-1], "''", "'"), nil
+	}
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		return parseInlineYAMLSequence(value)
+	}
+	if number, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return number, nil
+	}
+	if number, err := strconv.ParseFloat(value, 64); err == nil && strings.ContainsAny(value, ".eE") {
+		return number, nil
+	}
+	return value, nil
+}
+
+func isYAMLBlockScalar(raw string) bool {
+	value := strings.TrimSpace(raw)
+	if value == "|" || value == ">" || value == "|-" || value == ">-" || value == "|+" || value == ">+" {
+		return true
+	}
+	return false
+}
+
+func parseInlineYAMLSequence(value string) ([]any, error) {
+	inner := strings.TrimSpace(value[1 : len(value)-1])
+	if inner == "" {
+		return []any{}, nil
+	}
+	parts, err := splitInlineYAMLValues(inner)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]any, 0, len(parts))
+	for _, part := range parts {
+		item, err := parseYAMLScalar(part)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func splitInlineYAMLValues(value string) ([]string, error) {
+	parts := []string{}
+	start := 0
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for index, r := range value {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inDouble && r == '\\' {
+			escaped = true
+			continue
+		}
+		switch r {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case ',':
+			if !inSingle && !inDouble {
+				parts = append(parts, strings.TrimSpace(value[start:index]))
+				start = index + 1
+			}
+		}
+	}
+	if inSingle || inDouble {
+		return nil, fmt.Errorf("unterminated quoted inline sequence value")
+	}
+	parts = append(parts, strings.TrimSpace(value[start:]))
+	return parts, nil
+}
+
+func stripYAMLComment(value string) string {
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for index, r := range value {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inDouble && r == '\\' {
+			escaped = true
+			continue
+		}
+		switch r {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '#':
+			if !inSingle && !inDouble {
+				if index == 0 || value[index-1] == ' ' || value[index-1] == '\t' {
+					return strings.TrimRight(value[:index], " \t")
+				}
+			}
+		}
+	}
+	return value
+}
+
+func leadingSpaces(value string) int {
+	count := 0
+	for _, r := range value {
+		if r != ' ' {
+			break
+		}
+		count++
+	}
+	return count
+}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -31,6 +31,7 @@ type ServerOptions struct {
 	Store          *store.Store
 	AssetStore     *coreassets.Store
 	AppleSeed      *apple.SeedConfig
+	AWSSeed        *aws.SeedConfig
 	ClerkSeed      *clerk.SeedConfig
 	GitHubSeed     *github.SeedConfig
 	GoogleSeed     *google.SeedConfig
@@ -113,6 +114,7 @@ func NewServer(options ServerOptions) *Server {
 			S3PathFallback: len(services) == 1,
 			AssetStore:     assetStore,
 			BaseURL:        options.BaseURL,
+			Seed:           options.AWSSeed,
 		})
 	}
 	if serviceEnabled(services, "resend") {

--- a/internal/services/aws/seed.go
+++ b/internal/services/aws/seed.go
@@ -1,0 +1,178 @@
+package aws
+
+import (
+	"strings"
+	"time"
+
+	corestore "github.com/vercel-labs/emulate/internal/core/store"
+	"github.com/vercel-labs/emulate/internal/services/aws/auth"
+	"github.com/vercel-labs/emulate/internal/services/aws/gateway"
+)
+
+type SeedConfig struct {
+	Port      int     `json:"port"`
+	BaseURL   string  `json:"baseUrl"`
+	Region    string  `json:"region"`
+	AccountID string  `json:"account_id"`
+	S3        S3Seed  `json:"s3"`
+	SQS       SQSSeed `json:"sqs"`
+	IAM       IAMSeed `json:"iam"`
+}
+
+type S3Seed struct {
+	Buckets []S3BucketSeed `json:"buckets"`
+}
+
+type S3BucketSeed struct {
+	Name   string `json:"name"`
+	Region string `json:"region"`
+}
+
+type SQSSeed struct {
+	Queues []SQSQueueSeed `json:"queues"`
+}
+
+type SQSQueueSeed struct {
+	Name              string `json:"name"`
+	FIFO              bool   `json:"fifo"`
+	VisibilityTimeout int    `json:"visibility_timeout"`
+}
+
+type IAMSeed struct {
+	Users []IAMUserSeed `json:"users"`
+	Roles []IAMRoleSeed `json:"roles"`
+}
+
+type IAMUserSeed struct {
+	UserName        string `json:"user_name"`
+	Path            string `json:"path"`
+	CreateAccessKey bool   `json:"create_access_key"`
+}
+
+type IAMRoleSeed struct {
+	RoleName         string `json:"role_name"`
+	Path             string `json:"path"`
+	Description      string `json:"description"`
+	AssumeRolePolicy string `json:"assume_role_policy"`
+}
+
+func seedFromConfig(store Store, credentialStore *auth.Store, baseURL string, defaultAccountID string, defaultRegion string, config SeedConfig) {
+	accountID := firstNonEmpty(config.AccountID, defaultAccountID, gateway.DefaultAccountID)
+	region := firstNonEmpty(config.Region, defaultRegion, gateway.DefaultRegion)
+	if config.BaseURL != "" {
+		baseURL = config.BaseURL
+	}
+	seedS3FromConfig(store, region, config.S3)
+	seedSQSFromConfig(store, baseURL, accountID, region, config.SQS)
+	seedIAMFromConfig(store, credentialStore, accountID, config.IAM)
+}
+
+func seedS3FromConfig(store Store, defaultRegion string, config S3Seed) {
+	for _, bucket := range config.Buckets {
+		name := strings.TrimSpace(bucket.Name)
+		if name == "" || len(store.S3Buckets.FindBy("bucket_name", name)) > 0 {
+			continue
+		}
+		store.S3Buckets.Insert(corestore.Record{
+			"bucket_name":        name,
+			"region":             firstNonEmpty(bucket.Region, defaultRegion, gateway.DefaultRegion),
+			"creation_date":      time.Now().UTC().Format(time.RFC3339Nano),
+			"acl":                "private",
+			"versioning_enabled": false,
+		})
+	}
+}
+
+func seedSQSFromConfig(store Store, baseURL string, accountID string, region string, config SQSSeed) {
+	if accountID == "" {
+		accountID = gateway.DefaultAccountID
+	}
+	if region == "" {
+		region = gateway.DefaultRegion
+	}
+	if baseURL == "" {
+		baseURL = "http://127.0.0.1"
+	}
+	for _, queue := range config.Queues {
+		name := strings.TrimSpace(queue.Name)
+		if name == "" || len(store.SQSQueues.FindBy("queue_name", name)) > 0 {
+			continue
+		}
+		visibilityTimeout := queue.VisibilityTimeout
+		if visibilityTimeout == 0 {
+			visibilityTimeout = 30
+		}
+		store.SQSQueues.Insert(corestore.Record{
+			"queue_name":                name,
+			"queue_url":                 strings.TrimRight(baseURL, "/") + "/sqs/" + accountID + "/" + name,
+			"arn":                       "arn:aws:sqs:" + region + ":" + accountID + ":" + name,
+			"visibility_timeout":        visibilityTimeout,
+			"delay_seconds":             0,
+			"max_message_size":          262144,
+			"message_retention_period":  345600,
+			"receive_message_wait_time": 0,
+			"fifo":                      queue.FIFO || strings.HasSuffix(name, ".fifo"),
+		})
+	}
+}
+
+func seedIAMFromConfig(store Store, credentialStore *auth.Store, accountID string, config IAMSeed) {
+	if accountID == "" {
+		accountID = gateway.DefaultAccountID
+	}
+	for _, user := range config.Users {
+		userName := strings.TrimSpace(user.UserName)
+		if userName == "" || len(store.IAMUsers.FindBy("user_name", userName)) > 0 {
+			continue
+		}
+		path := firstNonEmpty(user.Path, "/")
+		accessKeys := []corestore.Record{}
+		arn := "arn:aws:iam::" + accountID + ":user" + path + userName
+		if user.CreateAccessKey {
+			accessKeyID := "AKIA" + generateAWSID("")
+			secretAccessKey := generateAWSID("") + generateAWSID("")
+			accessKeys = append(accessKeys, corestore.Record{
+				"access_key_id":     accessKeyID,
+				"secret_access_key": secretAccessKey,
+				"status":            "Active",
+			})
+			credentialStore.Put(auth.Credential{
+				AccessKeyID:     accessKeyID,
+				SecretAccessKey: secretAccessKey,
+				AccountID:       accountID,
+				PrincipalARN:    arn,
+			})
+		}
+		store.IAMUsers.Insert(corestore.Record{
+			"user_name":   userName,
+			"user_id":     generateAWSID("AIDA"),
+			"arn":         arn,
+			"path":        path,
+			"access_keys": accessKeys,
+		})
+	}
+	for _, role := range config.Roles {
+		roleName := strings.TrimSpace(role.RoleName)
+		if roleName == "" || len(store.IAMRoles.FindBy("role_name", roleName)) > 0 {
+			continue
+		}
+		path := firstNonEmpty(role.Path, "/")
+		store.IAMRoles.Insert(corestore.Record{
+			"role_name":                   roleName,
+			"role_id":                     generateAWSID("AROA"),
+			"arn":                         "arn:aws:iam::" + accountID + ":role" + path + roleName,
+			"path":                        path,
+			"assume_role_policy_document": firstNonEmpty(role.AssumeRolePolicy, "{}"),
+			"description":                 role.Description,
+		})
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/services/aws/service.go
+++ b/internal/services/aws/service.go
@@ -28,6 +28,7 @@ type Options struct {
 	S3PathFallback   bool
 	AssetStore       *coreassets.Store
 	BaseURL          string
+	Seed             *SeedConfig
 }
 
 type Service struct {
@@ -66,6 +67,14 @@ func New(options Options) *Service {
 	if defaultRegion == "" {
 		defaultRegion = gateway.DefaultRegion
 	}
+	if options.Seed != nil {
+		if defaultAccountID == gateway.DefaultAccountID && options.Seed.AccountID != "" {
+			defaultAccountID = options.Seed.AccountID
+		}
+		if defaultRegion == gateway.DefaultRegion && options.Seed.Region != "" {
+			defaultRegion = options.Seed.Region
+		}
+	}
 	assetStore := options.AssetStore
 	if assetStore == nil {
 		assetStore = coreassets.New()
@@ -79,6 +88,9 @@ func New(options Options) *Service {
 	seedSQSDefaults(awsStore, options.BaseURL, defaultAccountID, defaultRegion)
 	seedEventBridgeDefaults(awsStore, defaultAccountID, defaultRegion)
 	seedIAMDefaults(awsStore, credentialStore, defaultAccountID)
+	if options.Seed != nil {
+		seedFromConfig(awsStore, credentialStore, options.BaseURL, defaultAccountID, defaultRegion, *options.Seed)
+	}
 	return &Service{
 		store:            awsStore,
 		assets:           assetStore,

--- a/internal/services/aws/service_test.go
+++ b/internal/services/aws/service_test.go
@@ -2838,6 +2838,45 @@ func TestNewStoreCreatesAWSCollections(t *testing.T) {
 	}
 }
 
+func TestServiceSeedsAWSConfig(t *testing.T) {
+	router := corehttp.NewRouter()
+	Register(router, Options{
+		Store:           corestore.New(),
+		CredentialStore: auth.NewStore(),
+		BaseURL:         "http://localhost:4017",
+		Seed: &SeedConfig{
+			Region:    "us-west-2",
+			AccountID: "999999999999",
+			S3:        S3Seed{Buckets: []S3BucketSeed{{Name: "seeded-bucket", Region: "eu-west-1"}}},
+			SQS:       SQSSeed{Queues: []SQSQueueSeed{{Name: "seeded-queue", VisibilityTimeout: 45}}},
+			IAM: IAMSeed{
+				Users: []IAMUserSeed{{UserName: "developer", CreateAccessKey: true}},
+				Roles: []IAMRoleSeed{{RoleName: "worker", Description: "Worker role", AssumeRolePolicy: `{"Version":"2012-10-17","Statement":[]}`}},
+			},
+		},
+	})
+
+	res := executeAWSRequest(router, http.MethodHead, "http://127.0.0.1/seeded-bucket", nil, "s3", nil)
+	if res.Code != http.StatusOK || res.Header().Get("x-amz-bucket-region") != "eu-west-1" {
+		t.Fatalf("head bucket status = %d, headers = %#v, body = %s", res.Code, res.Header(), res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(router, "sqs", "Action=GetQueueUrl&QueueName=seeded-queue")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "http://localhost:4017/sqs/999999999999/seeded-queue") {
+		t.Fatalf("get seeded queue status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(router, "iam", "Action=GetUser&UserName=developer")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "arn:aws:iam::999999999999:user/developer") {
+		t.Fatalf("get seeded user status = %d, body = %s", res.Code, res.Body.String())
+	}
+
+	res = executeAWSQueryRequest(router, "iam", "Action=GetRole&RoleName=worker")
+	if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "Worker role") {
+		t.Fatalf("get seeded role status = %d, body = %s", res.Code, res.Body.String())
+	}
+}
+
 func newTestHandler() http.Handler {
 	return newTestHandlerWithCredentialStore(nil)
 }

--- a/packages/@emulators/emulate-darwin-arm64/package.json
+++ b/packages/@emulators/emulate-darwin-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@emulators/emulate-darwin-arm64",
+  "version": "0.5.0",
+  "description": "Native emulate binary for macOS arm64",
+  "license": "Apache-2.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/emulate-darwin-arm64"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@emulators/emulate-darwin-x64/package.json
+++ b/packages/@emulators/emulate-darwin-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@emulators/emulate-darwin-x64",
+  "version": "0.5.0",
+  "description": "Native emulate binary for macOS x64",
+  "license": "Apache-2.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/emulate-darwin-x64"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@emulators/emulate-linux-arm64/package.json
+++ b/packages/@emulators/emulate-linux-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@emulators/emulate-linux-arm64",
+  "version": "0.5.0",
+  "description": "Native emulate binary for Linux arm64",
+  "license": "Apache-2.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/emulate-linux-arm64"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@emulators/emulate-linux-x64/package.json
+++ b/packages/@emulators/emulate-linux-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@emulators/emulate-linux-x64",
+  "version": "0.5.0",
+  "description": "Native emulate binary for Linux x64",
+  "license": "Apache-2.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/emulate-linux-x64"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@emulators/emulate-win32-arm64/package.json
+++ b/packages/@emulators/emulate-win32-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@emulators/emulate-win32-arm64",
+  "version": "0.5.0",
+  "description": "Native emulate binary for Windows arm64",
+  "license": "Apache-2.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/emulate-win32-arm64"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@emulators/emulate-win32-x64/package.json
+++ b/packages/@emulators/emulate-win32-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@emulators/emulate-win32-x64",
+  "version": "0.5.0",
+  "description": "Native emulate binary for Windows x64",
+  "license": "Apache-2.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/emulate-win32-x64"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@emulators/resend/README.md
+++ b/packages/@emulators/resend/README.md
@@ -8,7 +8,7 @@ Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in repl
 
 Set `RESEND_BASE_URL` before importing the official `resend` Node.js SDK and the SDK will call the emulator without code changes.
 
-The native Go runtime implements the current Resend routes listed below, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime implements the current Resend routes listed below, supports YAML and JSON seed configs for Resend through `--seed`, and is verified against the official `resend` SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 ## Install
 

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -42,6 +42,14 @@
   "bin": {
     "emulate": "./dist/index.js"
   },
+  "optionalDependencies": {
+    "@emulators/emulate-darwin-arm64": "workspace:*",
+    "@emulators/emulate-darwin-x64": "workspace:*",
+    "@emulators/emulate-linux-arm64": "workspace:*",
+    "@emulators/emulate-linux-x64": "workspace:*",
+    "@emulators/emulate-win32-arm64": "workspace:*",
+    "@emulators/emulate-win32-x64": "workspace:*"
+  },
   "scripts": {
     "prepack": "cp ../../README.md .",
     "build": "tsup",
@@ -51,11 +59,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint src"
   },
-  "dependencies": {
-    "commander": "^14",
-    "picocolors": "^1.1.1",
-    "yaml": "^2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@emulators/core": "workspace:*",
     "@emulators/github": "workspace:*",
@@ -70,7 +74,10 @@
     "@emulators/resend": "workspace:*",
     "@emulators/stripe": "workspace:*",
     "@emulators/clerk": "workspace:*",
+    "commander": "^14",
+    "picocolors": "^1.1.1",
     "tsup": "^8",
-    "typescript": "^5.7"
+    "typescript": "^5.7",
+    "yaml": "^2"
   }
 }

--- a/packages/emulate/src/__tests__/native.test.ts
+++ b/packages/emulate/src/__tests__/native.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { nativePackageName, resolveNativeBinary } from "../native.js";
+
+describe("native binary resolution", () => {
+  it("maps supported npm platform and arch pairs to native packages", () => {
+    expect(nativePackageName({ platform: "darwin", arch: "arm64" })).toBe("@emulators/emulate-darwin-arm64");
+    expect(nativePackageName({ platform: "darwin", arch: "x64" })).toBe("@emulators/emulate-darwin-x64");
+    expect(nativePackageName({ platform: "linux", arch: "arm64" })).toBe("@emulators/emulate-linux-arm64");
+    expect(nativePackageName({ platform: "linux", arch: "x64" })).toBe("@emulators/emulate-linux-x64");
+    expect(nativePackageName({ platform: "win32", arch: "arm64" })).toBe("@emulators/emulate-win32-arm64");
+    expect(nativePackageName({ platform: "win32", arch: "x64" })).toBe("@emulators/emulate-win32-x64");
+  });
+
+  it("returns a clear error for unsupported targets", () => {
+    const resolved = resolveNativeBinary({
+      target: { platform: "freebsd", arch: "x64" },
+      env: {},
+      resolvePackage: () => {
+        throw new Error("not found");
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: false,
+      message: "No native emulate binary is published for freebsd/x64.",
+    });
+  });
+
+  it("resolves the platform package binary path", () => {
+    const resolved = resolveNativeBinary({
+      target: { platform: "linux", arch: "x64" },
+      env: {},
+      exists: () => true,
+      resolvePackage: (specifier) => {
+        expect(specifier).toBe("@emulators/emulate-linux-x64/package.json");
+        return "/repo/node_modules/@emulators/emulate-linux-x64/package.json";
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      packageName: "@emulators/emulate-linux-x64",
+      path: "/repo/node_modules/@emulators/emulate-linux-x64/bin/emulate",
+    });
+  });
+
+  it("uses the Windows executable name", () => {
+    const resolved = resolveNativeBinary({
+      target: { platform: "win32", arch: "arm64" },
+      env: {},
+      exists: () => true,
+      resolvePackage: () => "C:\\repo\\node_modules\\@emulators\\emulate-win32-arm64\\package.json",
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (resolved.ok) {
+      expect(resolved.path).toContain("emulate.exe");
+    }
+  });
+
+  it("fails clearly when the platform package is installed without a binary", () => {
+    const resolved = resolveNativeBinary({
+      target: { platform: "linux", arch: "arm64" },
+      env: {},
+      exists: () => false,
+      resolvePackage: () => "/repo/node_modules/@emulators/emulate-linux-arm64/package.json",
+    });
+
+    expect(resolved.ok).toBe(false);
+    if (!resolved.ok) {
+      expect(resolved.packageName).toBe("@emulators/emulate-linux-arm64");
+      expect(resolved.message).toContain("Missing native emulate binary package");
+    }
+  });
+});

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -1,73 +1,49 @@
-import { Command } from "commander";
-import { startCommand } from "./commands/start.js";
-import { initCommand } from "./commands/init.js";
-import { listCommand } from "./commands/list.js";
-import { DEFAULT_VERCEL_SERVICE_OPTION, vercelInitCommand } from "./commands/vercel.js";
+import { spawn } from "node:child_process";
+import { resolveNativeBinary } from "./native.js";
 
-declare const PKG_VERSION: string;
-const pkg = { version: PKG_VERSION };
+const args = process.argv.slice(2);
+const resolved = resolveNativeBinary();
 
-const defaultPort = process.env.EMULATE_PORT ?? process.env.PORT ?? "4000";
+if (!resolved.ok) {
+  console.error(resolved.message);
+  process.exit(1);
+}
 
-const program = new Command();
+const child = spawn(resolved.path, args, { stdio: "inherit" });
+const forwardedSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
 
-program
-  .name("npx emulate")
-  .description("Local drop-in replacement services for CI and no-network sandboxes")
-  .version(pkg.version);
+const forwardSignal = (signal: NodeJS.Signals) => {
+  if (!child.killed) {
+    child.kill(signal);
+  }
+};
 
-program
-  .command("start", { isDefault: true })
-  .description("Start the emulator server")
-  .option("-p, --port <port>", "Base port", defaultPort)
-  .option("-s, --service <services>", "Comma-separated services to enable")
-  .option("--seed <file>", "Path to seed config file")
-  .option("--base-url <url>", "Override advertised base URL (supports {service} template)")
-  .option("--portless", "Serve over HTTPS via portless (auto-registers aliases)")
-  .action(async (opts) => {
-    const port = parseInt(opts.port, 10);
-    if (Number.isNaN(port) || port < 1 || port > 65535) {
-      console.error(`Invalid port: ${opts.port}`);
-      process.exit(1);
-    }
-    await startCommand({
-      port,
-      service: opts.service,
-      seed: opts.seed,
-      baseUrl: opts.baseUrl,
-      portless: opts.portless,
-    });
-  });
+for (const signal of forwardedSignals) {
+  process.once(signal, () => forwardSignal(signal));
+}
 
-program
-  .command("init")
-  .description("Generate a starter config file")
-  .option("-s, --service <service>", "Service to generate config for", "all")
-  .action((opts) => {
-    initCommand({ service: opts.service });
-  });
+child.once("error", (error) => {
+  console.error(`Failed to run native emulate binary: ${error.message}`);
+  process.exit(1);
+});
 
-program
-  .command("list")
-  .alias("list-services")
-  .description("List available services")
-  .action(() => {
-    listCommand();
-  });
+child.once("exit", (code, signal) => {
+  for (const forwarded of forwardedSignals) {
+    process.removeAllListeners(forwarded);
+  }
+  if (signal) {
+    process.exit(exitCodeForSignal(signal));
+  }
+  process.exit(code ?? 1);
+});
 
-const vercel = program.command("vercel").description("Vercel preview helpers");
+function exitCodeForSignal(signal: NodeJS.Signals): number {
+  return 128 + (signalNumbers[signal] ?? 1);
+}
 
-vercel
-  .command("init")
-  .description("Scaffold a Vercel Go Function preview route")
-  .option("-s, --service <services>", "Comma-separated native services to enable", DEFAULT_VERCEL_SERVICE_OPTION)
-  .option("--force", "Overwrite generated files")
-  .action((opts) => {
-    vercelInitCommand({
-      service: opts.service,
-      force: opts.force,
-      version: pkg.version,
-    });
-  });
-
-program.parse();
+const signalNumbers: Partial<Record<NodeJS.Signals, number>> = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGKILL: 9,
+  SIGTERM: 15,
+};

--- a/packages/emulate/src/native.ts
+++ b/packages/emulate/src/native.ts
@@ -1,0 +1,90 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+export interface NativeTarget {
+  platform: NodeJS.Platform;
+  arch: NodeJS.Architecture;
+}
+
+export interface NativeResolveOptions {
+  target?: NativeTarget;
+  env?: NodeJS.ProcessEnv;
+  resolvePackage?: (specifier: string) => string;
+  exists?: (path: string) => boolean;
+}
+
+export type NativeResolveResult =
+  | { ok: true; path: string; packageName?: string }
+  | { ok: false; message: string; packageName?: string };
+
+const require = createRequire(import.meta.url);
+
+const packageByTarget = new Map<string, string>([
+  ["darwin:arm64", "@emulators/emulate-darwin-arm64"],
+  ["darwin:x64", "@emulators/emulate-darwin-x64"],
+  ["linux:arm64", "@emulators/emulate-linux-arm64"],
+  ["linux:x64", "@emulators/emulate-linux-x64"],
+  ["win32:arm64", "@emulators/emulate-win32-arm64"],
+  ["win32:x64", "@emulators/emulate-win32-x64"],
+]);
+
+export function nativePackageName(target: NativeTarget = process): string | undefined {
+  return packageByTarget.get(`${target.platform}:${target.arch}`);
+}
+
+export function resolveNativeBinary(options: NativeResolveOptions = {}): NativeResolveResult {
+  const env = options.env ?? process.env;
+  const exists = options.exists ?? existsSync;
+  const override = env.EMULATE_NATIVE_BINARY;
+  if (override) {
+    if (exists(override)) {
+      return { ok: true, path: override };
+    }
+    return { ok: false, message: `EMULATE_NATIVE_BINARY does not exist: ${override}` };
+  }
+
+  const target = options.target ?? process;
+  const packageName = nativePackageName(target);
+  if (!packageName) {
+    return {
+      ok: false,
+      message: `No native emulate binary is published for ${target.platform}/${target.arch}.`,
+    };
+  }
+
+  const resolvePackage = options.resolvePackage ?? require.resolve;
+  try {
+    const packageJSON = resolvePackage(`${packageName}/package.json`);
+    const executable = target.platform === "win32" ? "emulate.exe" : "emulate";
+    const binary = join(dirname(packageJSON), "bin", executable);
+    if (exists(binary)) {
+      return { ok: true, path: binary, packageName };
+    }
+  } catch {
+    // Fall back below so local development can still use a checked-out binary.
+  }
+
+  const localBinary = localDevelopmentBinary(target);
+  if (localBinary && exists(localBinary)) {
+    return { ok: true, path: localBinary, packageName };
+  }
+  return {
+    ok: false,
+    packageName,
+    message: [
+      `Missing native emulate binary package for ${target.platform}/${target.arch}: ${packageName}.`,
+      "Reinstall with optional dependencies enabled, or set EMULATE_NATIVE_BINARY to a locally built binary.",
+    ].join("\n"),
+  };
+}
+
+function localDevelopmentBinary(target: NativeTarget): string | undefined {
+  if (target.platform !== process.platform || target.arch !== process.arch) {
+    return undefined;
+  }
+  const currentFile = fileURLToPath(import.meta.url);
+  const executable = target.platform === "win32" ? "emulate.exe" : "emulate";
+  return join(dirname(currentFile), "native", executable);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,18 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/@emulators/emulate-darwin-arm64: {}
+
+  packages/@emulators/emulate-darwin-x64: {}
+
+  packages/@emulators/emulate-linux-arm64: {}
+
+  packages/@emulators/emulate-linux-x64: {}
+
+  packages/@emulators/emulate-win32-arm64: {}
+
+  packages/@emulators/emulate-win32-x64: {}
+
   packages/@emulators/github:
     dependencies:
       '@emulators/core':
@@ -638,16 +650,6 @@ importers:
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/emulate:
-    dependencies:
-      commander:
-        specifier: ^14
-        version: 14.0.3
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-      yaml:
-        specifier: ^2
-        version: 2.8.3
     devDependencies:
       '@emulators/apple':
         specifier: workspace:*
@@ -688,12 +690,40 @@ importers:
       '@emulators/vercel':
         specifier: workspace:*
         version: link:../@emulators/vercel
+      commander:
+        specifier: ^14
+        version: 14.0.3
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       tsup:
         specifier: ^8
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.7
         version: 5.9.3
+      yaml:
+        specifier: ^2
+        version: 2.8.3
+    optionalDependencies:
+      '@emulators/emulate-darwin-arm64':
+        specifier: workspace:*
+        version: link:../@emulators/emulate-darwin-arm64
+      '@emulators/emulate-darwin-x64':
+        specifier: workspace:*
+        version: link:../@emulators/emulate-darwin-x64
+      '@emulators/emulate-linux-arm64':
+        specifier: workspace:*
+        version: link:../@emulators/emulate-linux-arm64
+      '@emulators/emulate-linux-x64':
+        specifier: workspace:*
+        version: link:../@emulators/emulate-linux-x64
+      '@emulators/emulate-win32-arm64':
+        specifier: workspace:*
+        version: link:../@emulators/emulate-win32-arm64
+      '@emulators/emulate-win32-x64':
+        specifier: workspace:*
+        version: link:../@emulators/emulate-win32-x64
 
   tests/sdk-js:
     devDependencies:

--- a/scripts/build-native-packages.mjs
+++ b/scripts/build-native-packages.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { chmodSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const version = JSON.parse(readFileSync(join(root, "packages/emulate/package.json"), "utf8")).version;
+
+const targets = [
+  { pkg: "emulate-darwin-arm64", goos: "darwin", goarch: "arm64", exe: "emulate" },
+  { pkg: "emulate-darwin-x64", goos: "darwin", goarch: "amd64", exe: "emulate" },
+  { pkg: "emulate-linux-arm64", goos: "linux", goarch: "arm64", exe: "emulate" },
+  { pkg: "emulate-linux-x64", goos: "linux", goarch: "amd64", exe: "emulate" },
+  { pkg: "emulate-win32-arm64", goos: "windows", goarch: "arm64", exe: "emulate.exe" },
+  { pkg: "emulate-win32-x64", goos: "windows", goarch: "amd64", exe: "emulate.exe" },
+];
+
+for (const target of targets) {
+  const outDir = join(root, "packages/@emulators", target.pkg, "bin");
+  const outFile = join(outDir, target.exe);
+  mkdirSync(outDir, { recursive: true });
+
+  const result = spawnSync(
+    "go",
+    ["build", "-trimpath", "-ldflags", `-s -w -X main.version=${version}`, "-o", outFile, "./cmd/emulate"],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        CGO_ENABLED: "0",
+        GOOS: target.goos,
+        GOARCH: target.goarch,
+      },
+      stdio: "inherit",
+    },
+  );
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+
+  if (target.goos !== "windows") {
+    chmodSync(outFile, 0o755);
+  }
+  console.log(`Built @emulators/${target.pkg}/bin/${target.exe}`);
+}

--- a/skills/apple/SKILL.md
+++ b/skills/apple/SKILL.md
@@ -34,7 +34,7 @@ const apple = await createEmulator({ service: 'apple', port: 4004 })
 ### Environment Variable
 
 ```bash
-APPLE_EMULATOR_URL=http://localhost:4004
+APPLE_EMULATOR_URL=http://localhost:4000
 ```
 
 ### OAuth URL Mapping
@@ -114,7 +114,7 @@ PKCE is supported. Pass `code_challenge` and `code_challenge_method` on authoriz
 ### OIDC Discovery
 
 ```bash
-curl http://localhost:4004/.well-known/openid-configuration
+curl http://localhost:4000/.well-known/openid-configuration
 ```
 
 When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/apple/.well-known/openid-configuration` to avoid the shared root discovery path.
@@ -123,11 +123,11 @@ Returns the standard OIDC discovery document with all endpoints pointing to the 
 
 ```json
 {
-  "issuer": "http://localhost:4004",
-  "authorization_endpoint": "http://localhost:4004/auth/authorize",
-  "token_endpoint": "http://localhost:4004/auth/token",
-  "jwks_uri": "http://localhost:4004/auth/keys",
-  "revocation_endpoint": "http://localhost:4004/auth/revoke",
+  "issuer": "http://localhost:4000",
+  "authorization_endpoint": "http://localhost:4000/auth/authorize",
+  "token_endpoint": "http://localhost:4000/auth/token",
+  "jwks_uri": "http://localhost:4000/auth/keys",
+  "revocation_endpoint": "http://localhost:4000/auth/revoke",
   "response_types_supported": ["code"],
   "subject_types_supported": ["pairwise"],
   "id_token_signing_alg_values_supported": ["RS256"],
@@ -140,7 +140,7 @@ Returns the standard OIDC discovery document with all endpoints pointing to the 
 ### JWKS
 
 ```bash
-curl http://localhost:4004/auth/keys
+curl http://localhost:4000/auth/keys
 ```
 
 Returns an RSA public key (`kid`: `emulate-apple-1`) for verifying `id_token` signatures.
@@ -149,7 +149,7 @@ Returns an RSA public key (`kid`: `emulate-apple-1`) for verifying `id_token` si
 
 ```bash
 # Browser flow: redirects to a user picker page
-curl -v "http://localhost:4004/auth/authorize?\
+curl -v "http://localhost:4000/auth/authorize?\
 client_id=com.example.app&\
 redirect_uri=http://localhost:3000/api/auth/callback/apple&\
 scope=openid+email+name&\
@@ -175,7 +175,7 @@ The emulator renders an HTML page where you select a seeded user. After selectio
 ### Token Exchange
 
 ```bash
-curl -X POST http://localhost:4004/auth/token \
+curl -X POST http://localhost:4000/auth/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "code=<authorization_code>&\
 client_id=com.example.app&\
@@ -200,7 +200,7 @@ The `id_token` is an RS256 JWT containing `sub`, `email`, `email_verified` (stri
 ### Refresh Token
 
 ```bash
-curl -X POST http://localhost:4004/auth/token \
+curl -X POST http://localhost:4000/auth/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "refresh_token=r_apple_...&\
 client_id=com.example.app&\
@@ -212,7 +212,7 @@ Returns a new `access_token` and `id_token`. No new `refresh_token` is issued on
 ### Token Revocation
 
 ```bash
-curl -X POST http://localhost:4004/auth/revoke \
+curl -X POST http://localhost:4000/auth/revoke \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "token=apple_..."
 ```
@@ -224,7 +224,7 @@ Returns `200 OK`. The token is removed from the emulator's token map.
 ### Full Authorization Code Flow
 
 ```bash
-APPLE_URL="http://localhost:4004"
+APPLE_URL="http://localhost:4000"
 CLIENT_ID="com.example.app"
 REDIRECT_URI="http://localhost:3000/api/auth/callback/apple"
 

--- a/skills/aws/SKILL.md
+++ b/skills/aws/SKILL.md
@@ -42,7 +42,7 @@ const aws = await createEmulator({ service: 'aws', port: 4006 })
 Pass tokens as `Authorization: Bearer <token>`. Scoped permissions use `s3:*`, `sqs:*`, `sns:*`, `events:*`, `dynamodb:*`, `iam:*`, `sts:*` patterns.
 
 ```bash
-curl http://localhost:4007/ \
+curl http://localhost:4000/ \
   -H "Authorization: Bearer test_token_admin"
 ```
 
@@ -51,7 +51,7 @@ curl http://localhost:4007/ \
 ### Environment Variable
 
 ```bash
-AWS_EMULATOR_URL=http://localhost:4007
+AWS_EMULATOR_URL=http://localhost:4000
 ```
 
 ### AWS SDK v3
@@ -194,46 +194,46 @@ S3 routes use root paths matching the real AWS S3 wire format. Legacy `/s3/` pre
 
 ```bash
 # List all buckets
-curl http://localhost:4006/ \
+curl http://localhost:4000/ \
   -H "Authorization: Bearer $TOKEN"
 
 # Create bucket
-curl -X PUT http://localhost:4006/my-bucket \
+curl -X PUT http://localhost:4000/my-bucket \
   -H "Authorization: Bearer $TOKEN"
 
 # Delete bucket (must be empty)
-curl -X DELETE http://localhost:4006/my-bucket \
+curl -X DELETE http://localhost:4000/my-bucket \
   -H "Authorization: Bearer $TOKEN"
 
 # Head bucket (check existence, get region)
-curl -I http://localhost:4006/my-bucket \
+curl -I http://localhost:4000/my-bucket \
   -H "Authorization: Bearer $TOKEN"
 
 # List objects (with prefix, delimiter, pagination)
-curl "http://localhost:4006/my-bucket?prefix=uploads/&delimiter=/&max-keys=100" \
+curl "http://localhost:4000/my-bucket?prefix=uploads/&delimiter=/&max-keys=100" \
   -H "Authorization: Bearer $TOKEN"
 
 # Put object
-curl -X PUT http://localhost:4006/my-bucket/path/to/file.txt \
+curl -X PUT http://localhost:4000/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: text/plain" \
   -H "x-amz-meta-author: test" \
   --data-binary "file contents"
 
 # Get object
-curl http://localhost:4006/my-bucket/path/to/file.txt \
+curl http://localhost:4000/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN"
 
 # Head object (metadata only)
-curl -I http://localhost:4006/my-bucket/path/to/file.txt \
+curl -I http://localhost:4000/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN"
 
 # Delete object
-curl -X DELETE http://localhost:4006/my-bucket/path/to/file.txt \
+curl -X DELETE http://localhost:4000/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN"
 
 # Copy object
-curl -X PUT http://localhost:4006/dest-bucket/copy.txt \
+curl -X PUT http://localhost:4000/dest-bucket/copy.txt \
   -H "Authorization: Bearer $TOKEN" \
   -H "x-amz-copy-source: /source-bucket/original.txt"
 ```
@@ -244,64 +244,64 @@ Manual SQS calls can use AWS Query over `POST /sqs/` with `Action` as a form-url
 
 ```bash
 # Create queue
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "Action=CreateQueue&QueueName=my-queue"
 
 # Create queue with attributes
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "Action=CreateQueue&QueueName=my-queue&Attribute.1.Name=VisibilityTimeout&Attribute.1.Value=30"
 
 # List queues
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListQueues"
 
 # List queues with prefix filter
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListQueues&QueueNamePrefix=my-"
 
 # Get queue URL
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetQueueUrl&QueueName=my-queue"
 
 # Get queue attributes
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetQueueAttributes&QueueUrl=<queue_url>"
 
 # Send message
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=SendMessage&QueueUrl=<queue_url>&MessageBody=Hello+World"
 
 # Send message with attributes
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=SendMessage&QueueUrl=<queue_url>&MessageBody=Hello&MessageAttribute.1.Name=type&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=greeting"
 
 # Receive messages
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ReceiveMessage&QueueUrl=<queue_url>&MaxNumberOfMessages=5"
 
 # Delete message
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteMessage&QueueUrl=<queue_url>&ReceiptHandle=<receipt_handle>"
 
 # Purge queue
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=PurgeQueue&QueueUrl=<queue_url>"
 
 # Delete queue
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4000/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteQueue&QueueUrl=<queue_url>"
 ```
@@ -341,57 +341,57 @@ Manual IAM calls can use AWS Query over `POST /iam/` with `Action` as a form-url
 
 ```bash
 # Create user
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=CreateUser&UserName=new-user"
 
 # Get user
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetUser&UserName=new-user"
 
 # List users
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListUsers"
 
 # Delete user
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteUser&UserName=new-user"
 
 # Create access key
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=CreateAccessKey&UserName=developer"
 
 # List access keys
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListAccessKeys&UserName=developer"
 
 # Delete access key
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteAccessKey&UserName=developer&AccessKeyId=AKIA..."
 
 # Create role
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=CreateRole&RoleName=my-role&AssumeRolePolicyDocument={}"
 
 # Get role
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetRole&RoleName=my-role"
 
 # List roles
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListRoles"
 
 # Delete role
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4000/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteRole&RoleName=my-role"
 ```
@@ -402,12 +402,12 @@ Manual STS calls can use AWS Query over `POST /sts/` with `Action` as a form-url
 
 ```bash
 # Get caller identity
-curl -X POST http://localhost:4006/sts/ \
+curl -X POST http://localhost:4000/sts/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetCallerIdentity"
 
 # Assume role
-curl -X POST http://localhost:4006/sts/ \
+curl -X POST http://localhost:4000/sts/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=AssumeRole&RoleArn=arn:aws:iam::123456789012:role/my-role&RoleSessionName=my-session"
 ```
@@ -416,9 +416,9 @@ curl -X POST http://localhost:4006/sts/ \
 
 ```bash
 # HTML dashboard (shows S3, SQS, IAM state)
-curl http://localhost:4006/_inspector?tab=s3
-curl http://localhost:4006/_inspector?tab=sqs
-curl http://localhost:4006/_inspector?tab=iam
+curl http://localhost:4000/_inspector?tab=s3
+curl http://localhost:4000/_inspector?tab=sqs
+curl http://localhost:4000/_inspector?tab=iam
 ```
 
 ## Common Patterns
@@ -427,7 +427,7 @@ curl http://localhost:4006/_inspector?tab=iam
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4006"
+BASE="http://localhost:4000"
 
 # Create bucket
 curl -X PUT $BASE/my-data \
@@ -448,7 +448,7 @@ curl $BASE/my-data/config.json \
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4006"
+BASE="http://localhost:4000"
 
 # Get queue URL
 QUEUE_URL=$(curl -s -X POST $BASE/sqs/ \
@@ -470,7 +470,7 @@ curl -X POST $BASE/sqs/ \
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4006"
+BASE="http://localhost:4000"
 
 # Create user
 curl -X POST $BASE/iam/ \

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -14,7 +14,7 @@ The native Go runtime implements Clerk OIDC discovery, JWKS, authorization code 
 npx emulate --service clerk
 ```
 
-Default URL: `http://localhost:4000` when started alone. In the all-services default layout, Clerk is on `http://localhost:4011`.
+Default URL: `http://localhost:4000` when started alone.
 
 ## Vercel Go Function Preview
 
@@ -39,7 +39,7 @@ When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on on
 Management routes accept Clerk-style secret keys:
 
 ```bash
-curl http://localhost:4011/v1/users \
+curl http://localhost:4000/v1/users \
   -H "Authorization: Bearer sk_test_emulate"
 ```
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -14,22 +14,11 @@ Local drop-in replacement services for CI and no-network sandboxes. Fully statef
 npx emulate
 ```
 
-All services start with sensible defaults:
+The npm CLI launches the native Go engine. All services start on one local server with sensible defaults:
 
-| Service   | Default Port |
-|-----------|-------------|
-| Vercel    | 4000        |
-| GitHub    | 4001        |
-| Google    | 4002        |
-| Slack     | 4003        |
-| Apple     | 4004        |
-| Microsoft | 4005        |
-| Okta      | 4006        |
-| AWS       | 4007        |
-| Resend    | 4008        |
-| Stripe    | 4009        |
-| MongoDB Atlas | 4010   |
-| Clerk    | 4011        |
+```bash
+http://localhost:4000
+```
 
 ## CLI
 
@@ -40,7 +29,7 @@ npx emulate
 # Start specific services
 npx emulate --service vercel,github
 
-# Custom base port (auto-increments per service)
+# Custom native server port
 npx emulate --port 3000
 
 # Use a seed config file
@@ -63,7 +52,7 @@ npx emulate list
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-p, --port` | `4000` | Base port (auto-increments per service) |
+| `-p, --port` | `4000` | Port for the native server |
 | `-s, --service` | all | Comma-separated services to enable |
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
 | `--base-url` | none | Override advertised base URL (supports `{service}` template) |
@@ -71,7 +60,7 @@ npx emulate list
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 
-The advertised base URL (used in OAuth redirects, webhook URLs, etc.) can be overridden via `--base-url`, the `EMULATE_BASE_URL` env var (supports `{service}` template), or per-service `baseUrl` in the seed config. When running under portless, the `PORTLESS_URL` env var is also detected automatically.
+The advertised base URL can be overridden via `--base-url`, the `EMULATE_BASE_URL` env var, or per-service `baseUrl` in the seed config. `{service}` templates require exactly one selected service in native single-server mode; use `--portless` for per-service aliases.
 
 ## Programmatic API
 
@@ -275,7 +264,7 @@ npx emulate start --portless
 # ...
 ```
 
-This requires the portless proxy to be running (`portless proxy start`). If portless is not installed, emulate will prompt to install it.
+This requires the portless proxy to be running (`portless proxy start`). If portless is not installed, install it with `npm i -g portless`.
 
 The `--portless` flag overwrites any existing portless aliases matching `*.emulate`. Aliases are removed automatically when emulate shuts down.
 
@@ -288,12 +277,12 @@ portless github.emulate emulate start --service github
 For a custom base URL without portless (any reverse proxy):
 
 ```bash
-npx emulate start --base-url "https://{service}.myproxy.test"
+npx emulate start --service github --base-url "https://github.myproxy.test"
 # or
-EMULATE_BASE_URL="https://{service}.myproxy.test" npx emulate start
+EMULATE_BASE_URL="https://github.myproxy.test" npx emulate start --service github
 ```
 
-The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it (e.g. `portless github.emulate emulate start`), typically to a value like `https://{service}.emulate.localhost`. It supports `{service}` interpolation, just like `--base-url` and `EMULATE_BASE_URL`. When no explicit `baseUrl` is provided, it is used as a fallback.
+The `PORTLESS_URL` env var is automatically set by the `portless` CLI wrapper when running a command through it. `{service}` interpolation is supported when exactly one service is enabled. When no explicit `baseUrl` is provided, it is used as a fallback.
 
 Per-service overrides in the seed config (these take highest priority over all other base URL sources):
 
@@ -310,16 +299,16 @@ Set environment variables to override real service URLs:
 
 ```bash
 VERCEL_EMULATOR_URL=http://localhost:4000
-GITHUB_EMULATOR_URL=http://localhost:4001
-GOOGLE_EMULATOR_URL=http://localhost:4002
-SLACK_EMULATOR_URL=http://localhost:4003
-APPLE_EMULATOR_URL=http://localhost:4004
-MICROSOFT_EMULATOR_URL=http://localhost:4005
-OKTA_EMULATOR_URL=http://localhost:4006
-AWS_EMULATOR_URL=http://localhost:4007
-RESEND_EMULATOR_URL=http://localhost:4008
-STRIPE_EMULATOR_URL=http://localhost:4009
-MONGOATLAS_EMULATOR_URL=http://localhost:4010
+GITHUB_EMULATOR_URL=http://localhost:4000
+GOOGLE_EMULATOR_URL=http://localhost:4000
+SLACK_EMULATOR_URL=http://localhost:4000
+APPLE_EMULATOR_URL=http://localhost:4000
+MICROSOFT_EMULATOR_URL=http://localhost:4000
+OKTA_EMULATOR_URL=http://localhost:4000
+AWS_EMULATOR_URL=http://localhost:4000
+RESEND_EMULATOR_URL=http://localhost:4000
+STRIPE_EMULATOR_URL=http://localhost:4000
+MONGOATLAS_EMULATOR_URL=http://localhost:4000
 ```
 
 Then use these in your app to construct API and OAuth URLs. See each service's skill for SDK-specific override instructions.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -17,7 +17,7 @@ The native Go runtime implements the core SDK-facing GitHub surface for local CL
 npx emulate --service github
 
 # Default port
-# http://localhost:4001
+# http://localhost:4000
 ```
 
 Or programmatically:
@@ -34,7 +34,7 @@ const github = await createEmulator({ service: 'github', port: 4001 })
 Pass tokens as `Authorization: Bearer <token>` or `Authorization: token <token>`.
 
 ```bash
-curl http://localhost:4001/user \
+curl http://localhost:4000/user \
   -H "Authorization: Bearer test_token_admin"
 ```
 
@@ -76,7 +76,7 @@ github:
 ### Environment Variable
 
 ```bash
-GITHUB_EMULATOR_URL=http://localhost:4001
+GITHUB_EMULATOR_URL=http://localhost:4000
 ```
 
 ### Octokit
@@ -169,7 +169,7 @@ Repos are auto-initialized with a commit, branch, and README unless `auto_init: 
 All list endpoints support `page` and `per_page` query params with `Link` headers:
 
 ```bash
-curl "http://localhost:4001/repos/octocat/hello-world/issues?page=1&per_page=10" \
+curl "http://localhost:4000/repos/octocat/hello-world/issues?page=1&per_page=10" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -179,59 +179,59 @@ curl "http://localhost:4001/repos/octocat/hello-world/issues?page=1&per_page=10"
 
 ```bash
 # Authenticated user
-curl http://localhost:4001/user -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4000/user -H "Authorization: Bearer $TOKEN"
 
 # Update profile
-curl -X PATCH http://localhost:4001/user \
+curl -X PATCH http://localhost:4000/user \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"bio": "Hello!"}'
 
 # Get user by username
-curl http://localhost:4001/users/octocat
+curl http://localhost:4000/users/octocat
 
 # List users
-curl http://localhost:4001/users
+curl http://localhost:4000/users
 
 # User repos / orgs / followers / following
-curl http://localhost:4001/users/octocat/repos
-curl http://localhost:4001/users/octocat/orgs
-curl http://localhost:4001/users/octocat/followers
-curl http://localhost:4001/users/octocat/following
+curl http://localhost:4000/users/octocat/repos
+curl http://localhost:4000/users/octocat/orgs
+curl http://localhost:4000/users/octocat/followers
+curl http://localhost:4000/users/octocat/following
 
 # User hovercard
-curl http://localhost:4001/users/octocat/hovercard
+curl http://localhost:4000/users/octocat/hovercard
 
 # User emails
-curl http://localhost:4001/user/emails -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4000/user/emails -H "Authorization: Bearer $TOKEN"
 ```
 
 ### Repositories
 
 ```bash
 # Get repo
-curl http://localhost:4001/repos/octocat/hello-world
+curl http://localhost:4000/repos/octocat/hello-world
 
 # Create user repo
-curl -X POST http://localhost:4001/user/repos \
+curl -X POST http://localhost:4000/user/repos \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "new-repo", "private": false}'
 
 # Create org repo
-curl -X POST http://localhost:4001/orgs/my-org/repos \
+curl -X POST http://localhost:4000/orgs/my-org/repos \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "org-project"}'
 
 # Update repo
-curl -X PATCH http://localhost:4001/repos/octocat/hello-world \
+curl -X PATCH http://localhost:4000/repos/octocat/hello-world \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"description": "Updated description"}'
 
 # Delete repo (cascades issues, PRs, etc.)
-curl -X DELETE http://localhost:4001/repos/octocat/hello-world \
+curl -X DELETE http://localhost:4000/repos/octocat/hello-world \
   -H "Authorization: Bearer $TOKEN"
 
 # Topics, languages, contributors, forks, collaborators, tags, transfer
@@ -241,10 +241,10 @@ curl -X DELETE http://localhost:4001/repos/octocat/hello-world \
 
 ```bash
 # List issues (filter by state, labels, assignee, milestone, creator, since)
-curl "http://localhost:4001/repos/octocat/hello-world/issues?state=open&labels=bug"
+curl "http://localhost:4000/repos/octocat/hello-world/issues?state=open&labels=bug"
 
 # Create issue
-curl -X POST http://localhost:4001/repos/octocat/hello-world/issues \
+curl -X POST http://localhost:4000/repos/octocat/hello-world/issues \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"title": "Bug report", "body": "Details here", "labels": ["bug"]}'
@@ -256,16 +256,16 @@ curl -X POST http://localhost:4001/repos/octocat/hello-world/issues \
 
 ```bash
 # List PRs
-curl "http://localhost:4001/repos/octocat/hello-world/pulls?state=open"
+curl "http://localhost:4000/repos/octocat/hello-world/pulls?state=open"
 
 # Create PR
-curl -X POST http://localhost:4001/repos/octocat/hello-world/pulls \
+curl -X POST http://localhost:4000/repos/octocat/hello-world/pulls \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"title": "Feature", "head": "feature-branch", "base": "main"}'
 
 # Merge PR (enforces branch protection)
-curl -X PUT http://localhost:4001/repos/octocat/hello-world/pulls/1/merge \
+curl -X PUT http://localhost:4000/repos/octocat/hello-world/pulls/1/merge \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"merge_method": "squash"}'
@@ -277,33 +277,33 @@ curl -X PUT http://localhost:4001/repos/octocat/hello-world/pulls/1/merge \
 
 ```bash
 # Issue comments: full CRUD
-curl http://localhost:4001/repos/octocat/hello-world/issues/1/comments
-curl -X POST http://localhost:4001/repos/octocat/hello-world/issues/1/comments \
+curl http://localhost:4000/repos/octocat/hello-world/issues/1/comments
+curl -X POST http://localhost:4000/repos/octocat/hello-world/issues/1/comments \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"body": "Looks good!"}'
 
 # Comment by ID (cross-resource)
-curl http://localhost:4001/repos/octocat/hello-world/issues/comments/1
+curl http://localhost:4000/repos/octocat/hello-world/issues/comments/1
 
 # PR review comments
-curl http://localhost:4001/repos/octocat/hello-world/pulls/1/comments
+curl http://localhost:4000/repos/octocat/hello-world/pulls/1/comments
 
 # Commit comments
-curl http://localhost:4001/repos/octocat/hello-world/commits/abc123/comments
+curl http://localhost:4000/repos/octocat/hello-world/commits/abc123/comments
 
 # Repo-wide comment listings
-curl http://localhost:4001/repos/octocat/hello-world/issues/comments
-curl http://localhost:4001/repos/octocat/hello-world/pulls/comments
-curl http://localhost:4001/repos/octocat/hello-world/comments
+curl http://localhost:4000/repos/octocat/hello-world/issues/comments
+curl http://localhost:4000/repos/octocat/hello-world/pulls/comments
+curl http://localhost:4000/repos/octocat/hello-world/comments
 ```
 
 ### Reviews
 
 ```bash
 # List / create / get / update / submit / dismiss reviews
-curl http://localhost:4001/repos/octocat/hello-world/pulls/1/reviews
-curl -X POST http://localhost:4001/repos/octocat/hello-world/pulls/1/reviews \
+curl http://localhost:4000/repos/octocat/hello-world/pulls/1/reviews
+curl -X POST http://localhost:4000/repos/octocat/hello-world/pulls/1/reviews \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"event": "APPROVE", "body": "LGTM"}'
@@ -317,10 +317,10 @@ Full CRUD for labels and milestones. Add/remove labels from issues, replace all 
 
 ```bash
 # List branches
-curl http://localhost:4001/repos/octocat/hello-world/branches
+curl http://localhost:4000/repos/octocat/hello-world/branches
 
 # Branch protection CRUD (status checks, PR reviews, enforce admins)
-curl -X PUT http://localhost:4001/repos/octocat/hello-world/branches/main/protection \
+curl -X PUT http://localhost:4000/repos/octocat/hello-world/branches/main/protection \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"required_status_checks": {"strict": true, "contexts": ["ci"]}}'
@@ -332,76 +332,76 @@ curl -X PUT http://localhost:4001/repos/octocat/hello-world/branches/main/protec
 
 ```bash
 # List all orgs / user's orgs / get org / update org
-curl http://localhost:4001/organizations
-curl http://localhost:4001/user/orgs -H "Authorization: Bearer $TOKEN"
-curl http://localhost:4001/orgs/my-org
-curl -X PATCH http://localhost:4001/orgs/my-org \
+curl http://localhost:4000/organizations
+curl http://localhost:4000/user/orgs -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4000/orgs/my-org
+curl -X PATCH http://localhost:4000/orgs/my-org \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"description": "Updated org"}'
 
 # Org members: list, get, remove
-curl http://localhost:4001/orgs/my-org/members
-curl http://localhost:4001/orgs/my-org/members/octocat
-curl -X DELETE http://localhost:4001/orgs/my-org/members/octocat \
+curl http://localhost:4000/orgs/my-org/members
+curl http://localhost:4000/orgs/my-org/members/octocat
+curl -X DELETE http://localhost:4000/orgs/my-org/members/octocat \
   -H "Authorization: Bearer $TOKEN"
 
 # Org memberships: get, set (invite/update role)
-curl http://localhost:4001/orgs/my-org/memberships/octocat -H "Authorization: Bearer $TOKEN"
-curl -X PUT http://localhost:4001/orgs/my-org/memberships/octocat \
+curl http://localhost:4000/orgs/my-org/memberships/octocat -H "Authorization: Bearer $TOKEN"
+curl -X PUT http://localhost:4000/orgs/my-org/memberships/octocat \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"role": "admin"}'
 
 # Teams: CRUD
-curl http://localhost:4001/orgs/my-org/teams
-curl -X POST http://localhost:4001/orgs/my-org/teams \
+curl http://localhost:4000/orgs/my-org/teams
+curl -X POST http://localhost:4000/orgs/my-org/teams \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "engineering", "privacy": "closed"}'
 
 # Team members and memberships
-curl http://localhost:4001/orgs/my-org/teams/engineering/members
-curl -X PUT http://localhost:4001/orgs/my-org/teams/engineering/memberships/octocat \
+curl http://localhost:4000/orgs/my-org/teams/engineering/members
+curl -X PUT http://localhost:4000/orgs/my-org/teams/engineering/memberships/octocat \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"role": "maintainer"}'
 
 # Team repos: list, add, remove
-curl http://localhost:4001/orgs/my-org/teams/engineering/repos
-curl -X PUT http://localhost:4001/orgs/my-org/teams/engineering/repos/my-org/org-repo \
+curl http://localhost:4000/orgs/my-org/teams/engineering/repos
+curl -X PUT http://localhost:4000/orgs/my-org/teams/engineering/repos/my-org/org-repo \
   -H "Authorization: Bearer $TOKEN"
 
 # Legacy team endpoints by ID
-curl http://localhost:4001/teams/1
-curl http://localhost:4001/teams/1/members
+curl http://localhost:4000/teams/1
+curl http://localhost:4000/teams/1/members
 ```
 
 ### GitHub Apps
 
 ```bash
 # Get authenticated app (requires JWT auth)
-curl http://localhost:4001/app \
+curl http://localhost:4000/app \
   -H "Authorization: Bearer <jwt>"
 
 # List app installations
-curl http://localhost:4001/app/installations \
+curl http://localhost:4000/app/installations \
   -H "Authorization: Bearer <jwt>"
 
 # Get installation
-curl http://localhost:4001/app/installations/100 \
+curl http://localhost:4000/app/installations/100 \
   -H "Authorization: Bearer <jwt>"
 
 # Create installation access token (mints ghs_... token)
-curl -X POST http://localhost:4001/app/installations/100/access_tokens \
+curl -X POST http://localhost:4000/app/installations/100/access_tokens \
   -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"permissions": {"contents": "read"}}'
 
 # Find installation for repo / org / user
-curl http://localhost:4001/repos/my-org/org-repo/installation
-curl http://localhost:4001/orgs/my-org/installation
-curl http://localhost:4001/users/octocat/installation
+curl http://localhost:4000/repos/my-org/org-repo/installation
+curl http://localhost:4000/orgs/my-org/installation
+curl http://localhost:4000/users/octocat/installation
 ```
 
 App webhook delivery: when events occur, the emulator POSTs `event_callback` payloads to configured `webhook_url` with `X-GitHub-Event` and `X-Hub-Signature-256` headers.
@@ -410,7 +410,7 @@ App webhook delivery: when events occur, the emulator POSTs `event_callback` pay
 
 ```bash
 # Create release
-curl -X POST http://localhost:4001/repos/octocat/hello-world/releases \
+curl -X POST http://localhost:4000/repos/octocat/hello-world/releases \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"tag_name": "v1.0.0", "name": "v1.0.0"}'
@@ -418,8 +418,8 @@ curl -X POST http://localhost:4001/repos/octocat/hello-world/releases \
 # List, get, latest, by tag, generate notes
 
 # Release assets: list, upload
-curl http://localhost:4001/repos/octocat/hello-world/releases/1/assets
-curl -X POST http://localhost:4001/repos/octocat/hello-world/releases/1/assets \
+curl http://localhost:4000/repos/octocat/hello-world/releases/1/assets
+curl -X POST http://localhost:4000/repos/octocat/hello-world/releases/1/assets \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/octet-stream" \
   -H "name: binary.zip" \
@@ -430,7 +430,7 @@ curl -X POST http://localhost:4001/repos/octocat/hello-world/releases/1/assets \
 
 ```bash
 # Create webhook (real HTTP delivery on state changes)
-curl -X POST http://localhost:4001/repos/octocat/hello-world/hooks \
+curl -X POST http://localhost:4000/repos/octocat/hello-world/hooks \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"config": {"url": "http://localhost:8080/webhook"}, "events": ["push", "pull_request"]}'
@@ -443,10 +443,10 @@ curl -X POST http://localhost:4001/repos/octocat/hello-world/hooks \
 
 ```bash
 # Search repositories
-curl "http://localhost:4001/search/repositories?q=language:JavaScript+user:octocat"
+curl "http://localhost:4000/search/repositories?q=language:JavaScript+user:octocat"
 
 # Search issues and PRs
-curl "http://localhost:4001/search/issues?q=repo:octocat/hello-world+is:open"
+curl "http://localhost:4000/search/issues?q=repo:octocat/hello-world+is:open"
 
 # Search users, code, commits, topics, labels
 ```
@@ -465,7 +465,7 @@ curl "http://localhost:4001/search/issues?q=repo:octocat/hello-world+is:open"
 
 ```bash
 # Create check run
-curl -X POST http://localhost:4001/repos/octocat/hello-world/check-runs \
+curl -X POST http://localhost:4000/repos/octocat/hello-world/check-runs \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "CI", "head_sha": "abc123", "status": "completed", "conclusion": "success"}'
@@ -482,32 +482,32 @@ curl -X POST http://localhost:4001/repos/octocat/hello-world/check-runs \
 # GET /login/oauth/authorize?client_id=...&redirect_uri=...&scope=...&state=...
 
 # Token exchange
-curl -X POST http://localhost:4001/login/oauth/access_token \
+curl -X POST http://localhost:4000/login/oauth/access_token \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
   -d '{"client_id": "Iv1.abc123", "client_secret": "secret_abc123", "code": "<code>"}'
 
 # User emails
-curl http://localhost:4001/user/emails -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4000/user/emails -H "Authorization: Bearer $TOKEN"
 
 # OAuth app management (settings)
-curl http://localhost:4001/settings/applications -H "Authorization: Bearer $TOKEN"
-curl http://localhost:4001/settings/connections/applications/Iv1.abc123 -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4000/settings/applications -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4000/settings/connections/applications/Iv1.abc123 -H "Authorization: Bearer $TOKEN"
 
 # Revoke OAuth app
-curl -X POST http://localhost:4001/settings/connections/applications/Iv1.abc123/revoke \
+curl -X POST http://localhost:4000/settings/connections/applications/Iv1.abc123/revoke \
   -H "Authorization: Bearer $TOKEN"
 ```
 
 ### Misc
 
 ```bash
-curl http://localhost:4001/rate_limit
-curl http://localhost:4001/meta
-curl http://localhost:4001/emojis
-curl http://localhost:4001/versions
-curl http://localhost:4001/octocat
-curl http://localhost:4001/zen
+curl http://localhost:4000/rate_limit
+curl http://localhost:4000/meta
+curl http://localhost:4000/emojis
+curl http://localhost:4000/versions
+curl http://localhost:4000/octocat
+curl http://localhost:4000/zen
 ```
 
 ## Common Patterns
@@ -516,7 +516,7 @@ curl http://localhost:4001/zen
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4001"
+BASE="http://localhost:4000"
 
 # Create repo
 curl -X POST $BASE/user/repos \

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -17,7 +17,7 @@ The native Go runtime implements the Google OAuth/OIDC foundation with RS256 ID 
 npx emulate --service google
 
 # Default port
-# http://localhost:4002
+# http://localhost:4000
 ```
 
 Or programmatically:
@@ -34,7 +34,7 @@ const google = await createEmulator({ service: 'google', port: 4002 })
 ### Environment Variable
 
 ```bash
-GOOGLE_EMULATOR_URL=http://localhost:4002
+GOOGLE_EMULATOR_URL=http://localhost:4000
 ```
 
 ### OAuth URL Mapping
@@ -192,7 +192,7 @@ To override the derived value, set `hd` on a seeded user. To suppress the claim 
 ### OIDC Discovery
 
 ```bash
-curl http://localhost:4002/.well-known/openid-configuration
+curl http://localhost:4000/.well-known/openid-configuration
 ```
 
 When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/google/.well-known/openid-configuration` to avoid the shared root discovery path.
@@ -200,7 +200,7 @@ When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on on
 ### JWKS
 
 ```bash
-curl http://localhost:4002/oauth2/v3/certs
+curl http://localhost:4000/oauth2/v3/certs
 ```
 
 In the native Go runtime, this returns the RSA signing key. Native ID tokens are signed with RS256 and include a `kid` that matches the JWKS entry.
@@ -209,7 +209,7 @@ In the native Go runtime, this returns the RSA signing key. Native ID tokens are
 
 ```bash
 # Browser flow: redirects to a user picker page
-curl -v "http://localhost:4002/o/oauth2/v2/auth?\
+curl -v "http://localhost:4000/o/oauth2/v2/auth?\
 client_id=my-client-id.apps.googleusercontent.com&\
 redirect_uri=http://localhost:3000/api/auth/callback/google&\
 scope=openid+email+profile&\
@@ -223,7 +223,7 @@ Supports `code_challenge` and `code_challenge_method` for PKCE.
 ### Token Exchange
 
 ```bash
-curl -X POST http://localhost:4002/oauth2/token \
+curl -X POST http://localhost:4000/oauth2/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "code=<authorization_code>&\
 client_id=my-client-id.apps.googleusercontent.com&\
@@ -248,7 +248,7 @@ Also accepts `application/json` body. Returns:
 ### Refresh Token
 
 ```bash
-curl -X POST http://localhost:4002/oauth2/token \
+curl -X POST http://localhost:4000/oauth2/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "refresh_token=google_refresh_...&\
 client_id=my-client-id.apps.googleusercontent.com&\
@@ -261,14 +261,14 @@ Returns a new `access_token` (no new `refresh_token` or `id_token` on refresh).
 ### User Info
 
 ```bash
-curl http://localhost:4002/oauth2/v2/userinfo \
+curl http://localhost:4000/oauth2/v2/userinfo \
   -H "Authorization: Bearer google_..."
 ```
 
 ### Token Revocation
 
 ```bash
-curl -X POST http://localhost:4002/oauth2/revoke \
+curl -X POST http://localhost:4000/oauth2/revoke \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "token=google_..."
 ```
@@ -281,61 +281,61 @@ All Gmail endpoints are under `/gmail/v1/users/:userId/...` where `:userId` is `
 
 ```bash
 # List messages (filter by labels, search query)
-curl "http://localhost:4002/gmail/v1/users/me/messages?labelIds=INBOX&q=from:welcome&maxResults=10" \
+curl "http://localhost:4000/gmail/v1/users/me/messages?labelIds=INBOX&q=from:welcome&maxResults=10" \
   -H "Authorization: Bearer $TOKEN"
 
 # Get message (format: full, metadata, minimal, raw)
-curl "http://localhost:4002/gmail/v1/users/me/messages/msg_welcome?format=full" \
+curl "http://localhost:4000/gmail/v1/users/me/messages/msg_welcome?format=full" \
   -H "Authorization: Bearer $TOKEN"
 
 # Send message
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages/send \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages/send \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"to": "someone@example.com", "subject": "Hello", "body_text": "Hi there"}'
 
 # Insert message (bypass send)
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"to": "test@example.com", "from": "me@example.com", "subject": "Test", "body_text": "Body", "labelIds": ["INBOX"]}'
 
 # Import message
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages/import \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages/import \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"to": "test@example.com", "from": "external@example.com", "subject": "Imported", "body_text": "Content"}'
 
 # Modify labels on a message
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages/msg_welcome/modify \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages/msg_welcome/modify \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"addLabelIds": ["STARRED"], "removeLabelIds": ["UNREAD"]}'
 
 # Trash / untrash
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages/msg_welcome/trash \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages/msg_welcome/trash \
   -H "Authorization: Bearer $TOKEN"
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages/msg_welcome/untrash \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages/msg_welcome/untrash \
   -H "Authorization: Bearer $TOKEN"
 
 # Delete permanently
-curl -X DELETE http://localhost:4002/gmail/v1/users/me/messages/msg_welcome \
+curl -X DELETE http://localhost:4000/gmail/v1/users/me/messages/msg_welcome \
   -H "Authorization: Bearer $TOKEN"
 
 # Batch modify
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages/batchModify \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages/batchModify \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"ids": ["msg_welcome", "msg_build"], "addLabelIds": ["STARRED"]}'
 
 # Batch delete
-curl -X POST http://localhost:4002/gmail/v1/users/me/messages/batchDelete \
+curl -X POST http://localhost:4000/gmail/v1/users/me/messages/batchDelete \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"ids": ["msg_welcome"]}'
 
 # Get attachment
-curl http://localhost:4002/gmail/v1/users/me/messages/msg_id/attachments/att_id \
+curl http://localhost:4000/gmail/v1/users/me/messages/msg_id/attachments/att_id \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -345,33 +345,33 @@ Upload variants also available at `/upload/gmail/v1/users/:userId/messages`, `..
 
 ```bash
 # List drafts
-curl http://localhost:4002/gmail/v1/users/me/drafts \
+curl http://localhost:4000/gmail/v1/users/me/drafts \
   -H "Authorization: Bearer $TOKEN"
 
 # Create draft
-curl -X POST http://localhost:4002/gmail/v1/users/me/drafts \
+curl -X POST http://localhost:4000/gmail/v1/users/me/drafts \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"message": {"to": "someone@example.com", "subject": "Draft subject", "body_text": "Draft body"}}'
 
 # Get draft (format: full, metadata, minimal, raw)
-curl "http://localhost:4002/gmail/v1/users/me/drafts/draft_id?format=full" \
+curl "http://localhost:4000/gmail/v1/users/me/drafts/draft_id?format=full" \
   -H "Authorization: Bearer $TOKEN"
 
 # Update draft
-curl -X PUT http://localhost:4002/gmail/v1/users/me/drafts/draft_id \
+curl -X PUT http://localhost:4000/gmail/v1/users/me/drafts/draft_id \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"message": {"subject": "Updated subject", "body_text": "Updated body"}}'
 
 # Send draft
-curl -X POST http://localhost:4002/gmail/v1/users/me/drafts/send \
+curl -X POST http://localhost:4000/gmail/v1/users/me/drafts/send \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"id": "draft_id"}'
 
 # Delete draft
-curl -X DELETE http://localhost:4002/gmail/v1/users/me/drafts/draft_id \
+curl -X DELETE http://localhost:4000/gmail/v1/users/me/drafts/draft_id \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -379,23 +379,23 @@ curl -X DELETE http://localhost:4002/gmail/v1/users/me/drafts/draft_id \
 
 ```bash
 # List threads (filter by labels, search query)
-curl "http://localhost:4002/gmail/v1/users/me/threads?labelIds=INBOX&maxResults=20" \
+curl "http://localhost:4000/gmail/v1/users/me/threads?labelIds=INBOX&maxResults=20" \
   -H "Authorization: Bearer $TOKEN"
 
 # Get thread (all messages in thread)
-curl "http://localhost:4002/gmail/v1/users/me/threads/thr_welcome?format=full" \
+curl "http://localhost:4000/gmail/v1/users/me/threads/thr_welcome?format=full" \
   -H "Authorization: Bearer $TOKEN"
 
 # Modify labels on all messages in thread
-curl -X POST http://localhost:4002/gmail/v1/users/me/threads/thr_welcome/modify \
+curl -X POST http://localhost:4000/gmail/v1/users/me/threads/thr_welcome/modify \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"addLabelIds": ["STARRED"], "removeLabelIds": ["UNREAD"]}'
 
 # Trash / untrash / delete thread
-curl -X POST http://localhost:4002/gmail/v1/users/me/threads/thr_welcome/trash \
+curl -X POST http://localhost:4000/gmail/v1/users/me/threads/thr_welcome/trash \
   -H "Authorization: Bearer $TOKEN"
-curl -X DELETE http://localhost:4002/gmail/v1/users/me/threads/thr_welcome \
+curl -X DELETE http://localhost:4000/gmail/v1/users/me/threads/thr_welcome \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -403,27 +403,27 @@ curl -X DELETE http://localhost:4002/gmail/v1/users/me/threads/thr_welcome \
 
 ```bash
 # List labels
-curl http://localhost:4002/gmail/v1/users/me/labels \
+curl http://localhost:4000/gmail/v1/users/me/labels \
   -H "Authorization: Bearer $TOKEN"
 
 # Get label
-curl http://localhost:4002/gmail/v1/users/me/labels/INBOX \
+curl http://localhost:4000/gmail/v1/users/me/labels/INBOX \
   -H "Authorization: Bearer $TOKEN"
 
 # Create label
-curl -X POST http://localhost:4002/gmail/v1/users/me/labels \
+curl -X POST http://localhost:4000/gmail/v1/users/me/labels \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "My Label", "color": {"backgroundColor": "#DDEEFF", "textColor": "#111111"}}'
 
 # Update label (PUT replaces, PATCH merges)
-curl -X PATCH http://localhost:4002/gmail/v1/users/me/labels/Label_ops \
+curl -X PATCH http://localhost:4000/gmail/v1/users/me/labels/Label_ops \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "Ops/Reviewed"}'
 
 # Delete label (user labels only)
-curl -X DELETE http://localhost:4002/gmail/v1/users/me/labels/Label_ops \
+curl -X DELETE http://localhost:4000/gmail/v1/users/me/labels/Label_ops \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -431,17 +431,17 @@ curl -X DELETE http://localhost:4002/gmail/v1/users/me/labels/Label_ops \
 
 ```bash
 # List history changes since a given historyId
-curl "http://localhost:4002/gmail/v1/users/me/history?startHistoryId=1&historyTypes=messageAdded&maxResults=100" \
+curl "http://localhost:4000/gmail/v1/users/me/history?startHistoryId=1&historyTypes=messageAdded&maxResults=100" \
   -H "Authorization: Bearer $TOKEN"
 
 # Set up push notification watch (stub)
-curl -X POST http://localhost:4002/gmail/v1/users/me/watch \
+curl -X POST http://localhost:4000/gmail/v1/users/me/watch \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"topicName": "projects/my-project/topics/gmail", "labelIds": ["INBOX"]}'
 
 # Stop watch
-curl -X POST http://localhost:4002/gmail/v1/users/me/stop \
+curl -X POST http://localhost:4000/gmail/v1/users/me/stop \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -449,25 +449,25 @@ curl -X POST http://localhost:4002/gmail/v1/users/me/stop \
 
 ```bash
 # List filters
-curl http://localhost:4002/gmail/v1/users/me/settings/filters \
+curl http://localhost:4000/gmail/v1/users/me/settings/filters \
   -H "Authorization: Bearer $TOKEN"
 
 # Create filter (auto-label incoming messages matching criteria)
-curl -X POST http://localhost:4002/gmail/v1/users/me/settings/filters \
+curl -X POST http://localhost:4000/gmail/v1/users/me/settings/filters \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"criteria": {"from": "alerts@example.com"}, "action": {"addLabelIds": ["Label_ops"]}}'
 
 # Delete filter
-curl -X DELETE http://localhost:4002/gmail/v1/users/me/settings/filters/filter_id \
+curl -X DELETE http://localhost:4000/gmail/v1/users/me/settings/filters/filter_id \
   -H "Authorization: Bearer $TOKEN"
 
 # List forwarding addresses
-curl http://localhost:4002/gmail/v1/users/me/settings/forwardingAddresses \
+curl http://localhost:4000/gmail/v1/users/me/settings/forwardingAddresses \
   -H "Authorization: Bearer $TOKEN"
 
 # List send-as aliases
-curl http://localhost:4002/gmail/v1/users/me/settings/sendAs \
+curl http://localhost:4000/gmail/v1/users/me/settings/sendAs \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -476,7 +476,7 @@ curl http://localhost:4002/gmail/v1/users/me/settings/sendAs \
 ### Calendar List
 
 ```bash
-curl http://localhost:4002/calendar/v3/users/me/calendarList \
+curl http://localhost:4000/calendar/v3/users/me/calendarList \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -484,25 +484,25 @@ curl http://localhost:4002/calendar/v3/users/me/calendarList \
 
 ```bash
 # List events (filter by time range, search, order)
-curl "http://localhost:4002/calendar/v3/calendars/primary/events?\
+curl "http://localhost:4000/calendar/v3/calendars/primary/events?\
 timeMin=2025-01-01T00:00:00Z&timeMax=2025-12-31T23:59:59Z&maxResults=50&orderBy=startTime" \
   -H "Authorization: Bearer $TOKEN"
 
 # Create event
-curl -X POST http://localhost:4002/calendar/v3/calendars/primary/events \
+curl -X POST http://localhost:4000/calendar/v3/calendars/primary/events \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"summary": "Team Meeting", "start": {"dateTime": "2025-01-10T14:00:00Z"}, "end": {"dateTime": "2025-01-10T15:00:00Z"}, "attendees": [{"email": "dev@example.com"}]}'
 
 # Delete event
-curl -X DELETE http://localhost:4002/calendar/v3/calendars/primary/events/evt_kickoff \
+curl -X DELETE http://localhost:4000/calendar/v3/calendars/primary/events/evt_kickoff \
   -H "Authorization: Bearer $TOKEN"
 ```
 
 ### FreeBusy
 
 ```bash
-curl -X POST http://localhost:4002/calendar/v3/freeBusy \
+curl -X POST http://localhost:4000/calendar/v3/freeBusy \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"timeMin": "2025-01-10T00:00:00Z", "timeMax": "2025-01-10T23:59:59Z", "items": [{"id": "primary"}]}'
@@ -514,31 +514,31 @@ curl -X POST http://localhost:4002/calendar/v3/freeBusy \
 
 ```bash
 # List files (with query filter, pagination, ordering)
-curl "http://localhost:4002/drive/v3/files?q='root'+in+parents&pageSize=20" \
+curl "http://localhost:4000/drive/v3/files?q='root'+in+parents&pageSize=20" \
   -H "Authorization: Bearer $TOKEN"
 
 # Create file (JSON metadata)
-curl -X POST http://localhost:4002/drive/v3/files \
+curl -X POST http://localhost:4000/drive/v3/files \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "notes.txt", "mimeType": "text/plain", "parents": ["root"]}'
 
 # Create file with content (multipart/related upload)
-curl -X POST http://localhost:4002/upload/drive/v3/files \
+curl -X POST http://localhost:4000/upload/drive/v3/files \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: multipart/related; boundary=boundary" \
   --data-binary $'--boundary\r\nContent-Type: application/json\r\n\r\n{"name":"data.csv","mimeType":"text/csv"}\r\n--boundary\r\nContent-Type: text/csv\r\n\r\na,b,c\n1,2,3\r\n--boundary--'
 
 # Get file metadata
-curl http://localhost:4002/drive/v3/files/drv_readme \
+curl http://localhost:4000/drive/v3/files/drv_readme \
   -H "Authorization: Bearer $TOKEN"
 
 # Download file content
-curl "http://localhost:4002/drive/v3/files/drv_readme?alt=media" \
+curl "http://localhost:4000/drive/v3/files/drv_readme?alt=media" \
   -H "Authorization: Bearer $TOKEN"
 
 # Update file (PATCH or PUT; move parents with query params)
-curl -X PATCH "http://localhost:4002/drive/v3/files/drv_readme?addParents=folder_id&removeParents=root" \
+curl -X PATCH "http://localhost:4000/drive/v3/files/drv_readme?addParents=folder_id&removeParents=root" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "README-updated.md"}'
@@ -549,7 +549,7 @@ curl -X PATCH "http://localhost:4002/drive/v3/files/drv_readme?addParents=folder
 ### Full Authorization Code Flow
 
 ```bash
-GOOGLE_URL="http://localhost:4002"
+GOOGLE_URL="http://localhost:4000"
 CLIENT_ID="my-client-id.apps.googleusercontent.com"
 CLIENT_SECRET="GOCSPX-secret"
 REDIRECT_URI="http://localhost:3000/api/auth/callback/google"
@@ -590,7 +590,7 @@ const client = new googleIssuer.Client({
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4002"
+BASE="http://localhost:4000"
 
 # Send a message
 curl -X POST $BASE/gmail/v1/users/me/messages/send \

--- a/skills/microsoft/SKILL.md
+++ b/skills/microsoft/SKILL.md
@@ -34,7 +34,7 @@ const microsoft = await createEmulator({ service: 'microsoft', port: 4005 })
 ### Environment Variable
 
 ```bash
-MICROSOFT_EMULATOR_URL=http://localhost:4005
+MICROSOFT_EMULATOR_URL=http://localhost:4000
 ```
 
 ### OAuth URL Mapping
@@ -134,10 +134,10 @@ When no OAuth clients are configured, the emulator accepts any `client_id`. With
 
 ```bash
 # Default tenant
-curl http://localhost:4005/.well-known/openid-configuration
+curl http://localhost:4000/.well-known/openid-configuration
 
 # Tenant-scoped (common, organizations, consumers, or specific tenant ID)
-curl http://localhost:4005/common/v2.0/.well-known/openid-configuration
+curl http://localhost:4000/common/v2.0/.well-known/openid-configuration
 ```
 
 When more than one of Apple, Google, Microsoft, Okta, and Clerk is enabled on one native Go server, use `/microsoft/.well-known/openid-configuration` to avoid the shared root discovery path.
@@ -146,12 +146,12 @@ Returns the standard OIDC discovery document:
 
 ```json
 {
-  "issuer": "http://localhost:4005/{tenant}/v2.0",
-  "authorization_endpoint": "http://localhost:4005/oauth2/v2.0/authorize",
-  "token_endpoint": "http://localhost:4005/oauth2/v2.0/token",
-  "userinfo_endpoint": "http://localhost:4005/oidc/userinfo",
-  "end_session_endpoint": "http://localhost:4005/oauth2/v2.0/logout",
-  "jwks_uri": "http://localhost:4005/discovery/v2.0/keys",
+  "issuer": "http://localhost:4000/{tenant}/v2.0",
+  "authorization_endpoint": "http://localhost:4000/oauth2/v2.0/authorize",
+  "token_endpoint": "http://localhost:4000/oauth2/v2.0/token",
+  "userinfo_endpoint": "http://localhost:4000/oidc/userinfo",
+  "end_session_endpoint": "http://localhost:4000/oauth2/v2.0/logout",
+  "jwks_uri": "http://localhost:4000/discovery/v2.0/keys",
   "response_types_supported": ["code"],
   "subject_types_supported": ["pairwise"],
   "id_token_signing_alg_values_supported": ["RS256"],
@@ -163,7 +163,7 @@ Returns the standard OIDC discovery document:
 ### JWKS
 
 ```bash
-curl http://localhost:4005/discovery/v2.0/keys
+curl http://localhost:4000/discovery/v2.0/keys
 ```
 
 Returns an RSA public key (`kid`: `emulate-microsoft-1`) for verifying `id_token` signatures.
@@ -172,7 +172,7 @@ Returns an RSA public key (`kid`: `emulate-microsoft-1`) for verifying `id_token
 
 ```bash
 # Browser flow: redirects to a user picker page
-curl -v "http://localhost:4005/oauth2/v2.0/authorize?\
+curl -v "http://localhost:4000/oauth2/v2.0/authorize?\
 client_id=example-client-id&\
 redirect_uri=http://localhost:3000/api/auth/callback/microsoft-entra-id&\
 scope=openid+email+profile&\
@@ -197,7 +197,7 @@ Query parameters:
 ### Token Exchange
 
 ```bash
-curl -X POST http://localhost:4005/oauth2/v2.0/token \
+curl -X POST http://localhost:4000/oauth2/v2.0/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "code=<authorization_code>&\
 client_id=example-client-id&\
@@ -230,7 +230,7 @@ The v1 token endpoint at `/{tenant}/oauth2/token` accepts a `resource` parameter
 ### Client Credentials
 
 ```bash
-curl -X POST http://localhost:4005/oauth2/v2.0/token \
+curl -X POST http://localhost:4000/oauth2/v2.0/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "client_id=example-client-id&\
 client_secret=example-client-secret&\
@@ -243,7 +243,7 @@ Returns an `access_token` only (no `refresh_token` or `id_token`).
 ### Refresh Token
 
 ```bash
-curl -X POST http://localhost:4005/oauth2/v2.0/token \
+curl -X POST http://localhost:4000/oauth2/v2.0/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "refresh_token=r_microsoft_...&\
 client_id=example-client-id&\
@@ -255,7 +255,7 @@ Returns a new `access_token`, rotated `refresh_token`, and new `id_token`.
 ### User Info
 
 ```bash
-curl http://localhost:4005/oidc/userinfo \
+curl http://localhost:4000/oidc/userinfo \
   -H "Authorization: Bearer microsoft_..."
 ```
 
@@ -275,7 +275,7 @@ Returns:
 ### Microsoft Graph /me
 
 ```bash
-curl http://localhost:4005/v1.0/me \
+curl http://localhost:4000/v1.0/me \
   -H "Authorization: Bearer microsoft_..."
 ```
 
@@ -294,7 +294,7 @@ Returns an OData-style response:
 ### Logout
 
 ```bash
-curl "http://localhost:4005/oauth2/v2.0/logout?post_logout_redirect_uri=http://localhost:3000"
+curl "http://localhost:4000/oauth2/v2.0/logout?post_logout_redirect_uri=http://localhost:3000"
 ```
 
 Redirects to the `post_logout_redirect_uri` if provided and valid.
@@ -302,7 +302,7 @@ Redirects to the `post_logout_redirect_uri` if provided and valid.
 ### Token Revocation
 
 ```bash
-curl -X POST http://localhost:4005/oauth2/v2.0/revoke \
+curl -X POST http://localhost:4000/oauth2/v2.0/revoke \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "token=microsoft_..."
 ```
@@ -314,7 +314,7 @@ Returns `200 OK`. The token is removed from the emulator's token map.
 ### Full Authorization Code Flow
 
 ```bash
-MICROSOFT_URL="http://localhost:4005"
+MICROSOFT_URL="http://localhost:4000"
 CLIENT_ID="example-client-id"
 CLIENT_SECRET="example-client-secret"
 REDIRECT_URI="http://localhost:3000/api/auth/callback/microsoft-entra-id"

--- a/skills/mongoatlas/SKILL.md
+++ b/skills/mongoatlas/SKILL.md
@@ -20,7 +20,7 @@ When run alone, the default base URL is:
 http://localhost:4000
 ```
 
-When all services run together from the default base port, MongoDB Atlas is available at `http://localhost:4010`.
+When all services run together, MongoDB Atlas is available on the same native server base URL.
 
 ## Vercel Preview
 

--- a/skills/okta/SKILL.md
+++ b/skills/okta/SKILL.md
@@ -17,7 +17,7 @@ The native Go runtime implements this Okta OIDC and management API surface for l
 npx emulate --service okta
 
 # Default port when all services run
-# http://localhost:4006
+# http://localhost:4000
 ```
 
 Or programmatically:
@@ -34,7 +34,7 @@ const okta = await createEmulator({ service: 'okta', port: 4006 })
 ### Environment Variable
 
 ```bash
-OKTA_EMULATOR_URL=http://localhost:4006
+OKTA_EMULATOR_URL=http://localhost:4000
 ```
 
 ### URL Mapping

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -10,7 +10,7 @@ Fully stateful Resend API emulation. Emails, domains, API keys, audiences, and c
 
 No real emails are sent. Every call to `POST /emails` stores the message locally so you can inspect it programmatically or in the browser.
 
-The native Go runtime implements the current Resend routes, supports explicit JSON seed configs for Resend through `--seed`, and is verified against the official `resend` Node.js SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
+The native Go runtime implements the current Resend routes, supports YAML and JSON seed configs for Resend through `--seed`, and is verified against the official `resend` Node.js SDK for emails, batch email sends, domains, API keys, and legacy audience contacts.
 
 ## Vercel Preview
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -34,7 +34,7 @@ const slack = await createEmulator({ service: 'slack', port: 4003 })
 Pass tokens as `Authorization: Bearer <token>`. All Web API endpoints require authentication.
 
 ```bash
-curl -X POST http://localhost:4003/api/auth.test \
+curl -X POST http://localhost:4000/api/auth.test \
   -H "Authorization: Bearer xoxb-test-token"
 ```
 
@@ -45,7 +45,7 @@ The native Go runtime seeds `xoxb-test-token` for the default admin user. OAuth 
 ### Environment Variable
 
 ```bash
-SLACK_EMULATOR_URL=http://localhost:4003
+SLACK_EMULATOR_URL=http://localhost:4000
 ```
 
 ### Slack SDK / Bolt
@@ -127,7 +127,7 @@ When no OAuth apps are configured, the emulator accepts any `client_id`. With ap
 
 ```bash
 # Test authentication
-curl -X POST http://localhost:4003/api/auth.test \
+curl -X POST http://localhost:4000/api/auth.test \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -135,31 +135,31 @@ curl -X POST http://localhost:4003/api/auth.test \
 
 ```bash
 # Post message
-curl -X POST http://localhost:4003/api/chat.postMessage \
+curl -X POST http://localhost:4000/api/chat.postMessage \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "text": "Hello from the emulator!"}'
 
 # Post threaded reply
-curl -X POST http://localhost:4003/api/chat.postMessage \
+curl -X POST http://localhost:4000/api/chat.postMessage \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "text": "Thread reply", "thread_ts": "1234567890.123456"}'
 
 # Update message
-curl -X POST http://localhost:4003/api/chat.update \
+curl -X POST http://localhost:4000/api/chat.update \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "ts": "1234567890.123456", "text": "Updated message"}'
 
 # Delete message
-curl -X POST http://localhost:4003/api/chat.delete \
+curl -X POST http://localhost:4000/api/chat.delete \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "ts": "1234567890.123456"}'
 
 # /me message
-curl -X POST http://localhost:4003/api/chat.meMessage \
+curl -X POST http://localhost:4000/api/chat.meMessage \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "text": "is thinking..."}'
@@ -169,41 +169,41 @@ curl -X POST http://localhost:4003/api/chat.meMessage \
 
 ```bash
 # List channels (cursor pagination)
-curl -X POST http://localhost:4003/api/conversations.list \
+curl -X POST http://localhost:4000/api/conversations.list \
   -H "Authorization: Bearer $TOKEN"
 
 # Get channel info
-curl -X POST http://localhost:4003/api/conversations.info \
+curl -X POST http://localhost:4000/api/conversations.info \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001"}'
 
 # Create channel
-curl -X POST http://localhost:4003/api/conversations.create \
+curl -X POST http://localhost:4000/api/conversations.create \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "new-channel", "is_private": false}'
 
 # Channel history (top-level messages only)
-curl -X POST http://localhost:4003/api/conversations.history \
+curl -X POST http://localhost:4000/api/conversations.history \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001"}'
 
 # Thread replies
-curl -X POST http://localhost:4003/api/conversations.replies \
+curl -X POST http://localhost:4000/api/conversations.replies \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "ts": "1234567890.123456"}'
 
 # Join / leave channel
-curl -X POST http://localhost:4003/api/conversations.join \
+curl -X POST http://localhost:4000/api/conversations.join \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001"}'
 
 # List members
-curl -X POST http://localhost:4003/api/conversations.members \
+curl -X POST http://localhost:4000/api/conversations.members \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001"}'
@@ -213,17 +213,17 @@ curl -X POST http://localhost:4003/api/conversations.members \
 
 ```bash
 # List users (cursor pagination)
-curl -X POST http://localhost:4003/api/users.list \
+curl -X POST http://localhost:4000/api/users.list \
   -H "Authorization: Bearer $TOKEN"
 
 # Get user info
-curl -X POST http://localhost:4003/api/users.info \
+curl -X POST http://localhost:4000/api/users.info \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"user": "U000000001"}'
 
 # Lookup by email
-curl -X POST http://localhost:4003/api/users.lookupByEmail \
+curl -X POST http://localhost:4000/api/users.lookupByEmail \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"email": "dev@example.com"}'
@@ -233,19 +233,19 @@ curl -X POST http://localhost:4003/api/users.lookupByEmail \
 
 ```bash
 # Add reaction
-curl -X POST http://localhost:4003/api/reactions.add \
+curl -X POST http://localhost:4000/api/reactions.add \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "timestamp": "1234567890.123456", "name": "thumbsup"}'
 
 # Remove reaction
-curl -X POST http://localhost:4003/api/reactions.remove \
+curl -X POST http://localhost:4000/api/reactions.remove \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "timestamp": "1234567890.123456", "name": "thumbsup"}'
 
 # Get reactions
-curl -X POST http://localhost:4003/api/reactions.get \
+curl -X POST http://localhost:4000/api/reactions.get \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "timestamp": "1234567890.123456"}'
@@ -255,7 +255,7 @@ curl -X POST http://localhost:4003/api/reactions.get \
 
 ```bash
 # Get workspace info
-curl -X POST http://localhost:4003/api/team.info \
+curl -X POST http://localhost:4000/api/team.info \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -263,7 +263,7 @@ curl -X POST http://localhost:4003/api/team.info \
 
 ```bash
 # Get bot info
-curl -X POST http://localhost:4003/api/bots.info \
+curl -X POST http://localhost:4000/api/bots.info \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"bot": "B000000001"}'
@@ -273,17 +273,17 @@ curl -X POST http://localhost:4003/api/bots.info \
 
 ```bash
 # Post via incoming webhook
-curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+curl -X POST http://localhost:4000/services/T000000001/B000000001/X000000001 \
   -H "Content-Type: application/json" \
   -d '{"text": "Deployment complete!"}'
 
 # Post to a specific channel
-curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+curl -X POST http://localhost:4000/services/T000000001/B000000001/X000000001 \
   -H "Content-Type: application/json" \
   -d '{"text": "Alert!", "channel": "C000000002"}'
 
 # Post threaded webhook message
-curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+curl -X POST http://localhost:4000/services/T000000001/B000000001/X000000001 \
   -H "Content-Type: application/json" \
   -d '{"text": "Thread update", "thread_ts": "1234567890.123456"}'
 ```
@@ -295,7 +295,7 @@ curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
 # GET /oauth/v2/authorize?client_id=...&redirect_uri=...&scope=...&state=...
 
 # Token exchange
-curl -X POST http://localhost:4003/api/oauth.v2.access \
+curl -X POST http://localhost:4000/api/oauth.v2.access \
   -H "Content-Type: application/json" \
   -d '{"client_id": "12345.67890", "client_secret": "example_client_secret", "code": "<code>"}'
 ```
@@ -327,7 +327,7 @@ In embedded JavaScript mode, when messages are posted or reactions are added/rem
 
 ```bash
 TOKEN="xoxb-test-token"
-BASE="http://localhost:4003"
+BASE="http://localhost:4000"
 
 # Post a message
 curl -X POST $BASE/api/chat.postMessage \
@@ -354,7 +354,7 @@ curl -X POST $BASE/api/reactions.add \
 
 ```bash
 # Use the default incoming webhook
-curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+curl -X POST http://localhost:4000/services/T000000001/B000000001/X000000001 \
   -H "Content-Type: application/json" \
   -d '{"text": "Build passed on main"}'
 ```

--- a/tests/sdk-js/src/harness.mjs
+++ b/tests/sdk-js/src/harness.mjs
@@ -39,7 +39,7 @@ export async function allocatePort(host = DEFAULT_HOST) {
 export function selectRuntime(env = process.env) {
   if (env.EMULATE_SDK_RUNTIME) return env.EMULATE_SDK_RUNTIME;
   if (env.EMULATE_TARGET_URL) return "external";
-  return "typescript";
+  return "cli";
 }
 
 export async function startRuntime(options = {}) {
@@ -166,15 +166,15 @@ export async function waitForHttp(url, options = {}) {
 }
 
 async function runtimeCommand(options) {
-  if (options.runtime === "typescript") return typeScriptCommand(options);
+  if (options.runtime === "cli" || options.runtime === "typescript") return cliCommand(options);
   if (options.runtime === "go") return goCommand(options);
   throw new Error(`Unsupported runtime: ${options.runtime}`);
 }
 
-async function typeScriptCommand(options) {
+async function cliCommand(options) {
   const cliPath =
-    options.cliPath ?? options.env.EMULATE_TYPESCRIPT_CLI ?? path.join(repoRoot, "packages/emulate/dist/index.js");
-  await assertExecutableFile(cliPath, "TypeScript CLI");
+    options.cliPath ?? options.env.EMULATE_CLI ?? options.env.EMULATE_TYPESCRIPT_CLI ?? path.join(repoRoot, "packages/emulate/dist/index.js");
+  await assertExecutableFile(cliPath, "emulate CLI");
   const workingDirectory = await runtimeWorkingDirectory(options);
   return {
     args: [
@@ -190,7 +190,7 @@ async function typeScriptCommand(options) {
     command: process.execPath,
     cwd: workingDirectory.cwd,
     cleanup: workingDirectory.cleanup,
-    label: "TypeScript runtime",
+    label: "emulate CLI runtime",
     readinessPath: "/rate_limit",
   };
 }

--- a/tests/sdk-js/test/lifecycle.test.mjs
+++ b/tests/sdk-js/test/lifecycle.test.mjs
@@ -3,8 +3,8 @@ import net from "node:net";
 import test from "node:test";
 import { connectRuntime, selectRuntime, startRuntime, waitForHttp } from "../src/harness.mjs";
 
-test("selectRuntime defaults to the TypeScript runtime", () => {
-  assert.equal(selectRuntime({}), "typescript");
+test("selectRuntime defaults to the npm CLI runtime", () => {
+  assert.equal(selectRuntime({}), "cli");
   assert.equal(selectRuntime({ EMULATE_TARGET_URL: "http://127.0.0.1:4000" }), "external");
   assert.equal(selectRuntime({ EMULATE_SDK_RUNTIME: "go" }), "go");
 });
@@ -18,8 +18,8 @@ test("connectRuntime returns an external target handle", async () => {
   await target.stop();
 });
 
-test("TypeScript runtime starts and serves the GitHub rate limit route", async (t) => {
-  const target = await startRuntime({ runtime: "typescript", service: "github", readinessPath: "/rate_limit" });
+test("npm CLI runtime starts and serves the GitHub rate limit route", async (t) => {
+  const target = await startRuntime({ runtime: "cli", service: "github", readinessPath: "/rate_limit" });
   t.after(async () => {
     await target.stop();
   });


### PR DESCRIPTION
Adds platform native binary packages and release wiring for npm distribution.

Switches npx emulate to a signal-forwarding Go engine launcher while preserving package imports and JS/TS SDK tests.

Closes native CLI gaps for YAML seeds, AWS seed config, portless, and Vercel Go Function scaffolding.