### PR TITLE
Add native compatibility facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,7 +901,7 @@ GitHub({
 
 No `oauth_apps` need to be seeded. When none are configured, the emulator skips `client_id`, `client_secret`, and `redirect_uri` validation.
 
-`createEmulateHandler` is deprecated. In-process service handlers have been removed; use `createEmulateProxy` for local native runtimes or `npx emulate vercel init` for Vercel previews.
+`createEmulateHandler` remains as a compatibility facade for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
 
 ## Architecture
 
@@ -909,15 +909,15 @@ No `oauth_apps` need to be seeded. When none are configured, the emulator skips 
 packages/
   emulate/          # npm CLI shim and native process programmatic API
   @emulators/
-    core/           # compatibility helpers
+    core/           # compatibility helpers and native proxy facade
     adapter-next/   # Next.js App Router proxy integration
-    vercel/         # Vercel API metadata package
-    github/         # GitHub API metadata package
-    google/         # Google metadata package
-    slack/          # Slack metadata package
-    apple/          # Apple metadata package
-    microsoft/      # Microsoft metadata package
-    aws/            # AWS metadata package and SDK conformance tests
+    vercel/         # Vercel API metadata and compatibility package
+    github/         # GitHub API metadata and compatibility package
+    google/         # Google metadata and compatibility package
+    slack/          # Slack metadata and compatibility package
+    apple/          # Apple metadata and compatibility package
+    microsoft/      # Microsoft metadata and compatibility package
+    aws/            # AWS metadata, compatibility package, and SDK conformance tests
 apps/
   web/              # Documentation site (Next.js)
 ```

--- a/README.md
+++ b/README.md
@@ -901,7 +901,7 @@ GitHub({
 
 No `oauth_apps` need to be seeded. When none are configured, the emulator skips `client_id`, `client_secret`, and `redirect_uri` validation.
 
-`createEmulateHandler` remains as a compatibility facade for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
+`createEmulateHandler` remains as a compatibility facade for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. The legacy `persistence` option is rejected because state lives in the native runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
 
 ## Architecture
 

--- a/apps/web/app/docs/architecture/page.mdx
+++ b/apps/web/app/docs/architecture/page.mdx
@@ -4,15 +4,15 @@
 packages/
   emulate/          # npm CLI shim and native process programmatic API
   @emulators/
-    core/           # compatibility helpers
+    core/           # compatibility helpers and native proxy facade
     adapter-next/   # Next.js App Router proxy integration
-    vercel/         # Vercel API metadata package
-    github/         # GitHub API metadata package
-    google/         # Google metadata package
-    slack/          # Slack metadata package
-    apple/          # Apple metadata package
-    microsoft/      # Microsoft metadata package
-    aws/            # AWS metadata package and SDK conformance tests
+    vercel/         # Vercel API metadata and compatibility package
+    github/         # GitHub API metadata and compatibility package
+    google/         # Google metadata and compatibility package
+    slack/          # Slack metadata and compatibility package
+    apple/          # Apple metadata and compatibility package
+    microsoft/      # Microsoft metadata and compatibility package
+    aws/            # AWS metadata, compatibility package, and SDK conformance tests
     okta/           # Okta metadata package
     clerk/          # Clerk metadata package
     mongoatlas/     # MongoDB Atlas metadata package
@@ -28,7 +28,7 @@ apps/
 
 ## Native Runtime
 
-The native Go runtime is the service engine for the CLI, the programmatic API, SDK conformance tests, and Vercel Go Function previews. It serves selected services from one local server by default. `--portless` starts service-specific native listeners so each service can keep a named HTTPS alias.
+The native Go runtime is the service engine for the CLI, the programmatic API, SDK conformance tests, compatibility facades, and Vercel Go Function previews. It serves selected services from one local server by default. `--portless` starts service-specific native listeners so each service can keep a named HTTPS alias.
 
 ## npm Packages
 

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -1,6 +1,6 @@
 # Next.js Integration
 
-The `@emulators/adapter-next` package proxies a native emulate runtime through a Next.js App Router route. In-process service handlers have been removed.
+The `@emulators/adapter-next` package proxies a native emulate runtime through a Next.js App Router route. Legacy in-process handler imports remain available as a compatibility facade over the native runtime.
 
 ## Vercel Go Function Preview
 
@@ -79,6 +79,6 @@ GitHub({
 
 No `oauth_apps` need to be seeded. When none are configured, the emulator skips `client_id`, `client_secret`, and `redirect_uri` validation.
 
-## Deprecated In-Process Handler
+## Compatibility Handler
 
-`createEmulateHandler` remains exported so existing imports fail gracefully at request time, but it no longer runs services in-process. New code should use `createEmulateProxy` for local native runtimes or `npx emulate vercel init` for Vercel previews.
+`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -81,4 +81,4 @@ No `oauth_apps` need to be seeded. When none are configured, the emulator skips 
 
 ## Compatibility Handler
 
-`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
+`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. The legacy `persistence` option is rejected because state lives in the native runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -141,7 +141,7 @@ npm install @emulators/github @emulators/google @emulators/stripe
 
 ### Direct usage
 
-Each scoped package exports metadata only. Service routing, state, and protocol behavior run in the native Go engine:
+Each scoped package exports metadata plus legacy plugin-shaped markers for compatibility. Service routing, state, and protocol behavior run in the native Go engine:
 
 ```typescript
 import * as github from '@emulators/github'

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -141,7 +141,7 @@ npm install @emulators/github @emulators/google @emulators/stripe
 
 ### Direct usage
 
-Each scoped package exports metadata plus legacy plugin-shaped markers for compatibility. Service routing, state, and protocol behavior run in the native Go engine:
+Each scoped package exports metadata plus legacy plugin-shaped markers for compatibility. Service routing, state, and protocol behavior run in the native Go engine. Legacy `seedFromConfig` exports fail loudly; pass seed config to `createEmulator` instead.
 
 ```typescript
 import * as github from '@emulators/github'

--- a/packages/@emulators/adapter-next/README.md
+++ b/packages/@emulators/adapter-next/README.md
@@ -51,9 +51,9 @@ npx emulate vercel init --service github,google
 
 The scaffold creates `api/emulate.go`, updates `go.mod`, and adds a `/emulate/:path*` rewrite in `vercel.json`.
 
-## Deprecated In-Process Handler
+## Compatibility Handler
 
-`createEmulateHandler` remains exported so existing imports fail gracefully, but in-process service handlers have been removed. New code should use `createEmulateProxy` for a separately running native runtime or `npx emulate vercel init` for Vercel previews.
+`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
 
 ## Links
 

--- a/packages/@emulators/adapter-next/README.md
+++ b/packages/@emulators/adapter-next/README.md
@@ -53,7 +53,7 @@ The scaffold creates `api/emulate.go`, updates `go.mod`, and adds a `/emulate/:p
 
 ## Compatibility Handler
 
-`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
+`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. The legacy `persistence` option is rejected because state lives in the native runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
 
 ## Links
 

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -35,7 +35,9 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint src"
   },
-  "dependencies": {},
+  "dependencies": {
+    "emulate": "workspace:*"
+  },
   "devDependencies": {
     "tsup": "^8",
     "typescript": "^5.7",

--- a/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
+++ b/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createEmulateProxy } from "../index";
+import { createEmulateHandler, createEmulateProxy } from "../index";
+
+const emulateMocks = vi.hoisted(() => ({
+  createEmulator: vi.fn(),
+}));
 
 const ctx = (path: string[]) => ({ params: Promise.resolve({ path }) });
 
@@ -285,5 +289,105 @@ describe("createEmulateProxy", () => {
         },
       }),
     ).toThrow("createEmulateProxy accepts either `target` or `targets`, not both");
+  });
+});
+
+describe("createEmulateHandler compatibility", () => {
+  afterEach(() => {
+    delete process.env.EMULATE_GITHUB_URL;
+    delete process.env.EMULATE_GITHUB_PORT;
+    delete (globalThis as { __emulateCompatLoadEmulateApi?: unknown }).__emulateCompatLoadEmulateApi;
+    emulateMocks.createEmulator.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("proxies old handler configs to an explicit native target", async () => {
+    process.env.EMULATE_GITHUB_URL = "http://127.0.0.1:4999";
+    let forwardedRequest: Request | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        forwardedRequest = input as Request;
+        return new Response("ok");
+      }),
+    );
+
+    const handler = createEmulateHandler({
+      services: {
+        github: {
+          emulator: { serviceName: "github" },
+        },
+      },
+    });
+
+    const response = await handler.GET(
+      new Request("https://preview.example.com/emulate/github/rate_limit"),
+      ctx(["github", "rate_limit"]),
+    );
+
+    expect(response.status).toBe(200);
+    expect(emulateMocks.createEmulator).not.toHaveBeenCalled();
+    expect(forwardedRequest).not.toBeNull();
+    expect(forwardedRequest!.url).toBe("http://127.0.0.1:4999/rate_limit");
+    expect(forwardedRequest!.headers.get("x-forwarded-prefix")).toBe("/emulate/github");
+  });
+
+  it("starts a native runtime for legacy in-process handler configs", async () => {
+    process.env.EMULATE_GITHUB_PORT = "4998";
+    (globalThis as { __emulateCompatLoadEmulateApi?: unknown }).__emulateCompatLoadEmulateApi = async () => ({
+      createEmulator: emulateMocks.createEmulator,
+    });
+    emulateMocks.createEmulator.mockResolvedValue({
+      url: "https://preview.example.com/api/emulate/github",
+      reset: async () => undefined,
+      close: async () => undefined,
+    });
+    let forwardedRequest: Request | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        forwardedRequest = input as Request;
+        return new Response("ok", {
+          headers: { Location: "/rate_limit" },
+        });
+      }),
+    );
+
+    const handler = createEmulateHandler({
+      services: {
+        github: {
+          emulator: {
+            default: {
+              name: "github",
+              runtime: "native-go",
+            },
+          },
+          seed: {
+            repositories: [],
+          },
+        },
+      },
+    });
+
+    const response = await handler.GET(
+      new Request("https://preview.example.com/api/emulate/github/rate_limit?limit=1"),
+      ctx(["github", "rate_limit"]),
+    );
+
+    expect(emulateMocks.createEmulator).toHaveBeenCalledTimes(1);
+    const options = emulateMocks.createEmulator.mock.calls[0][0];
+    expect(options).toMatchObject({
+      service: "github",
+      baseUrl: "https://preview.example.com/api/emulate/github",
+      seed: {
+        github: {
+          repositories: [],
+        },
+      },
+    });
+    expect(options.port).toBe(4998);
+    expect(forwardedRequest).not.toBeNull();
+    expect(forwardedRequest!.url).toBe("http://127.0.0.1:4998/rate_limit?limit=1");
+    expect(response.headers.get("Location")).toBe("/api/emulate/github/rate_limit");
   });
 });

--- a/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
+++ b/packages/@emulators/adapter-next/src/__tests__/proxy.test.ts
@@ -332,6 +332,18 @@ describe("createEmulateHandler compatibility", () => {
     expect(forwardedRequest!.headers.get("x-forwarded-prefix")).toBe("/emulate/github");
   });
 
+  it("rejects legacy persistence configs instead of ignoring them", () => {
+    expect(() =>
+      createEmulateHandler({
+        services: {},
+        persistence: {
+          load: () => null,
+          save: () => undefined,
+        },
+      }),
+    ).toThrow("createEmulateHandler persistence is not supported");
+  });
+
   it("starts a native runtime for legacy in-process handler configs", async () => {
     process.env.EMULATE_GITHUB_PORT = "4998";
     (globalThis as { __emulateCompatLoadEmulateApi?: unknown }).__emulateCompatLoadEmulateApi = async () => ({

--- a/packages/@emulators/adapter-next/src/index.ts
+++ b/packages/@emulators/adapter-next/src/index.ts
@@ -1,3 +1,6 @@
+import { createServer as createTcpServer } from "node:net";
+import type { Emulator, SeedConfig, ServiceName } from "emulate";
+
 export interface PersistenceAdapter {
   load(): string | null | Promise<string | null>;
   save(data: string): void | Promise<void>;
@@ -5,7 +8,16 @@ export interface PersistenceAdapter {
 
 export interface EmulatorModule {
   serviceName?: string;
+  name?: string;
   service?: {
+    name?: string;
+    runtime?: string;
+  };
+  plugin?: {
+    name?: string;
+    runtime?: string;
+  };
+  default?: {
     name?: string;
     runtime?: string;
   };
@@ -75,12 +87,86 @@ interface ResponseRewriteOptions {
   upstreamPrefix?: string;
 }
 
-export function createEmulateHandler(_config: EmulateHandlerConfig) {
-  const handler: RouteHandler = async () =>
-    new Response(
-      "In-process service handlers were removed. Use createEmulateProxy for local native runtimes or npx emulate vercel init for Vercel previews.",
-      { status: 501 },
-    );
+interface NativeHandlerRuntime {
+  emulator?: Emulator;
+  target: string;
+}
+
+const NATIVE_SERVICE_NAMES = [
+  "vercel",
+  "github",
+  "google",
+  "slack",
+  "apple",
+  "microsoft",
+  "okta",
+  "aws",
+  "resend",
+  "stripe",
+  "mongoatlas",
+  "clerk",
+] as const satisfies readonly ServiceName[];
+
+const nativeServiceSet = new Set<string>(NATIVE_SERVICE_NAMES);
+
+export function createEmulateHandler(config: EmulateHandlerConfig) {
+  const runtimes = new Map<string, Promise<NativeHandlerRuntime>>();
+
+  async function ensureRuntime(
+    serviceKey: string,
+    entry: EmulatorEntry,
+    publicBaseUrl: string,
+  ): Promise<NativeHandlerRuntime> {
+    const service = resolveNativeServiceName(serviceKey, entry.emulator);
+    const externalTarget = configuredHandlerTarget(service, serviceKey);
+    if (externalTarget) {
+      return { target: externalTarget };
+    }
+
+    const existing = runtimes.get(serviceKey);
+    if (existing) return existing;
+
+    const created = startNativeHandlerRuntime(service, serviceKey, entry.seed, publicBaseUrl);
+    runtimes.set(serviceKey, created);
+    return created;
+  }
+
+  async function handleRequest(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }): Promise<NextResponse> {
+    const { path: pathSegments } = await ctx.params;
+    if (pathSegments.length === 0) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const serviceKey = pathSegments[0];
+    const entry = config.services[serviceKey];
+    if (!entry) {
+      return new Response(`Unknown service: ${serviceKey}`, { status: 404 });
+    }
+
+    const requestUrl = new URL(req.url);
+    const mountPath = detectPrefix(req.url, pathSegments);
+    const publicPrefix = appendPath(mountPath, serviceKey);
+    const publicBaseUrl = `${requestUrl.origin}${publicPrefix}`;
+    const runtime = await ensureRuntime(serviceKey, entry, publicBaseUrl);
+    const targetConfig: EmulateProxyTargetConfig = { target: runtime.target };
+    const forwardedPathSegments = pathSegments.slice(1);
+    const targetUrl = buildProxyUrl(targetConfig, forwardedPathSegments, requestUrl.search);
+    const upstreamPrefix = buildProxyUpstreamPrefix(targetConfig);
+    const context: EmulateProxyContext = {
+      service: serviceKey,
+      mountPath,
+      publicPrefix,
+      target: targetUrl,
+      pathSegments,
+      forwardedPathSegments,
+    };
+    const headers = await buildProxyHeaders(req, context, undefined, undefined);
+    const proxyRequest = buildProxyRequest(req, targetUrl, headers);
+    const response = await fetch(proxyRequest);
+    return rewriteResponse(response, { publicPrefix, upstreamPrefix });
+  }
+
+  const handler: RouteHandler = handleRequest;
 
   return {
     GET: handler,
@@ -91,6 +177,95 @@ export function createEmulateHandler(_config: EmulateHandlerConfig) {
     DELETE: handler,
     OPTIONS: handler,
   };
+}
+
+function resolveNativeServiceName(serviceKey: string, mod: EmulatorModule): ServiceName {
+  const candidates = [
+    mod.serviceName,
+    mod.service?.name,
+    mod.plugin?.name,
+    mod.default?.name,
+    mod.name,
+    serviceKey,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && nativeServiceSet.has(candidate)) {
+      return candidate as ServiceName;
+    }
+  }
+  throw new Error(`Unsupported native emulator service: ${serviceKey}`);
+}
+
+function configuredHandlerTarget(service: ServiceName, serviceKey: string): string | undefined {
+  const names = new Set([service, serviceKey]);
+  for (const name of names) {
+    const envKey = name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    const value = process.env[`EMULATE_${envKey}_URL`] ?? process.env[`EMULATE_${envKey}_TARGET_URL`];
+    if (value) return value;
+  }
+  return process.env.EMULATE_TARGET_URL ?? process.env.EMULATE_URL;
+}
+
+function configuredHandlerPort(service: ServiceName, serviceKey: string): number | undefined {
+  const names = new Set([service, serviceKey]);
+  for (const name of names) {
+    const envKey = name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    const value = process.env[`EMULATE_${envKey}_PORT`];
+    if (value) return Number(value);
+  }
+  return process.env.EMULATE_PORT ? Number(process.env.EMULATE_PORT) : undefined;
+}
+
+async function startNativeHandlerRuntime(
+  service: ServiceName,
+  serviceKey: string,
+  serviceSeed: Record<string, unknown> | undefined,
+  publicBaseUrl: string,
+): Promise<NativeHandlerRuntime> {
+  const port = configuredHandlerPort(service, serviceKey) ?? (await allocatePort());
+  const { createEmulator } = await loadEmulateApi();
+  const seed = serviceSeed ? ({ [service]: serviceSeed } as SeedConfig) : undefined;
+  const emulator = await createEmulator({
+    service,
+    port,
+    seed,
+    baseUrl: publicBaseUrl,
+  });
+  return {
+    emulator,
+    target: `http://127.0.0.1:${port}`,
+  };
+}
+
+async function loadEmulateApi(): Promise<typeof import("emulate")> {
+  const globalLoader = (globalThis as { __emulateCompatLoadEmulateApi?: () => Promise<typeof import("emulate")> })
+    .__emulateCompatLoadEmulateApi;
+  if (globalLoader) return globalLoader();
+  const dynamicImport = new Function("specifier", "return import(specifier)") as (
+    specifier: string,
+  ) => Promise<typeof import("emulate")>;
+  return dynamicImport("emulate");
+}
+
+async function allocatePort(host = "127.0.0.1"): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createTcpServer();
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (!address || typeof address === "string") {
+          reject(new Error("Port allocation did not return a TCP address"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
 }
 
 function detectPrefix(url: string, pathSegments: string[]): string {

--- a/packages/@emulators/adapter-next/src/index.ts
+++ b/packages/@emulators/adapter-next/src/index.ts
@@ -110,6 +110,12 @@ const NATIVE_SERVICE_NAMES = [
 const nativeServiceSet = new Set<string>(NATIVE_SERVICE_NAMES);
 
 export function createEmulateHandler(config: EmulateHandlerConfig) {
+  if (config.persistence) {
+    throw new Error(
+      "createEmulateHandler persistence is not supported by the native compatibility facade. Use createEmulateProxy with a persistent native runtime instead.",
+    );
+  }
+
   const runtimes = new Map<string, Promise<NativeHandlerRuntime>>();
 
   async function ensureRuntime(
@@ -180,14 +186,7 @@ export function createEmulateHandler(config: EmulateHandlerConfig) {
 }
 
 function resolveNativeServiceName(serviceKey: string, mod: EmulatorModule): ServiceName {
-  const candidates = [
-    mod.serviceName,
-    mod.service?.name,
-    mod.plugin?.name,
-    mod.default?.name,
-    mod.name,
-    serviceKey,
-  ];
+  const candidates = [mod.serviceName, mod.service?.name, mod.plugin?.name, mod.default?.name, mod.name, serviceKey];
   for (const candidate of candidates) {
     if (typeof candidate === "string" && nativeServiceSet.has(candidate)) {
       return candidate as ServiceName;

--- a/packages/@emulators/apple/src/index.ts
+++ b/packages/@emulators/apple/src/index.ts
@@ -1,6 +1,82 @@
 export const serviceName = "apple";
-export const serviceLabel = "Apple Sign In / OIDC";
+export const serviceLabel = "Apple Sign In and OIDC";
 export const runtime = "native-go";
+
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface AppleUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface AppleOAuthClient extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface AppleSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface AppleStore {
+  users: CompatCollection<AppleUser>;
+  oauthClients: CompatCollection<AppleOAuthClient>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getAppleStore(store: CompatStoreSource): AppleStore {
+  return {
+    users: compatCollection<AppleUser>(store, "apple.users", ["uid", "email"]),
+    oauthClients: compatCollection<AppleOAuthClient>(store, "apple.oauth_clients", ["client_id"]),
+  };
+}
 
 export const service = {
   name: serviceName,
@@ -8,4 +84,24 @@ export const service = {
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const applePlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: AppleSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/apple/src/index.ts
+++ b/packages/@emulators/apple/src/index.ts
@@ -78,6 +78,44 @@ export function getAppleStore(store: CompatStoreSource): AppleStore {
   };
 }
 
+// Legacy public entity type augmentations.
+export interface AppleUser extends CompatEntity {
+  uid: string;
+  email: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  email_verified: boolean;
+  is_private_email: boolean;
+  private_relay_email: string | null;
+  real_user_status: number;
+}
+
+export interface AppleOAuthClient extends CompatEntity {
+  client_id: string;
+  team_id: string;
+  key_id: string;
+  name: string;
+  redirect_uris: string[];
+}
+
+// Legacy public seed config type augmentations.
+export interface AppleSeedConfig {
+  users?: Array<{
+    email: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
+    is_private_email?: boolean;
+  }>;
+  oauth_clients?: Array<{
+    client_id: string;
+    team_id: string;
+    key_id?: string;
+    name: string;
+    redirect_uris: string[];
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -97,7 +135,9 @@ export const plugin = {
 export const applePlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: AppleSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/aws/src/index.ts
+++ b/packages/@emulators/aws/src/index.ts
@@ -2,10 +2,126 @@ export const serviceName = "aws";
 export const serviceLabel = "AWS cloud services";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface S3Bucket extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface S3Object extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SqsQueue extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SqsMessage extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface IamUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface IamRole extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface AwsSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface AwsStore {
+  s3Buckets: CompatCollection<S3Bucket>;
+  s3Objects: CompatCollection<S3Object>;
+  sqsQueues: CompatCollection<SqsQueue>;
+  sqsMessages: CompatCollection<SqsMessage>;
+  iamUsers: CompatCollection<IamUser>;
+  iamRoles: CompatCollection<IamRole>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getAwsStore(store: CompatStoreSource): AwsStore {
+  return {
+    s3Buckets: compatCollection<S3Bucket>(store, "aws.s3_buckets", ["bucket_name"]),
+    s3Objects: compatCollection<S3Object>(store, "aws.s3_objects", ["key", "bucket_name"]),
+    sqsQueues: compatCollection<SqsQueue>(store, "aws.sqs_queues", ["queue_name", "queue_url"]),
+    sqsMessages: compatCollection<SqsMessage>(store, "aws.sqs_messages", ["message_id", "queue_name"]),
+    iamUsers: compatCollection<IamUser>(store, "aws.iam_users", ["user_name", "user_id"]),
+    iamRoles: compatCollection<IamRole>(store, "aws.iam_roles", ["role_name", "role_id"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const awsPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: AwsSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/aws/src/index.ts
+++ b/packages/@emulators/aws/src/index.ts
@@ -98,6 +98,101 @@ export function getAwsStore(store: CompatStoreSource): AwsStore {
   };
 }
 
+// Legacy public entity type augmentations.
+export interface S3Bucket extends CompatEntity {
+  bucket_name: string;
+  region: string;
+  creation_date: string;
+  acl: "private" | "public-read" | "public-read-write";
+  versioning_enabled: boolean;
+}
+
+export interface S3Object extends CompatEntity {
+  bucket_name: string;
+  key: string;
+  body: string;
+  content_type: string;
+  content_length: number;
+  etag: string;
+  last_modified: string;
+  metadata: Record<string, string>;
+  version_id?: string;
+}
+
+export interface SqsQueue extends CompatEntity {
+  queue_name: string;
+  queue_url: string;
+  arn: string;
+  visibility_timeout: number;
+  delay_seconds: number;
+  max_message_size: number;
+  message_retention_period: number;
+  receive_message_wait_time: number;
+  fifo: boolean;
+}
+
+export interface SqsMessage extends CompatEntity {
+  queue_name: string;
+  message_id: string;
+  receipt_handle: string;
+  body: string;
+  md5_of_body: string;
+  attributes: Record<string, string>;
+  message_attributes: Record<string, { DataType: string; StringValue?: string; BinaryValue?: string }>;
+  visible_after: number;
+  sent_timestamp: number;
+  receive_count: number;
+}
+
+export interface IamUser extends CompatEntity {
+  user_name: string;
+  user_id: string;
+  arn: string;
+  path: string;
+  access_keys: Array<{ access_key_id: string; secret_access_key: string; status: "Active" | "Inactive" }>;
+}
+
+export interface IamRole extends CompatEntity {
+  role_name: string;
+  role_id: string;
+  arn: string;
+  path: string;
+  assume_role_policy_document: string;
+  description: string;
+}
+
+// Legacy public seed config type augmentations.
+export interface AwsSeedConfig {
+  port?: number;
+  region?: string;
+  account_id?: string;
+  s3?: {
+    buckets?: Array<{
+      name: string;
+      region?: string;
+    }>;
+  };
+  sqs?: {
+    queues?: Array<{
+      name: string;
+      fifo?: boolean;
+      visibility_timeout?: number;
+    }>;
+  };
+  iam?: {
+    users?: Array<{
+      user_name: string;
+      path?: string;
+      create_access_key?: boolean;
+    }>;
+    roles?: Array<{
+      role_name: string;
+      path?: string;
+      description?: string;
+      assume_role_policy?: string;
+    }>;
+  };
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -117,7 +212,9 @@ export const plugin = {
 export const awsPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: AwsSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/clerk/src/index.ts
+++ b/packages/@emulators/clerk/src/index.ts
@@ -2,10 +2,131 @@ export const serviceName = "clerk";
 export const serviceLabel = "Clerk authentication and user management";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface ClerkUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ClerkEmailAddress extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ClerkOrganization extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ClerkOrganizationMembership extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ClerkOrganizationInvitation extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ClerkSession extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ClerkOAuthApplication extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface ClerkSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface ClerkStore {
+  users: CompatCollection<ClerkUser>;
+  emailAddresses: CompatCollection<ClerkEmailAddress>;
+  organizations: CompatCollection<ClerkOrganization>;
+  memberships: CompatCollection<ClerkOrganizationMembership>;
+  invitations: CompatCollection<ClerkOrganizationInvitation>;
+  sessions: CompatCollection<ClerkSession>;
+  oauthApps: CompatCollection<ClerkOAuthApplication>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getClerkStore(store: CompatStoreSource): ClerkStore {
+  return {
+    users: compatCollection<ClerkUser>(store, "clerk.users", ["clerk_id", "username"]),
+    emailAddresses: compatCollection<ClerkEmailAddress>(store, "clerk.emails", ["email_id", "user_id", "email_address"]),
+    organizations: compatCollection<ClerkOrganization>(store, "clerk.orgs", ["clerk_id", "slug"]),
+    memberships: compatCollection<ClerkOrganizationMembership>(store, "clerk.memberships", ["membership_id", "org_id", "user_id"]),
+    invitations: compatCollection<ClerkOrganizationInvitation>(store, "clerk.invitations", ["invitation_id", "org_id"]),
+    sessions: compatCollection<ClerkSession>(store, "clerk.sessions", ["clerk_id", "user_id"]),
+    oauthApps: compatCollection<ClerkOAuthApplication>(store, "clerk.oauth_apps", ["app_id", "client_id"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const clerkPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: ClerkSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/clerk/src/index.ts
+++ b/packages/@emulators/clerk/src/index.ts
@@ -94,15 +94,160 @@ function compatCollection<T extends CompatEntity>(
 export function getClerkStore(store: CompatStoreSource): ClerkStore {
   return {
     users: compatCollection<ClerkUser>(store, "clerk.users", ["clerk_id", "username"]),
-    emailAddresses: compatCollection<ClerkEmailAddress>(store, "clerk.emails", ["email_id", "user_id", "email_address"]),
+    emailAddresses: compatCollection<ClerkEmailAddress>(store, "clerk.emails", [
+      "email_id",
+      "user_id",
+      "email_address",
+    ]),
     organizations: compatCollection<ClerkOrganization>(store, "clerk.orgs", ["clerk_id", "slug"]),
-    memberships: compatCollection<ClerkOrganizationMembership>(store, "clerk.memberships", ["membership_id", "org_id", "user_id"]),
+    memberships: compatCollection<ClerkOrganizationMembership>(store, "clerk.memberships", [
+      "membership_id",
+      "org_id",
+      "user_id",
+    ]),
     invitations: compatCollection<ClerkOrganizationInvitation>(store, "clerk.invitations", ["invitation_id", "org_id"]),
     sessions: compatCollection<ClerkSession>(store, "clerk.sessions", ["clerk_id", "user_id"]),
     oauthApps: compatCollection<ClerkOAuthApplication>(store, "clerk.oauth_apps", ["app_id", "client_id"]),
   };
 }
 
+// Legacy public entity type augmentations.
+export interface ClerkUser extends CompatEntity {
+  clerk_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  image_url: string | null;
+  profile_image_url: string | null;
+  external_id: string | null;
+  primary_email_address_id: string | null;
+  primary_phone_number_id: string | null;
+  password_enabled: boolean;
+  password_hash: string | null;
+  totp_enabled: boolean;
+  backup_code_enabled: boolean;
+  two_factor_enabled: boolean;
+  banned: boolean;
+  locked: boolean;
+  public_metadata: Record<string, unknown>;
+  private_metadata: Record<string, unknown>;
+  unsafe_metadata: Record<string, unknown>;
+  last_active_at: number | null;
+  last_sign_in_at: number | null;
+  created_at_unix: number;
+  updated_at_unix: number;
+}
+
+export interface ClerkEmailAddress extends CompatEntity {
+  email_id: string;
+  email_address: string;
+  user_id: string;
+  verification_status: "verified" | "unverified";
+  verification_strategy: string;
+  is_primary: boolean;
+  reserved: boolean;
+  created_at_unix: number;
+  updated_at_unix: number;
+}
+
+export interface ClerkOrganization extends CompatEntity {
+  clerk_id: string;
+  name: string;
+  slug: string;
+  image_url: string | null;
+  has_logo: boolean;
+  members_count: number;
+  pending_invitations_count: number;
+  public_metadata: Record<string, unknown>;
+  private_metadata: Record<string, unknown>;
+  max_allowed_memberships: number | null;
+  admin_delete_enabled: boolean;
+  created_at_unix: number;
+  updated_at_unix: number;
+}
+
+export interface ClerkOrganizationMembership extends CompatEntity {
+  membership_id: string;
+  org_id: string;
+  user_id: string;
+  role: string;
+  permissions: string[];
+  public_metadata: Record<string, unknown>;
+  private_metadata: Record<string, unknown>;
+  created_at_unix: number;
+  updated_at_unix: number;
+}
+
+export interface ClerkOrganizationInvitation extends CompatEntity {
+  invitation_id: string;
+  email_address: string;
+  org_id: string;
+  role: string;
+  status: "pending" | "accepted" | "revoked" | "expired";
+  expires_at: number;
+  created_at_unix: number;
+  updated_at_unix: number;
+}
+
+export interface ClerkSession extends CompatEntity {
+  clerk_id: string;
+  user_id: string;
+  client_id: string;
+  status: "active" | "revoked" | "ended";
+  last_active_at: number | null;
+  expire_at: number;
+  abandon_at: number;
+  created_at_unix: number;
+  updated_at_unix: number;
+}
+
+export interface ClerkOAuthApplication extends CompatEntity {
+  app_id: string;
+  name: string;
+  client_id: string;
+  client_secret: string;
+  is_public: boolean;
+  scopes: string[];
+  redirect_uris: string[];
+  created_at_unix: number;
+  updated_at_unix: number;
+}
+
+// Legacy public seed config type augmentations.
+export interface ClerkSeedConfig {
+  users?: Array<{
+    clerk_id?: string;
+    email_addresses: string[];
+    first_name?: string;
+    last_name?: string;
+    username?: string;
+    password?: string;
+    external_id?: string;
+    public_metadata?: Record<string, unknown>;
+    private_metadata?: Record<string, unknown>;
+    unsafe_metadata?: Record<string, unknown>;
+  }>;
+  organizations?: Array<{
+    clerk_id?: string;
+    name: string;
+    slug?: string;
+    max_allowed_memberships?: number;
+    public_metadata?: Record<string, unknown>;
+    private_metadata?: Record<string, unknown>;
+    members?: Array<{
+      email: string;
+      role: string;
+    }>;
+  }>;
+  oauth_applications?: Array<{
+    client_id: string;
+    client_secret?: string;
+    name: string;
+    redirect_uris: string[];
+    scopes?: string[];
+    public?: boolean;
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -122,7 +267,9 @@ export const plugin = {
 export const clerkPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: ClerkSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/core/package.json
+++ b/packages/@emulators/core/package.json
@@ -33,6 +33,9 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint src"
   },
+  "dependencies": {
+    "emulate": "workspace:*"
+  },
   "devDependencies": {
     "tsup": "^8",
     "typescript": "^5.7"

--- a/packages/@emulators/core/src/index.ts
+++ b/packages/@emulators/core/src/index.ts
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises";
+import type { Emulator, SeedConfig, ServiceName } from "emulate";
 
 export interface PersistenceAdapter {
   load(): string | null | Promise<string | null>;
@@ -11,7 +12,7 @@ export function filePersistence(path: string): PersistenceAdapter {
       try {
         return await readFile(path, "utf8");
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+        if ((error as { code?: string }).code === "ENOENT") return null;
         throw error;
       }
     },
@@ -19,6 +20,632 @@ export function filePersistence(path: string): PersistenceAdapter {
       await writeFile(path, data);
     },
   };
+}
+
+export interface Entity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type InsertInput<T extends Entity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+export type FilterFn<T> = (item: T) => boolean;
+export type SortFn<T> = (a: T, b: T) => number;
+
+export interface QueryOptions<T> {
+  filter?: FilterFn<T>;
+  sort?: SortFn<T>;
+  page?: number;
+  per_page?: number;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CollectionSnapshot<T extends Entity = Entity> {
+  items: T[];
+  autoId: number;
+  indexFields: string[];
+}
+
+export interface StoreSnapshot {
+  collections: Record<string, CollectionSnapshot>;
+  data: Record<string, unknown>;
+}
+
+export function serializeValue(value: unknown): unknown {
+  if (value instanceof Map) {
+    return { __type: "Map" as const, entries: [...value.entries()].map(([key, val]) => [key, serializeValue(val)]) };
+  }
+  if (value instanceof Set) {
+    return { __type: "Set" as const, values: [...value.values()] };
+  }
+  return value;
+}
+
+export function deserializeValue(value: unknown): unknown {
+  if (value !== null && typeof value === "object" && "__type" in value) {
+    const tagged = value as Record<string, unknown>;
+    if (tagged.__type === "Map") {
+      const entries = tagged.entries as [unknown, unknown][];
+      return new Map(entries.map(([key, val]) => [key, deserializeValue(val)]));
+    }
+    if (tagged.__type === "Set") {
+      return new Set(tagged.values as unknown[]);
+    }
+  }
+  return value;
+}
+
+export class Collection<T extends Entity> {
+  private items = new Map<number, T>();
+  private autoId = 1;
+  readonly fieldNames: string[];
+
+  constructor(private indexFields: (keyof T)[] = []) {
+    this.fieldNames = indexFields.map(String).sort();
+  }
+
+  insert(data: InsertInput<T>): T {
+    const now = new Date().toISOString();
+    const explicitId = data.id != null && data.id > 0 ? data.id : undefined;
+    const id = explicitId ?? this.autoId++;
+    if (id >= this.autoId) this.autoId = id + 1;
+    const item = { ...data, id, created_at: now, updated_at: now } as unknown as T;
+    this.items.set(id, item);
+    return item;
+  }
+
+  get(id: number): T | undefined {
+    return this.items.get(id);
+  }
+
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[] {
+    return this.all().filter((item) => item[field] === value);
+  }
+
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined {
+    return this.findBy(field, value)[0];
+  }
+
+  update(id: number, data: Partial<T>): T | undefined {
+    const existing = this.items.get(id);
+    if (!existing) return undefined;
+    const updated = { ...existing, ...data, id, updated_at: new Date().toISOString() } as T;
+    this.items.set(id, updated);
+    return updated;
+  }
+
+  delete(id: number): boolean {
+    return this.items.delete(id);
+  }
+
+  all(): T[] {
+    return Array.from(this.items.values());
+  }
+
+  query(options: QueryOptions<T> = {}): PaginatedResult<T> {
+    let results = this.all();
+    if (options.filter) results = results.filter(options.filter);
+    if (options.sort) results.sort(options.sort);
+    const total_count = results.length;
+    const page = options.page ?? 1;
+    const per_page = Math.min(options.per_page ?? 30, 100);
+    const start = (page - 1) * per_page;
+    return {
+      items: results.slice(start, start + per_page),
+      total_count,
+      page,
+      per_page,
+      has_next: start + per_page < total_count,
+      has_prev: page > 1,
+    };
+  }
+
+  count(filter?: FilterFn<T>): number {
+    return filter ? this.all().filter(filter).length : this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+    this.autoId = 1;
+  }
+
+  snapshot(): CollectionSnapshot<T> {
+    return { items: this.all(), autoId: this.autoId, indexFields: this.fieldNames };
+  }
+
+  restore(snap: CollectionSnapshot<T>): void {
+    this.clear();
+    this.autoId = snap.autoId;
+    for (const item of snap.items) this.items.set(item.id, item);
+  }
+}
+
+export class Store {
+  private collections = new Map<string, Collection<Entity>>();
+  private data = new Map<string, unknown>();
+
+  collection<T extends Entity>(name: string, indexFields: (keyof T)[] = []): Collection<T> {
+    const existing = this.collections.get(name);
+    if (existing) return existing as unknown as Collection<T>;
+    const collection = new Collection<T>(indexFields);
+    this.collections.set(name, collection as unknown as Collection<Entity>);
+    return collection;
+  }
+
+  getData<V>(key: string): V | undefined {
+    return this.data.get(key) as V | undefined;
+  }
+
+  setData<V>(key: string, value: V): void {
+    this.data.set(key, value);
+  }
+
+  reset(): void {
+    for (const collection of this.collections.values()) collection.clear();
+    this.data.clear();
+  }
+
+  snapshot(): StoreSnapshot {
+    const collections: Record<string, CollectionSnapshot> = {};
+    for (const [name, collection] of this.collections) collections[name] = collection.snapshot();
+    const data: Record<string, unknown> = {};
+    for (const [key, value] of this.data) data[key] = serializeValue(value);
+    return { collections, data };
+  }
+
+  restore(snapshot: StoreSnapshot): void {
+    this.collections.clear();
+    for (const [name, collectionSnapshot] of Object.entries(snapshot.collections)) {
+      const collection = this.collection(name, collectionSnapshot.indexFields as (keyof Entity)[]);
+      collection.restore(collectionSnapshot);
+    }
+    this.data.clear();
+    for (const [key, value] of Object.entries(snapshot.data)) this.data.set(key, deserializeValue(value));
+  }
+}
+
+export type ContentfulStatusCode = number;
+export type Next = () => Promise<void>;
+export type Handler = (context: Context, next?: Next) => Response | Promise<Response> | void | Promise<void>;
+export type MiddlewareHandler = Handler;
+export type ErrorHandler = (error: Error, context: Context) => Response | Promise<Response>;
+export type FetchHandler = (request: Request, ...rest: unknown[]) => Response | Promise<Response>;
+
+export interface CorsOptions {
+  origin?: string | string[];
+}
+
+export interface ServeOptions {
+  fetch?: FetchHandler;
+  port?: number;
+}
+
+export class Context {
+  req = new HonoRequest();
+}
+
+export class HonoRequest {}
+
+export class Hono<TEnv = unknown> {
+  fetch: FetchHandler = async () => new Response("Not found", { status: 404 });
+
+  constructor(readonly env?: TEnv) {}
+
+  use(..._args: unknown[]): this {
+    return this;
+  }
+
+  get(..._args: unknown[]): this {
+    return this;
+  }
+
+  post(..._args: unknown[]): this {
+    return this;
+  }
+
+  put(..._args: unknown[]): this {
+    return this;
+  }
+
+  patch(..._args: unknown[]): this {
+    return this;
+  }
+
+  delete(..._args: unknown[]): this {
+    return this;
+  }
+
+  options(..._args: unknown[]): this {
+    return this;
+  }
+
+  onError(..._args: unknown[]): this {
+    return this;
+  }
+
+  notFound(..._args: unknown[]): this {
+    return this;
+  }
+}
+
+export function cors(): MiddlewareHandler {
+  return async (_context, next) => {
+    await next?.();
+  };
+}
+
+export function serve(_options: ServeOptions): never {
+  throw new Error("The TypeScript server runtime has been removed. Use npx emulate or createServer as a native proxy.");
+}
+
+export interface AuthUser {
+  login: string;
+  id?: number;
+  scopes?: string[];
+}
+
+export interface AuthApp {
+  id: string;
+  slug?: string;
+}
+
+export interface AuthInstallation {
+  id: number;
+}
+
+export type AuthFallback = AuthUser | (() => AuthUser | undefined);
+export type AppKeyResolver = (appId: string) => Promise<unknown | string | undefined> | unknown | string | undefined;
+export type AppEnv = Record<string, unknown>;
+
+export interface TokenEntry {
+  token?: string;
+  login: string;
+  id?: number;
+  scopes?: string[];
+}
+
+export type TokenMap = Map<string, TokenEntry>;
+
+export function serializeTokenMap(tokenMap: TokenMap): Record<string, TokenEntry[]> {
+  return { tokens: [...tokenMap.entries()].map(([token, entry]) => ({ ...entry, token })) };
+}
+
+export function restoreTokenMap(tokenMap: TokenMap, entries: TokenEntry[] | Record<string, TokenEntry[]>): void {
+  tokenMap.clear();
+  const list = Array.isArray(entries) ? entries : entries.tokens;
+  for (const entry of list ?? []) {
+    if (entry.token) tokenMap.set(entry.token, entry);
+  }
+}
+
+export interface WebhookSubscription {
+  url: string;
+  events?: string[];
+  secret?: string;
+}
+
+export interface WebhookDelivery {
+  event: string;
+  payload: unknown;
+}
+
+export class WebhookDispatcher {
+  subscriptions: WebhookSubscription[] = [];
+
+  subscribe(subscription: WebhookSubscription): void {
+    this.subscriptions.push(subscription);
+  }
+
+  async dispatch(event: string, _action: string | undefined, payload: unknown): Promise<WebhookDelivery[]> {
+    return this.subscriptions.map(() => ({ event, payload }));
+  }
+}
+
+export interface RouteContext {
+  app: Hono<AppEnv>;
+  store: Store;
+  webhooks: WebhookDispatcher;
+  baseUrl: string;
+  tokenMap?: TokenMap;
+}
+
+export interface ServicePlugin {
+  name: string;
+  runtime?: string;
+  register?(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void;
+  seed?(store: Store, baseUrl: string): void;
+}
+
+export interface ServerOptions {
+  port?: number;
+  baseUrl?: string;
+  docsUrl?: string;
+  tokens?: Record<string, { login: string; id?: number; scopes?: string[] }>;
+  appKeyResolver?: AppKeyResolver;
+  fallbackUser?: AuthFallback;
+}
+
+export function createServer(plugin: ServicePlugin, options: ServerOptions = {}) {
+  const port = options.port ?? 4000;
+  const baseUrl = options.baseUrl ?? `http://localhost:${port}`;
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  for (const [token, user] of Object.entries(options.tokens ?? {})) {
+    tokenMap.set(token, { token, ...user });
+  }
+
+  let runtime: Promise<{ emulator: Emulator; target: string }> | undefined;
+  async function ensureRuntime(): Promise<{ emulator: Emulator; target: string }> {
+    if (runtime) return runtime;
+    runtime = startNativeServerRuntime(plugin.name, port, baseUrl, options.tokens);
+    return runtime;
+  }
+
+  const app = {
+    async fetch(request: Request): Promise<Response> {
+      const native = await ensureRuntime();
+      const url = new URL(request.url);
+      const target = new URL(`${url.pathname}${url.search}`, native.target);
+      const init: RequestInit & { duplex?: string } = {
+        method: request.method,
+        headers: request.headers,
+        redirect: "manual",
+      };
+      if (!["GET", "HEAD"].includes(request.method)) {
+        init.body = request.body;
+        init.duplex = "half";
+      }
+      return fetch(new Request(target, init));
+    },
+  };
+
+  return {
+    app,
+    store,
+    webhooks,
+    port,
+    baseUrl,
+    tokenMap,
+    async close() {
+      const native = await runtime;
+      await native?.emulator.close();
+    },
+  };
+}
+
+async function startNativeServerRuntime(
+  service: string,
+  port: number,
+  baseUrl: string | undefined,
+  tokens: ServerOptions["tokens"],
+): Promise<{ emulator: Emulator; target: string }> {
+  if (!isServiceName(service)) {
+    throw new Error(`Unsupported native emulator service: ${service}`);
+  }
+  const { createEmulator } = await loadEmulateApi();
+  const seed = tokens
+    ? ({
+        tokens: Object.fromEntries(
+          Object.entries(tokens).map(([token, user]) => [token, { login: user.login, scopes: user.scopes }]),
+        ),
+      } as SeedConfig)
+    : undefined;
+  const emulator = await createEmulator({ service, port, baseUrl, seed });
+  return { emulator, target: `http://127.0.0.1:${port}` };
+}
+
+async function loadEmulateApi(): Promise<typeof import("emulate")> {
+  const globalLoader = (globalThis as { __emulateCompatLoadEmulateApi?: () => Promise<typeof import("emulate")> })
+    .__emulateCompatLoadEmulateApi;
+  if (globalLoader) return globalLoader();
+  const dynamicImport = new Function("specifier", "return import(specifier)") as (
+    specifier: string,
+  ) => Promise<typeof import("emulate")>;
+  return dynamicImport("emulate");
+}
+
+function isServiceName(service: string): service is ServiceName {
+  return [
+    "vercel",
+    "github",
+    "google",
+    "slack",
+    "apple",
+    "microsoft",
+    "okta",
+    "aws",
+    "resend",
+    "stripe",
+    "mongoatlas",
+    "clerk",
+  ].includes(service);
+}
+
+export function errorHandler(error: Error): Response {
+  return renderErrorPage(error.message, 500);
+}
+
+export function createErrorHandler(): ErrorHandler {
+  return (error) => errorHandler(error);
+}
+
+export function createApiErrorHandler(): ErrorHandler {
+  return (error) => Response.json({ message: error.message }, { status: 500 });
+}
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status = 400,
+  ) {
+    super(message);
+  }
+}
+
+export function notFound(message = "Not Found"): never {
+  throw new ApiError(message, 404);
+}
+
+export function validationError(message: string): never {
+  throw new ApiError(message, 400);
+}
+
+export function unauthorized(message = "Unauthorized"): never {
+  throw new ApiError(message, 401);
+}
+
+export function forbidden(message = "Forbidden"): never {
+  throw new ApiError(message, 403);
+}
+
+export async function parseJsonBody<T = unknown>(request: Request): Promise<T> {
+  return (await request.json()) as T;
+}
+
+export function authMiddleware(): MiddlewareHandler {
+  return async (_context, next) => {
+    await next?.();
+  };
+}
+
+export function requireAuth(): AuthUser {
+  return { login: "emulate" };
+}
+
+export function requireAppAuth(): AuthApp {
+  return { id: "emulate" };
+}
+
+export interface PaginationParams {
+  page: number;
+  per_page: number;
+}
+
+export function parsePagination(url: string | URL): PaginationParams {
+  const parsed = new URL(url.toString());
+  return {
+    page: Number(parsed.searchParams.get("page") ?? 1),
+    per_page: Number(parsed.searchParams.get("per_page") ?? 30),
+  };
+}
+
+export function setLinkHeader(): void {
+  return undefined;
+}
+
+export function escapeHtml(value: unknown): string {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function escapeAttr(value: unknown): string {
+  return escapeHtml(value);
+}
+
+export interface UserButtonOptions {
+  label: string;
+  value?: string;
+}
+
+export interface CheckoutLineItem {
+  name: string;
+  amount?: number;
+  quantity?: number;
+}
+
+export interface CheckoutPageOptions {
+  title?: string;
+  lineItems?: CheckoutLineItem[];
+}
+
+export interface InspectorTab {
+  id: string;
+  label: string;
+  content: string;
+}
+
+export function renderCardPage(options: { title?: string; body?: string } | string): string {
+  const title = typeof options === "string" ? options : (options.title ?? "emulate");
+  const body = typeof options === "string" ? "" : (options.body ?? "");
+  return `<!doctype html><html><head><title>${escapeHtml(title)}</title></head><body>${body}</body></html>`;
+}
+
+export function renderErrorPage(message: string, status = 500): Response {
+  return new Response(renderCardPage({ title: String(status), body: escapeHtml(message) }), {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+export function renderSettingsPage(options: { title?: string; body?: string }): string {
+  return renderCardPage(options);
+}
+
+export function renderInspectorPage(options: { title?: string; tabs?: InspectorTab[] }): string {
+  return renderCardPage({ title: options.title, body: options.tabs?.map((tab) => tab.content).join("") ?? "" });
+}
+
+export function renderFormPostPage(action: string, fields: Record<string, string>): string {
+  const inputs = Object.entries(fields)
+    .map(([name, value]) => `<input type="hidden" name="${escapeAttr(name)}" value="${escapeAttr(value)}">`)
+    .join("");
+  return renderCardPage({ title: "Redirecting", body: `<form method="post" action="${escapeAttr(action)}">${inputs}</form>` });
+}
+
+export function renderCheckoutPage(options: CheckoutPageOptions): string {
+  return renderCardPage({ title: options.title ?? "Checkout" });
+}
+
+export function renderUserButton(options: UserButtonOptions): string {
+  return `<button value="${escapeAttr(options.value ?? options.label)}">${escapeHtml(options.label)}</button>`;
+}
+
+export function registerFontRoutes(): void {
+  return undefined;
+}
+
+export function normalizeUri(uri: string): string {
+  return uri.replace(/\/+$/, "");
+}
+
+export function matchesRedirectUri(actual: string, expected: string): boolean {
+  return normalizeUri(actual) === normalizeUri(expected);
+}
+
+export function constantTimeSecretEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let index = 0; index < a.length; index += 1) diff |= a.charCodeAt(index) ^ b.charCodeAt(index);
+  return diff === 0;
+}
+
+export async function bodyStr(request: Request): Promise<string> {
+  return request.text();
+}
+
+export function parseCookies(header: string | null | undefined): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  for (const part of header?.split(";") ?? []) {
+    const [name, ...value] = part.trim().split("=");
+    if (name) cookies[name] = value.join("=");
+  }
+  return cookies;
+}
+
+export function debug(..._args: unknown[]): void {
+  return undefined;
 }
 
 export const runtime = "native-go";

--- a/packages/@emulators/core/src/index.ts
+++ b/packages/@emulators/core/src/index.ts
@@ -601,7 +601,9 @@ export class WebhookDispatcher {
     return stored;
   }
 
-  subscribe(subscription: Omit<WebhookSubscription, "id" | "active" | "events" | "owner"> & Partial<WebhookSubscription>): void {
+  subscribe(
+    subscription: Omit<WebhookSubscription, "id" | "active" | "events" | "owner"> & Partial<WebhookSubscription>,
+  ): void {
     this.register({
       url: subscription.url,
       events: subscription.events ?? ["*"],
@@ -642,7 +644,13 @@ export class WebhookDispatcher {
     return subscription;
   }
 
-  async dispatch(event: string, action: string | undefined, payload: unknown, owner = "", repo?: string): Promise<void> {
+  async dispatch(
+    event: string,
+    action: string | undefined,
+    payload: unknown,
+    owner = "",
+    repo?: string,
+  ): Promise<void> {
     const matchingSubscriptions = this.subscriptions.filter((subscription) => {
       if (!subscription.active) return false;
       if (owner && subscription.owner !== owner) return false;
@@ -673,7 +681,8 @@ export class WebhookDispatcher {
         "X-GitHub-Delivery": String(delivery.id),
       };
       if (subscription.secret) {
-        headers["X-Hub-Signature-256"] = `sha256=${createHmac("sha256", subscription.secret).update(body).digest("hex")}`;
+        headers["X-Hub-Signature-256"] =
+          `sha256=${createHmac("sha256", subscription.secret).update(body).digest("hex")}`;
       }
 
       try {
@@ -698,7 +707,9 @@ export class WebhookDispatcher {
   }
 
   getDeliveries(hookId?: number): WebhookDelivery[] {
-    return hookId === undefined ? [...this.deliveries] : this.deliveries.filter((delivery) => delivery.hook_id === hookId);
+    return hookId === undefined
+      ? [...this.deliveries]
+      : this.deliveries.filter((delivery) => delivery.hook_id === hookId);
   }
 
   clear(): void {
@@ -930,7 +941,8 @@ export interface PaginationParams {
 }
 
 export function parsePagination(input: Context | string | URL): PaginationParams {
-  const pageValue = input instanceof Context ? input.req.query("page") : new URL(input.toString()).searchParams.get("page");
+  const pageValue =
+    input instanceof Context ? input.req.query("page") : new URL(input.toString()).searchParams.get("page");
   const perPageValue =
     input instanceof Context ? input.req.query("per_page") : new URL(input.toString()).searchParams.get("per_page");
   return {

--- a/packages/@emulators/core/src/index.ts
+++ b/packages/@emulators/core/src/index.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
 import type { Emulator, SeedConfig, ServiceName } from "emulate";
 
@@ -230,11 +231,23 @@ export class Store {
   }
 }
 
+type BodyInitCompat = ConstructorParameters<typeof Response>[0];
+type HeadersInitCompat = ConstructorParameters<typeof Headers>[0];
+type FormDataEntryValueCompat = string | File;
+type VariablesOf<E> = unknown extends E
+  ? Record<string, unknown>
+  : E extends { Variables: infer V }
+    ? V
+    : Record<string, unknown>;
+
 export type ContentfulStatusCode = number;
 export type Next = () => Promise<void>;
-export type Handler = (context: Context, next?: Next) => Response | Promise<Response> | void | Promise<void>;
-export type MiddlewareHandler = Handler;
-export type ErrorHandler = (error: Error, context: Context) => Response | Promise<Response>;
+export type Handler<E = unknown, P extends string = string> = (
+  context: Context<E, P>,
+  next: Next,
+) => Response | Promise<Response> | void | Promise<void>;
+export type MiddlewareHandler<E = unknown> = Handler<E>;
+export type ErrorHandler<E = unknown> = (error: unknown, context: Context<E>) => Response | Promise<Response>;
 export type FetchHandler = (request: Request, ...rest: unknown[]) => Response | Promise<Response>;
 
 export interface CorsOptions {
@@ -246,11 +259,192 @@ export interface ServeOptions {
   port?: number;
 }
 
-export class Context {
-  req = new HonoRequest();
+export class Context<E = unknown, P extends string = string> {
+  req: HonoRequest<P>;
+  private values = new Map<string, unknown>();
+  private responseHeaders = new Headers();
+  private responseStatus = 200;
+
+  constructor(
+    request?: Request,
+    params: Record<string, string> = {},
+    private notFoundHandler: (context: Context<E>) => Response | Promise<Response> = () =>
+      new Response("404 Not Found", { status: 404 }),
+  ) {
+    this.req = new HonoRequest<P>(request, params);
+  }
+
+  get<K extends keyof VariablesOf<E> & string>(key: K): VariablesOf<E>[K] | undefined {
+    return this.values.get(key) as VariablesOf<E>[K] | undefined;
+  }
+
+  set<K extends keyof VariablesOf<E> & string>(key: K, value: VariablesOf<E>[K]): void {
+    this.values.set(key, value);
+  }
+
+  header(name: string, value: string): void {
+    this.responseHeaders.set(name, value);
+  }
+
+  status(status: number): void {
+    this.responseStatus = status;
+  }
+
+  json(value: unknown, status?: ContentfulStatusCode, headers?: HeadersInitCompat): Response {
+    return this.response(JSON.stringify(value), status, defaultContentType(headers, "application/json; charset=UTF-8"));
+  }
+
+  text(text: string, status?: ContentfulStatusCode, headers?: HeadersInitCompat): Response {
+    return this.response(text, status, defaultContentType(headers, "text/plain; charset=UTF-8"));
+  }
+
+  html(html: string, status?: ContentfulStatusCode, headers?: HeadersInitCompat): Response {
+    return this.response(html, status, defaultContentType(headers, "text/html; charset=UTF-8"));
+  }
+
+  body(body: BodyInitCompat | null, status?: ContentfulStatusCode, headers?: HeadersInitCompat): Response {
+    return this.response(body, status, headers);
+  }
+
+  redirect(location: string, status: ContentfulStatusCode = 302): Response {
+    return this.response(null, status, { Location: location });
+  }
+
+  notFound(): Response | Promise<Response> {
+    return this.notFoundHandler(this);
+  }
+
+  finalize(response: Response): Response {
+    const headers = new Headers(response.headers);
+    this.responseHeaders.forEach((value, key) => {
+      headers.set(key, value);
+    });
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  private response(body: BodyInitCompat | null, status?: ContentfulStatusCode, headers?: HeadersInitCompat): Response {
+    const merged = new Headers(headers);
+    this.responseHeaders.forEach((value, key) => {
+      merged.set(key, value);
+    });
+    return new Response(body, {
+      status: status ?? this.responseStatus,
+      headers: merged,
+    });
+  }
 }
 
-export class HonoRequest {}
+export class HonoRequest<P extends string = string> {
+  readonly url: string;
+  readonly method: string;
+  readonly path: string;
+
+  constructor(
+    private request?: Request,
+    private params: Record<string, string> = {},
+  ) {
+    this.url = request?.url ?? "http://localhost/";
+    this.method = request?.method ?? "GET";
+    this.path = new URL(this.url).pathname;
+  }
+
+  header(): Record<string, string>;
+  header(name: string): string | undefined;
+  header(name?: string): Record<string, string> | string | undefined {
+    if (!this.request) return name ? undefined : {};
+    if (name) return this.request.headers.get(name) ?? undefined;
+    const headers: Record<string, string> = {};
+    this.request.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    return headers;
+  }
+
+  query(name: string): string | undefined {
+    return new URL(this.url).searchParams.get(name) ?? undefined;
+  }
+
+  queries(name: string): string[] | undefined {
+    const values = new URL(this.url).searchParams.getAll(name);
+    return values.length > 0 ? values : undefined;
+  }
+
+  param(): Record<string, string>;
+  param(name: P): string;
+  param(name?: P): Record<string, string> | string {
+    if (!name) return { ...this.params };
+    return this.params[name] ?? "";
+  }
+
+  json<T = unknown>(): Promise<T> {
+    return (this.request?.json() ?? Promise.resolve({})) as Promise<T>;
+  }
+
+  text(): Promise<string> {
+    return this.request?.text() ?? Promise.resolve("");
+  }
+
+  arrayBuffer(): Promise<ArrayBuffer> {
+    return this.request?.arrayBuffer() ?? Promise.resolve(new ArrayBuffer(0));
+  }
+
+  async parseBody(): Promise<Record<string, FormDataEntryValueCompat | FormDataEntryValueCompat[]>> {
+    const contentType = this.header("Content-Type") ?? "";
+    if (!this.request) return {};
+    if (contentType.includes("multipart/form-data")) {
+      return formDataToObject(await this.request.formData());
+    }
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+      const params = new URLSearchParams(await this.request.text());
+      const body: Record<string, string | string[]> = {};
+      for (const [key, value] of params) appendBodyValue(body, key, value);
+      return body;
+    }
+    if (contentType.includes("application/json")) {
+      const body = await this.request.json().catch(() => ({}));
+      return body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, FormDataEntryValueCompat | FormDataEntryValueCompat[]>)
+        : {};
+    }
+    return {};
+  }
+}
+
+function defaultContentType(headers: HeadersInitCompat | undefined, contentType: string): Headers {
+  const merged = new Headers(headers);
+  if (!merged.has("Content-Type")) merged.set("Content-Type", contentType);
+  return merged;
+}
+
+function appendBodyValue(out: Record<string, string | string[]>, key: string, value: string): void {
+  const existing = out[key];
+  if (existing === undefined) {
+    out[key] = value;
+  } else if (Array.isArray(existing)) {
+    existing.push(value);
+  } else {
+    out[key] = [existing, value];
+  }
+}
+
+function formDataToObject(form: FormData): Record<string, FormDataEntryValueCompat | FormDataEntryValueCompat[]> {
+  const out: Record<string, FormDataEntryValueCompat | FormDataEntryValueCompat[]> = {};
+  for (const [key, value] of form) {
+    const existing = out[key];
+    if (existing === undefined) {
+      out[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      out[key] = [existing, value];
+    }
+  }
+  return out;
+}
 
 export class Hono<TEnv = unknown> {
   fetch: FetchHandler = async () => new Response("Not found", { status: 404 });
@@ -306,64 +500,212 @@ export function serve(_options: ServeOptions): never {
 
 export interface AuthUser {
   login: string;
-  id?: number;
-  scopes?: string[];
+  id: number;
+  scopes: string[];
 }
 
 export interface AuthApp {
-  id: string;
-  slug?: string;
+  appId: number;
+  slug: string;
+  name: string;
 }
 
 export interface AuthInstallation {
-  id: number;
+  installationId: number;
+  appId: number;
+  permissions: Record<string, string>;
+  repositoryIds: number[];
+  repositorySelection: "all" | "selected";
 }
 
-export type AuthFallback = AuthUser | (() => AuthUser | undefined);
-export type AppKeyResolver = (appId: string) => Promise<unknown | string | undefined> | unknown | string | undefined;
-export type AppEnv = Record<string, unknown>;
+export interface AuthFallback {
+  login: string;
+  id: number;
+  scopes: string[];
+}
+
+export interface AppKeyResolver {
+  (appId: number): { privateKey: string; slug: string; name: string } | null;
+}
+
+export type AppEnv = {
+  Variables: {
+    authUser?: AuthUser;
+    authApp?: AuthApp;
+    authToken?: string;
+    authScopes?: string[];
+    docsUrl?: string;
+  };
+};
 
 export interface TokenEntry {
-  token?: string;
+  token: string;
   login: string;
-  id?: number;
-  scopes?: string[];
+  id: number;
+  scopes: string[];
 }
 
-export type TokenMap = Map<string, TokenEntry>;
+export type TokenMap = Map<string, AuthUser>;
 
-export function serializeTokenMap(tokenMap: TokenMap): Record<string, TokenEntry[]> {
-  return { tokens: [...tokenMap.entries()].map(([token, entry]) => ({ ...entry, token })) };
+export function serializeTokenMap(tokenMap: TokenMap): TokenEntry[] {
+  return [...tokenMap.entries()].map(([token, user]) => ({
+    token,
+    login: user.login,
+    id: user.id,
+    scopes: user.scopes,
+  }));
 }
 
 export function restoreTokenMap(tokenMap: TokenMap, entries: TokenEntry[] | Record<string, TokenEntry[]>): void {
   tokenMap.clear();
   const list = Array.isArray(entries) ? entries : entries.tokens;
   for (const entry of list ?? []) {
-    if (entry.token) tokenMap.set(entry.token, entry);
+    if (entry.token) tokenMap.set(entry.token, { login: entry.login, id: entry.id, scopes: entry.scopes });
   }
 }
 
 export interface WebhookSubscription {
+  id: number;
   url: string;
-  events?: string[];
+  events: string[];
+  active: boolean;
   secret?: string;
+  owner: string;
+  repo?: string;
 }
 
 export interface WebhookDelivery {
+  id: number;
+  hook_id: number;
   event: string;
+  action?: string;
   payload: unknown;
+  status_code: number | null;
+  delivered_at: string;
+  duration: number | null;
+  success: boolean;
 }
 
 export class WebhookDispatcher {
-  subscriptions: WebhookSubscription[] = [];
+  private subscriptions: WebhookSubscription[] = [];
+  private deliveries: WebhookDelivery[] = [];
+  private subscriptionIdCounter = 1;
+  private deliveryIdCounter = 1;
 
-  subscribe(subscription: WebhookSubscription): void {
-    this.subscriptions.push(subscription);
+  register(subscription: Omit<WebhookSubscription, "id"> & { id?: number }): WebhookSubscription {
+    const { id: explicitId, ...rest } = subscription;
+    const id = explicitId !== undefined ? explicitId : this.subscriptionIdCounter++;
+    if (id >= this.subscriptionIdCounter) this.subscriptionIdCounter = id + 1;
+    const stored = { ...rest, id };
+    this.subscriptions.push(stored);
+    return stored;
   }
 
-  async dispatch(event: string, _action: string | undefined, payload: unknown): Promise<WebhookDelivery[]> {
-    return this.subscriptions.map(() => ({ event, payload }));
+  subscribe(subscription: Omit<WebhookSubscription, "id" | "active" | "events" | "owner"> & Partial<WebhookSubscription>): void {
+    this.register({
+      url: subscription.url,
+      events: subscription.events ?? ["*"],
+      active: subscription.active ?? true,
+      secret: subscription.secret,
+      owner: subscription.owner ?? "",
+      repo: subscription.repo,
+      id: subscription.id,
+    });
+  }
+
+  unregister(id: number): boolean {
+    const index = this.subscriptions.findIndex((subscription) => subscription.id === id);
+    if (index === -1) return false;
+    this.subscriptions.splice(index, 1);
+    return true;
+  }
+
+  getSubscription(id: number): WebhookSubscription | undefined {
+    return this.subscriptions.find((subscription) => subscription.id === id);
+  }
+
+  getSubscriptions(owner?: string, repo?: string): WebhookSubscription[] {
+    return this.subscriptions.filter((subscription) => {
+      if (owner && subscription.owner !== owner) return false;
+      if (repo !== undefined && subscription.repo !== repo) return false;
+      return true;
+    });
+  }
+
+  updateSubscription(
+    id: number,
+    data: Partial<Pick<WebhookSubscription, "url" | "events" | "active" | "secret">>,
+  ): WebhookSubscription | undefined {
+    const subscription = this.subscriptions.find((item) => item.id === id);
+    if (!subscription) return undefined;
+    Object.assign(subscription, data);
+    return subscription;
+  }
+
+  async dispatch(event: string, action: string | undefined, payload: unknown, owner = "", repo?: string): Promise<void> {
+    const matchingSubscriptions = this.subscriptions.filter((subscription) => {
+      if (!subscription.active) return false;
+      if (owner && subscription.owner !== owner) return false;
+      if (repo !== undefined) {
+        if (subscription.repo !== repo) return false;
+      } else if (subscription.repo !== undefined) {
+        return false;
+      }
+      return event === "ping" || subscription.events.includes("*") || subscription.events.includes(event);
+    });
+
+    for (const subscription of matchingSubscriptions) {
+      const delivery: WebhookDelivery = {
+        id: this.deliveryIdCounter++,
+        hook_id: subscription.id,
+        event,
+        action,
+        payload,
+        status_code: null,
+        delivered_at: new Date().toISOString(),
+        duration: null,
+        success: false,
+      };
+      const body = JSON.stringify(payload);
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "X-GitHub-Event": event,
+        "X-GitHub-Delivery": String(delivery.id),
+      };
+      if (subscription.secret) {
+        headers["X-Hub-Signature-256"] = `sha256=${createHmac("sha256", subscription.secret).update(body).digest("hex")}`;
+      }
+
+      try {
+        const start = Date.now();
+        const response = await fetch(subscription.url, {
+          method: "POST",
+          headers,
+          body,
+          signal: AbortSignal.timeout(10000),
+        });
+        delivery.duration = Date.now() - start;
+        delivery.status_code = response.status;
+        delivery.success = response.ok;
+      } catch {
+        delivery.duration = 0;
+      }
+      this.deliveries.push(delivery);
+      if (this.deliveries.length > 1000) {
+        this.deliveries.splice(0, this.deliveries.length - 1000);
+      }
+    }
+  }
+
+  getDeliveries(hookId?: number): WebhookDelivery[] {
+    return hookId === undefined ? [...this.deliveries] : this.deliveries.filter((delivery) => delivery.hook_id === hookId);
+  }
+
+  clear(): void {
+    this.subscriptions.length = 0;
+    this.deliveries.length = 0;
+    this.subscriptionIdCounter = 1;
+    this.deliveryIdCounter = 1;
   }
 }
 
@@ -398,7 +740,11 @@ export function createServer(plugin: ServicePlugin, options: ServerOptions = {})
   const webhooks = new WebhookDispatcher();
   const tokenMap: TokenMap = new Map();
   for (const [token, user] of Object.entries(options.tokens ?? {})) {
-    tokenMap.set(token, { token, ...user });
+    tokenMap.set(token, {
+      login: user.login,
+      id: user.id ?? 0,
+      scopes: user.scopes ?? ["repo", "user", "admin:org", "admin:repo_hook"],
+    });
   }
 
   let runtime: Promise<{ emulator: Emulator; target: string }> | undefined;
@@ -488,45 +834,80 @@ function isServiceName(service: string): service is ServiceName {
   ].includes(service);
 }
 
-export function errorHandler(error: Error): Response {
-  return renderErrorPage(error.message, 500);
+function contextDocsUrl(context: Context): string {
+  return (context.get("docsUrl") as string | undefined) ?? "https://emulate.dev";
 }
 
-export function createErrorHandler(): ErrorHandler {
-  return (error) => errorHandler(error);
+function errorStatus(error: unknown): number {
+  if (error && typeof error === "object" && "status" in error) {
+    const status = (error as { status: unknown }).status;
+    if (typeof status === "number" && Number.isFinite(status)) return status;
+  }
+  return 500;
 }
 
-export function createApiErrorHandler(): ErrorHandler {
-  return (error) => Response.json({ message: error.message }, { status: 500 });
+export function createApiErrorHandler(documentationUrl?: string): ErrorHandler {
+  return (error, context) => {
+    if (documentationUrl) context.set("docsUrl", documentationUrl);
+    const status = errorStatus(error);
+    const message = error instanceof Error ? error.message : "Internal Server Error";
+    return context.json({ message, documentation_url: contextDocsUrl(context) }, status);
+  };
 }
+
+export function createErrorHandler(documentationUrl?: string): MiddlewareHandler {
+  return async (context, next) => {
+    if (documentationUrl) context.set("docsUrl", documentationUrl);
+    await next?.();
+  };
+}
+
+export const errorHandler: MiddlewareHandler = createErrorHandler();
 
 export class ApiError extends Error {
+  status: number;
+  errors?: Array<{ resource: string; field: string; code: string }>;
+
+  constructor(status: number, message: string, errors?: ApiError["errors"]);
+  constructor(message: string, status?: number, errors?: ApiError["errors"]);
   constructor(
-    message: string,
-    readonly status = 400,
+    first: number | string,
+    second?: string | number,
+    errors?: Array<{ resource: string; field: string; code: string }>,
   ) {
+    const status = typeof first === "number" ? first : typeof second === "number" ? second : 400;
+    const message = typeof first === "number" ? (typeof second === "string" ? second : "Error") : first;
     super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.errors = errors;
   }
 }
 
-export function notFound(message = "Not Found"): never {
-  throw new ApiError(message, 404);
+export function notFound(resource?: string): ApiError {
+  return new ApiError(404, resource ? `${resource} not found` : "Not Found");
 }
 
-export function validationError(message: string): never {
-  throw new ApiError(message, 400);
+export function validationError(message: string, errors?: ApiError["errors"]): ApiError {
+  return new ApiError(422, message, errors);
 }
 
-export function unauthorized(message = "Unauthorized"): never {
-  throw new ApiError(message, 401);
+export function unauthorized(): ApiError {
+  return new ApiError(401, "Requires authentication");
 }
 
-export function forbidden(message = "Forbidden"): never {
-  throw new ApiError(message, 403);
+export function forbidden(): ApiError {
+  return new ApiError(403, "Forbidden");
 }
 
-export async function parseJsonBody<T = unknown>(request: Request): Promise<T> {
-  return (await request.json()) as T;
+export async function parseJsonBody<T = Record<string, unknown>>(input: Context | Request): Promise<T> {
+  try {
+    const body = input instanceof Request ? await input.json() : await input.req.json();
+    if (body && typeof body === "object" && !Array.isArray(body)) return body as T;
+    return {} as T;
+  } catch {
+    throw new ApiError(400, "Problems parsing JSON");
+  }
 }
 
 export function authMiddleware(): MiddlewareHandler {
@@ -536,11 +917,11 @@ export function authMiddleware(): MiddlewareHandler {
 }
 
 export function requireAuth(): AuthUser {
-  return { login: "emulate" };
+  return { login: "emulate", id: 0, scopes: [] };
 }
 
 export function requireAppAuth(): AuthApp {
-  return { id: "emulate" };
+  return { appId: 0, slug: "emulate", name: "emulate" };
 }
 
 export interface PaginationParams {
@@ -548,16 +929,34 @@ export interface PaginationParams {
   per_page: number;
 }
 
-export function parsePagination(url: string | URL): PaginationParams {
-  const parsed = new URL(url.toString());
+export function parsePagination(input: Context | string | URL): PaginationParams {
+  const pageValue = input instanceof Context ? input.req.query("page") : new URL(input.toString()).searchParams.get("page");
+  const perPageValue =
+    input instanceof Context ? input.req.query("per_page") : new URL(input.toString()).searchParams.get("per_page");
   return {
-    page: Number(parsed.searchParams.get("page") ?? 1),
-    per_page: Number(parsed.searchParams.get("per_page") ?? 30),
+    page: Math.max(1, parseInt(pageValue ?? "1", 10) || 1),
+    per_page: Math.min(100, Math.max(1, parseInt(perPageValue ?? "30", 10) || 30)),
   };
 }
 
-export function setLinkHeader(): void {
-  return undefined;
+export function setLinkHeader(context: Context, totalCount: number, page: number, perPage: number): void {
+  const lastPage = Math.max(1, Math.ceil(totalCount / perPage));
+  const baseUrl = new URL(context.req.url);
+  const links: string[] = [];
+  const makeLink = (targetPage: number, rel: string) => {
+    baseUrl.searchParams.set("page", String(targetPage));
+    baseUrl.searchParams.set("per_page", String(perPage));
+    return `<${baseUrl.toString()}>; rel="${rel}"`;
+  };
+  if (page < lastPage) {
+    links.push(makeLink(page + 1, "next"));
+    links.push(makeLink(lastPage, "last"));
+  }
+  if (page > 1) {
+    links.push(makeLink(1, "first"));
+    links.push(makeLink(page - 1, "prev"));
+  }
+  if (links.length > 0) context.header("Link", links.join(", "));
 }
 
 export function escapeHtml(value: unknown): string {

--- a/packages/@emulators/core/src/index.ts
+++ b/packages/@emulators/core/src/index.ts
@@ -174,7 +174,20 @@ export class Store {
 
   collection<T extends Entity>(name: string, indexFields: (keyof T)[] = []): Collection<T> {
     const existing = this.collections.get(name);
-    if (existing) return existing as unknown as Collection<T>;
+    if (existing) {
+      if (indexFields.length > 0) {
+        const requested = indexFields.map(String).sort();
+        if (
+          existing.fieldNames.length !== requested.length ||
+          existing.fieldNames.some((field, index) => field !== requested[index])
+        ) {
+          throw new Error(
+            `Collection "${name}" already exists with indexes [${existing.fieldNames}] but was requested with [${requested}]`,
+          );
+        }
+      }
+      return existing as unknown as Collection<T>;
+    }
     const collection = new Collection<T>(indexFields);
     this.collections.set(name, collection as unknown as Collection<Entity>);
     return collection;
@@ -202,7 +215,12 @@ export class Store {
   }
 
   restore(snapshot: StoreSnapshot): void {
-    this.collections.clear();
+    const snapshotNames = new Set(Object.keys(snapshot.collections));
+    for (const name of this.collections.keys()) {
+      if (!snapshotNames.has(name)) {
+        this.collections.delete(name);
+      }
+    }
     for (const [name, collectionSnapshot] of Object.entries(snapshot.collections)) {
       const collection = this.collection(name, collectionSnapshot.indexFields as (keyof Entity)[]);
       collection.restore(collectionSnapshot);
@@ -601,7 +619,10 @@ export function renderFormPostPage(action: string, fields: Record<string, string
   const inputs = Object.entries(fields)
     .map(([name, value]) => `<input type="hidden" name="${escapeAttr(name)}" value="${escapeAttr(value)}">`)
     .join("");
-  return renderCardPage({ title: "Redirecting", body: `<form method="post" action="${escapeAttr(action)}">${inputs}</form>` });
+  return renderCardPage({
+    title: "Redirecting",
+    body: `<form method="post" action="${escapeAttr(action)}">${inputs}</form>`,
+  });
 }
 
 export function renderCheckoutPage(options: CheckoutPageOptions): string {

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -2,10 +2,274 @@ export const serviceName = "github";
 export const serviceLabel = "GitHub REST, OAuth, and webhooks";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface GitHubUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubOrg extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubTeam extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubTeamMember extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubTeamRepo extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubRepo extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubCollaborator extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubIssue extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubPullRequest extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubLabel extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubMilestone extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubComment extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubReview extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubIssueEvent extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubBranch extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubBranchProtection extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubRef extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubCommit extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubTree extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubBlob extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubTag extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubRelease extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubReleaseAsset extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubWebhook extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubWorkflow extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubWorkflowRun extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubJob extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubArtifact extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubSecret extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubCheckAnnotation {
+  [key: string]: unknown;
+}
+export interface GitHubCheckRun extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubCheckSuite extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubOAuthApp extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubApp extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubAppInstallation extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GitHubOAuthGrant extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface GitHubSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface GitHubStore {
+  users: CompatCollection<GitHubUser>;
+  orgs: CompatCollection<GitHubOrg>;
+  teams: CompatCollection<GitHubTeam>;
+  teamMembers: CompatCollection<GitHubTeamMember>;
+  teamRepos: CompatCollection<GitHubTeamRepo>;
+  repos: CompatCollection<GitHubRepo>;
+  collaborators: CompatCollection<GitHubCollaborator>;
+  issues: CompatCollection<GitHubIssue>;
+  pullRequests: CompatCollection<GitHubPullRequest>;
+  labels: CompatCollection<GitHubLabel>;
+  milestones: CompatCollection<GitHubMilestone>;
+  comments: CompatCollection<GitHubComment>;
+  reviews: CompatCollection<GitHubReview>;
+  issueEvents: CompatCollection<GitHubIssueEvent>;
+  branches: CompatCollection<GitHubBranch>;
+  branchProtections: CompatCollection<GitHubBranchProtection>;
+  refs: CompatCollection<GitHubRef>;
+  commits: CompatCollection<GitHubCommit>;
+  trees: CompatCollection<GitHubTree>;
+  blobs: CompatCollection<GitHubBlob>;
+  tags: CompatCollection<GitHubTag>;
+  releases: CompatCollection<GitHubRelease>;
+  releaseAssets: CompatCollection<GitHubReleaseAsset>;
+  webhooks: CompatCollection<GitHubWebhook>;
+  workflows: CompatCollection<GitHubWorkflow>;
+  workflowRuns: CompatCollection<GitHubWorkflowRun>;
+  jobs: CompatCollection<GitHubJob>;
+  artifacts: CompatCollection<GitHubArtifact>;
+  secrets: CompatCollection<GitHubSecret>;
+  checkRuns: CompatCollection<GitHubCheckRun>;
+  checkSuites: CompatCollection<GitHubCheckSuite>;
+  oauthApps: CompatCollection<GitHubOAuthApp>;
+  apps: CompatCollection<GitHubApp>;
+  appInstallations: CompatCollection<GitHubAppInstallation>;
+  oauthGrants: CompatCollection<GitHubOAuthGrant>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getGitHubStore(store: CompatStoreSource): GitHubStore {
+  return {
+    users: compatCollection<GitHubUser>(store, "github.users", ["login"]),
+    orgs: compatCollection<GitHubOrg>(store, "github.orgs", ["login"]),
+    teams: compatCollection<GitHubTeam>(store, "github.teams", ["org_id", "slug"]),
+    teamMembers: compatCollection<GitHubTeamMember>(store, "github.team_members", ["team_id", "user_id"]),
+    teamRepos: compatCollection<GitHubTeamRepo>(store, "github.team_repos", ["team_id", "repo_id"]),
+    repos: compatCollection<GitHubRepo>(store, "github.repos", ["owner_id", "full_name"]),
+    collaborators: compatCollection<GitHubCollaborator>(store, "github.collaborators", ["repo_id", "user_id"]),
+    issues: compatCollection<GitHubIssue>(store, "github.issues", ["repo_id", "number"]),
+    pullRequests: compatCollection<GitHubPullRequest>(store, "github.pull_requests", ["repo_id", "number"]),
+    labels: compatCollection<GitHubLabel>(store, "github.labels", ["repo_id"]),
+    milestones: compatCollection<GitHubMilestone>(store, "github.milestones", ["repo_id", "number"]),
+    comments: compatCollection<GitHubComment>(store, "github.comments", ["repo_id"]),
+    reviews: compatCollection<GitHubReview>(store, "github.reviews", ["repo_id", "pull_number"]),
+    issueEvents: compatCollection<GitHubIssueEvent>(store, "github.issue_events", ["repo_id", "issue_number"]),
+    branches: compatCollection<GitHubBranch>(store, "github.branches", ["repo_id"]),
+    branchProtections: compatCollection<GitHubBranchProtection>(store, "github.branch_protections", ["repo_id"]),
+    refs: compatCollection<GitHubRef>(store, "github.refs", ["repo_id"]),
+    commits: compatCollection<GitHubCommit>(store, "github.commits", ["repo_id", "sha"]),
+    trees: compatCollection<GitHubTree>(store, "github.trees", ["repo_id", "sha"]),
+    blobs: compatCollection<GitHubBlob>(store, "github.blobs", ["repo_id", "sha"]),
+    tags: compatCollection<GitHubTag>(store, "github.tags", ["repo_id"]),
+    releases: compatCollection<GitHubRelease>(store, "github.releases", ["repo_id"]),
+    releaseAssets: compatCollection<GitHubReleaseAsset>(store, "github.release_assets", ["release_id", "repo_id"]),
+    webhooks: compatCollection<GitHubWebhook>(store, "github.webhooks", ["repo_id", "org_id"]),
+    workflows: compatCollection<GitHubWorkflow>(store, "github.workflows", ["repo_id"]),
+    workflowRuns: compatCollection<GitHubWorkflowRun>(store, "github.workflow_runs", ["repo_id", "workflow_id"]),
+    jobs: compatCollection<GitHubJob>(store, "github.jobs", ["run_id"]),
+    artifacts: compatCollection<GitHubArtifact>(store, "github.artifacts", ["run_id", "repo_id"]),
+    secrets: compatCollection<GitHubSecret>(store, "github.secrets", ["repo_id", "org_id"]),
+    checkRuns: compatCollection<GitHubCheckRun>(store, "github.check_runs", ["repo_id", "head_sha"]),
+    checkSuites: compatCollection<GitHubCheckSuite>(store, "github.check_suites", ["repo_id", "head_sha"]),
+    oauthApps: compatCollection<GitHubOAuthApp>(store, "github.oauth_apps", ["client_id"]),
+    apps: compatCollection<GitHubApp>(store, "github.apps", ["slug"]),
+    appInstallations: compatCollection<GitHubAppInstallation>(store, "github.app_installations", ["app_id", "installation_id"]),
+    oauthGrants: compatCollection<GitHubOAuthGrant>(store, "github.oauth_grants", ["user_id", "client_id"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const githubPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: GitHubSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -241,11 +241,589 @@ export function getGitHubStore(store: CompatStoreSource): GitHubStore {
     checkSuites: compatCollection<GitHubCheckSuite>(store, "github.check_suites", ["repo_id", "head_sha"]),
     oauthApps: compatCollection<GitHubOAuthApp>(store, "github.oauth_apps", ["client_id"]),
     apps: compatCollection<GitHubApp>(store, "github.apps", ["slug"]),
-    appInstallations: compatCollection<GitHubAppInstallation>(store, "github.app_installations", ["app_id", "installation_id"]),
+    appInstallations: compatCollection<GitHubAppInstallation>(store, "github.app_installations", [
+      "app_id",
+      "installation_id",
+    ]),
     oauthGrants: compatCollection<GitHubOAuthGrant>(store, "github.oauth_grants", ["user_id", "client_id"]),
   };
 }
 
+// Legacy public entity type augmentations.
+export interface GitHubUser extends CompatEntity {
+  login: string;
+  node_id: string;
+  avatar_url: string;
+  gravatar_id: string;
+  type: "User" | "Organization" | "Bot";
+  site_admin: boolean;
+  name: string | null;
+  company: string | null;
+  blog: string;
+  location: string | null;
+  email: string | null;
+  hireable: boolean | null;
+  bio: string | null;
+  twitter_username: string | null;
+  public_repos: number;
+  public_gists: number;
+  followers: number;
+  following: number;
+}
+
+export interface GitHubOrg extends CompatEntity {
+  login: string;
+  node_id: string;
+  description: string | null;
+  name: string | null;
+  company: string | null;
+  blog: string;
+  location: string | null;
+  email: string | null;
+  twitter_username: string | null;
+  is_verified: boolean;
+  has_organization_projects: boolean;
+  has_repository_projects: boolean;
+  public_repos: number;
+  public_gists: number;
+  followers: number;
+  following: number;
+  members_can_create_repositories: boolean;
+  default_repository_permission: string;
+  billing_email: string | null;
+}
+
+export interface GitHubTeam extends CompatEntity {
+  node_id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  privacy: "closed" | "secret";
+  permission: string;
+  org_id: number;
+  parent_id: number | null;
+  members_count: number;
+  repos_count: number;
+}
+
+export interface GitHubTeamMember extends CompatEntity {
+  team_id: number;
+  user_id: number;
+  role: "member" | "maintainer";
+}
+
+export interface GitHubTeamRepo extends CompatEntity {
+  team_id: number;
+  repo_id: number;
+}
+
+export interface GitHubRepo extends CompatEntity {
+  node_id: string;
+  name: string;
+  full_name: string;
+  owner_id: number;
+  owner_type: "User" | "Organization";
+  private: boolean;
+  description: string | null;
+  fork: boolean;
+  forked_from_id: number | null;
+  homepage: string | null;
+  language: string | null;
+  languages: Record<string, number>;
+  forks_count: number;
+  stargazers_count: number;
+  watchers_count: number;
+  size: number;
+  default_branch: string;
+  open_issues_count: number;
+  topics: string[];
+  has_issues: boolean;
+  has_projects: boolean;
+  has_wiki: boolean;
+  has_pages: boolean;
+  has_downloads: boolean;
+  has_discussions: boolean;
+  archived: boolean;
+  disabled: boolean;
+  visibility: "public" | "private" | "internal";
+  pushed_at: string | null;
+  allow_rebase_merge: boolean;
+  allow_squash_merge: boolean;
+  allow_merge_commit: boolean;
+  allow_auto_merge: boolean;
+  delete_branch_on_merge: boolean;
+  allow_forking: boolean;
+  is_template: boolean;
+  license: { key: string; name: string; spdx_id: string } | null;
+}
+
+export interface GitHubCollaborator extends CompatEntity {
+  repo_id: number;
+  user_id: number;
+  permission: "pull" | "triage" | "push" | "maintain" | "admin";
+}
+
+export interface GitHubIssue extends CompatEntity {
+  node_id: string;
+  number: number;
+  repo_id: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  state_reason: "completed" | "not_planned" | "reopened" | null;
+  locked: boolean;
+  active_lock_reason: string | null;
+  user_id: number;
+  assignee_ids: number[];
+  label_ids: number[];
+  milestone_id: number | null;
+  comments: number;
+  closed_at: string | null;
+  closed_by_id: number | null;
+  is_pull_request: boolean;
+}
+
+export interface GitHubPullRequest extends CompatEntity {
+  node_id: string;
+  number: number;
+  repo_id: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  locked: boolean;
+  user_id: number;
+  assignee_ids: number[];
+  label_ids: number[];
+  milestone_id: number | null;
+  head_ref: string;
+  head_sha: string;
+  head_repo_id: number;
+  base_ref: string;
+  base_sha: string;
+  base_repo_id: number;
+  merged: boolean;
+  merged_at: string | null;
+  merged_by_id: number | null;
+  merge_commit_sha: string | null;
+  mergeable: boolean | null;
+  mergeable_state: string;
+  comments: number;
+  review_comments: number;
+  commits: number;
+  additions: number;
+  deletions: number;
+  changed_files: number;
+  draft: boolean;
+  requested_reviewer_ids: number[];
+  requested_team_ids: number[];
+  closed_at: string | null;
+  auto_merge: null;
+}
+
+export interface GitHubLabel extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  name: string;
+  description: string | null;
+  color: string;
+  default: boolean;
+}
+
+export interface GitHubMilestone extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  number: number;
+  title: string;
+  description: string | null;
+  state: "open" | "closed";
+  open_issues: number;
+  closed_issues: number;
+  due_on: string | null;
+  closed_at: string | null;
+  creator_id: number;
+}
+
+export interface GitHubComment extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  issue_number: number | null;
+  pull_number: number | null;
+  commit_sha: string | null;
+  body: string;
+  user_id: number;
+  in_reply_to_id: number | null;
+  path: string | null;
+  position: number | null;
+  line: number | null;
+  side: "LEFT" | "RIGHT" | null;
+  subject_type: "line" | "file" | null;
+  comment_type: "issue" | "review" | "commit";
+  /** Set for line comments created as part of a pull request review. */
+  review_id: number | null;
+}
+
+export interface GitHubReview extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  pull_number: number;
+  user_id: number;
+  body: string | null;
+  state: "PENDING" | "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED";
+  commit_id: string;
+  submitted_at: string | null;
+}
+
+export interface GitHubIssueEvent extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  issue_number: number;
+  event: string;
+  actor_id: number;
+  commit_id: string | null;
+  commit_url: string | null;
+  label_name: string | null;
+  assignee_id: number | null;
+  milestone_title: string | null;
+  rename: { from: string; to: string } | null;
+}
+
+export interface GitHubBranch extends CompatEntity {
+  repo_id: number;
+  name: string;
+  sha: string;
+  protected: boolean;
+}
+
+export interface GitHubBranchProtection extends CompatEntity {
+  repo_id: number;
+  branch_name: string;
+  required_status_checks: {
+    strict: boolean;
+    contexts: string[];
+  } | null;
+  enforce_admins: boolean;
+  required_pull_request_reviews: {
+    required_approving_review_count: number;
+    dismiss_stale_reviews: boolean;
+    require_code_owner_reviews: boolean;
+  } | null;
+  restrictions: {
+    users: string[];
+    teams: string[];
+  } | null;
+  required_linear_history: boolean;
+  allow_force_pushes: boolean;
+  allow_deletions: boolean;
+  required_signatures: boolean;
+}
+
+export interface GitHubRef extends CompatEntity {
+  repo_id: number;
+  ref: string;
+  sha: string;
+  node_id: string;
+}
+
+export interface GitHubCommit extends CompatEntity {
+  repo_id: number;
+  sha: string;
+  node_id: string;
+  message: string;
+  author_name: string;
+  author_email: string;
+  author_date: string;
+  committer_name: string;
+  committer_email: string;
+  committer_date: string;
+  tree_sha: string;
+  parent_shas: string[];
+  user_id: number | null;
+}
+
+export interface GitHubTree extends CompatEntity {
+  repo_id: number;
+  sha: string;
+  node_id: string;
+  tree: Array<{
+    path: string;
+    mode: string;
+    type: "blob" | "tree";
+    sha: string;
+    size?: number;
+  }>;
+  truncated: boolean;
+}
+
+export interface GitHubBlob extends CompatEntity {
+  repo_id: number;
+  sha: string;
+  node_id: string;
+  content: string;
+  encoding: "base64" | "utf-8";
+  size: number;
+}
+
+export interface GitHubTag extends CompatEntity {
+  repo_id: number;
+  tag: string;
+  sha: string;
+  node_id: string;
+  message: string;
+  tagger_name: string;
+  tagger_email: string;
+  tagger_date: string;
+  object_type: string;
+  object_sha: string;
+}
+
+export interface GitHubRelease extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  tag_name: string;
+  target_commitish: string;
+  name: string | null;
+  body: string | null;
+  draft: boolean;
+  prerelease: boolean;
+  author_id: number;
+  published_at: string | null;
+}
+
+export interface GitHubReleaseAsset extends CompatEntity {
+  node_id: string;
+  release_id: number;
+  repo_id: number;
+  name: string;
+  label: string | null;
+  state: "uploaded" | "open";
+  content_type: string;
+  size: number;
+  download_count: number;
+  uploader_id: number;
+}
+
+export interface GitHubWebhook extends CompatEntity {
+  repo_id: number | null;
+  org_id: number | null;
+  name: string;
+  active: boolean;
+  events: string[];
+  config: {
+    url: string;
+    content_type: string;
+    secret?: string;
+    insecure_ssl: string;
+  };
+  last_response: {
+    code: number | null;
+    status: string;
+    message: string | null;
+  };
+}
+
+export interface GitHubWorkflow extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  name: string;
+  path: string;
+  state: "active" | "disabled_manually" | "disabled_inactivity";
+  badge_url: string;
+}
+
+export interface GitHubWorkflowRun extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  workflow_id: number;
+  name: string;
+  head_branch: string;
+  head_sha: string;
+  run_number: number;
+  event: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required" | null;
+  actor_id: number;
+  run_attempt: number;
+  run_started_at: string;
+}
+
+export interface GitHubJob extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  run_id: number;
+  name: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required" | null;
+  started_at: string | null;
+  completed_at: string | null;
+  runner_id: number | null;
+  runner_name: string | null;
+  steps: Array<{
+    name: string;
+    status: string;
+    conclusion: string | null;
+    number: number;
+    started_at: string | null;
+    completed_at: string | null;
+  }>;
+}
+
+export interface GitHubArtifact extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  run_id: number;
+  name: string;
+  size_in_bytes: number;
+  expired: boolean;
+  expires_at: string;
+}
+
+export interface GitHubSecret extends CompatEntity {
+  repo_id: number | null;
+  org_id: number | null;
+  name: string;
+  visibility: "all" | "private" | "selected";
+}
+
+export interface GitHubCheckAnnotation {
+  path: string;
+  start_line: number;
+  end_line: number;
+  annotation_level: string;
+  message: string;
+}
+
+export interface GitHubCheckRun extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  head_sha: string;
+  name: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required" | null;
+  started_at: string | null;
+  completed_at: string | null;
+  external_id: string;
+  details_url: string | null;
+  actions: { id: string; label: string; description: string }[] | null;
+  output: {
+    title: string | null;
+    summary: string | null;
+    text: string | null;
+    annotations_count: number;
+    annotations: GitHubCheckAnnotation[];
+  };
+  check_suite_id: number | null;
+  app_id: number | null;
+}
+
+export interface GitHubCheckSuite extends CompatEntity {
+  node_id: string;
+  repo_id: number;
+  head_branch: string;
+  head_sha: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required" | null;
+  before: string;
+  after: string;
+  app_id: number | null;
+}
+
+export interface GitHubOAuthApp extends CompatEntity {
+  client_id: string;
+  client_secret: string;
+  name: string;
+  redirect_uris: string[];
+}
+
+export interface GitHubApp extends CompatEntity {
+  app_id: number;
+  slug: string;
+  name: string;
+  private_key: string;
+  permissions: Record<string, string>;
+  events: string[];
+  webhook_url: string | null;
+  webhook_secret: string | null;
+  description: string | null;
+}
+
+export interface GitHubAppInstallation extends CompatEntity {
+  installation_id: number;
+  app_id: number;
+  account_type: "User" | "Organization";
+  account_id: number;
+  account_login: string;
+  repository_selection: "all" | "selected";
+  repository_ids: number[];
+  permissions: Record<string, string>;
+  events: string[];
+  suspended_at: string | null;
+}
+
+export interface GitHubOAuthGrant extends CompatEntity {
+  user_id: number;
+  oauth_app_id: number;
+  client_id: string;
+  scopes: string[];
+  org_access: Record<string, "granted" | "denied" | "requested">;
+}
+
+// Legacy public seed config type augmentations.
+export interface GitHubSeedConfig {
+  port?: number;
+  users?: Array<{
+    login: string;
+    name?: string;
+    email?: string;
+    bio?: string;
+    company?: string;
+    location?: string;
+    blog?: string;
+    twitter_username?: string;
+    site_admin?: boolean;
+  }>;
+  orgs?: Array<{
+    login: string;
+    name?: string;
+    description?: string;
+    email?: string;
+  }>;
+  tokens?: Record<string, { login: string; scopes?: string[] }>;
+  repos?: Array<{
+    owner: string;
+    name: string;
+    description?: string;
+    private?: boolean;
+    language?: string;
+    topics?: string[];
+    default_branch?: string;
+    auto_init?: boolean;
+  }>;
+  oauth_apps?: Array<{
+    client_id: string;
+    client_secret: string;
+    name: string;
+    redirect_uris: string[];
+  }>;
+  apps?: Array<{
+    app_id: number;
+    slug: string;
+    name: string;
+    private_key: string;
+    permissions?: Record<string, string>;
+    events?: string[];
+    webhook_url?: string;
+    webhook_secret?: string;
+    description?: string;
+    installations?: Array<{
+      installation_id: number;
+      account: string;
+      repository_selection?: "all" | "selected";
+      repositories?: string[];
+      permissions?: Record<string, string>;
+      events?: string[];
+    }>;
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -265,7 +843,9 @@ export const plugin = {
 export const githubPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: GitHubSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/google/src/index.ts
+++ b/packages/@emulators/google/src/index.ts
@@ -2,10 +2,191 @@ export const serviceName = "google";
 export const serviceLabel = "Google OAuth, Gmail, Calendar, and Drive";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface GoogleUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleOAuthClient extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleMessage extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleDraft extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleAttachment extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleHistoryEvent extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleLabel extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleFilter extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleForwardingAddress extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleSendAs extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleCalendar extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleCalendarEventAttendee {
+  [key: string]: unknown;
+}
+export interface GoogleCalendarConferenceEntryPoint {
+  [key: string]: unknown;
+}
+export interface GoogleCalendarEvent extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface GoogleDriveItem extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface GoogleSeedUser {
+  [key: string]: unknown;
+}
+
+export interface GoogleSeedLabel {
+  [key: string]: unknown;
+}
+
+export interface GoogleSeedMessage {
+  [key: string]: unknown;
+}
+
+export interface GoogleSeedCalendar {
+  [key: string]: unknown;
+}
+
+export interface GoogleSeedCalendarEvent {
+  [key: string]: unknown;
+}
+
+export interface GoogleSeedDriveItem {
+  [key: string]: unknown;
+}
+
+export interface GoogleSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface GoogleStore {
+  users: CompatCollection<GoogleUser>;
+  oauthClients: CompatCollection<GoogleOAuthClient>;
+  messages: CompatCollection<GoogleMessage>;
+  drafts: CompatCollection<GoogleDraft>;
+  attachments: CompatCollection<GoogleAttachment>;
+  history: CompatCollection<GoogleHistoryEvent>;
+  labels: CompatCollection<GoogleLabel>;
+  filters: CompatCollection<GoogleFilter>;
+  forwardingAddresses: CompatCollection<GoogleForwardingAddress>;
+  sendAs: CompatCollection<GoogleSendAs>;
+  calendars: CompatCollection<GoogleCalendar>;
+  calendarEvents: CompatCollection<GoogleCalendarEvent>;
+  driveItems: CompatCollection<GoogleDriveItem>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getGoogleStore(store: CompatStoreSource): GoogleStore {
+  return {
+    users: compatCollection<GoogleUser>(store, "google.users", ["uid", "email"]),
+    oauthClients: compatCollection<GoogleOAuthClient>(store, "google.oauth_clients", ["client_id"]),
+    messages: compatCollection<GoogleMessage>(store, "google.messages", ["gmail_id", "thread_id", "user_email"]),
+    drafts: compatCollection<GoogleDraft>(store, "google.drafts", ["gmail_id", "message_gmail_id", "user_email"]),
+    attachments: compatCollection<GoogleAttachment>(store, "google.attachments", ["gmail_id", "message_gmail_id", "user_email"]),
+    history: compatCollection<GoogleHistoryEvent>(store, "google.history", ["gmail_id", "message_gmail_id", "user_email"]),
+    labels: compatCollection<GoogleLabel>(store, "google.labels", ["gmail_id", "user_email", "name"]),
+    filters: compatCollection<GoogleFilter>(store, "google.filters", ["gmail_id", "user_email"]),
+    forwardingAddresses: compatCollection<GoogleForwardingAddress>(store, "google.forwarding_addresses", ["user_email", "forwarding_email"]),
+    sendAs: compatCollection<GoogleSendAs>(store, "google.send_as", ["user_email", "send_as_email"]),
+    calendars: compatCollection<GoogleCalendar>(store, "google.calendars", ["google_id", "user_email"]),
+    calendarEvents: compatCollection<GoogleCalendarEvent>(store, "google.calendar_events", ["google_id", "calendar_google_id", "user_email"]),
+    driveItems: compatCollection<GoogleDriveItem>(store, "google.drive_items", ["google_id", "user_email", "mime_type"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const googlePlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: GoogleSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/google/src/index.ts
+++ b/packages/@emulators/google/src/index.ts
@@ -151,18 +151,303 @@ export function getGoogleStore(store: CompatStoreSource): GoogleStore {
     oauthClients: compatCollection<GoogleOAuthClient>(store, "google.oauth_clients", ["client_id"]),
     messages: compatCollection<GoogleMessage>(store, "google.messages", ["gmail_id", "thread_id", "user_email"]),
     drafts: compatCollection<GoogleDraft>(store, "google.drafts", ["gmail_id", "message_gmail_id", "user_email"]),
-    attachments: compatCollection<GoogleAttachment>(store, "google.attachments", ["gmail_id", "message_gmail_id", "user_email"]),
-    history: compatCollection<GoogleHistoryEvent>(store, "google.history", ["gmail_id", "message_gmail_id", "user_email"]),
+    attachments: compatCollection<GoogleAttachment>(store, "google.attachments", [
+      "gmail_id",
+      "message_gmail_id",
+      "user_email",
+    ]),
+    history: compatCollection<GoogleHistoryEvent>(store, "google.history", [
+      "gmail_id",
+      "message_gmail_id",
+      "user_email",
+    ]),
     labels: compatCollection<GoogleLabel>(store, "google.labels", ["gmail_id", "user_email", "name"]),
     filters: compatCollection<GoogleFilter>(store, "google.filters", ["gmail_id", "user_email"]),
-    forwardingAddresses: compatCollection<GoogleForwardingAddress>(store, "google.forwarding_addresses", ["user_email", "forwarding_email"]),
+    forwardingAddresses: compatCollection<GoogleForwardingAddress>(store, "google.forwarding_addresses", [
+      "user_email",
+      "forwarding_email",
+    ]),
     sendAs: compatCollection<GoogleSendAs>(store, "google.send_as", ["user_email", "send_as_email"]),
     calendars: compatCollection<GoogleCalendar>(store, "google.calendars", ["google_id", "user_email"]),
-    calendarEvents: compatCollection<GoogleCalendarEvent>(store, "google.calendar_events", ["google_id", "calendar_google_id", "user_email"]),
-    driveItems: compatCollection<GoogleDriveItem>(store, "google.drive_items", ["google_id", "user_email", "mime_type"]),
+    calendarEvents: compatCollection<GoogleCalendarEvent>(store, "google.calendar_events", [
+      "google_id",
+      "calendar_google_id",
+      "user_email",
+    ]),
+    driveItems: compatCollection<GoogleDriveItem>(store, "google.drive_items", [
+      "google_id",
+      "user_email",
+      "mime_type",
+    ]),
   };
 }
 
+// Legacy public entity type augmentations.
+export interface GoogleUser extends CompatEntity {
+  uid: string;
+  email: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  picture: string | null;
+  email_verified: boolean;
+  locale: string;
+  hd: string | null;
+}
+
+export interface GoogleOAuthClient extends CompatEntity {
+  client_id: string;
+  client_secret: string;
+  name: string;
+  redirect_uris: string[];
+}
+
+export interface GoogleMessage extends CompatEntity {
+  gmail_id: string;
+  thread_id: string;
+  user_email: string;
+  history_id: string;
+  internal_date: string;
+  raw: string | null;
+  label_ids: string[];
+  snippet: string;
+  subject: string;
+  from: string;
+  to: string;
+  cc: string | null;
+  bcc: string | null;
+  reply_to: string | null;
+  message_id: string;
+  references: string | null;
+  in_reply_to: string | null;
+  date_header: string;
+  body_text: string | null;
+  body_html: string | null;
+}
+
+export interface GoogleDraft extends CompatEntity {
+  gmail_id: string;
+  user_email: string;
+  message_gmail_id: string;
+}
+
+export interface GoogleAttachment extends CompatEntity {
+  gmail_id: string;
+  user_email: string;
+  message_gmail_id: string;
+  filename: string;
+  mime_type: string;
+  disposition: string | null;
+  content_id: string | null;
+  transfer_encoding: string | null;
+  data: string;
+  size: number;
+}
+
+export interface GoogleHistoryEvent extends CompatEntity {
+  gmail_id: string;
+  user_email: string;
+  change_type: "messageAdded" | "messageDeleted" | "labelAdded" | "labelRemoved";
+  message_gmail_id: string;
+  thread_id: string;
+  label_ids: string[];
+}
+
+export interface GoogleLabel extends CompatEntity {
+  gmail_id: string;
+  user_email: string;
+  name: string;
+  type: "system" | "user";
+  message_list_visibility: string | null;
+  label_list_visibility: string | null;
+  color_background: string | null;
+  color_text: string | null;
+}
+
+export interface GoogleFilter extends CompatEntity {
+  gmail_id: string;
+  user_email: string;
+  criteria_from: string | null;
+  add_label_ids: string[];
+  remove_label_ids: string[];
+}
+
+export interface GoogleForwardingAddress extends CompatEntity {
+  user_email: string;
+  forwarding_email: string;
+  verification_status: string;
+}
+
+export interface GoogleSendAs extends CompatEntity {
+  user_email: string;
+  send_as_email: string;
+  display_name: string | null;
+  is_default: boolean;
+  signature: string;
+}
+
+export interface GoogleCalendar extends CompatEntity {
+  google_id: string;
+  user_email: string;
+  summary: string;
+  description: string | null;
+  time_zone: string;
+  primary: boolean;
+  selected: boolean;
+  access_role: string;
+  background_color: string | null;
+  foreground_color: string | null;
+}
+
+export interface GoogleCalendarEventAttendee {
+  email: string;
+  display_name: string | null;
+  response_status: string | null;
+  organizer: boolean;
+  self: boolean;
+}
+
+export interface GoogleCalendarConferenceEntryPoint {
+  entry_point_type: string;
+  uri: string;
+  label: string | null;
+}
+
+export interface GoogleCalendarEvent extends CompatEntity {
+  google_id: string;
+  user_email: string;
+  calendar_google_id: string;
+  status: string;
+  summary: string;
+  description: string | null;
+  location: string | null;
+  html_link: string | null;
+  hangout_link: string | null;
+  start_date_time: string | null;
+  start_date: string | null;
+  end_date_time: string | null;
+  end_date: string | null;
+  attendees: GoogleCalendarEventAttendee[];
+  conference_entry_points: GoogleCalendarConferenceEntryPoint[];
+  transparency: string | null;
+}
+
+export interface GoogleDriveItem extends CompatEntity {
+  google_id: string;
+  user_email: string;
+  name: string;
+  mime_type: string;
+  parent_google_ids: string[];
+  web_view_link: string | null;
+  size: number | null;
+  trashed: boolean;
+  data: string | null;
+}
+
+// Legacy public seed config type augmentations.
+export interface GoogleSeedUser {
+  email: string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  picture?: string;
+  locale?: string;
+  email_verified?: boolean;
+  hd?: string;
+}
+
+export interface GoogleSeedLabel {
+  id?: string;
+  user_email?: string;
+  name: string;
+  type?: "system" | "user";
+  message_list_visibility?: string;
+  label_list_visibility?: string;
+  color_background?: string;
+  color_text?: string;
+}
+
+export interface GoogleSeedMessage {
+  id?: string;
+  thread_id?: string;
+  user_email?: string;
+  raw?: string;
+  from?: string;
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  reply_to?: string;
+  subject?: string;
+  snippet?: string;
+  body_text?: string;
+  body_html?: string;
+  label_ids?: string[];
+  date?: string;
+  internal_date?: string;
+  message_id?: string;
+  references?: string;
+  in_reply_to?: string;
+}
+
+export interface GoogleSeedCalendar {
+  id?: string;
+  user_email?: string;
+  summary: string;
+  description?: string;
+  time_zone?: string;
+  primary?: boolean;
+  selected?: boolean;
+  access_role?: string;
+}
+
+export interface GoogleSeedCalendarEvent {
+  id?: string;
+  user_email?: string;
+  calendar_id?: string;
+  status?: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  start_date_time?: string;
+  start_date?: string;
+  end_date_time?: string;
+  end_date?: string;
+  attendees?: Array<{
+    email: string;
+    display_name?: string;
+  }>;
+  conference_entry_points?: Array<{
+    entry_point_type: string;
+    uri: string;
+    label?: string;
+  }>;
+  hangout_link?: string;
+}
+
+export interface GoogleSeedDriveItem {
+  id?: string;
+  user_email?: string;
+  name: string;
+  mime_type: string;
+  parent_ids?: string[];
+  data?: string;
+}
+
+export interface GoogleSeedConfig {
+  port?: number;
+  users?: GoogleSeedUser[];
+  oauth_clients?: Array<{
+    client_id: string;
+    client_secret: string;
+    name?: string;
+    redirect_uris: string[];
+  }>;
+  labels?: GoogleSeedLabel[];
+  messages?: GoogleSeedMessage[];
+  calendars?: GoogleSeedCalendar[];
+  calendar_events?: GoogleSeedCalendarEvent[];
+  drive_items?: GoogleSeedDriveItem[];
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -182,7 +467,9 @@ export const plugin = {
 export const googlePlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: GoogleSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/microsoft/src/index.ts
+++ b/packages/@emulators/microsoft/src/index.ts
@@ -1,6 +1,82 @@
 export const serviceName = "microsoft";
-export const serviceLabel = "Microsoft Entra ID and Graph";
+export const serviceLabel = "Microsoft Entra ID and Graph API";
 export const runtime = "native-go";
+
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface MicrosoftUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface MicrosoftOAuthClient extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface MicrosoftSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface MicrosoftStore {
+  users: CompatCollection<MicrosoftUser>;
+  oauthClients: CompatCollection<MicrosoftOAuthClient>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getMicrosoftStore(store: CompatStoreSource): MicrosoftStore {
+  return {
+    users: compatCollection<MicrosoftUser>(store, "microsoft.users", ["oid", "email"]),
+    oauthClients: compatCollection<MicrosoftOAuthClient>(store, "microsoft.oauth_clients", ["client_id"]),
+  };
+}
 
 export const service = {
   name: serviceName,
@@ -8,4 +84,24 @@ export const service = {
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const microsoftPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: MicrosoftSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/microsoft/src/index.ts
+++ b/packages/@emulators/microsoft/src/index.ts
@@ -78,6 +78,47 @@ export function getMicrosoftStore(store: CompatStoreSource): MicrosoftStore {
   };
 }
 
+// Legacy public entity type augmentations.
+export interface MicrosoftUser extends CompatEntity {
+  /** Object ID (oid) — unique per-tenant user identifier */
+  oid: string;
+  email: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  email_verified: boolean;
+  /** Microsoft tenant ID */
+  tenant_id: string;
+  /** User principal name (usually email) */
+  preferred_username: string;
+}
+
+export interface MicrosoftOAuthClient extends CompatEntity {
+  client_id: string;
+  client_secret: string;
+  name: string;
+  redirect_uris: string[];
+  /** Tenant ID this app is registered in */
+  tenant_id: string;
+}
+
+// Legacy public seed config type augmentations.
+export interface MicrosoftSeedConfig {
+  users?: Array<{
+    email: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
+    tenant_id?: string;
+  }>;
+  oauth_clients?: Array<{
+    client_id: string;
+    client_secret: string;
+    name: string;
+    redirect_uris: string[];
+    tenant_id?: string;
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -97,7 +138,9 @@ export const plugin = {
 export const microsoftPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: MicrosoftSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/mongoatlas/src/index.ts
+++ b/packages/@emulators/mongoatlas/src/index.ts
@@ -2,10 +2,126 @@ export const serviceName = "mongoatlas";
 export const serviceLabel = "MongoDB Atlas Admin API and Data API";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface MongoAtlasCluster extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface MongoAtlasDatabase extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface MongoAtlasCollection extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface MongoAtlasDocument extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface MongoAtlasProject extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface MongoAtlasUser extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface MongoAtlasSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface MongoAtlasStore {
+  clusters: CompatCollection<MongoAtlasCluster>;
+  databases: CompatCollection<MongoAtlasDatabase>;
+  collections: CompatCollection<MongoAtlasCollection>;
+  documents: CompatCollection<MongoAtlasDocument>;
+  projects: CompatCollection<MongoAtlasProject>;
+  users: CompatCollection<MongoAtlasUser>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getMongoAtlasStore(store: CompatStoreSource): MongoAtlasStore {
+  return {
+    clusters: compatCollection<MongoAtlasCluster>(store, "mongoatlas.clusters", ["cluster_id", "name"]),
+    databases: compatCollection<MongoAtlasDatabase>(store, "mongoatlas.databases", ["cluster_id", "name"]),
+    collections: compatCollection<MongoAtlasCollection>(store, "mongoatlas.collections", ["cluster_id", "database", "name"]),
+    documents: compatCollection<MongoAtlasDocument>(store, "mongoatlas.documents", ["cluster_id", "doc_id"]),
+    projects: compatCollection<MongoAtlasProject>(store, "mongoatlas.projects", ["group_id"]),
+    users: compatCollection<MongoAtlasUser>(store, "mongoatlas.users", ["user_id", "username"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const mongoatlasPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: MongoAtlasSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/mongoatlas/src/index.ts
+++ b/packages/@emulators/mongoatlas/src/index.ts
@@ -91,13 +91,98 @@ export function getMongoAtlasStore(store: CompatStoreSource): MongoAtlasStore {
   return {
     clusters: compatCollection<MongoAtlasCluster>(store, "mongoatlas.clusters", ["cluster_id", "name"]),
     databases: compatCollection<MongoAtlasDatabase>(store, "mongoatlas.databases", ["cluster_id", "name"]),
-    collections: compatCollection<MongoAtlasCollection>(store, "mongoatlas.collections", ["cluster_id", "database", "name"]),
+    collections: compatCollection<MongoAtlasCollection>(store, "mongoatlas.collections", [
+      "cluster_id",
+      "database",
+      "name",
+    ]),
     documents: compatCollection<MongoAtlasDocument>(store, "mongoatlas.documents", ["cluster_id", "doc_id"]),
     projects: compatCollection<MongoAtlasProject>(store, "mongoatlas.projects", ["group_id"]),
     users: compatCollection<MongoAtlasUser>(store, "mongoatlas.users", ["user_id", "username"]),
   };
 }
 
+// Legacy public entity type augmentations.
+export interface MongoAtlasCluster extends CompatEntity {
+  cluster_id: string;
+  name: string;
+  group_id: string;
+  state: "IDLE" | "CREATING" | "UPDATING" | "DELETING" | "DELETED" | "REPAIRING";
+  mongo_uri: string;
+  connection_strings: {
+    standard: string;
+    standard_srv: string;
+  };
+  provider_settings: {
+    provider_name: string;
+    instance_size_name: string;
+    region_name: string;
+  };
+  cluster_type: "REPLICASET" | "SHARDED";
+  disk_size_gb: number;
+  mongodb_version: string;
+}
+
+export interface MongoAtlasDatabase extends CompatEntity {
+  cluster_id: string;
+  name: string;
+}
+
+export interface MongoAtlasCollection extends CompatEntity {
+  cluster_id: string;
+  database: string;
+  name: string;
+}
+
+export interface MongoAtlasDocument extends CompatEntity {
+  cluster_id: string;
+  database: string;
+  collection: string;
+  doc_id: string;
+  data: Record<string, unknown>;
+}
+
+export interface MongoAtlasProject extends CompatEntity {
+  group_id: string;
+  name: string;
+  org_id: string;
+  cluster_count: number;
+}
+
+export interface MongoAtlasUser extends CompatEntity {
+  user_id: string;
+  username: string;
+  group_id: string;
+  roles: Array<{ database_name: string; role_name: string }>;
+}
+
+// Legacy public seed config type augmentations.
+export interface MongoAtlasSeedConfig {
+  port?: number;
+  projects?: Array<{
+    name: string;
+    org_id?: string;
+  }>;
+  clusters?: Array<{
+    name: string;
+    project: string;
+    provider?: string;
+    instance_size?: string;
+    region?: string;
+    disk_size_gb?: number;
+    mongodb_version?: string;
+  }>;
+  database_users?: Array<{
+    username: string;
+    project: string;
+    roles?: Array<{ database_name: string; role_name: string }>;
+  }>;
+  databases?: Array<{
+    cluster: string;
+    name: string;
+    collections?: string[];
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -117,7 +202,9 @@ export const plugin = {
 export const mongoatlasPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: MongoAtlasSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/okta/src/index.ts
+++ b/packages/@emulators/okta/src/index.ts
@@ -1,6 +1,112 @@
 export const serviceName = "okta";
-export const serviceLabel = "Okta identity and management APIs";
+export const serviceLabel = "Okta identity provider and management API";
 export const runtime = "native-go";
+
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export type OktaUserStatus = string;
+export type OktaGroupType = string;
+export type OktaAppStatus = string;
+export type OktaAuthorizationServerStatus = string;
+
+export interface OktaUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface OktaGroup extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface OktaApp extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface OktaOAuthClient extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface OktaAuthorizationServer extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface OktaGroupMembership extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface OktaAppAssignment extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface OktaSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface OktaStore {
+  users: CompatCollection<OktaUser>;
+  groups: CompatCollection<OktaGroup>;
+  apps: CompatCollection<OktaApp>;
+  oauthClients: CompatCollection<OktaOAuthClient>;
+  authorizationServers: CompatCollection<OktaAuthorizationServer>;
+  groupMemberships: CompatCollection<OktaGroupMembership>;
+  appAssignments: CompatCollection<OktaAppAssignment>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getOktaStore(store: CompatStoreSource): OktaStore {
+  return {
+    users: compatCollection<OktaUser>(store, "okta.users", ["okta_id", "login", "email"]),
+    groups: compatCollection<OktaGroup>(store, "okta.groups", ["okta_id", "name"]),
+    apps: compatCollection<OktaApp>(store, "okta.apps", ["okta_id", "name"]),
+    oauthClients: compatCollection<OktaOAuthClient>(store, "okta.oauth_clients", ["client_id", "auth_server_id"]),
+    authorizationServers: compatCollection<OktaAuthorizationServer>(store, "okta.auth_servers", ["server_id"]),
+    groupMemberships: compatCollection<OktaGroupMembership>(store, "okta.group_memberships", ["group_okta_id", "user_okta_id"]),
+    appAssignments: compatCollection<OktaAppAssignment>(store, "okta.app_assignments", ["app_okta_id", "user_okta_id"]),
+  };
+}
 
 export const service = {
   name: serviceName,
@@ -8,4 +114,24 @@ export const service = {
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const oktaPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: OktaSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/okta/src/index.ts
+++ b/packages/@emulators/okta/src/index.ts
@@ -47,10 +47,10 @@ export interface CompatStoreSource {
   collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
 }
 
-export type OktaUserStatus = string;
-export type OktaGroupType = string;
-export type OktaAppStatus = string;
-export type OktaAuthorizationServerStatus = string;
+export type OktaUserStatus = "STAGED" | "PROVISIONED" | "ACTIVE" | "SUSPENDED" | "DEPROVISIONED";
+export type OktaGroupType = "OKTA_GROUP" | "BUILT_IN";
+export type OktaAppStatus = "ACTIVE" | "INACTIVE";
+export type OktaAuthorizationServerStatus = "ACTIVE" | "INACTIVE";
 
 export interface OktaUser extends CompatEntity {
   [key: string]: unknown;
@@ -103,11 +103,132 @@ export function getOktaStore(store: CompatStoreSource): OktaStore {
     apps: compatCollection<OktaApp>(store, "okta.apps", ["okta_id", "name"]),
     oauthClients: compatCollection<OktaOAuthClient>(store, "okta.oauth_clients", ["client_id", "auth_server_id"]),
     authorizationServers: compatCollection<OktaAuthorizationServer>(store, "okta.auth_servers", ["server_id"]),
-    groupMemberships: compatCollection<OktaGroupMembership>(store, "okta.group_memberships", ["group_okta_id", "user_okta_id"]),
+    groupMemberships: compatCollection<OktaGroupMembership>(store, "okta.group_memberships", [
+      "group_okta_id",
+      "user_okta_id",
+    ]),
     appAssignments: compatCollection<OktaAppAssignment>(store, "okta.app_assignments", ["app_okta_id", "user_okta_id"]),
   };
 }
 
+// Legacy public entity type augmentations.
+export interface OktaUser extends CompatEntity {
+  okta_id: string;
+  status: OktaUserStatus;
+  activated_at: string | null;
+  status_changed_at: string;
+  last_login_at: string | null;
+  password_changed_at: string | null;
+  transitioning_to_status: OktaUserStatus | null;
+  login: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  display_name: string;
+  locale: string;
+  time_zone: string;
+}
+
+export interface OktaGroup extends CompatEntity {
+  okta_id: string;
+  type: OktaGroupType;
+  name: string;
+  description: string | null;
+}
+
+export interface OktaApp extends CompatEntity {
+  okta_id: string;
+  name: string;
+  label: string;
+  status: OktaAppStatus;
+  sign_on_mode: string;
+  settings: Record<string, unknown>;
+  credentials: Record<string, unknown>;
+}
+
+export interface OktaOAuthClient extends CompatEntity {
+  client_id: string;
+  client_secret?: string;
+  name: string;
+  redirect_uris: string[];
+  response_types: string[];
+  grant_types: string[];
+  token_endpoint_auth_method: "client_secret_post" | "client_secret_basic" | "none";
+  auth_server_id: string;
+}
+
+export interface OktaAuthorizationServer extends CompatEntity {
+  server_id: string;
+  name: string;
+  description: string;
+  audiences: string[];
+  status: OktaAuthorizationServerStatus;
+}
+
+export interface OktaGroupMembership extends CompatEntity {
+  group_okta_id: string;
+  user_okta_id: string;
+}
+
+export interface OktaAppAssignment extends CompatEntity {
+  app_okta_id: string;
+  user_okta_id: string;
+}
+
+// Legacy public seed config type augmentations.
+export interface OktaSeedConfig {
+  users?: Array<{
+    okta_id?: string;
+    status?: OktaUserStatus;
+    login: string;
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+    display_name?: string;
+    locale?: string;
+    time_zone?: string;
+  }>;
+  groups?: Array<{
+    okta_id?: string;
+    type?: OktaGroupType;
+    name: string;
+    description?: string;
+  }>;
+  apps?: Array<{
+    okta_id?: string;
+    name: string;
+    label?: string;
+    status?: "ACTIVE" | "INACTIVE";
+    sign_on_mode?: string;
+    settings?: Record<string, unknown>;
+    credentials?: Record<string, unknown>;
+  }>;
+  oauth_clients?: Array<{
+    client_id: string;
+    client_secret?: string;
+    name: string;
+    redirect_uris: string[];
+    response_types?: string[];
+    grant_types?: string[];
+    token_endpoint_auth_method?: "client_secret_post" | "client_secret_basic" | "none";
+    auth_server_id?: string;
+  }>;
+  authorization_servers?: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    audiences?: string[];
+    status?: OktaAuthorizationServerStatus;
+  }>;
+  group_memberships?: Array<{
+    group_okta_id: string;
+    user_okta_id: string;
+  }>;
+  app_assignments?: Array<{
+    app_okta_id: string;
+    user_okta_id: string;
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -127,7 +248,9 @@ export const plugin = {
 export const oktaPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: OktaSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/resend/src/index.ts
+++ b/packages/@emulators/resend/src/index.ts
@@ -2,10 +2,121 @@ export const serviceName = "resend";
 export const serviceLabel = "Resend email API";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface ResendEmail extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ResendDomain extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ResendApiKey extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ResendAudience extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface ResendContact extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface ResendSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface ResendStore {
+  emails: CompatCollection<ResendEmail>;
+  domains: CompatCollection<ResendDomain>;
+  apiKeys: CompatCollection<ResendApiKey>;
+  audiences: CompatCollection<ResendAudience>;
+  contacts: CompatCollection<ResendContact>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getResendStore(store: CompatStoreSource): ResendStore {
+  return {
+    emails: compatCollection<ResendEmail>(store, "resend.emails", ["uuid"]),
+    domains: compatCollection<ResendDomain>(store, "resend.domains", ["uuid", "name"]),
+    apiKeys: compatCollection<ResendApiKey>(store, "resend.api_keys", ["uuid"]),
+    audiences: compatCollection<ResendAudience>(store, "resend.audiences", ["uuid"]),
+    contacts: compatCollection<ResendContact>(store, "resend.contacts", ["uuid", "audience_id"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const resendPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: ResendSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/resend/src/index.ts
+++ b/packages/@emulators/resend/src/index.ts
@@ -93,6 +93,74 @@ export function getResendStore(store: CompatStoreSource): ResendStore {
   };
 }
 
+// Legacy public entity type augmentations.
+export interface ResendEmail extends CompatEntity {
+  uuid: string;
+  from: string;
+  to: string[];
+  subject: string;
+  html: string | null;
+  text: string | null;
+  cc: string[];
+  bcc: string[];
+  reply_to: string[];
+  headers: Record<string, string>;
+  tags: Array<{ name: string; value: string }>;
+  status: "sent" | "delivered" | "bounced" | "canceled" | "scheduled";
+  scheduled_at: string | null;
+  last_event: string;
+}
+
+export interface ResendDomain extends CompatEntity {
+  uuid: string;
+  name: string;
+  status: "pending" | "verified";
+  region: string;
+  records: Array<{
+    record: string;
+    name: string;
+    type: string;
+    ttl: string;
+    status: "pending" | "verified";
+    value: string;
+    priority?: number;
+  }>;
+}
+
+export interface ResendApiKey extends CompatEntity {
+  uuid: string;
+  name: string;
+  token: string;
+}
+
+export interface ResendAudience extends CompatEntity {
+  uuid: string;
+  name: string;
+}
+
+export interface ResendContact extends CompatEntity {
+  uuid: string;
+  audience_id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  unsubscribed: boolean;
+}
+
+// Legacy public seed config type augmentations.
+export interface ResendSeedConfig {
+  port?: number;
+  domains?: Array<{
+    name: string;
+    region?: string;
+  }>;
+  contacts?: Array<{
+    email: string;
+    first_name?: string;
+    last_name?: string;
+    audience?: string;
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -112,7 +180,9 @@ export const plugin = {
 export const resendPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: ResendSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/slack/src/index.ts
+++ b/packages/@emulators/slack/src/index.ts
@@ -2,10 +2,131 @@ export const serviceName = "slack";
 export const serviceLabel = "Slack Web API, OAuth, and webhooks";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface SlackTeam extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SlackUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SlackChannel extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SlackMessage extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SlackBot extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SlackOAuthApp extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface SlackIncomingWebhook extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface SlackSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface SlackStore {
+  teams: CompatCollection<SlackTeam>;
+  users: CompatCollection<SlackUser>;
+  channels: CompatCollection<SlackChannel>;
+  messages: CompatCollection<SlackMessage>;
+  bots: CompatCollection<SlackBot>;
+  oauthApps: CompatCollection<SlackOAuthApp>;
+  incomingWebhooks: CompatCollection<SlackIncomingWebhook>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getSlackStore(store: CompatStoreSource): SlackStore {
+  return {
+    teams: compatCollection<SlackTeam>(store, "slack.teams", ["team_id"]),
+    users: compatCollection<SlackUser>(store, "slack.users", ["user_id", "email"]),
+    channels: compatCollection<SlackChannel>(store, "slack.channels", ["channel_id", "name"]),
+    messages: compatCollection<SlackMessage>(store, "slack.messages", ["ts", "channel_id"]),
+    bots: compatCollection<SlackBot>(store, "slack.bots", ["bot_id"]),
+    oauthApps: compatCollection<SlackOAuthApp>(store, "slack.oauth_apps", ["client_id"]),
+    incomingWebhooks: compatCollection<SlackIncomingWebhook>(store, "slack.incoming_webhooks", ["token"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const slackPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: SlackSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/slack/src/index.ts
+++ b/packages/@emulators/slack/src/index.ts
@@ -103,6 +103,115 @@ export function getSlackStore(store: CompatStoreSource): SlackStore {
   };
 }
 
+// Legacy public entity type augmentations.
+export interface SlackTeam extends CompatEntity {
+  team_id: string;
+  name: string;
+  domain: string;
+}
+
+export interface SlackUser extends CompatEntity {
+  user_id: string;
+  team_id: string;
+  name: string;
+  real_name: string;
+  email: string;
+  is_admin: boolean;
+  is_bot: boolean;
+  deleted: boolean;
+  profile: {
+    display_name: string;
+    real_name: string;
+    email: string;
+    image_48: string;
+    image_192: string;
+  };
+}
+
+export interface SlackChannel extends CompatEntity {
+  channel_id: string;
+  team_id: string;
+  name: string;
+  is_channel: boolean;
+  is_private: boolean;
+  is_archived: boolean;
+  topic: { value: string; creator: string; last_set: number };
+  purpose: { value: string; creator: string; last_set: number };
+  members: string[];
+  creator: string;
+  num_members: number;
+}
+
+export interface SlackMessage extends CompatEntity {
+  ts: string;
+  channel_id: string;
+  user: string;
+  text: string;
+  type: "message";
+  subtype?: string;
+  thread_ts?: string;
+  reply_count: number;
+  reply_users: string[];
+  reactions: Array<{ name: string; users: string[]; count: number }>;
+}
+
+export interface SlackBot extends CompatEntity {
+  bot_id: string;
+  name: string;
+  deleted: boolean;
+  icons: { image_48: string };
+}
+
+export interface SlackOAuthApp extends CompatEntity {
+  client_id: string;
+  client_secret: string;
+  name: string;
+  redirect_uris: string[];
+}
+
+export interface SlackIncomingWebhook extends CompatEntity {
+  token: string;
+  team_id: string;
+  bot_id: string;
+  default_channel: string;
+  label: string;
+  url: string;
+}
+
+// Legacy public seed config type augmentations.
+export interface SlackSeedConfig {
+  port?: number;
+  team?: {
+    name?: string;
+    domain?: string;
+  };
+  users?: Array<{
+    name: string;
+    real_name?: string;
+    email?: string;
+    is_admin?: boolean;
+  }>;
+  channels?: Array<{
+    name: string;
+    topic?: string;
+    purpose?: string;
+    is_private?: boolean;
+  }>;
+  bots?: Array<{
+    name: string;
+  }>;
+  oauth_apps?: Array<{
+    client_id: string;
+    client_secret: string;
+    name: string;
+    redirect_uris: string[];
+  }>;
+  incoming_webhooks?: Array<{
+    channel: string;
+    label?: string;
+  }>;
+  signing_secret?: string;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -122,7 +231,9 @@ export const plugin = {
 export const slackPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: SlackSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/stripe/src/index.ts
+++ b/packages/@emulators/stripe/src/index.ts
@@ -2,10 +2,128 @@ export const serviceName = "stripe";
 export const serviceLabel = "Stripe billing and payments API";
 export const runtime = "native-go";
 
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export type PaymentIntentStatus = string;
+
+export interface StripeCustomer extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface StripeProduct extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface StripePrice extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface StripePaymentIntent extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface StripeCharge extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface StripeCheckoutSession extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface StripeSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface StripeStore {
+  customers: CompatCollection<StripeCustomer>;
+  products: CompatCollection<StripeProduct>;
+  prices: CompatCollection<StripePrice>;
+  paymentIntents: CompatCollection<StripePaymentIntent>;
+  charges: CompatCollection<StripeCharge>;
+  checkoutSessions: CompatCollection<StripeCheckoutSession>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getStripeStore(store: CompatStoreSource): StripeStore {
+  return {
+    customers: compatCollection<StripeCustomer>(store, "stripe.customers", ["stripe_id", "email"]),
+    products: compatCollection<StripeProduct>(store, "stripe.products", ["stripe_id"]),
+    prices: compatCollection<StripePrice>(store, "stripe.prices", ["stripe_id", "product_id"]),
+    paymentIntents: compatCollection<StripePaymentIntent>(store, "stripe.payment_intents", ["stripe_id", "customer_id"]),
+    charges: compatCollection<StripeCharge>(store, "stripe.charges", ["stripe_id", "customer_id", "payment_intent_id"]),
+    checkoutSessions: compatCollection<StripeCheckoutSession>(store, "stripe.checkout_sessions", ["stripe_id", "customer_id"]),
+  };
+}
+
 export const service = {
   name: serviceName,
   label: serviceLabel,
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const stripePlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: StripeSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/stripe/src/index.ts
+++ b/packages/@emulators/stripe/src/index.ts
@@ -47,7 +47,13 @@ export interface CompatStoreSource {
   collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
 }
 
-export type PaymentIntentStatus = string;
+export type PaymentIntentStatus =
+  | "requires_payment_method"
+  | "requires_confirmation"
+  | "requires_action"
+  | "processing"
+  | "succeeded"
+  | "canceled";
 
 export interface StripeCustomer extends CompatEntity {
   [key: string]: unknown;
@@ -94,12 +100,105 @@ export function getStripeStore(store: CompatStoreSource): StripeStore {
     customers: compatCollection<StripeCustomer>(store, "stripe.customers", ["stripe_id", "email"]),
     products: compatCollection<StripeProduct>(store, "stripe.products", ["stripe_id"]),
     prices: compatCollection<StripePrice>(store, "stripe.prices", ["stripe_id", "product_id"]),
-    paymentIntents: compatCollection<StripePaymentIntent>(store, "stripe.payment_intents", ["stripe_id", "customer_id"]),
+    paymentIntents: compatCollection<StripePaymentIntent>(store, "stripe.payment_intents", [
+      "stripe_id",
+      "customer_id",
+    ]),
     charges: compatCollection<StripeCharge>(store, "stripe.charges", ["stripe_id", "customer_id", "payment_intent_id"]),
-    checkoutSessions: compatCollection<StripeCheckoutSession>(store, "stripe.checkout_sessions", ["stripe_id", "customer_id"]),
+    checkoutSessions: compatCollection<StripeCheckoutSession>(store, "stripe.checkout_sessions", [
+      "stripe_id",
+      "customer_id",
+    ]),
   };
 }
 
+// Legacy public entity type augmentations.
+export interface StripeCustomer extends CompatEntity {
+  stripe_id: string;
+  email: string | null;
+  name: string | null;
+  description: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface StripeProduct extends CompatEntity {
+  stripe_id: string;
+  name: string;
+  description: string | null;
+  active: boolean;
+  metadata: Record<string, string>;
+}
+
+export interface StripePrice extends CompatEntity {
+  stripe_id: string;
+  product_id: string;
+  currency: string;
+  unit_amount: number | null;
+  type: "one_time" | "recurring";
+  active: boolean;
+  metadata: Record<string, string>;
+}
+
+export interface StripePaymentIntent extends CompatEntity {
+  stripe_id: string;
+  amount: number;
+  currency: string;
+  status: PaymentIntentStatus;
+  customer_id: string | null;
+  description: string | null;
+  payment_method: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface StripeCharge extends CompatEntity {
+  stripe_id: string;
+  amount: number;
+  currency: string;
+  status: "succeeded" | "pending" | "failed";
+  customer_id: string | null;
+  payment_intent_id: string | null;
+  description: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface StripeCheckoutSession extends CompatEntity {
+  stripe_id: string;
+  mode: "payment" | "setup" | "subscription";
+  status: "open" | "complete" | "expired";
+  payment_status: "paid" | "unpaid" | "no_payment_required";
+  customer_id: string | null;
+  success_url: string | null;
+  cancel_url: string | null;
+  line_items: Array<{ price: string; quantity: number }>;
+  metadata: Record<string, string>;
+}
+
+// Legacy public seed config type augmentations.
+export interface StripeSeedConfig {
+  port?: number;
+  customers?: Array<{
+    id?: string;
+    email?: string;
+    name?: string;
+    description?: string;
+  }>;
+  products?: Array<{
+    id?: string;
+    name: string;
+    description?: string;
+  }>;
+  prices?: Array<{
+    id?: string;
+    product_name: string;
+    currency: string;
+    unit_amount: number;
+  }>;
+  webhooks?: Array<{
+    url: string;
+    events: string[];
+    secret?: string;
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -119,7 +218,9 @@ export const plugin = {
 export const stripePlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: StripeSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/packages/@emulators/vercel/src/index.ts
+++ b/packages/@emulators/vercel/src/index.ts
@@ -1,6 +1,147 @@
 export const serviceName = "vercel";
-export const serviceLabel = "Vercel REST API";
+export const serviceLabel = "Vercel API";
 export const runtime = "native-go";
+
+export interface CompatEntity {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export type CompatInsertInput<T extends CompatEntity> = Omit<T, "id" | "created_at" | "updated_at"> & { id?: number };
+
+export interface CompatQueryOptions<T> {
+  filter?: (item: T) => boolean;
+  sort?: (a: T, b: T) => number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CompatPaginatedResult<T> {
+  items: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface CompatCollection<T extends CompatEntity = CompatEntity> {
+  readonly fieldNames?: string[];
+  insert(data: CompatInsertInput<T>): T;
+  get(id: number): T | undefined;
+  findBy(field: keyof T, value: T[keyof T] | string | number): T[];
+  findOneBy(field: keyof T, value: T[keyof T] | string | number): T | undefined;
+  update(id: number, data: Partial<T>): T | undefined;
+  delete(id: number): boolean;
+  all(): T[];
+  query(options?: CompatQueryOptions<T>): CompatPaginatedResult<T>;
+  count(filter?: (item: T) => boolean): number;
+  clear(): void;
+  snapshot(): unknown;
+  restore(snapshot: unknown): void;
+}
+
+export interface CompatStoreSource {
+  collection<T extends CompatEntity>(name: string, indexFields?: string[]): CompatCollection<T>;
+}
+
+export interface VercelUser extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelTeam extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelTeamMember extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelProject extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelDeployment extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelDeploymentAlias extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelBuild extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelDeploymentEvent extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelFile extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelDeploymentFile extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelDomain extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelEnvVar extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelProtectionBypass extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelApiKey extends CompatEntity {
+  [key: string]: unknown;
+}
+export interface VercelIntegration extends CompatEntity {
+  [key: string]: unknown;
+}
+
+export interface VercelSeedConfig {
+  [key: string]: unknown;
+}
+
+export interface VercelStore {
+  users: CompatCollection<VercelUser>;
+  teams: CompatCollection<VercelTeam>;
+  teamMembers: CompatCollection<VercelTeamMember>;
+  projects: CompatCollection<VercelProject>;
+  deployments: CompatCollection<VercelDeployment>;
+  deploymentAliases: CompatCollection<VercelDeploymentAlias>;
+  builds: CompatCollection<VercelBuild>;
+  deploymentEvents: CompatCollection<VercelDeploymentEvent>;
+  files: CompatCollection<VercelFile>;
+  deploymentFiles: CompatCollection<VercelDeploymentFile>;
+  domains: CompatCollection<VercelDomain>;
+  envVars: CompatCollection<VercelEnvVar>;
+  protectionBypasses: CompatCollection<VercelProtectionBypass>;
+  apiKeys: CompatCollection<VercelApiKey>;
+  integrations: CompatCollection<VercelIntegration>;
+}
+
+function compatCollection<T extends CompatEntity>(
+  store: CompatStoreSource,
+  name: string,
+  indexFields: string[],
+): CompatCollection<T> {
+  return store.collection<T>(name, indexFields);
+}
+
+export function getVercelStore(store: CompatStoreSource): VercelStore {
+  return {
+    users: compatCollection<VercelUser>(store, "vercel.users", ["uid", "username"]),
+    teams: compatCollection<VercelTeam>(store, "vercel.teams", ["uid", "slug"]),
+    teamMembers: compatCollection<VercelTeamMember>(store, "vercel.team_members", ["teamId", "userId"]),
+    projects: compatCollection<VercelProject>(store, "vercel.projects", ["uid", "name", "accountId"]),
+    deployments: compatCollection<VercelDeployment>(store, "vercel.deployments", ["uid", "projectId", "url"]),
+    deploymentAliases: compatCollection<VercelDeploymentAlias>(store, "vercel.deployment_aliases", ["deploymentId", "projectId"]),
+    builds: compatCollection<VercelBuild>(store, "vercel.builds", ["deploymentId"]),
+    deploymentEvents: compatCollection<VercelDeploymentEvent>(store, "vercel.deployment_events", ["deploymentId"]),
+    files: compatCollection<VercelFile>(store, "vercel.files", ["digest"]),
+    deploymentFiles: compatCollection<VercelDeploymentFile>(store, "vercel.deployment_files", ["deploymentId"]),
+    domains: compatCollection<VercelDomain>(store, "vercel.domains", ["projectId", "name"]),
+    envVars: compatCollection<VercelEnvVar>(store, "vercel.env_vars", ["projectId", "uid"]),
+    protectionBypasses: compatCollection<VercelProtectionBypass>(store, "vercel.protection_bypasses", ["projectId"]),
+    apiKeys: compatCollection<VercelApiKey>(store, "vercel.api_keys", ["uid", "teamId", "userId"]),
+    integrations: compatCollection<VercelIntegration>(store, "vercel.integrations", ["client_id"]),
+  };
+}
 
 export const service = {
   name: serviceName,
@@ -8,4 +149,24 @@ export const service = {
   runtime,
 } as const;
 
-export default service;
+export const plugin = {
+  ...service,
+  register(): void {
+    return undefined;
+  },
+  seed(): void {
+    return undefined;
+  },
+} as const;
+
+export const vercelPlugin = plugin;
+
+export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: VercelSeedConfig): void {
+  return undefined;
+}
+
+export function createAppKeyResolver(): undefined {
+  return undefined;
+}
+
+export default plugin;

--- a/packages/@emulators/vercel/src/index.ts
+++ b/packages/@emulators/vercel/src/index.ts
@@ -130,7 +130,10 @@ export function getVercelStore(store: CompatStoreSource): VercelStore {
     teamMembers: compatCollection<VercelTeamMember>(store, "vercel.team_members", ["teamId", "userId"]),
     projects: compatCollection<VercelProject>(store, "vercel.projects", ["uid", "name", "accountId"]),
     deployments: compatCollection<VercelDeployment>(store, "vercel.deployments", ["uid", "projectId", "url"]),
-    deploymentAliases: compatCollection<VercelDeploymentAlias>(store, "vercel.deployment_aliases", ["deploymentId", "projectId"]),
+    deploymentAliases: compatCollection<VercelDeploymentAlias>(store, "vercel.deployment_aliases", [
+      "deploymentId",
+      "projectId",
+    ]),
     builds: compatCollection<VercelBuild>(store, "vercel.builds", ["deploymentId"]),
     deploymentEvents: compatCollection<VercelDeploymentEvent>(store, "vercel.deployment_events", ["deploymentId"]),
     files: compatCollection<VercelFile>(store, "vercel.files", ["digest"]),
@@ -143,6 +146,285 @@ export function getVercelStore(store: CompatStoreSource): VercelStore {
   };
 }
 
+// Legacy public entity type augmentations.
+export interface VercelUser extends CompatEntity {
+  uid: string;
+  email: string;
+  username: string;
+  name: string | null;
+  avatar: string | null;
+  defaultTeamId: string | null;
+  softBlock: null;
+  billing: {
+    plan: string;
+    period: null;
+    trial: null;
+    cancelation: null;
+    addons: null;
+  };
+  resourceConfig: {
+    nodeType: string;
+    concurrentBuilds: number;
+  };
+  stagingPrefix: string;
+  version: string | null;
+}
+
+export interface VercelTeam extends CompatEntity {
+  uid: string;
+  slug: string;
+  name: string;
+  avatar: string | null;
+  description: string | null;
+  creatorId: string;
+  membership: {
+    confirmed: boolean;
+    role: "OWNER" | "MEMBER" | "DEVELOPER" | "VIEWER";
+  };
+  billing: {
+    plan: string;
+    period: null;
+    trial: null;
+    cancelation: null;
+    addons: null;
+  };
+  resourceConfig: {
+    nodeType: string;
+    concurrentBuilds: number;
+  };
+  stagingPrefix: string;
+}
+
+export interface VercelTeamMember extends CompatEntity {
+  teamId: string;
+  userId: string;
+  role: "OWNER" | "MEMBER" | "DEVELOPER" | "VIEWER";
+  confirmed: boolean;
+  joinedFrom: string;
+}
+
+export interface VercelProject extends CompatEntity {
+  uid: string;
+  name: string;
+  accountId: string;
+  framework: string | null;
+  buildCommand: string | null;
+  devCommand: string | null;
+  installCommand: string | null;
+  outputDirectory: string | null;
+  rootDirectory: string | null;
+  commandForIgnoringBuildStep: string | null;
+  nodeVersion: string;
+  serverlessFunctionRegion: string | null;
+  publicSource: boolean;
+  autoAssignCustomDomains: boolean;
+  autoAssignCustomDomainsUpdatedBy: string | null;
+  gitForkProtection: boolean;
+  sourceFilesOutsideRootDirectory: boolean;
+  live: boolean;
+  link: {
+    type: string;
+    repo: string;
+    repoId: number;
+    org: string;
+    gitCredentialId: string;
+    productionBranch: string;
+    createdAt: number;
+    updatedAt: number;
+    deployHooks: Array<{ id: string; name: string; ref: string; url: string }>;
+  } | null;
+  latestDeployments: Array<{ id: string; url: string; state: string; createdAt: number }>;
+  targets: Record<string, { id: string; url: string; state: string; createdAt: number }>;
+  protectionBypass: Record<string, { createdAt: number; createdBy: string; scope: string }>;
+  passwordProtection: null;
+  ssoProtection: null;
+  trustedIps: null;
+  connectConfigurationId: string | null;
+  gitComments: { onPullRequest: boolean; onCommit: boolean };
+  webAnalytics: { id: string } | null;
+  speedInsights: { id: string } | null;
+  oidcTokenConfig: { enabled: boolean } | null;
+  tier: string;
+}
+
+export interface VercelDeployment extends CompatEntity {
+  uid: string;
+  name: string;
+  url: string;
+  projectId: string;
+  source: string;
+  target: "production" | "preview" | "staging" | null;
+  readyState: "QUEUED" | "BUILDING" | "INITIALIZING" | "READY" | "ERROR" | "CANCELED";
+  readySubstate: "STAGED" | "ROLLING" | "PROMOTED" | null;
+  state: "QUEUED" | "BUILDING" | "INITIALIZING" | "READY" | "ERROR" | "CANCELED";
+  creatorId: string;
+  inspectorUrl: string;
+  meta: Record<string, string>;
+  gitSource: {
+    type: string;
+    ref: string;
+    sha: string;
+    repoId: string;
+    org: string;
+    repo: string;
+    message: string;
+    authorName: string;
+    commitAuthorName: string;
+  } | null;
+  buildingAt: number | null;
+  readyAt: number | null;
+  canceledAt: number | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  regions: string[];
+  functions: Record<string, unknown> | null;
+  routes: unknown[] | null;
+  plan: string;
+  aliasAssigned: boolean;
+  aliasError: null;
+  bootedAt: number | null;
+}
+
+export interface VercelDeploymentAlias extends CompatEntity {
+  uid: string;
+  alias: string;
+  deploymentId: string;
+  projectId: string;
+}
+
+export interface VercelBuild extends CompatEntity {
+  uid: string;
+  deploymentId: string;
+  entrypoint: string;
+  readyState: "QUEUED" | "BUILDING" | "READY" | "ERROR";
+  output: Array<{
+    path: string;
+    functionName: string;
+    type: string;
+    size: number;
+  }>;
+  readyStateAt: number;
+  fingerprint: string;
+}
+
+export interface VercelDeploymentEvent extends CompatEntity {
+  deploymentId: string;
+  type: string;
+  payload: {
+    text: string;
+    statusCode?: number;
+    deploymentId?: string;
+  };
+  date: number;
+  serial: string;
+}
+
+export interface VercelFile extends CompatEntity {
+  digest: string;
+  size: number;
+  contentType: string;
+}
+
+export interface VercelDeploymentFile extends CompatEntity {
+  deploymentId: string;
+  name: string;
+  type: "file" | "directory" | "symlink" | "lambda" | "middleware";
+  uid: string;
+  children: string[];
+  contentType: string | null;
+  mode: number;
+  size: number;
+}
+
+export interface VercelDomain extends CompatEntity {
+  uid: string;
+  projectId: string;
+  name: string;
+  apexName: string;
+  redirect: string | null;
+  redirectStatusCode: 301 | 302 | 307 | 308 | null;
+  gitBranch: string | null;
+  customEnvironmentId: string | null;
+  verified: boolean;
+  verification: Array<{
+    type: string;
+    domain: string;
+    value: string;
+    reason: string;
+  }>;
+}
+
+export interface VercelEnvVar extends CompatEntity {
+  uid: string;
+  projectId: string;
+  key: string;
+  value: string;
+  type: "system" | "encrypted" | "plain" | "secret" | "sensitive";
+  target: Array<"production" | "preview" | "development">;
+  gitBranch: string | null;
+  customEnvironmentIds: string[];
+  comment: string | null;
+  decrypted: boolean;
+}
+
+export interface VercelProtectionBypass extends CompatEntity {
+  projectId: string;
+  secret: string;
+  note: string | null;
+  scope: string;
+  createdBy: string;
+}
+
+export interface VercelApiKey extends CompatEntity {
+  uid: string;
+  name: string;
+  teamId: string | null;
+  userId: string;
+  tokenString: string;
+}
+
+export interface VercelIntegration extends CompatEntity {
+  client_id: string;
+  client_secret: string;
+  name: string;
+  redirect_uris: string[];
+}
+
+// Legacy public seed config type augmentations.
+export interface VercelSeedConfig {
+  port?: number;
+  users?: Array<{
+    username: string;
+    email?: string;
+    name?: string;
+  }>;
+  teams?: Array<{
+    slug: string;
+    name?: string;
+    description?: string;
+  }>;
+  projects?: Array<{
+    name: string;
+    team?: string;
+    framework?: string;
+    buildCommand?: string;
+    outputDirectory?: string;
+    rootDirectory?: string;
+    nodeVersion?: string;
+    envVars?: Array<{
+      key: string;
+      value: string;
+      type?: string;
+      target?: string[];
+    }>;
+  }>;
+  integrations?: Array<{
+    client_id: string;
+    client_secret: string;
+    name: string;
+    redirect_uris: string[];
+  }>;
+}
 export const service = {
   name: serviceName,
   label: serviceLabel,
@@ -162,7 +444,9 @@ export const plugin = {
 export const vercelPlugin = plugin;
 
 export function seedFromConfig(_store?: unknown, _baseUrl?: string, _config?: VercelSeedConfig): void {
-  return undefined;
+  throw new Error(
+    "seedFromConfig is no longer supported by native compatibility facade packages. Pass seed data to createEmulateHandler or createEmulator instead.",
+  );
 }
 
 export function createAppKeyResolver(): undefined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,10 @@ importers:
         version: 5.9.3
 
   packages/@emulators/adapter-next:
+    dependencies:
+      emulate:
+        specifier: workspace:*
+        version: link:../../emulate
     devDependencies:
       tsup:
         specifier: ^8
@@ -426,6 +430,10 @@ importers:
         version: 5.9.3
 
   packages/@emulators/core:
+    dependencies:
+      emulate:
+        specifier: workspace:*
+        version: link:../../emulate
     devDependencies:
       tsup:
         specifier: ^8

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -327,15 +327,15 @@ By default, all local CLI and programmatic API state is in-memory. Vercel Go Fun
 packages/
   emulate/           # npm CLI shim + native process programmatic API
   @emulators/
-    core/            # compatibility helpers
+    core/            # compatibility helpers and native proxy facade
     adapter-next/    # Next.js App Router proxy integration
-    vercel/          # Vercel API metadata package
-    github/          # GitHub API metadata package
-    google/          # Google metadata package
-    slack/           # Slack metadata package
-    apple/           # Apple metadata package
-    microsoft/       # Microsoft metadata package
-    aws/             # AWS metadata package and SDK conformance tests
+    vercel/          # Vercel API metadata and compatibility package
+    github/          # GitHub API metadata and compatibility package
+    google/          # Google metadata and compatibility package
+    slack/           # Slack metadata and compatibility package
+    apple/           # Apple metadata and compatibility package
+    microsoft/       # Microsoft metadata and compatibility package
+    aws/             # AWS metadata, compatibility package, and SDK conformance tests
 ```
 
 Service routing, state, UI, and protocol behavior live in Go under `internal/`.

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx emulate:*)
 
 # Next.js Integration
 
-The `@emulators/adapter-next` package proxies native emulate runtimes through a Next.js App Router route. In-process service handlers have been removed.
+The `@emulators/adapter-next` package proxies native emulate runtimes through a Next.js App Router route. Legacy in-process handler imports remain available as a compatibility facade over the native runtime.
 
 ## Vercel Go Function Preview
 
@@ -83,6 +83,6 @@ GitHub({
 
 No `oauth_apps` need to be seeded. When none are configured, the emulator skips `client_id`, `client_secret`, and `redirect_uri` validation.
 
-## Deprecated In-Process Handler
+## Compatibility Handler
 
-`createEmulateHandler` remains exported so existing imports fail gracefully at request time, but it no longer runs services in-process. New code should use `createEmulateProxy` for local native runtimes or `npx emulate vercel init` for Vercel previews.
+`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -85,4 +85,4 @@ No `oauth_apps` need to be seeded. When none are configured, the emulator skips 
 
 ## Compatibility Handler
 
-`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.
+`createEmulateHandler` remains exported for existing App Router routes. It accepts the old `services` config shape, starts the native runtime on first local request, and proxies each service path to that runtime. The legacy `persistence` option is rejected because state lives in the native runtime. For deployed Vercel previews, prefer `npx emulate vercel init`; alternatively set `EMULATE_<SERVICE>_URL` to a reachable native target. New code should use `createEmulateProxy` for explicit local proxying.


### PR DESCRIPTION
- Restores documented 0.5.0 adapter and package-root imports as native-backed compatibility facades.
- Adds native runtime proxying for legacy Next.js handler configs while keeping explicit proxy support.
- Updates docs and skills to describe the compatibility path for the Go engine migration.