### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,36 @@
 # Changelog
 
-## 0.5.0
+## 0.6.0
 
 <!-- release:start -->
+### New Features
+
+- **Native Go runtime** — the CLI now ships platform native binaries and runs services through the Go engine (#103, #133)
+- **API Gateway v2 and Lambda** — local HTTP API proxy events, Lambda control plane APIs, and Node.js Lambda invocation support (#144, #145, #147)
+- **EventBridge Lambda targets** — EventBridge rules can now deliver events to Lambda functions in the AWS emulator (#146)
+- **Expanded AWS coverage** — added DynamoDB, SNS, CloudWatch Logs, Secrets Manager, SSM Parameter Store, KMS, and deeper IAM and STS support (#122, #123, #136, #138, #139, #140, #143)
+- **Native service parity** — added Go backed implementations for Apple, Clerk, GitHub, Google, Microsoft Entra, MongoDB Atlas, Okta, Resend, Slack, Stripe, and Vercel (#114, #119, #120, #124, #125, #126, #127, #128, #129, #130, #131)
+- **Vercel and Next.js foundations** — added Vercel API parity, Go Function scaffolding, and the Next proxy adapter foundation (#116, #117, #118, #119)
+
+### Improvements
+
+- **AWS SDK compatibility** — hardened gateway parsing, SigV4 auth, AWS error responses, S3 range and conditional reads, and SQS batch APIs (#107, #108, #141, #142)
+- **Package compatibility facades** — package APIs now route to native implementations while preserving existing SDK entry points (#135)
+- **Dependency policy** — added a minimum dependency release age requirement (#137)
+- **Development runtime** — moved the repo to pnpm 11 and Node.js 24 (#115)
+- **Docs and agent skills** — updated README, docs site, and service skills for the native runtime and expanded service coverage (#87, #119, #120, #124, #125, #126, #127, #128, #129, #130, #131)
+
+### Breaking Changes
+
+- **Node service engines removed** — emulator services now run through the native Go engine instead of the previous Hono based Node service implementations (#102, #134)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.5.0
+
 ### New Features
 
 - **Clerk emulator** — local emulation of Clerk authentication and session management (#38)
@@ -29,7 +57,6 @@
 - @jlucaso1
 - @Railly
 - @tmm
-<!-- release:end -->
 
 ## 0.4.1
 

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-next",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/apple/package.json
+++ b/packages/@emulators/apple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/apple",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/aws",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/clerk/package.json
+++ b/packages/@emulators/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/clerk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/core/package.json
+++ b/packages/@emulators/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/emulate-darwin-arm64/package.json
+++ b/packages/@emulators/emulate-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/emulate-darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native emulate binary for macOS arm64",
   "license": "Apache-2.0",
   "os": [

--- a/packages/@emulators/emulate-darwin-x64/package.json
+++ b/packages/@emulators/emulate-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/emulate-darwin-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native emulate binary for macOS x64",
   "license": "Apache-2.0",
   "os": [

--- a/packages/@emulators/emulate-linux-arm64/package.json
+++ b/packages/@emulators/emulate-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/emulate-linux-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native emulate binary for Linux arm64",
   "license": "Apache-2.0",
   "os": [

--- a/packages/@emulators/emulate-linux-x64/package.json
+++ b/packages/@emulators/emulate-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/emulate-linux-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native emulate binary for Linux x64",
   "license": "Apache-2.0",
   "os": [

--- a/packages/@emulators/emulate-win32-arm64/package.json
+++ b/packages/@emulators/emulate-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/emulate-win32-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native emulate binary for Windows arm64",
   "license": "Apache-2.0",
   "os": [

--- a/packages/@emulators/emulate-win32-x64/package.json
+++ b/packages/@emulators/emulate-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/emulate-win32-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native emulate binary for Windows x64",
   "license": "Apache-2.0",
   "os": [

--- a/packages/@emulators/github/package.json
+++ b/packages/@emulators/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/github",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/google/package.json
+++ b/packages/@emulators/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/google",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/microsoft/package.json
+++ b/packages/@emulators/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/microsoft",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/mongoatlas/package.json
+++ b/packages/@emulators/mongoatlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/mongoatlas",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/okta/package.json
+++ b/packages/@emulators/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/okta",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/resend/package.json
+++ b/packages/@emulators/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/resend",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/slack/package.json
+++ b/packages/@emulators/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/slack",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/stripe/package.json
+++ b/packages/@emulators/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/stripe",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/vercel/package.json
+++ b/packages/@emulators/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/vercel",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulate",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Local drop-in replacement services for CI and no-network sandboxes",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Summary:
- Bump emulate and all @emulators/* packages to 0.6.0.
- Add the 0.6.0 changelog entry with release markers and remove markers from 0.5.0.

Validation:
- pnpm run sync-versions --check
- go test ./...
- pnpm test
- pnpm type-check