### PR TITLE
Add Slack rich message parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,12 +598,12 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 ## Slack API
 
-Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks.
+Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. Chat writes preserve common rich message fields such as `blocks`, `attachments`, `metadata`, formatting flags, unfurl flags, and client message ids.
 
 ### Auth & Chat
 - `POST /api/auth.test` - test authentication
-- `POST /api/chat.postMessage` - post message (supports threads via `thread_ts`)
-- `POST /api/chat.update` - update message
+- `POST /api/chat.postMessage` - post message with text or rich payload fields (supports threads via `thread_ts`)
+- `POST /api/chat.update` - update message text and rich payload fields
 - `POST /api/chat.delete` - delete message
 - `POST /api/chat.meMessage` - /me message
 
@@ -611,8 +611,8 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/conversations.list` - list channels (cursor pagination)
 - `POST /api/conversations.info` - get channel info
 - `POST /api/conversations.create` - create channel
-- `POST /api/conversations.history` - channel history
-- `POST /api/conversations.replies` - thread replies
+- `POST /api/conversations.history` - channel history with rich message fields
+- `POST /api/conversations.replies` - thread replies with rich message fields
 - `POST /api/conversations.join` / `conversations.leave` - join/leave
 - `POST /api/conversations.members` - list members
 
@@ -625,7 +625,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 ### Team, Bots & Webhooks
 - `POST /api/team.info` - workspace info
 - `POST /api/bots.info` - bot info
-- `POST /services/:teamId/:botId/:webhookId` - incoming webhook
+- `POST /services/:teamId/:botId/:webhookId` - incoming webhook with text or rich payload fields
 
 ### OAuth
 - `GET /oauth/v2/authorize` - authorization (shows user picker)

--- a/apps/web/app/docs/slack/page.mdx
+++ b/apps/web/app/docs/slack/page.mdx
@@ -1,6 +1,6 @@
 # Slack API
 
-Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. State changes dispatch `event_callback` payloads to configured webhook URLs.
+Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. Chat writes preserve common rich message fields such as `blocks`, `attachments`, `metadata`, formatting flags, unfurl flags, and client message ids. State changes dispatch `event_callback` payloads to configured webhook URLs.
 
 ## Auth
 
@@ -8,8 +8,8 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 
 ## Chat
 
-- `POST /api/chat.postMessage` - post message (supports threads via `thread_ts`)
-- `POST /api/chat.update` - update message
+- `POST /api/chat.postMessage` - post message with text or rich payload fields (supports threads via `thread_ts`)
+- `POST /api/chat.update` - update message text and rich payload fields
 - `POST /api/chat.delete` - delete message
 - `POST /api/chat.meMessage` - /me message
 
@@ -18,8 +18,8 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/conversations.list` - list channels (cursor pagination)
 - `POST /api/conversations.info` - get channel info
 - `POST /api/conversations.create` - create channel
-- `POST /api/conversations.history` - channel history (top-level messages)
-- `POST /api/conversations.replies` - thread replies
+- `POST /api/conversations.history` - channel history with rich message fields (top-level messages)
+- `POST /api/conversations.replies` - thread replies with rich message fields
 - `POST /api/conversations.join` - join channel
 - `POST /api/conversations.leave` - leave channel
 - `POST /api/conversations.members` - list members
@@ -46,7 +46,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 
 ## Incoming Webhooks
 
-- `POST /services/:teamId/:botId/:webhookId` - post via incoming webhook (supports `channel` override and `thread_ts`)
+- `POST /services/:teamId/:botId/:webhookId` - post text or rich payload fields via incoming webhook (supports `channel` override and `thread_ts`)
 
 ## OAuth
 
@@ -57,6 +57,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 
 When messages are posted or reactions change, the emulator dispatches `event_callback` payloads to configured webhook URLs matching Slack's Events API format:
 
-- `message` events on `chat.postMessage`, `chat.update`, `chat.delete`
+- `message` events on `chat.postMessage`
+- rich message fields are included on posted `message` events when present
 - `reaction_added` / `reaction_removed` events on `reactions.add` / `reactions.remove`
 - `message` with `subtype: bot_message` on incoming webhook posts

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -1,6 +1,6 @@
 # @emulators/slack
 
-Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks.
+Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. Chat writes preserve common rich message fields such as `blocks`, `attachments`, `metadata`, formatting flags, unfurl flags, and client message ids.
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
@@ -14,8 +14,8 @@ npm install @emulators/slack
 
 ### Auth & Chat
 - `POST /api/auth.test` — test authentication
-- `POST /api/chat.postMessage` — post message (supports threads via `thread_ts`)
-- `POST /api/chat.update` — update message
+- `POST /api/chat.postMessage` — post message with text or rich payload fields (supports threads via `thread_ts`)
+- `POST /api/chat.update` — update message text and rich payload fields
 - `POST /api/chat.delete` — delete message
 - `POST /api/chat.meMessage` — /me message
 
@@ -23,8 +23,8 @@ npm install @emulators/slack
 - `POST /api/conversations.list` — list channels (cursor pagination)
 - `POST /api/conversations.info` — get channel info
 - `POST /api/conversations.create` — create channel
-- `POST /api/conversations.history` — channel history
-- `POST /api/conversations.replies` — thread replies
+- `POST /api/conversations.history` — channel history with rich message fields
+- `POST /api/conversations.replies` — thread replies with rich message fields
 - `POST /api/conversations.join` / `conversations.leave` — join/leave
 - `POST /api/conversations.members` — list members
 
@@ -37,7 +37,7 @@ npm install @emulators/slack
 ### Team, Bots & Webhooks
 - `POST /api/team.info` — workspace info
 - `POST /api/bots.info` — bot info
-- `POST /services/:teamId/:botId/:webhookId` — incoming webhook
+- `POST /services/:teamId/:botId/:webhookId` — incoming webhook with text or rich payload fields
 
 ### OAuth
 - `GET /oauth/v2/authorize` — authorization (shows user picker)

--- a/packages/@emulators/slack/src/__tests__/slack-coverage.ts
+++ b/packages/@emulators/slack/src/__tests__/slack-coverage.ts
@@ -25,7 +25,7 @@ export const slackCoverageMatrix: SlackCoverageEntry[] = [
     status: "partial",
     testedBy: ["slack.test.ts", "slack-sdk.test.ts", "slack-events.test.ts"],
     notes:
-      "Text messages and thread replies work. Rich message payloads, DMs, permalinks, and membership checks are future work.",
+      "Text, thread replies, blocks, attachments, metadata, formatting flags, unfurl flags, and client message ids round trip. DMs, permalinks, and membership checks are future work.",
   },
   {
     family: "chat",
@@ -33,7 +33,7 @@ export const slackCoverageMatrix: SlackCoverageEntry[] = [
     route: "POST /api/chat.update",
     status: "partial",
     testedBy: ["slack.test.ts", "slack-sdk.test.ts"],
-    notes: "Stored text is updated. Slack shaped message_changed events are future work.",
+    notes: "Stored text and rich message fields are updated. Slack shaped message_changed events are future work.",
   },
   {
     family: "chat",
@@ -81,7 +81,7 @@ export const slackCoverageMatrix: SlackCoverageEntry[] = [
     route: "POST /api/conversations.history",
     status: "partial",
     testedBy: ["slack.test.ts", "slack-sdk.test.ts"],
-    notes: "Returns top level messages for a channel. Time filtering and richer message fields are future work.",
+    notes: "Returns top level messages for a channel, including rich message fields. Time filtering is future work.",
   },
   {
     family: "conversations",
@@ -89,7 +89,7 @@ export const slackCoverageMatrix: SlackCoverageEntry[] = [
     route: "POST /api/conversations.replies",
     status: "partial",
     testedBy: ["slack.test.ts", "slack-sdk.test.ts"],
-    notes: "Returns parent and replies for a thread.",
+    notes: "Returns parent and replies for a thread, including rich message fields.",
   },
   {
     family: "conversations",
@@ -209,7 +209,7 @@ export const slackCoverageMatrix: SlackCoverageEntry[] = [
     route: "POST /services/:teamId/:botId/:token",
     status: "partial",
     testedBy: ["slack.test.ts", "slack-events.test.ts"],
-    notes: "Posts text webhook messages. Rich payload preservation is future work.",
+    notes: "Posts text and rich webhook messages with blocks, attachments, and common formatting fields preserved.",
   },
   {
     family: "inspector",

--- a/packages/@emulators/slack/src/__tests__/slack-events.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack-events.test.ts
@@ -110,5 +110,6 @@ describe("Slack plugin - event dispatch baseline", () => {
         text: "webhook event baseline",
       },
     });
+    expect((capture.jsonBodies()[0] as any).event.user).toBeUndefined();
   });
 });

--- a/packages/@emulators/slack/src/__tests__/slack-events.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack-events.test.ts
@@ -19,10 +19,12 @@ describe("Slack plugin - event dispatch baseline", () => {
     registerSlackEventSubscription(webhooks, ["message"]);
 
     const ch = getSlackStore(store).channels.findOneBy("name", "general")!;
+    const blocks = [{ type: "section", text: { type: "plain_text", text: "event baseline" } }];
+    const metadata = { event_type: "message_posted", event_payload: { id: "event_1" } };
     const res = await app.request(`${base}/api/chat.postMessage`, {
       method: "POST",
       headers: authHeaders(),
-      body: JSON.stringify({ channel: ch.channel_id, text: "event baseline" }),
+      body: JSON.stringify({ channel: ch.channel_id, text: "event baseline", blocks, metadata }),
     });
     expect(res.status).toBe(200);
 
@@ -34,6 +36,8 @@ describe("Slack plugin - event dispatch baseline", () => {
         channel: ch.channel_id,
         user: "U000000001",
         text: "event baseline",
+        blocks,
+        metadata,
       },
     });
   });

--- a/packages/@emulators/slack/src/__tests__/slack-sdk.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack-sdk.test.ts
@@ -72,6 +72,38 @@ describe("Slack plugin - real @slack/web-api WebClient baseline", () => {
     expect(deleted.ok).toBe(true);
   });
 
+  it("round trips rich chat messages through the Slack SDK", async () => {
+    expect(emulator).toBeDefined();
+    const channel = getSlackStore(emulator!.store).channels.findOneBy("name", "general")!.channel_id;
+    const blocks = [{ type: "section", text: { type: "plain_text", text: "rich from WebClient" } }];
+    const attachments = [{ color: "#ecb22e", text: "legacy attachment" }];
+    const metadata = { event_type: "sdk_rich_message", event_payload: { id: "sdk_1" } };
+
+    const posted = await client.chat.postMessage({
+      channel,
+      text: "rich from WebClient",
+      blocks,
+      attachments,
+      metadata,
+      unfurl_links: false,
+      unfurl_media: false,
+      client_msg_id: "sdk-client-message-1",
+    } as any);
+    expect(posted.ok).toBe(true);
+    expect((posted.message as any).blocks).toEqual(blocks);
+    expect((posted.message as any).attachments).toEqual(attachments);
+    expect((posted.message as any).metadata).toEqual(metadata);
+    expect((posted.message as any).unfurl_links).toBe(false);
+    expect((posted.message as any).unfurl_media).toBe(false);
+    expect((posted.message as any).client_msg_id).toBe("sdk-client-message-1");
+
+    const history = await client.conversations.history({ channel });
+    const message = history.messages?.find((item) => item.ts === posted.ts) as any;
+    expect(message.blocks).toEqual(blocks);
+    expect(message.attachments).toEqual(attachments);
+    expect(message.metadata).toEqual(metadata);
+  });
+
   it("exercises conversation membership through the Slack SDK", async () => {
     const created = await client.conversations.create({ name: "sdk-membership" });
     const channel = created.channel!.id!;

--- a/packages/@emulators/slack/src/__tests__/slack.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack.test.ts
@@ -923,6 +923,26 @@ describe("Slack plugin - Message Inspector", () => {
     expect(html).toContain("Inspector test message");
   });
 
+  it("shows rich messages with no text in the inspector", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+
+    await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        channel: ch.channel_id,
+        blocks: [{ type: "section", text: { type: "plain_text", text: "Inspector rich block" } }],
+      }),
+    });
+
+    const res = await app.request(`${base}/?channel=${ch.channel_id}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Inspector rich block");
+    expect(html).toContain('badge badge-granted">rich');
+  });
+
   it("switches channels via query param", async () => {
     const ss = getSlackStore(store);
     const randomCh = ss.channels.findOneBy("name", "random")!;

--- a/packages/@emulators/slack/src/__tests__/slack.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack.test.ts
@@ -122,6 +122,115 @@ describe("Slack plugin - chat.postMessage", () => {
     expect(body.ok).toBe(true);
     expect(body.message.text).toBe("urlencoded message");
   });
+
+  it("round trips rich JSON message payloads through history", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+    const blocks = [
+      { type: "section", text: { type: "mrkdwn", text: "*Deploy* completed" } },
+      { type: "context", elements: [{ type: "plain_text", text: "production" }] },
+    ];
+    const attachments = [{ color: "#2eb67d", text: "Release 2026.05.23" }];
+    const metadata = { event_type: "deploy_completed", event_payload: { deploy_id: "dep_123" } };
+
+    const res = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        channel: ch.channel_id,
+        text: "deploy completed",
+        blocks,
+        attachments,
+        metadata,
+        mrkdwn: false,
+        parse: "none",
+        link_names: true,
+        unfurl_links: false,
+        unfurl_media: false,
+        username: "Deploy Bot",
+        icon_emoji: ":bell:",
+        client_msg_id: "client-message-1",
+      }),
+    });
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.message).toMatchObject({
+      text: "deploy completed",
+      blocks,
+      attachments,
+      metadata,
+      mrkdwn: false,
+      parse: "none",
+      link_names: true,
+      unfurl_links: false,
+      unfurl_media: false,
+      username: "Deploy Bot",
+      icon_emoji: ":bell:",
+      client_msg_id: "client-message-1",
+    });
+
+    const stored = ss.messages.findOneBy("ts", body.ts);
+    expect(stored?.blocks).toEqual(blocks);
+    expect(stored?.metadata).toEqual(metadata);
+
+    const historyRes = await app.request(`${base}/api/conversations.history`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: ch.channel_id }),
+    });
+    const history = (await historyRes.json()) as any;
+    expect(history.messages[0]).toMatchObject({
+      text: "deploy completed",
+      blocks,
+      attachments,
+      metadata,
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+  });
+
+  it("parses form-encoded rich message fields", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+    const blocks = [{ type: "section", text: { type: "plain_text", text: "blocks only" } }];
+    const metadata = { event_type: "blocks_only", event_payload: { source: "form" } };
+    const form = new URLSearchParams();
+    form.set("channel", ch.channel_id);
+    form.set("blocks", JSON.stringify(blocks));
+    form.set("metadata", JSON.stringify(metadata));
+    form.set("unfurl_links", "false");
+    form.set("unfurl_media", "0");
+
+    const res = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders("application/x-www-form-urlencoded"),
+      body: form.toString(),
+    });
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.message.text).toBe("");
+    expect(body.message.blocks).toEqual(blocks);
+    expect(body.message.metadata).toEqual(metadata);
+    expect(body.message.unfurl_links).toBe(false);
+    expect(body.message.unfurl_media).toBe(false);
+  });
+
+  it("rejects invalid rich payload JSON", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+    const form = new URLSearchParams();
+    form.set("channel", ch.channel_id);
+    form.set("blocks", "[");
+
+    const res = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders("application/x-www-form-urlencoded"),
+      body: form.toString(),
+    });
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("invalid_blocks");
+  });
 });
 
 describe("Slack plugin - chat.update", () => {
@@ -151,6 +260,79 @@ describe("Slack plugin - chat.update", () => {
     const updated = (await updateRes.json()) as any;
     expect(updated.ok).toBe(true);
     expect(updated.text).toBe("updated");
+  });
+
+  it("updates rich message fields and returns the full message", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+    const originalBlocks = [{ type: "section", text: { type: "plain_text", text: "original" } }];
+    const updatedBlocks = [{ type: "section", text: { type: "plain_text", text: "updated" } }];
+    const updatedAttachments = [{ color: "#36c5f0", text: "updated attachment" }];
+    const metadata = { event_type: "message_updated", event_payload: { id: "msg_1" } };
+
+    const postRes = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: ch.channel_id, text: "original", blocks: originalBlocks }),
+    });
+    const posted = (await postRes.json()) as any;
+
+    const updateRes = await app.request(`${base}/api/chat.update`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        channel: ch.channel_id,
+        ts: posted.ts,
+        text: "updated rich",
+        blocks: updatedBlocks,
+        attachments: updatedAttachments,
+        metadata,
+        unfurl_links: false,
+      }),
+    });
+    const updated = (await updateRes.json()) as any;
+    expect(updated.ok).toBe(true);
+    expect(updated.message).toMatchObject({
+      text: "updated rich",
+      blocks: updatedBlocks,
+      attachments: updatedAttachments,
+      metadata,
+      unfurl_links: false,
+    });
+
+    const historyRes = await app.request(`${base}/api/conversations.history`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: ch.channel_id }),
+    });
+    const history = (await historyRes.json()) as any;
+    expect(history.messages[0].blocks).toEqual(updatedBlocks);
+    expect(history.messages[0].attachments).toEqual(updatedAttachments);
+  });
+
+  it("clears blocks when text is updated without new blocks", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+
+    const postRes = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        channel: ch.channel_id,
+        text: "original",
+        blocks: [{ type: "section", text: { type: "plain_text", text: "original" } }],
+      }),
+    });
+    const posted = (await postRes.json()) as any;
+
+    const updateRes = await app.request(`${base}/api/chat.update`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: ch.channel_id, ts: posted.ts, text: "text only" }),
+    });
+    const updated = (await updateRes.json()) as any;
+    expect(updated.ok).toBe(true);
+    expect(updated.message.blocks).toBeUndefined();
   });
 });
 
@@ -652,6 +834,28 @@ describe("Slack plugin - Incoming Webhooks", () => {
     expect(messages.length).toBe(1);
     expect(messages[0].text).toBe("Deploy succeeded!");
     expect(messages[0].subtype).toBe("bot_message");
+  });
+
+  it("preserves rich payloads from incoming webhooks", async () => {
+    const ss = getSlackStore(store);
+    const webhook = ss.incomingWebhooks.all()[0];
+    const blocks = [{ type: "section", text: { type: "plain_text", text: "Webhook block" } }];
+    const attachments = [{ color: "#e01e5a", text: "Webhook attachment" }];
+
+    const res = await app.request(`${base}${webhook.url}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ blocks, attachments, unfurl_links: false }),
+    });
+    expect(res.status).toBe(200);
+
+    const messages = ss.messages.findBy("channel_id", "C000000001");
+    expect(messages.length).toBe(1);
+    expect(messages[0].text).toBe("");
+    expect(messages[0].blocks).toEqual(blocks);
+    expect(messages[0].attachments).toEqual(attachments);
+    expect(messages[0].unfurl_links).toBe(false);
+    expect(messages[0].bot_id).toBe(webhook.bot_id);
   });
 
   it("posts to a specific channel via webhook", async () => {

--- a/packages/@emulators/slack/src/entities.ts
+++ b/packages/@emulators/slack/src/entities.ts
@@ -38,6 +38,8 @@ export interface SlackChannel extends Entity {
   num_members: number;
 }
 
+export type SlackJsonObject = Record<string, unknown>;
+
 export interface SlackMessage extends Entity {
   ts: string;
   channel_id: string;
@@ -45,6 +47,21 @@ export interface SlackMessage extends Entity {
   text: string;
   type: "message";
   subtype?: string;
+  blocks?: SlackJsonObject[];
+  attachments?: SlackJsonObject[];
+  metadata?: SlackJsonObject;
+  mrkdwn?: boolean;
+  parse?: string;
+  link_names?: boolean;
+  unfurl_links?: boolean;
+  unfurl_media?: boolean;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
+  bot_id?: string;
+  app_id?: string;
+  client_msg_id?: string;
+  reply_broadcast?: boolean;
   thread_ts?: string;
   reply_count: number;
   reply_users: string[];

--- a/packages/@emulators/slack/src/helpers.ts
+++ b/packages/@emulators/slack/src/helpers.ts
@@ -1,8 +1,39 @@
 import { randomBytes } from "crypto";
 import type { Context } from "@emulators/core";
 import type { ContentfulStatusCode } from "@emulators/core";
+import type { SlackJsonObject, SlackMessage } from "./entities.js";
 
 let tsCounter = 0;
+
+export type SlackRichMessageFieldName =
+  | "blocks"
+  | "attachments"
+  | "metadata"
+  | "mrkdwn"
+  | "parse"
+  | "link_names"
+  | "unfurl_links"
+  | "unfurl_media"
+  | "username"
+  | "icon_url"
+  | "icon_emoji"
+  | "bot_id"
+  | "app_id"
+  | "client_msg_id"
+  | "reply_broadcast";
+
+export type SlackRichMessageFields = Partial<Pick<SlackMessage, SlackRichMessageFieldName>>;
+
+export interface SlackRichMessageParseResult {
+  fields: SlackRichMessageFields;
+  providedFields: SlackRichMessageFieldName[];
+  error?: string;
+}
+
+interface ParsedField<T> {
+  value?: T;
+  error?: string;
+}
 
 export function generateSlackId(prefix: string): string {
   return prefix + randomBytes(5).toString("hex").toUpperCase().slice(0, 9);
@@ -28,7 +59,11 @@ export async function parseSlackBody(c: Context): Promise<Record<string, unknown
 
   if (contentType.includes("application/json")) {
     try {
-      return JSON.parse(rawText);
+      const parsed = JSON.parse(rawText) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return {};
     } catch {
       return {};
     }
@@ -43,6 +78,169 @@ export async function parseSlackBody(c: Context): Promise<Record<string, unknown
   return result;
 }
 
+export function formatSlackMessage(msg: SlackMessage) {
+  return {
+    type: msg.type,
+    user: msg.user,
+    text: msg.text,
+    ts: msg.ts,
+    ...(msg.subtype ? { subtype: msg.subtype } : {}),
+    ...(msg.bot_id ? { bot_id: msg.bot_id } : {}),
+    ...(msg.app_id ? { app_id: msg.app_id } : {}),
+    ...(msg.username ? { username: msg.username } : {}),
+    ...(msg.icon_url ? { icon_url: msg.icon_url } : {}),
+    ...(msg.icon_emoji ? { icon_emoji: msg.icon_emoji } : {}),
+    ...(msg.client_msg_id ? { client_msg_id: msg.client_msg_id } : {}),
+    ...(msg.blocks !== undefined ? { blocks: msg.blocks } : {}),
+    ...(msg.attachments !== undefined ? { attachments: msg.attachments } : {}),
+    ...(msg.metadata !== undefined ? { metadata: msg.metadata } : {}),
+    ...(msg.mrkdwn !== undefined ? { mrkdwn: msg.mrkdwn } : {}),
+    ...(msg.parse !== undefined ? { parse: msg.parse } : {}),
+    ...(msg.link_names !== undefined ? { link_names: msg.link_names } : {}),
+    ...(msg.unfurl_links !== undefined ? { unfurl_links: msg.unfurl_links } : {}),
+    ...(msg.unfurl_media !== undefined ? { unfurl_media: msg.unfurl_media } : {}),
+    ...(msg.reply_broadcast !== undefined ? { reply_broadcast: msg.reply_broadcast } : {}),
+    ...(msg.thread_ts ? { thread_ts: msg.thread_ts } : {}),
+    ...(msg.reply_count > 0 ? { reply_count: msg.reply_count, reply_users: msg.reply_users } : {}),
+    ...(msg.reactions.length > 0 ? { reactions: msg.reactions } : {}),
+  };
+}
+
+export function parseSlackRichMessageFields(body: Record<string, unknown>): SlackRichMessageParseResult {
+  const fields: SlackRichMessageFields = {};
+  const providedFields: SlackRichMessageFieldName[] = [];
+
+  const blocks = parseSlackObjectArray(body.blocks, "invalid_blocks");
+  if (blocks.error) return { fields, providedFields, error: blocks.error };
+  if (hasBodyField(body, "blocks")) {
+    providedFields.push("blocks");
+    if (blocks.value !== undefined) fields.blocks = blocks.value;
+  }
+
+  const attachments = parseSlackObjectArray(body.attachments, "invalid_attachments");
+  if (attachments.error) return { fields, providedFields, error: attachments.error };
+  if (hasBodyField(body, "attachments")) {
+    providedFields.push("attachments");
+    if (attachments.value !== undefined) fields.attachments = attachments.value;
+  }
+
+  const metadata = parseSlackObject(body.metadata, "invalid_metadata_format");
+  if (metadata.error) return { fields, providedFields, error: metadata.error };
+  if (hasBodyField(body, "metadata")) {
+    providedFields.push("metadata");
+    if (metadata.value !== undefined) fields.metadata = metadata.value;
+  }
+
+  setOptionalStringField(body, fields, providedFields, "parse");
+  setOptionalStringField(body, fields, providedFields, "username");
+  setOptionalStringField(body, fields, providedFields, "icon_url");
+  setOptionalStringField(body, fields, providedFields, "icon_emoji");
+  setOptionalStringField(body, fields, providedFields, "bot_id");
+  setOptionalStringField(body, fields, providedFields, "app_id");
+  setOptionalStringField(body, fields, providedFields, "client_msg_id");
+
+  setOptionalBooleanField(body, fields, providedFields, "mrkdwn");
+  setOptionalBooleanField(body, fields, providedFields, "link_names");
+  setOptionalBooleanField(body, fields, providedFields, "unfurl_links");
+  setOptionalBooleanField(body, fields, providedFields, "unfurl_media");
+  setOptionalBooleanField(body, fields, providedFields, "reply_broadcast");
+
+  return { fields, providedFields };
+}
+
+export function hasSlackMessageContent(text: string, fields: SlackRichMessageFields): boolean {
+  return text.length > 0 || (fields.blocks?.length ?? 0) > 0 || (fields.attachments?.length ?? 0) > 0;
+}
+
 export function resetTsCounter(): void {
   tsCounter = 0;
+}
+
+function hasBodyField(body: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, field);
+}
+
+function isSlackJsonObject(value: unknown): value is SlackJsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseSlackJsonString(value: string): ParsedField<unknown> {
+  if (value.length === 0) return {};
+  try {
+    return { value: JSON.parse(value) as unknown };
+  } catch {
+    return { error: "invalid_json" };
+  }
+}
+
+function parseSlackObjectArray(value: unknown, error: string): ParsedField<SlackJsonObject[]> {
+  let parsed = value;
+  if (parsed === undefined || parsed === null || parsed === "") return {};
+  if (typeof parsed === "string") {
+    const result = parseSlackJsonString(parsed);
+    if (result.error) return { error };
+    parsed = result.value;
+  }
+
+  if (!Array.isArray(parsed) || !parsed.every(isSlackJsonObject)) {
+    return { error };
+  }
+  return { value: parsed };
+}
+
+function parseSlackObject(value: unknown, error: string): ParsedField<SlackJsonObject> {
+  let parsed = value;
+  if (parsed === undefined || parsed === null || parsed === "") return {};
+  if (typeof parsed === "string") {
+    const result = parseSlackJsonString(parsed);
+    if (result.error) return { error };
+    parsed = result.value;
+  }
+
+  if (!isSlackJsonObject(parsed)) {
+    return { error };
+  }
+  return { value: parsed };
+}
+
+function parseSlackBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  if (typeof value === "string") {
+    const normalized = value.toLowerCase();
+    if (normalized === "true" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "0") return false;
+  }
+  return undefined;
+}
+
+function setOptionalStringField<K extends Extract<SlackRichMessageFieldName, keyof SlackRichMessageFields>>(
+  body: Record<string, unknown>,
+  fields: SlackRichMessageFields,
+  providedFields: SlackRichMessageFieldName[],
+  field: K,
+): void {
+  if (!hasBodyField(body, field)) return;
+  providedFields.push(field);
+  const value = body[field];
+  if (typeof value === "string" && value.length > 0) {
+    fields[field] = value as SlackRichMessageFields[K];
+  }
+}
+
+function setOptionalBooleanField<K extends Extract<SlackRichMessageFieldName, keyof SlackRichMessageFields>>(
+  body: Record<string, unknown>,
+  fields: SlackRichMessageFields,
+  providedFields: SlackRichMessageFieldName[],
+  field: K,
+): void {
+  if (!hasBodyField(body, field)) return;
+  providedFields.push(field);
+  const value = parseSlackBoolean(body[field]);
+  if (value !== undefined) {
+    fields[field] = value as SlackRichMessageFields[K];
+  }
 }

--- a/packages/@emulators/slack/src/routes/chat.ts
+++ b/packages/@emulators/slack/src/routes/chat.ts
@@ -1,6 +1,15 @@
 import type { RouteContext } from "@emulators/core";
+import type { SlackMessage } from "../entities.js";
 import { getSlackStore } from "../store.js";
-import { generateTs, slackOk, slackError, parseSlackBody } from "../helpers.js";
+import {
+  formatSlackMessage,
+  generateTs,
+  hasSlackMessageContent,
+  parseSlackBody,
+  parseSlackRichMessageFields,
+  slackError,
+  slackOk,
+} from "../helpers.js";
 
 export function chatRoutes(ctx: RouteContext): void {
   const { app, store, webhooks } = ctx;
@@ -15,11 +24,15 @@ export function chatRoutes(ctx: RouteContext): void {
     const channel = typeof body.channel === "string" ? body.channel : "";
     const text = typeof body.text === "string" ? body.text : "";
     const thread_ts = typeof body.thread_ts === "string" ? body.thread_ts : undefined;
+    const richMessage = parseSlackRichMessageFields(body);
+    if (richMessage.error) return slackError(c, richMessage.error);
 
     if (!channel) return slackError(c, "channel_not_found");
+    if (!hasSlackMessageContent(text, richMessage.fields)) return slackError(c, "no_text");
 
     const ch = ss().channels.findOneBy("channel_id", channel) ?? ss().channels.findOneBy("name", channel);
     if (!ch) return slackError(c, "channel_not_found");
+    if (ch.is_archived) return slackError(c, "is_archived");
 
     const ts = generateTs();
     const msg = ss().messages.insert({
@@ -29,6 +42,7 @@ export function chatRoutes(ctx: RouteContext): void {
       text,
       type: "message" as const,
       thread_ts,
+      ...richMessage.fields,
       reply_count: 0,
       reply_users: [],
       reactions: [],
@@ -56,12 +70,9 @@ export function chatRoutes(ctx: RouteContext): void {
       {
         type: "event_callback",
         event: {
+          ...formatSlackMessage(msg),
           type: "message",
           channel: ch.channel_id,
-          user: authUser.login,
-          text,
-          ts,
-          thread_ts,
         },
       },
       "slack",
@@ -70,13 +81,7 @@ export function chatRoutes(ctx: RouteContext): void {
     return slackOk(c, {
       channel: ch.channel_id,
       ts,
-      message: {
-        text: msg.text,
-        user: msg.user,
-        type: msg.type,
-        ts: msg.ts,
-        thread_ts: msg.thread_ts,
-      },
+      message: formatSlackMessage(msg),
     });
   });
 
@@ -88,7 +93,10 @@ export function chatRoutes(ctx: RouteContext): void {
     const body = await parseSlackBody(c);
     const channel = typeof body.channel === "string" ? body.channel : "";
     const ts = typeof body.ts === "string" ? body.ts : "";
-    const text = typeof body.text === "string" ? body.text : "";
+    const hasText = typeof body.text === "string";
+    const text = hasText ? (body.text as string) : "";
+    const richMessage = parseSlackRichMessageFields(body);
+    if (richMessage.error) return slackError(c, richMessage.error);
 
     if (!channel || !ts) return slackError(c, "message_not_found");
 
@@ -97,12 +105,24 @@ export function chatRoutes(ctx: RouteContext): void {
       .find((m) => m.ts === ts && m.channel_id === channel);
     if (!msg) return slackError(c, "message_not_found");
 
-    ss().messages.update(msg.id, { text });
+    const updates: Partial<SlackMessage> = { ...richMessage.fields };
+    if (hasText) {
+      updates.text = text;
+      if (!richMessage.providedFields.includes("blocks")) updates.blocks = undefined;
+      if (!richMessage.providedFields.includes("attachments")) updates.attachments = undefined;
+    }
+
+    if (!hasText && Object.keys(updates).length === 0) {
+      return slackError(c, "no_text");
+    }
+
+    const updated = ss().messages.update(msg.id, updates)!;
 
     return slackOk(c, {
       channel,
       ts,
-      text,
+      text: updated.text,
+      message: formatSlackMessage(updated),
     });
   });
 

--- a/packages/@emulators/slack/src/routes/conversations.ts
+++ b/packages/@emulators/slack/src/routes/conversations.ts
@@ -1,6 +1,6 @@
 import type { RouteContext } from "@emulators/core";
 import { getSlackStore } from "../store.js";
-import { generateSlackId, slackOk, slackError, parseSlackBody } from "../helpers.js";
+import { formatSlackMessage, generateSlackId, parseSlackBody, slackError, slackOk } from "../helpers.js";
 
 export function conversationsRoutes(ctx: RouteContext): void {
   const { app, store } = ctx;
@@ -117,7 +117,7 @@ export function conversationsRoutes(ctx: RouteContext): void {
     const nextCursor = hasMore ? allMessages[startIndex + limit].ts : "";
 
     return slackOk(c, {
-      messages: page.map(formatMessage),
+      messages: page.map(formatSlackMessage),
       has_more: hasMore,
       response_metadata: { next_cursor: nextCursor },
     });
@@ -140,7 +140,7 @@ export function conversationsRoutes(ctx: RouteContext): void {
       .sort((a, b) => (a.ts > b.ts ? 1 : -1));
 
     return slackOk(c, {
-      messages: allMessages.map(formatMessage),
+      messages: allMessages.map(formatSlackMessage),
       has_more: false,
     });
   });
@@ -229,28 +229,5 @@ function formatChannel(ch: {
     creator: ch.creator,
     num_members: ch.num_members,
     created: Math.floor(new Date(ch.created_at).getTime() / 1000),
-  };
-}
-
-function formatMessage(msg: {
-  ts: string;
-  user: string;
-  text: string;
-  type: string;
-  subtype?: string;
-  thread_ts?: string;
-  reply_count: number;
-  reply_users: string[];
-  reactions: Array<{ name: string; users: string[]; count: number }>;
-}) {
-  return {
-    type: msg.type,
-    user: msg.user,
-    text: msg.text,
-    ts: msg.ts,
-    ...(msg.subtype ? { subtype: msg.subtype } : {}),
-    ...(msg.thread_ts ? { thread_ts: msg.thread_ts } : {}),
-    ...(msg.reply_count > 0 ? { reply_count: msg.reply_count, reply_users: msg.reply_users } : {}),
-    ...(msg.reactions.length > 0 ? { reactions: msg.reactions } : {}),
   };
 }

--- a/packages/@emulators/slack/src/routes/inspector.ts
+++ b/packages/@emulators/slack/src/routes/inspector.ts
@@ -21,10 +21,54 @@ function renderReactions(reactions: Array<{ name: string; count: number }>): str
   return `<div style="margin-top:4px">${badges}</div>`;
 }
 
+function collectTextValues(value: unknown, output: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectTextValues(item, output);
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+
+  const record = value as Record<string, unknown>;
+  const text = record.text;
+  if (typeof text === "string" && text.trim().length > 0) {
+    output.push(text);
+  } else {
+    collectTextValues(text, output);
+  }
+  collectTextValues(record.fields, output);
+  collectTextValues(record.elements, output);
+  collectTextValues(record.accessory, output);
+}
+
+function richMessagePreview(msg: SlackMessage): string {
+  if (msg.text.trim().length > 0) return msg.text;
+
+  const blockText: string[] = [];
+  collectTextValues(msg.blocks, blockText);
+  if (blockText.length > 0) return blockText.join(" ");
+
+  const attachmentText =
+    msg.attachments
+      ?.flatMap((attachment) => [attachment.text, attachment.title])
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0) ?? [];
+  if (attachmentText.length > 0) return attachmentText.join(" ");
+
+  if (msg.blocks?.length) return `${msg.blocks.length} ${msg.blocks.length === 1 ? "block" : "blocks"}`;
+  if (msg.attachments?.length) {
+    return `${msg.attachments.length} ${msg.attachments.length === 1 ? "attachment" : "attachments"}`;
+  }
+  return msg.text;
+}
+
 function renderMessage(msg: SlackMessage, users: Map<string, string>): string {
   const displayName = users.get(msg.user) ?? msg.user;
   const isBot = msg.subtype === "bot_message";
   const letter = isBot ? "B" : (displayName[0] ?? "?").toUpperCase();
+  const messageText = richMessagePreview(msg);
+  const richBadge =
+    msg.text.length === 0 && ((msg.blocks?.length ?? 0) > 0 || (msg.attachments?.length ?? 0) > 0)
+      ? ' <span class="badge badge-granted">rich</span>'
+      : "";
   const threadBadge =
     msg.reply_count > 0
       ? ` <span class="badge badge-requested">${msg.reply_count} ${msg.reply_count === 1 ? "reply" : "replies"}</span>`
@@ -37,7 +81,7 @@ function renderMessage(msg: SlackMessage, users: Map<string, string>): string {
   <span class="org-name">${escapeHtml(displayName)}${isBot ? ' <span class="badge badge-granted">bot</span>' : ""}</span>
   <span class="user-meta" style="margin-left:auto">${timeAgo(msg.created_at)}</span>
 </div>
-<div class="info-text">${threadIndicator}${escapeHtml(msg.text)}${threadBadge}</div>
+<div class="info-text">${threadIndicator}${escapeHtml(messageText)}${richBadge}${threadBadge}</div>
 ${renderReactions(msg.reactions)}`;
 }
 

--- a/packages/@emulators/slack/src/routes/reactions.ts
+++ b/packages/@emulators/slack/src/routes/reactions.ts
@@ -1,6 +1,6 @@
 import type { RouteContext } from "@emulators/core";
 import { getSlackStore } from "../store.js";
-import { slackOk, slackError, parseSlackBody } from "../helpers.js";
+import { formatSlackMessage, slackOk, slackError, parseSlackBody } from "../helpers.js";
 
 export function reactionsRoutes(ctx: RouteContext): void {
   const { app, store, webhooks } = ctx;
@@ -118,12 +118,7 @@ export function reactionsRoutes(ctx: RouteContext): void {
 
     return slackOk(c, {
       type: "message",
-      message: {
-        type: msg.type,
-        text: msg.text,
-        ts: msg.ts,
-        reactions: msg.reactions,
-      },
+      message: { ...formatSlackMessage(msg), reactions: msg.reactions },
     });
   });
 }

--- a/packages/@emulators/slack/src/routes/webhooks.ts
+++ b/packages/@emulators/slack/src/routes/webhooks.ts
@@ -87,13 +87,15 @@ export function webhookRoutes(ctx: RouteContext): void {
       reactions: [],
     });
 
+    const { user: _user, ...eventMessage } = formatSlackMessage(msg);
+
     await webhooks.dispatch(
       "message",
       undefined,
       {
         type: "event_callback",
         event: {
-          ...formatSlackMessage(msg),
+          ...eventMessage,
           type: "message",
           subtype: "bot_message",
           channel: targetChannel.channel_id,

--- a/packages/@emulators/slack/src/routes/webhooks.ts
+++ b/packages/@emulators/slack/src/routes/webhooks.ts
@@ -1,6 +1,6 @@
 import type { RouteContext } from "@emulators/core";
 import { getSlackStore } from "../store.js";
-import { generateTs } from "../helpers.js";
+import { formatSlackMessage, generateTs, hasSlackMessageContent, parseSlackRichMessageFields } from "../helpers.js";
 
 export function webhookRoutes(ctx: RouteContext): void {
   const { app, store, webhooks } = ctx;
@@ -37,8 +37,12 @@ export function webhookRoutes(ctx: RouteContext): void {
     const text = typeof body.text === "string" ? body.text : "";
     const channelName = typeof body.channel === "string" ? body.channel : "";
     const threadTs = typeof body.thread_ts === "string" ? body.thread_ts : undefined;
+    const richMessage = parseSlackRichMessageFields(body);
+    if (richMessage.error) {
+      return c.text(richMessage.error, 400);
+    }
 
-    if (!text && !body.blocks && !body.attachments) {
+    if (!hasSlackMessageContent(text, richMessage.fields)) {
       return c.text("no_text", 400);
     }
 
@@ -68,14 +72,16 @@ export function webhookRoutes(ctx: RouteContext): void {
     const ts = generateTs();
     const botId = c.req.param("botId");
 
-    ss().messages.insert({
+    const msg = ss().messages.insert({
       ts,
       channel_id: targetChannel.channel_id,
       user: botId,
-      text: text || "(rich message)",
+      text,
       type: "message" as const,
       subtype: "bot_message",
       thread_ts: threadTs,
+      ...richMessage.fields,
+      bot_id: botId,
       reply_count: 0,
       reply_users: [],
       reactions: [],
@@ -87,13 +93,11 @@ export function webhookRoutes(ctx: RouteContext): void {
       {
         type: "event_callback",
         event: {
+          ...formatSlackMessage(msg),
           type: "message",
           subtype: "bot_message",
           channel: targetChannel.channel_id,
           bot_id: botId,
-          text: text || "(rich message)",
-          ts,
-          thread_ts: threadTs,
         },
       },
       "slack",

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
 
 # Slack API Emulator
 
-Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. State changes dispatch `event_callback` payloads to configured webhook URLs.
+Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. Chat writes preserve common rich message fields such as `blocks`, `attachments`, `metadata`, formatting flags, unfurl flags, and client message ids. State changes dispatch `event_callback` payloads to configured webhook URLs.
 
 ## Start
 
@@ -131,6 +131,8 @@ curl -X POST http://localhost:4003/api/auth.test \
 
 ### Chat
 
+`chat.postMessage`, `chat.update`, `conversations.history`, and `conversations.replies` round trip text plus common rich message fields: `blocks`, `attachments`, `metadata`, `mrkdwn`, `parse`, `link_names`, `unfurl_links`, `unfurl_media`, `username`, `icon_url`, `icon_emoji`, `bot_id`, `app_id`, `client_msg_id`, and `reply_broadcast`.
+
 ```bash
 # Post message
 curl -X POST http://localhost:4003/api/chat.postMessage \
@@ -143,6 +145,12 @@ curl -X POST http://localhost:4003/api/chat.postMessage \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"channel": "C000000001", "text": "Thread reply", "thread_ts": "1234567890.123456"}'
+
+# Post rich message
+curl -X POST http://localhost:4003/api/chat.postMessage \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "text": "Deploy complete", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "*Deploy* complete"}}], "metadata": {"event_type": "deploy_complete", "event_payload": {"deploy_id": "dep_123"}}, "unfurl_links": false}'
 
 # Update message
 curl -X POST http://localhost:4003/api/chat.update \
@@ -315,7 +323,8 @@ Returns a Slack-style response:
 
 When messages are posted or reactions are added/removed, the emulator dispatches `event_callback` payloads to configured webhook URLs. These payloads match Slack's Events API format:
 
-- `message` events on `chat.postMessage`, `chat.update`, `chat.delete`
+- `message` events on `chat.postMessage`
+- rich message fields are included on posted `message` events when present
 - `reaction_added` / `reaction_removed` events on `reactions.add` / `reactions.remove`
 - `message` with `subtype: bot_message` on incoming webhook posts
 


### PR DESCRIPTION
- Preserve rich chat and webhook payloads through storage and reads.
- Add route, event, and Slack SDK coverage for rich message round trips.
- Update Slack docs and coverage notes for the supported surface.