### PR TITLE
Expand Slack inspector audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,9 @@ Modal opens and pushes require values from `/api/views.generateTriggerId`. Pass 
 - `GET /oauth/v2/authorize` - authorization (shows user picker)
 - `POST /api/oauth.v2.access` - token exchange
 
+### Inspector
+- `GET /` - tabbed local inspector for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries
+
 Slack scope checks are relaxed by default so local tests can use simple bearer tokens. Set `slack.strict_scopes: true` in seed config to make supported Web API methods return Slack-style `missing_scope` errors with `needed` and `provided` fields. Supported user, presence, file, pin, and bookmark checks include `users:read`, `users:read.email`, `users.profile:read`, `users.profile:write`, `users:write`, `files:read`, `files:write`, `pins:read`, `pins:write`, `bookmarks:read`, and `bookmarks:write`. Slack lists no method-specific scopes for `views.publish`, `views.open`, `views.update`, or `views.push`, so the emulator requires auth but does not add strict-scope checks for those methods.
 
 ## Apple Sign In

--- a/apps/web/app/docs/slack/page.mdx
+++ b/apps/web/app/docs/slack/page.mdx
@@ -104,6 +104,10 @@ Modal opens and pushes require values from `/api/views.generateTriggerId`. Pass 
 - `GET /oauth/v2/authorize` - authorization endpoint (shows user picker)
 - `POST /api/oauth.v2.access` - token exchange
 
+## Inspector
+
+- `GET /` - tabbed local inspector for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries
+
 `oauth.v2.access` returns a bot token, `bot_user_id`, `app_id`, team details, and the `authed_user` object. When `user_scope` is requested, `authed_user` also includes a user token and granted user scopes.
 
 ## Event Dispatching

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -85,6 +85,9 @@ Modal opens and pushes require values from `/api/views.generateTriggerId`. Pass 
 - `GET /oauth/v2/authorize` — authorization (shows user picker)
 - `POST /api/oauth.v2.access` — token exchange
 
+### Inspector
+- `GET /` — tabbed local inspector for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries
+
 ## Auth
 
 All Web API endpoints require `Authorization: Bearer <token>`. Seeded OAuth apps create local installation state, and the OAuth v2 flow with user picker UI returns Slack-style bot tokens. Scope checks are relaxed by default for local development. Set `strict_scopes: true` in Slack seed config to return Slack-style `missing_scope` errors when a token lacks the required method scope. Supported user, presence, file, pin, and bookmark checks include `users:read`, `users:read.email`, `users.profile:read`, `users.profile:write`, `users:write`, `files:read`, `files:write`, `pins:read`, `pins:write`, `bookmarks:read`, and `bookmarks:write`. Slack lists no method-specific scopes for `views.publish`, `views.open`, `views.update`, or `views.push`, so the emulator requires auth but does not add strict-scope checks for those methods.

--- a/packages/@emulators/slack/src/__tests__/slack-coverage.ts
+++ b/packages/@emulators/slack/src/__tests__/slack-coverage.ts
@@ -474,7 +474,8 @@ export const slackCoverageMatrix: SlackCoverageEntry[] = [
     route: "GET /",
     status: "partial",
     testedBy: ["slack.test.ts"],
-    notes: "Shows channels, recent messages, scheduled messages, ephemeral messages, pins, and bookmarks.",
+    notes:
+      "Shows tabbed Slack state for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries.",
   },
   {
     family: "files",

--- a/packages/@emulators/slack/src/__tests__/slack.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack.test.ts
@@ -4436,6 +4436,30 @@ describe("Slack plugin - Message Inspector", () => {
     expect(html).toContain("Inspector test message");
   });
 
+  it("shows message reactions in the inspector", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+
+    const postRes = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: ch.channel_id, text: "Inspector reaction message" }),
+    });
+    const posted = (await postRes.json()) as any;
+
+    await app.request(`${base}/api/reactions.add`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: ch.channel_id, timestamp: posted.ts, name: "wave" }),
+    });
+
+    const res = await app.request(`${base}/?channel=${ch.channel_id}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Reactions");
+    expect(html).toContain(":wave: 1");
+  });
+
   it("shows pins and bookmarks in the inspector", async () => {
     const ss = getSlackStore(store);
     const ch = ss.channels.all()[0];

--- a/packages/@emulators/slack/src/__tests__/slack.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack.test.ts
@@ -4546,10 +4546,16 @@ describe("Slack plugin - Message Inspector", () => {
   it("shows channels and DMs in the inspector", async () => {
     insertSlackTestUser(store, "U000000222", "inspector-peer");
 
-    await app.request(`${base}/api/conversations.open`, {
+    const openRes = await app.request(`${base}/api/conversations.open`, {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ users: "U000000222", return_im: true }),
+    });
+    const opened = (await openRes.json()) as any;
+    await app.request(`${base}/api/conversations.close`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: opened.channel.id }),
     });
 
     const res = await app.request(`${base}/?tab=channels`);
@@ -4559,6 +4565,8 @@ describe("Slack plugin - Message Inspector", () => {
     expect(html).toContain("Direct Messages");
     expect(html).toContain("inspector-peer");
     expect(html).toContain("DM");
+    expect(html).toContain(">closed<");
+    expect(html).not.toContain("<td>U000000001</td>");
   });
 
   it("shows files, views, auth state, and event deliveries in inspector tabs", async () => {
@@ -4621,6 +4629,14 @@ describe("Slack plugin - Message Inspector", () => {
       headers: authHeaders(),
       body: JSON.stringify({ channel, text: "Inspector event delivery" }),
     });
+    captureFetchRequests(200);
+    for (let index = 0; index < 100; index++) {
+      await app.request(`${base}/api/chat.postMessage`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ channel, text: `Inspector success event delivery ${index}` }),
+      });
+    }
 
     const files = await app.request(`${base}/?tab=files`);
     expect(await files.text()).toContain("Inspector File");

--- a/packages/@emulators/slack/src/__tests__/slack.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack.test.ts
@@ -3,7 +3,9 @@ import { Hono, Store, WebhookDispatcher } from "@emulators/core";
 import { slackPlugin, seedFromConfig, getSlackStore } from "../index.js";
 import {
   authHeaders,
+  captureFetchRequests,
   createSlackTestApp as createTestApp,
+  registerSlackEventSubscription,
   slackTestBaseUrl as base,
   type SlackTestApp,
 } from "./helpers.js";
@@ -4397,9 +4399,14 @@ describe("Slack plugin - views", () => {
 describe("Slack plugin - Message Inspector", () => {
   let app: SlackTestApp["app"];
   let store: Store;
+  let webhooks: WebhookDispatcher;
 
   beforeEach(() => {
-    ({ app, store } = createTestApp());
+    ({ app, store, webhooks } = createTestApp());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders the message inspector page", async () => {
@@ -4534,5 +4541,104 @@ describe("Slack plugin - Message Inspector", () => {
     const html = await res.text();
     expect(html).toContain("random");
     expect(html).toContain("Random stuff");
+  });
+
+  it("shows channels and DMs in the inspector", async () => {
+    insertSlackTestUser(store, "U000000222", "inspector-peer");
+
+    await app.request(`${base}/api/conversations.open`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ users: "U000000222", return_im: true }),
+    });
+
+    const res = await app.request(`${base}/?tab=channels`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Channels");
+    expect(html).toContain("Direct Messages");
+    expect(html).toContain("inspector-peer");
+    expect(html).toContain("DM");
+  });
+
+  it("shows files, views, auth state, and event deliveries in inspector tabs", async () => {
+    const ss = getSlackStore(store);
+    const channel = ss.channels.findOneBy("name", "general")!.channel_id;
+    ss.files.insert({
+      file_id: "FINSPECT001",
+      team_id: "T000000001",
+      user: "U000000001",
+      name: "inspector-file.txt",
+      title: "Inspector File",
+      mimetype: "text/plain",
+      filetype: "text",
+      pretty_type: "Text",
+      mode: "hosted",
+      size: 14,
+      created: Math.floor(Date.now() / 1000),
+      timestamp: Math.floor(Date.now() / 1000),
+      url_private: `${base}/files-pri/FINSPECT001/inspector-file.txt`,
+      url_private_download: `${base}/files-pri/FINSPECT001/inspector-file.txt`,
+      permalink: `${base}/files/FINSPECT001`,
+      is_external: false,
+      external_type: "",
+      is_public: false,
+      public_url_shared: false,
+      display_as_bot: false,
+      editable: false,
+      deleted: false,
+      channels: [channel],
+      groups: [],
+      ims: [],
+      shares: {},
+    });
+    ss.tokens.insert({
+      token: "xoxb-inspector-token",
+      token_type: "bot",
+      team_id: "T000000001",
+      user_id: "U000000001",
+      scopes: ["chat:write", "files:read"],
+      app_id: "AINSPECT001",
+      bot_id: "BINSPECT001",
+    });
+
+    await app.request(`${base}/api/views.publish`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        user_id: "U000000001",
+        view: {
+          type: "home",
+          blocks: [{ type: "section", text: { type: "plain_text", text: "Inspector App Home" } }],
+        },
+      }),
+    });
+
+    captureFetchRequests(500);
+    registerSlackEventSubscription(webhooks, ["message"]);
+    await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel, text: "Inspector event delivery" }),
+    });
+
+    const files = await app.request(`${base}/?tab=files`);
+    expect(await files.text()).toContain("Inspector File");
+
+    const views = await app.request(`${base}/?tab=views`);
+    expect(await views.text()).toContain("Inspector App Home");
+
+    const auth = await app.request(`${base}/?tab=auth`);
+    const authHtml = await auth.text();
+    expect(authHtml).toContain("Tokens");
+    expect(authHtml).toContain("xoxb-ins...oken");
+    expect(authHtml).toContain("Incoming Webhooks");
+
+    const events = await app.request(`${base}/?tab=events`);
+    const eventsHtml = await events.text();
+    expect(eventsHtml).toContain("Event Deliveries");
+    expect(eventsHtml).toContain("message");
+    expect(eventsHtml).toContain("500");
+    expect(eventsHtml).toContain("Last Errors");
   });
 });

--- a/packages/@emulators/slack/src/routes/inspector.ts
+++ b/packages/@emulators/slack/src/routes/inspector.ts
@@ -121,6 +121,11 @@ function badge(label: string, tone: "granted" | "requested" | "denied" = "reques
   return `<span class="badge badge-${tone}">${escapeHtml(label)}</span>`;
 }
 
+function renderReactionBadges(reactions: Array<{ name: string; count: number }>): string {
+  if (reactions.length === 0) return "";
+  return reactions.map((reaction) => badge(`:${reaction.name}: ${reaction.count}`, "granted")).join(" ");
+}
+
 function linkCell(href: string, label: string): string {
   return `<a href="${escapeAttr(href)}">${escapeHtml(label)}</a>`;
 }
@@ -437,7 +442,7 @@ export function inspectorRoutes(ctx: RouteContext): void {
 
 function renderMessagesTable(messages: SlackMessage[], users: Map<string, string>, empty: string): string {
   return renderTable(
-    ["Time", "User", "Message", "TS"],
+    ["Time", "User", "Message", "Reactions", "TS"],
     messages.map((msg) => {
       const isBot = msg.subtype === "bot_message";
       const richBadge =
@@ -456,6 +461,7 @@ function renderMessagesTable(messages: SlackMessage[], users: Map<string, string
         escapeHtml(timeAgo(msg.created_at)),
         `${escapeHtml(userLabel(users, msg.user))}${isBot ? ` ${badge("bot", "granted")}` : ""}`,
         `${threadIndicator}${escapeHtml(richMessagePreview(msg))}${richBadge}${fileBadge}${threadBadge}`,
+        renderReactionBadges(msg.reactions),
         escapeHtml(msg.ts),
       ];
     }),

--- a/packages/@emulators/slack/src/routes/inspector.ts
+++ b/packages/@emulators/slack/src/routes/inspector.ts
@@ -1,18 +1,34 @@
-import type { RouteContext } from "@emulators/core";
-import { escapeHtml, renderSettingsPage } from "@emulators/core";
+import type { InspectorTab, RouteContext, WebhookDelivery, WebhookSubscription } from "@emulators/core";
+import { escapeAttr, escapeHtml, renderInspectorPage } from "@emulators/core";
 import { getSlackStore } from "../store.js";
 import type {
   SlackBookmark,
   SlackChannel,
   SlackEphemeralMessage,
+  SlackIncomingWebhook,
+  SlackInstallation,
   SlackMessage,
+  SlackOAuthApp,
   SlackPin,
   SlackScheduledMessage,
+  SlackToken,
   SlackView,
+  SlackViewTrigger,
 } from "../entities.js";
 import { compareSlackBookmarks } from "./bookmarks.js";
 
 const SERVICE_LABEL = "Slack";
+
+const INSPECTOR_TABS: InspectorTab[] = [
+  { id: "messages", label: "Messages", href: "/?tab=messages" },
+  { id: "channels", label: "Channels", href: "/?tab=channels" },
+  { id: "files", label: "Files", href: "/?tab=files" },
+  { id: "views", label: "Views", href: "/?tab=views" },
+  { id: "auth", label: "Auth", href: "/?tab=auth" },
+  { id: "events", label: "Events", href: "/?tab=events" },
+];
+
+type InspectorTabId = (typeof INSPECTOR_TABS)[number]["id"];
 
 function timeAgo(isoDate: string): string {
   const seconds = Math.floor((Date.now() - new Date(isoDate).getTime()) / 1000);
@@ -20,14 +36,6 @@ function timeAgo(isoDate: string): string {
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
   return `${Math.floor(seconds / 86400)}d ago`;
-}
-
-function renderReactions(reactions: Array<{ name: string; count: number }>): string {
-  if (!reactions || reactions.length === 0) return "";
-  const badges = reactions
-    .map((r) => `<span class="badge badge-granted">:${escapeHtml(r.name)}: ${r.count}</span>`)
-    .join(" ");
-  return `<div style="margin-top:4px">${badges}</div>`;
 }
 
 function collectTextValues(value: unknown, output: string[]): void {
@@ -49,7 +57,9 @@ function collectTextValues(value: unknown, output: string[]): void {
   collectTextValues(record.accessory, output);
 }
 
-function richMessagePreview(msg: Pick<SlackMessage, "text" | "blocks" | "attachments" | "files">): string {
+function richMessagePreview(
+  msg: Pick<SlackMessage, "text" | "blocks" | "attachments" | "files"> | SlackScheduledMessage,
+): string {
   if (msg.text.trim().length > 0) return msg.text;
 
   const blockText: string[] = [];
@@ -62,83 +72,16 @@ function richMessagePreview(msg: Pick<SlackMessage, "text" | "blocks" | "attachm
       .filter((value): value is string => typeof value === "string" && value.trim().length > 0) ?? [];
   if (attachmentText.length > 0) return attachmentText.join(" ");
 
-  const fileText = msg.files?.map((file) => file.title || file.name).filter((value) => value.trim().length > 0) ?? [];
+  const files = "files" in msg ? msg.files : undefined;
+  const fileText = files?.map((file) => file.title || file.name).filter((value) => value.trim().length > 0) ?? [];
   if (fileText.length > 0) return fileText.join(" ");
 
   if (msg.blocks?.length) return `${msg.blocks.length} ${msg.blocks.length === 1 ? "block" : "blocks"}`;
   if (msg.attachments?.length) {
     return `${msg.attachments.length} ${msg.attachments.length === 1 ? "attachment" : "attachments"}`;
   }
-  if (msg.files?.length) return `${msg.files.length} ${msg.files.length === 1 ? "file" : "files"}`;
+  if (files?.length) return `${files.length} ${files.length === 1 ? "file" : "files"}`;
   return msg.text;
-}
-
-function renderMessage(msg: SlackMessage, users: Map<string, string>): string {
-  const displayName = users.get(msg.user) ?? msg.user;
-  const isBot = msg.subtype === "bot_message";
-  const letter = isBot ? "B" : (displayName[0] ?? "?").toUpperCase();
-  const messageText = richMessagePreview(msg);
-  const richBadge =
-    msg.text.length === 0 && ((msg.blocks?.length ?? 0) > 0 || (msg.attachments?.length ?? 0) > 0)
-      ? ' <span class="badge badge-granted">rich</span>'
-      : "";
-  const threadBadge =
-    msg.reply_count > 0
-      ? ` <span class="badge badge-requested">${msg.reply_count} ${msg.reply_count === 1 ? "reply" : "replies"}</span>`
-      : "";
-  const fileBadge = msg.files?.length
-    ? ` <span class="badge badge-granted">${msg.files.length} ${msg.files.length === 1 ? "file" : "files"}</span>`
-    : "";
-  const threadIndicator =
-    msg.thread_ts && msg.thread_ts !== msg.ts ? `<span class="badge badge-denied">thread</span> ` : "";
-
-  return `<div class="org-row">
-  <span class="org-icon">${escapeHtml(letter)}</span>
-  <span class="org-name">${escapeHtml(displayName)}${isBot ? ' <span class="badge badge-granted">bot</span>' : ""}</span>
-  <span class="user-meta" style="margin-left:auto">${timeAgo(msg.created_at)}</span>
-</div>
-<div class="info-text">${threadIndicator}${escapeHtml(messageText)}${richBadge}${fileBadge}${threadBadge}</div>
-${renderReactions(msg.reactions)}`;
-}
-
-function renderEphemeralMessage(msg: SlackEphemeralMessage, users: Map<string, string>): string {
-  const displayName = users.get(msg.target_user) ?? msg.target_user;
-  return `<div class="org-row">
-  <span class="org-icon">E</span>
-  <span class="org-name">${escapeHtml(displayName)} <span class="badge badge-requested">ephemeral</span></span>
-  <span class="user-meta" style="margin-left:auto">${timeAgo(msg.created_at)}</span>
-</div>
-<div class="info-text">${escapeHtml(richMessagePreview(msg))}</div>`;
-}
-
-function renderScheduledMessage(msg: SlackScheduledMessage): string {
-  const scheduledAt = new Date(msg.post_at * 1000).toLocaleString("en-US", { timeZone: "UTC" });
-  return `<div class="org-row">
-  <span class="org-icon">S</span>
-  <span class="org-name">${escapeHtml(msg.scheduled_message_id)} <span class="badge badge-requested">scheduled</span></span>
-  <span class="user-meta" style="margin-left:auto">${escapeHtml(scheduledAt)} UTC</span>
-</div>
-<div class="info-text">${escapeHtml(richMessagePreview(msg))}</div>`;
-}
-
-function renderPin(pin: SlackPin, message: SlackMessage | undefined, users: Map<string, string>): string {
-  const creator = users.get(pin.created_by) ?? pin.created_by;
-  const text = message ? richMessagePreview(message) : pin.message_ts;
-  return `<div class="org-row">
-  <span class="org-icon">P</span>
-  <span class="org-name">${escapeHtml(creator)} <span class="badge badge-requested">pin</span></span>
-  <span class="user-meta">${timeAgo(new Date(pin.created * 1000).toISOString())}</span>
-</div>
-<div class="info-text">${escapeHtml(text)}</div>`;
-}
-
-function renderBookmark(bookmark: SlackBookmark): string {
-  return `<div class="org-row">
-  <span class="org-icon">B</span>
-  <span class="org-name">${escapeHtml(bookmark.title)} <span class="badge badge-granted">bookmark</span></span>
-  <span class="user-meta">${escapeHtml(bookmark.type)}</span>
-</div>
-<div class="info-text">${escapeHtml(bookmark.link)}</div>`;
 }
 
 function viewPreview(view: SlackView): string {
@@ -154,54 +97,108 @@ function viewPreview(view: SlackView): string {
   return `${view.blocks.length} ${view.blocks.length === 1 ? "block" : "blocks"}`;
 }
 
-function renderView(view: SlackView, users: Map<string, string>): string {
-  const userName = users.get(view.user_id) ?? view.user_id;
-  const label = view.type === "home" ? "app home" : "modal";
-  return `<div class="org-row">
-  <span class="org-icon">${view.type === "home" ? "H" : "M"}</span>
-  <span class="org-name">${escapeHtml(userName)} <span class="badge badge-granted">${label}</span></span>
-  <span class="user-meta">${escapeHtml(view.hash)}</span>
-</div>
-<div class="info-text">${escapeHtml(viewPreview(view))}</div>`;
+function renderSection(title: string, body: string): string {
+  return `<section class="inspector-section">
+  <h2>${escapeHtml(title)}</h2>
+  ${body}
+</section>`;
 }
 
-function renderChannelSidebar(channels: SlackChannel[], activeId: string): string {
-  return channels
-    .map((ch) => {
-      const active = ch.channel_id === activeId ? ' class="active"' : "";
-      const prefix = ch.is_private ? "private " : "# ";
-      return `<a href="/?channel=${escapeHtml(ch.channel_id)}"${active}>${prefix}${escapeHtml(ch.name)}</a>`;
-    })
-    .join("\n");
+function renderTable(headers: string[], rows: string[][], empty: string): string {
+  if (rows.length === 0) return `<p class="inspector-empty">${escapeHtml(empty)}</p>`;
+
+  const headerHtml = headers.map((header) => `<th>${escapeHtml(header)}</th>`).join("");
+  const rowsHtml = rows.map((row) => `<tr>${row.map((cell) => `<td>${cell}</td>`).join("")}</tr>`).join("\n");
+  return `<table class="inspector-table">
+  <thead><tr>${headerHtml}</tr></thead>
+  <tbody>
+${rowsHtml}
+  </tbody>
+</table>`;
+}
+
+function badge(label: string, tone: "granted" | "requested" | "denied" = "requested"): string {
+  return `<span class="badge badge-${tone}">${escapeHtml(label)}</span>`;
+}
+
+function linkCell(href: string, label: string): string {
+  return `<a href="${escapeAttr(href)}">${escapeHtml(label)}</a>`;
+}
+
+function scopePreview(scopes: string[] | undefined): string {
+  if (!scopes || scopes.length === 0) return "";
+  return scopes.join(", ");
+}
+
+function userLabel(users: Map<string, string>, id: string): string {
+  return users.get(id) ?? id;
+}
+
+function channelLabel(ch: SlackChannel): string {
+  if (ch.is_im) return `DM ${ch.name}`;
+  if (ch.is_mpim) return `MPIM ${ch.name}`;
+  if (ch.is_private) return `private ${ch.name}`;
+  return `# ${ch.name}`;
+}
+
+function channelKind(ch: SlackChannel): string {
+  if (ch.is_im) return "DM";
+  if (ch.is_mpim) return "MPIM";
+  if (ch.is_private) return "Private";
+  return "Public";
+}
+
+function maskToken(value: string): string {
+  if (value.length <= 10) return value;
+  return `${value.slice(0, 8)}...${value.slice(-4)}`;
+}
+
+function sortedChannels(channels: SlackChannel[]): SlackChannel[] {
+  return [...channels].sort(
+    (a, b) =>
+      Number(a.is_archived) - Number(b.is_archived) ||
+      channelKind(a).localeCompare(channelKind(b)) ||
+      a.name.localeCompare(b.name),
+  );
 }
 
 export function inspectorRoutes(ctx: RouteContext): void {
-  const { app, store } = ctx;
+  const { app, store, webhooks } = ctx;
   const ss = () => getSlackStore(store);
 
-  // Message Inspector - the visual dashboard
   app.get("/", (c) => {
-    const channels = ss()
-      .channels.all()
-      .filter((ch) => !ch.is_archived);
     const team = ss().teams.all()[0];
+    const requestedTab = c.req.query("tab") ?? "messages";
+    const activeTab = INSPECTOR_TABS.some((tab) => tab.id === requestedTab)
+      ? (requestedTab as InspectorTabId)
+      : "messages";
+    const users = buildUserMap();
 
-    if (channels.length === 0) {
-      return c.html(
-        renderSettingsPage(
-          "Slack Inspector",
-          "<p class='empty'>No channels</p>",
-          "<p class='empty'>No channels in the emulator store.</p>",
-          SERVICE_LABEL,
-        ),
-      );
-    }
+    const body =
+      activeTab === "channels"
+        ? renderChannelsView(users)
+        : activeTab === "files"
+          ? renderFilesView(users)
+          : activeTab === "views"
+            ? renderViewsView(users)
+            : activeTab === "auth"
+              ? renderAuthView()
+              : activeTab === "events"
+                ? renderEventsView()
+                : renderMessagesView(c.req.query("channel") ?? "", users);
 
-    // Pick active channel from query param or default to first
-    const requestedChannel = c.req.query("channel") ?? "";
-    const activeChannel = channels.find((ch) => ch.channel_id === requestedChannel) ?? channels[0];
+    return c.html(
+      renderInspectorPage(
+        `${team?.name ?? "Slack"} - Message Inspector`,
+        INSPECTOR_TABS,
+        activeTab,
+        body,
+        SERVICE_LABEL,
+      ),
+    );
+  });
 
-    // Build user lookup map
+  function buildUserMap(): Map<string, string> {
     const userMap = new Map<string, string>();
     for (const u of ss().users.all()) {
       userMap.set(u.user_id, u.name);
@@ -209,13 +206,27 @@ export function inspectorRoutes(ctx: RouteContext): void {
     }
     for (const b of ss().bots.all()) {
       userMap.set(b.bot_id, b.name);
+      if (b.user_id) userMap.set(b.user_id, b.name);
+    }
+    return userMap;
+  }
+
+  function renderMessagesView(requestedChannel: string, users: Map<string, string>): string {
+    const channels = sortedChannels(ss().channels.all());
+    const visibleChannels = channels.filter((ch) => !ch.is_archived);
+    const activeChannel =
+      channels.find((ch) => ch.channel_id === requestedChannel) ?? visibleChannels[0] ?? channels[0];
+    if (!activeChannel) {
+      return renderSection("Messages", '<p class="inspector-empty">No conversations in the emulator store.</p>');
     }
 
-    // Get messages for the active channel, newest first
     const channelMessages = ss()
       .messages.findBy("channel_id", activeChannel.channel_id)
       .sort((a, b) => (b.ts > a.ts ? 1 : -1));
     const messages = channelMessages.slice(0, 50);
+    const threads = channelMessages
+      .filter((message) => message.thread_ts && message.thread_ts !== message.ts)
+      .slice(0, 20);
     const ephemeralMessages = ss()
       .ephemeralMessages.findBy("channel_id", activeChannel.channel_id)
       .sort((a, b) => (b.ts > a.ts ? 1 : -1))
@@ -233,91 +244,408 @@ export function inspectorRoutes(ctx: RouteContext): void {
       .bookmarks.findBy("channel_id", activeChannel.channel_id)
       .sort(compareSlackBookmarks)
       .slice(0, 20);
-    const homeViews = ss()
+    const views = ss()
       .views.all()
-      .filter((view) => view.type === "home")
-      .sort((a, b) => b.updated - a.updated || b.id - a.id)
-      .slice(0, 20);
-    const modalViews = ss()
+      .sort((a, b) => b.updated - a.updated || b.id - a.id);
+    const homeViews = views.filter((view) => view.type === "home").slice(0, 20);
+    const modalViews = views.filter((view) => view.type === "modal").slice(0, 20);
+
+    const stats = `${ss().users.all().length} users, ${channels.length} conversations, ${ss().messages.all().length} messages, ${ss().views.all().length} views`;
+    const body = [
+      renderConversationSelector(channels, activeChannel.channel_id),
+      renderSection(
+        `Messages In ${channelLabel(activeChannel)}`,
+        `<p class="info-text">${escapeHtml(activeChannel.topic.value || "No topic set")} - ${escapeHtml(stats)}</p>` +
+          renderMessagesTable(
+            messages,
+            users,
+            "No messages yet. Post one with chat.postMessage or an incoming webhook.",
+          ),
+      ),
+      renderSection("Threads", renderMessagesTable(threads, users, "No thread replies for this conversation.")),
+      renderSection(
+        "Ephemeral",
+        renderEphemeralTable(ephemeralMessages, users, "No ephemeral messages for this conversation."),
+      ),
+      renderSection(
+        "Scheduled",
+        renderScheduledTable(scheduledMessages, users, "No scheduled messages for this conversation."),
+      ),
+      renderSection("Pins", renderPinsTable(pins, channelMessages, users, "No pins for this conversation.")),
+      renderSection("Bookmarks", renderBookmarksTable(bookmarks, "No bookmarks for this conversation.")),
+      renderSection("App Home", renderViewsTable(homeViews, users, "No App Home views have been published.")),
+      renderSection("Modals", renderViewsTable(modalViews, users, "No modal views have been opened.")),
+    ];
+    return body.join("\n");
+  }
+
+  function renderConversationSelector(channels: SlackChannel[], activeChannelId: string): string {
+    const rows = channels.map((ch) => [
+      ch.channel_id === activeChannelId ? badge("active", "granted") : "",
+      linkCell(`/?tab=messages&channel=${encodeURIComponent(ch.channel_id)}`, channelLabel(ch)),
+      escapeHtml(channelKind(ch)),
+      escapeHtml(String(ch.num_members)),
+      ch.is_archived ? badge("archived", "denied") : badge("open", "granted"),
+    ]);
+    return renderSection(
+      "Conversations",
+      renderTable(["", "Name", "Type", "Members", "State"], rows, "No conversations in the emulator store."),
+    );
+  }
+
+  function renderChannelsView(users: Map<string, string>): string {
+    const channels = sortedChannels(ss().channels.all());
+    const conversations = channels.filter((channel) => !channel.is_im && !channel.is_mpim);
+    const dms = channels.filter((channel) => channel.is_im || channel.is_mpim);
+
+    return [
+      renderSection(
+        "Channels",
+        renderTable(
+          ["ID", "Name", "Type", "Members", "Topic", "Purpose", "State"],
+          conversations.map((ch) => [
+            escapeHtml(ch.channel_id),
+            linkCell(`/?tab=messages&channel=${encodeURIComponent(ch.channel_id)}`, channelLabel(ch)),
+            escapeHtml(channelKind(ch)),
+            escapeHtml(ch.members.map((member) => userLabel(users, member)).join(", ")),
+            escapeHtml(ch.topic.value),
+            escapeHtml(ch.purpose.value),
+            ch.is_archived ? badge("archived", "denied") : badge("open", "granted"),
+          ]),
+          "No channels in the emulator store.",
+        ),
+      ),
+      renderSection(
+        "Direct Messages",
+        renderTable(
+          ["ID", "Name", "Type", "Members", "Open State"],
+          dms.map((ch) => [
+            escapeHtml(ch.channel_id),
+            linkCell(`/?tab=messages&channel=${encodeURIComponent(ch.channel_id)}`, channelLabel(ch)),
+            escapeHtml(channelKind(ch)),
+            escapeHtml(ch.members.map((member) => userLabel(users, member)).join(", ")),
+            escapeHtml(ch.is_open_by_user ? Object.keys(ch.is_open_by_user).join(", ") : String(ch.is_open ?? false)),
+          ]),
+          "No DMs or MPIMs in the emulator store.",
+        ),
+      ),
+    ].join("\n");
+  }
+
+  function renderFilesView(users: Map<string, string>): string {
+    const files = ss()
+      .files.all()
+      .sort((a, b) => b.created - a.created || b.id - a.id);
+    const sessions = ss()
+      .fileUploadSessions.all()
+      .filter((session) => !session.completed)
+      .sort((a, b) => b.id - a.id);
+
+    return [
+      renderSection(
+        "Files",
+        renderTable(
+          ["ID", "Title", "User", "Channels", "Size", "State", "Created"],
+          files.map((file) => [
+            escapeHtml(file.file_id),
+            escapeHtml(file.title || file.name),
+            escapeHtml(userLabel(users, file.user)),
+            escapeHtml([...file.channels, ...file.groups, ...file.ims].join(", ")),
+            escapeHtml(String(file.size)),
+            file.deleted ? badge("deleted", "denied") : badge("available", "granted"),
+            escapeHtml(new Date(file.created * 1000).toISOString()),
+          ]),
+          "No completed files in the emulator store.",
+        ),
+      ),
+      renderSection(
+        "Pending Uploads",
+        renderTable(
+          ["File ID", "Filename", "Title", "Length", "Uploaded", "Completed"],
+          sessions.map((session) => [
+            escapeHtml(session.file_id),
+            escapeHtml(session.filename),
+            escapeHtml(session.title),
+            escapeHtml(String(session.length)),
+            session.uploaded ? badge("uploaded", "granted") : badge("pending"),
+            session.completed ? badge("complete", "granted") : badge("pending"),
+          ]),
+          "No pending external upload sessions.",
+        ),
+      ),
+    ].join("\n");
+  }
+
+  function renderViewsView(users: Map<string, string>): string {
+    const views = ss()
       .views.all()
-      .filter((view) => view.type === "modal")
-      .sort((a, b) => b.updated - a.updated || b.id - a.id)
-      .slice(0, 20);
+      .sort((a, b) => b.updated - a.updated || b.id - a.id);
+    const homeViews = views.filter((view) => view.type === "home");
+    const modalViews = views.filter((view) => view.type === "modal");
+    const triggers = ss()
+      .viewTriggers.all()
+      .sort((a, b) => b.expires_at - a.expires_at || b.id - a.id);
 
-    const sidebar = renderChannelSidebar(channels, activeChannel.channel_id);
+    return [
+      renderSection("App Home", renderViewsTable(homeViews, users, "No App Home views have been published.")),
+      renderSection("Modals", renderViewsTable(modalViews, users, "No modal views have been opened.")),
+      renderSection("Trigger IDs", renderTriggerTable(triggers, users)),
+    ].join("\n");
+  }
 
-    // Build the message list
-    const messageHtml =
-      messages.length === 0
-        ? '<p class="empty">No messages yet. Post one with chat.postMessage or an incoming webhook.</p>'
-        : messages.map((m) => renderMessage(m, userMap)).join("\n<div style='height:8px'></div>\n");
-    const ephemeralHtml =
-      ephemeralMessages.length === 0
-        ? ""
-        : `<div class="section-heading">Ephemeral</div>${ephemeralMessages
-            .map((m) => renderEphemeralMessage(m, userMap))
-            .join("\n<div style='height:8px'></div>\n")}`;
-    const scheduledHtml =
-      scheduledMessages.length === 0
-        ? ""
-        : `<div class="section-heading">Scheduled</div>${scheduledMessages
-            .map(renderScheduledMessage)
-            .join("\n<div style='height:8px'></div>\n")}`;
-    const pinsHtml =
-      pins.length === 0
-        ? ""
-        : `<div class="section-heading">Pins</div>${pins
-            .map((pin) =>
-              renderPin(
-                pin,
-                channelMessages.find((message) => message.ts === pin.message_ts),
-                userMap,
-              ),
-            )
-            .join("\n<div style='height:8px'></div>\n")}`;
-    const bookmarksHtml =
-      bookmarks.length === 0
-        ? ""
-        : `<div class="section-heading">Bookmarks</div>${bookmarks
-            .map(renderBookmark)
-            .join("\n<div style='height:8px'></div>\n")}`;
-    const homeViewsHtml =
-      homeViews.length === 0
-        ? ""
-        : `<div class="section-heading">App Home</div>${homeViews
-            .map((view) => renderView(view, userMap))
-            .join("\n<div style='height:8px'></div>\n")}`;
-    const modalViewsHtml =
-      modalViews.length === 0
-        ? ""
-        : `<div class="section-heading">Modals</div>${modalViews
-            .map((view) => renderView(view, userMap))
-            .join("\n<div style='height:8px'></div>\n")}`;
+  function renderAuthView(): string {
+    const subscriptions = webhooks.getSubscriptions("slack");
+    return [
+      renderSection("OAuth Apps", renderOAuthAppsTable(ss().oauthApps.all())),
+      renderSection("Installations", renderInstallationsTable(ss().installations.all())),
+      renderSection("Tokens", renderTokensTable(ss().tokens.all())),
+      renderSection("Incoming Webhooks", renderIncomingWebhooksTable(ss().incomingWebhooks.all())),
+      renderSection("Event Subscriptions", renderSubscriptionsTable(subscriptions)),
+    ].join("\n");
+  }
 
-    const stats = `${ss().users.all().length} users, ${channels.length} channels, ${ss().messages.all().length} messages, ${ss().views.all().length} views`;
+  function renderEventsView(): string {
+    const subscriptions = webhooks.getSubscriptions("slack");
+    const slackHookIds = new Set(subscriptions.map((subscription) => subscription.id));
+    const deliveries = webhooks
+      .getDeliveries()
+      .filter((delivery) => slackHookIds.has(delivery.hook_id))
+      .sort((a, b) => b.id - a.id)
+      .slice(0, 100);
+    const failed = deliveries.filter((delivery) => !delivery.success);
 
-    const bodyHtml = `
-<div class="s-card">
-  <div class="s-card-header">
-    <div class="s-icon">#</div>
-    <div>
-      <div class="s-title">${escapeHtml(activeChannel.name)}</div>
-      <div class="s-subtitle">${escapeHtml(activeChannel.topic.value || "No topic set")} - ${activeChannel.num_members} members</div>
-    </div>
-  </div>
-  <div class="section-heading">
-    Messages
-    <span class="user-meta">${stats}</span>
-  </div>
-  ${messageHtml}
-  ${ephemeralHtml}
-  ${scheduledHtml}
-  ${pinsHtml}
-  ${bookmarksHtml}
-  ${homeViewsHtml}
-  ${modalViewsHtml}
-</div>`;
+    return [
+      renderSection("Event Subscriptions", renderSubscriptionsTable(subscriptions)),
+      renderSection(
+        "Event Deliveries",
+        renderDeliveriesTable(deliveries, subscriptions, "No Slack event deliveries yet."),
+      ),
+      renderSection("Last Errors", renderDeliveriesTable(failed, subscriptions, "No failed Slack event deliveries.")),
+    ].join("\n");
+  }
+}
 
-    return c.html(renderSettingsPage(`${team?.name ?? "Slack"} - Message Inspector`, sidebar, bodyHtml, SERVICE_LABEL));
-  });
+function renderMessagesTable(messages: SlackMessage[], users: Map<string, string>, empty: string): string {
+  return renderTable(
+    ["Time", "User", "Message", "TS"],
+    messages.map((msg) => {
+      const isBot = msg.subtype === "bot_message";
+      const richBadge =
+        msg.text.length === 0 && ((msg.blocks?.length ?? 0) > 0 || (msg.attachments?.length ?? 0) > 0)
+          ? ` ${badge("rich", "granted")}`
+          : "";
+      const threadBadge =
+        msg.reply_count > 0
+          ? ` ${badge(`${msg.reply_count} ${msg.reply_count === 1 ? "reply" : "replies"}`, "requested")}`
+          : "";
+      const fileBadge = msg.files?.length
+        ? ` ${badge(`${msg.files.length} ${msg.files.length === 1 ? "file" : "files"}`, "granted")}`
+        : "";
+      const threadIndicator = msg.thread_ts && msg.thread_ts !== msg.ts ? `${badge("thread", "denied")} ` : "";
+      return [
+        escapeHtml(timeAgo(msg.created_at)),
+        `${escapeHtml(userLabel(users, msg.user))}${isBot ? ` ${badge("bot", "granted")}` : ""}`,
+        `${threadIndicator}${escapeHtml(richMessagePreview(msg))}${richBadge}${fileBadge}${threadBadge}`,
+        escapeHtml(msg.ts),
+      ];
+    }),
+    empty,
+  );
+}
+
+function renderEphemeralTable(messages: SlackEphemeralMessage[], users: Map<string, string>, empty: string): string {
+  return renderTable(
+    ["Time", "Target", "Message", "TS"],
+    messages.map((msg) => [
+      escapeHtml(timeAgo(msg.created_at)),
+      `${escapeHtml(userLabel(users, msg.target_user))} ${badge("ephemeral", "requested")}`,
+      escapeHtml(richMessagePreview(msg)),
+      escapeHtml(msg.ts),
+    ]),
+    empty,
+  );
+}
+
+function renderScheduledTable(messages: SlackScheduledMessage[], users: Map<string, string>, empty: string): string {
+  return renderTable(
+    ["Post At", "User", "Message", "ID"],
+    messages.map((msg) => [
+      escapeHtml(new Date(msg.post_at * 1000).toISOString()),
+      escapeHtml(userLabel(users, msg.user)),
+      escapeHtml(richMessagePreview(msg)),
+      escapeHtml(msg.scheduled_message_id),
+    ]),
+    empty,
+  );
+}
+
+function renderPinsTable(
+  pins: SlackPin[],
+  channelMessages: SlackMessage[],
+  users: Map<string, string>,
+  empty: string,
+): string {
+  return renderTable(
+    ["Created", "Creator", "Message", "TS"],
+    pins.map((pin) => {
+      const message = channelMessages.find((candidate) => candidate.ts === pin.message_ts);
+      return [
+        escapeHtml(new Date(pin.created * 1000).toISOString()),
+        escapeHtml(userLabel(users, pin.created_by)),
+        escapeHtml(message ? richMessagePreview(message) : pin.message_ts),
+        escapeHtml(pin.message_ts),
+      ];
+    }),
+    empty,
+  );
+}
+
+function renderBookmarksTable(bookmarks: SlackBookmark[], empty: string): string {
+  return renderTable(
+    ["Title", "Type", "Link", "Rank"],
+    bookmarks.map((bookmark) => [
+      escapeHtml(bookmark.title),
+      escapeHtml(bookmark.type),
+      escapeHtml(bookmark.link),
+      escapeHtml(bookmark.rank),
+    ]),
+    empty,
+  );
+}
+
+function renderViewsTable(views: SlackView[], users: Map<string, string>, empty: string): string {
+  return renderTable(
+    ["ID", "Type", "User", "App", "Preview", "Hash", "Root", "Previous"],
+    views.map((view) => [
+      escapeHtml(view.view_id),
+      view.type === "home" ? badge("app home", "granted") : badge("modal", "requested"),
+      escapeHtml(userLabel(users, view.user_id)),
+      escapeHtml(view.app_id),
+      escapeHtml(viewPreview(view)),
+      escapeHtml(view.hash),
+      escapeHtml(view.root_view_id),
+      escapeHtml(view.previous_view_id ?? ""),
+    ]),
+    empty,
+  );
+}
+
+function renderTriggerTable(triggers: SlackViewTrigger[], users: Map<string, string>): string {
+  const now = Math.floor(Date.now() / 1000);
+  return renderTable(
+    ["Trigger ID", "User", "App", "View", "Expires", "State"],
+    triggers.map((trigger) => [
+      escapeHtml(trigger.trigger_id),
+      escapeHtml(userLabel(users, trigger.user_id)),
+      escapeHtml(trigger.app_id),
+      escapeHtml(trigger.view_id ?? ""),
+      escapeHtml(new Date(trigger.expires_at * 1000).toISOString()),
+      trigger.used
+        ? badge("used", "denied")
+        : trigger.expires_at <= now
+          ? badge("expired", "denied")
+          : badge("active", "granted"),
+    ]),
+    "No local trigger ids have been generated.",
+  );
+}
+
+function renderOAuthAppsTable(apps: SlackOAuthApp[]): string {
+  return renderTable(
+    ["App ID", "Client ID", "Name", "Bot", "Scopes", "User Scopes"],
+    apps.map((app) => [
+      escapeHtml(app.app_id ?? ""),
+      escapeHtml(app.client_id),
+      escapeHtml(app.name),
+      escapeHtml(app.bot_id ?? app.bot_name ?? ""),
+      escapeHtml(scopePreview(app.scopes)),
+      escapeHtml(scopePreview(app.user_scopes)),
+    ]),
+    "No OAuth apps are configured.",
+  );
+}
+
+function renderInstallationsTable(installations: SlackInstallation[]): string {
+  return renderTable(
+    ["Installation", "App", "Team", "Bot User", "Installer", "Scopes"],
+    installations.map((installation) => [
+      escapeHtml(installation.installation_id),
+      escapeHtml(installation.app_id),
+      escapeHtml(installation.team_id),
+      escapeHtml(installation.bot_user_id),
+      escapeHtml(installation.installer_user_id),
+      escapeHtml(scopePreview(installation.scopes)),
+    ]),
+    "No OAuth installations have been recorded.",
+  );
+}
+
+function renderTokensTable(tokens: SlackToken[]): string {
+  return renderTable(
+    ["Token", "Type", "Team", "User", "App", "Bot", "Scopes"],
+    tokens.map((token) => [
+      escapeHtml(maskToken(token.token)),
+      escapeHtml(token.token_type),
+      escapeHtml(token.team_id),
+      escapeHtml(token.user_id),
+      escapeHtml(token.app_id ?? ""),
+      escapeHtml(token.bot_id ?? token.bot_user_id ?? ""),
+      escapeHtml(scopePreview(token.scopes)),
+    ]),
+    "No Slack token records have been seeded or exchanged.",
+  );
+}
+
+function renderIncomingWebhooksTable(webhooks: SlackIncomingWebhook[]): string {
+  return renderTable(
+    ["Token", "Team", "Bot", "Default Channel", "Label", "URL"],
+    webhooks.map((webhook) => [
+      escapeHtml(maskToken(webhook.token)),
+      escapeHtml(webhook.team_id),
+      escapeHtml(webhook.bot_id),
+      escapeHtml(webhook.default_channel),
+      escapeHtml(webhook.label),
+      escapeHtml(webhook.url),
+    ]),
+    "No incoming webhooks are configured.",
+  );
+}
+
+function renderSubscriptionsTable(subscriptions: WebhookSubscription[]): string {
+  return renderTable(
+    ["ID", "URL", "Events", "State"],
+    subscriptions.map((subscription) => [
+      escapeHtml(String(subscription.id)),
+      escapeHtml(subscription.url),
+      escapeHtml(subscription.events.join(", ")),
+      subscription.active ? badge("active", "granted") : badge("inactive", "denied"),
+    ]),
+    "No Slack event subscriptions are registered.",
+  );
+}
+
+function renderDeliveriesTable(
+  deliveries: WebhookDelivery[],
+  subscriptions: WebhookSubscription[],
+  empty: string,
+): string {
+  const subscriptionsById = new Map(subscriptions.map((subscription) => [subscription.id, subscription]));
+  return renderTable(
+    ["ID", "Event", "Hook", "URL", "Status", "Duration", "Delivered"],
+    deliveries.map((delivery) => {
+      const subscription = subscriptionsById.get(delivery.hook_id);
+      return [
+        escapeHtml(String(delivery.id)),
+        escapeHtml(delivery.event),
+        escapeHtml(String(delivery.hook_id)),
+        escapeHtml(subscription?.url ?? ""),
+        delivery.success
+          ? badge(String(delivery.status_code ?? "ok"), "granted")
+          : badge(String(delivery.status_code ?? "failed"), "denied"),
+        escapeHtml(delivery.duration === null ? "" : `${delivery.duration}ms`),
+        escapeHtml(delivery.delivered_at),
+      ];
+    }),
+    empty,
+  );
 }

--- a/packages/@emulators/slack/src/routes/inspector.ts
+++ b/packages/@emulators/slack/src/routes/inspector.ts
@@ -148,6 +148,16 @@ function channelKind(ch: SlackChannel): string {
   return "Public";
 }
 
+function openStateLabel(ch: SlackChannel, users: Map<string, string>): string {
+  if (ch.is_open_by_user) {
+    const openUsers = Object.entries(ch.is_open_by_user)
+      .filter(([, isOpen]) => isOpen === true)
+      .map(([userId]) => userLabel(users, userId));
+    return openUsers.length > 0 ? openUsers.join(", ") : "closed";
+  }
+  return ch.is_open ? "open" : "closed";
+}
+
 function maskToken(value: string): string {
   if (value.length <= 10) return value;
   return `${value.slice(0, 8)}...${value.slice(-4)}`;
@@ -324,7 +334,7 @@ export function inspectorRoutes(ctx: RouteContext): void {
             linkCell(`/?tab=messages&channel=${encodeURIComponent(ch.channel_id)}`, channelLabel(ch)),
             escapeHtml(channelKind(ch)),
             escapeHtml(ch.members.map((member) => userLabel(users, member)).join(", ")),
-            escapeHtml(ch.is_open_by_user ? Object.keys(ch.is_open_by_user).join(", ") : String(ch.is_open ?? false)),
+            escapeHtml(openStateLabel(ch, users)),
           ]),
           "No DMs or MPIMs in the emulator store.",
         ),
@@ -407,12 +417,12 @@ export function inspectorRoutes(ctx: RouteContext): void {
   function renderEventsView(): string {
     const subscriptions = webhooks.getSubscriptions("slack");
     const slackHookIds = new Set(subscriptions.map((subscription) => subscription.id));
-    const deliveries = webhooks
+    const allDeliveries = webhooks
       .getDeliveries()
       .filter((delivery) => slackHookIds.has(delivery.hook_id))
-      .sort((a, b) => b.id - a.id)
-      .slice(0, 100);
-    const failed = deliveries.filter((delivery) => !delivery.success);
+      .sort((a, b) => b.id - a.id);
+    const deliveries = allDeliveries.slice(0, 100);
+    const failed = allDeliveries.filter((delivery) => !delivery.success).slice(0, 100);
 
     return [
       renderSection("Event Subscriptions", renderSubscriptionsTable(subscriptions)),

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -621,6 +621,10 @@ Returns a Slack-style response:
 }
 ```
 
+### Inspector
+
+Open `GET /` in the Slack emulator to inspect conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries.
+
 ## Event Dispatching
 
 When messages are posted, updated, deleted, reactions change, pins change, or files change, the emulator dispatches `event_callback` payloads to configured webhook URLs. These payloads match Slack's Events API format:


### PR DESCRIPTION
- Add tabbed inspector views for Slack conversations, files, views, auth state, and events.
- Cover expanded inspector state with route tests and coverage notes.
- Update Slack docs and skill guidance for the local inspector.