### PR TITLE
Allow optional uid in Google seed config to stabilize sub claim across restarts

### DIFF
--- a/packages/@emulators/google/src/__tests__/google.test.ts
+++ b/packages/@emulators/google/src/__tests__/google.test.ts
@@ -933,6 +933,49 @@ describe("Google plugin integration", () => {
     expect(((await userinfoRes.json()) as { hd?: string }).hd).toBe("override.io");
   });
 
+  describe("seed from config", () => {
+    it("uses the uid from seed config as the sub claim when provided", async () => {
+      const seedStore = new Store();
+      const webhooks = new WebhookDispatcher();
+      const localTokenMap: TokenMap = new Map();
+      const localApp = new Hono();
+      localApp.onError(createApiErrorHandler());
+      localApp.use("*", createErrorHandler());
+      localApp.use("*", authMiddleware(localTokenMap));
+      googlePlugin.register(localApp as any, seedStore, webhooks, base, localTokenMap);
+      seedFromConfig(seedStore, base, {
+        users: [{ email: "pinned@example.com", uid: "goog_fixed_uid_123" }],
+        oauth_clients: [
+          {
+            client_id: "emu_google_client_id",
+            client_secret: "emu_google_client_secret",
+            name: "Test App",
+            redirect_uris: ["http://localhost:3000/api/auth/callback/google"],
+          },
+        ],
+      });
+
+      const authorizeRes = await formRequest(localApp, "/o/oauth2/v2/auth/callback", {
+        email: "pinned@example.com",
+        redirect_uri: "http://localhost:3000/api/auth/callback/google",
+        scope: "openid email profile",
+        client_id: "emu_google_client_id",
+      });
+      const code = new URL(authorizeRes.headers.get("Location")!).searchParams.get("code")!;
+
+      const tokenRes = await formRequest(localApp, "/oauth2/token", {
+        code,
+        grant_type: "authorization_code",
+        redirect_uri: "http://localhost:3000/api/auth/callback/google",
+        client_id: "emu_google_client_id",
+        client_secret: "emu_google_client_secret",
+      });
+      const { id_token } = (await tokenRes.json()) as { id_token: string };
+      const claims = decodeJwt(id_token);
+      expect(claims.sub).toBe("goog_fixed_uid_123");
+    });
+  });
+
   it("lists calendar resources, creates events, queries freebusy, and deletes events", async () => {
     const calendarListRes = await app.request(`${base}/calendar/v3/users/me/calendarList`, {
       headers: authHeaders(),

--- a/packages/@emulators/google/src/index.ts
+++ b/packages/@emulators/google/src/index.ts
@@ -26,6 +26,7 @@ export * from "./entities.js";
 
 export interface GoogleSeedUser {
   email: string;
+  uid?: string;
   name?: string;
   given_name?: string;
   family_name?: string;
@@ -300,7 +301,7 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: GoogleSee
       if (!existing) {
         const nameParts = (user.name ?? "").split(/\s+/).filter(Boolean);
         gs.users.insert({
-          uid: generateUid("goog"),
+          uid: user.uid ?? generateUid("goog"),
           email: user.email,
           name: user.name ?? user.email.split("@")[0],
           given_name: user.given_name ?? nameParts[0] ?? "",


### PR DESCRIPTION
## Summary

- Add optional `uid` field to `GoogleSeedUser` interface
- Use the provided `uid` when seeding users, falling back to `generateUid("goog")` if omitted

## Problem

When running the Google emulator in Docker or any environment where the process restarts, the `sub` claim in id_tokens changes on every restart because `uid` is always generated randomly. Applications that store users by their `sub` value treat the same person as a different user after each restart.

## Solution

Follow the same pattern already established by the Okta emulator (`okta_id?: string` with `user.okta_id ?? generateOktaId("00u")`), allowing operators to pin a stable `uid` in their seed configuration:

```ts
seedFromConfig(store, base, {
  users: [
    { email: "alice@example.com", uid: "goog_stable_uid_alice" }
  ]
})
```

When `uid` is omitted the behavior is unchanged — a random ID is generated as before.