### PR TITLE
fix(aws/s3): store object bodies as base64 so binary uploads survive

### DIFF
--- a/packages/@emulators/aws/src/__tests__/aws.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws.test.ts
@@ -204,6 +204,35 @@ describe("AWS plugin - S3 Objects", () => {
     const body = await getRes.text();
     expect(body).toBe("copy me");
   });
+
+  it("round-trips a binary object byte-for-byte", async () => {
+    // Bytes that are NOT valid UTF-8 (0x80, 0xff, 0xfe) plus a NUL and PNG
+    // magic. The old handler called `.text()`, which decodes the body as
+    // UTF-8 and replaces every non-UTF-8 byte with U+FFFD (EF BF BD) — so
+    // binary uploads (audio, images, gzip, …) came back corrupted and longer
+    // than they went in. Storing the body base64 round-trips any byte exactly.
+    const binary = new Uint8Array([0x00, 0x01, 0x02, 0x80, 0xff, 0xfe, 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+
+    const putRes = await app.request(`${base}/emulate-default/audio.bin`, {
+      method: "PUT",
+      headers: { ...authHeaders(), "Content-Type": "application/octet-stream" },
+      body: binary,
+    });
+    expect(putRes.status).toBe(200);
+
+    const getRes = await app.request(`${base}/emulate-default/audio.bin`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    expect(getRes.status).toBe(200);
+    expect(getRes.headers.get("Content-Type")).toBe("application/octet-stream");
+
+    const received = new Uint8Array(await getRes.arrayBuffer());
+    expect(Array.from(received)).toEqual(Array.from(binary));
+    // Content-Length must reflect the raw byte count, not the inflated
+    // U+FFFD-substituted or base64 length.
+    expect(getRes.headers.get("Content-Length")).toBe(String(binary.byteLength));
+  });
 });
 
 describe("AWS plugin - S3 ListObjectsV2 pagination", () => {

--- a/packages/@emulators/aws/src/entities.ts
+++ b/packages/@emulators/aws/src/entities.ts
@@ -11,6 +11,7 @@ export interface S3Bucket extends Entity {
 export interface S3Object extends Entity {
   bucket_name: string;
   key: string;
+  /** Object bytes, base64-encoded (binary-safe — see s3.ts handlePutObject). */
   body: string;
   content_type: string;
   content_length: number;

--- a/packages/@emulators/aws/src/helpers.ts
+++ b/packages/@emulators/aws/src/helpers.ts
@@ -23,7 +23,7 @@ export function generateReceiptHandle(): string {
   return randomBytes(48).toString("base64url");
 }
 
-export function md5(content: string): string {
+export function md5(content: string | Buffer | Uint8Array): string {
   return createHash("md5").update(content).digest("hex");
 }
 

--- a/packages/@emulators/aws/src/routes/s3.ts
+++ b/packages/@emulators/aws/src/routes/s3.ts
@@ -231,11 +231,13 @@ ${prefixesXml}
       }
     }
 
-    // Store the object
-    const fileContent = await file.text();
+    // Store the object. Read as raw bytes and persist base64 so binary
+    // payloads (audio/images/etc.) survive — `.text()` would UTF-8-mangle them.
+    const fileBuf = Buffer.from(await file.arrayBuffer());
+    const fileContent = fileBuf.toString("base64");
     const contentType = (body["Content-Type"] as string) ?? file.type ?? "application/octet-stream";
-    const etag = md5(fileContent);
-    const contentLength = new TextEncoder().encode(fileContent).byteLength;
+    const etag = md5(fileBuf);
+    const contentLength = fileBuf.byteLength;
 
     const existing = aws()
       .s3Objects.findBy("bucket_name", bucketName)
@@ -347,9 +349,15 @@ ${prefixesXml}
       });
     }
 
-    const body = await c.req.text();
+    // Read the raw request bytes and store them base64-encoded. Using
+    // `c.req.text()` here would decode the body as UTF-8 and replace every
+    // non-UTF-8 byte with U+FFFD (EF BF BD), corrupting binary uploads
+    // (audio, images, gzip, …). base64 round-trips any byte exactly.
+    const bodyBuf = Buffer.from(await c.req.arrayBuffer());
+    const body = bodyBuf.toString("base64");
+    const contentLength = bodyBuf.byteLength;
     const contentType = c.req.header("Content-Type") ?? "application/octet-stream";
-    const etag = md5(body);
+    const etag = md5(bodyBuf);
 
     // Extract user metadata (x-amz-meta-*)
     const metadata: Record<string, string> = {};
@@ -367,7 +375,7 @@ ${prefixesXml}
       aws().s3Objects.update(existing.id, {
         body,
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: contentLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -378,7 +386,7 @@ ${prefixesXml}
         key,
         body,
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: contentLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -415,7 +423,9 @@ ${prefixesXml}
       headers[`x-amz-meta-${k}`] = v;
     }
 
-    return c.text(obj.body, 200, headers);
+    // obj.body is base64 (see handlePutObject); decode back to raw bytes so
+    // binary objects stream out byte-for-byte. c.body sends a Uint8Array as-is.
+    return c.body(Buffer.from(obj.body, "base64"), 200, headers);
   };
 
   const handleHeadObject = (c: S3ObjectContext) => {


### PR DESCRIPTION
## Problem

The S3 emulator corrupts any non-text upload. `PutObject` reads the request body with `c.req.text()` (and the presigned-POST path with `file.text()`), which decodes the bytes as UTF-8 and replaces every byte that isn't valid UTF-8 with the replacement character `U+FFFD` (`EF BF BD`).

As a result, any binary object — audio, images, gzip, protobuf, etc. — comes back **corrupted** on `GetObject`, and `Content-Length` is **inflated** (each `U+FFFD` re-encodes to 3 bytes).

## Fix

- `PutObject` / presigned `POST` now read the raw bytes via `arrayBuffer()` and persist them **base64-encoded**.
- `ETag` is computed from the raw bytes, and `Content-Length` is the true byte count.
- `GetObject` decodes the stored base64 back to a byte-exact `Uint8Array` (sent via `c.body(...)`).
- `CopyObject` already round-trips the stored body verbatim, so it inherits the fix.
- `md5()` now accepts `Buffer`/`Uint8Array` so it can hash raw bytes directly.

No new dependencies; no behavioral change for text objects.

## Test

Adds a round-trip test that uploads a binary object (NUL, `0x80`/`0xff`/`0xfe`, PNG magic), reads it back, and asserts it is **byte-for-byte identical** and that `Content-Length` equals the raw byte count.

`pnpm --filter @emulators/aws test` → all green; `type-check` clean.