### PR TITLE
feat(aws/sts): extract STS into a dedicated route and harden AssumeRole

### DIFF
--- a/packages/@emulators/aws/src/__tests__/sts.test.ts
+++ b/packages/@emulators/aws/src/__tests__/sts.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "@emulators/core";
+import type { AppEnv } from "@emulators/core";
+import { createTestApp, testAuthHeaders as authHeaders, testBaseUrl as base } from "./helpers.js";
+
+function xmlValue(xml: string, tagName: string): string | undefined {
+  return xml.match(new RegExp(`<${tagName}>([\\s\\S]*?)<\\/${tagName}>`))?.[1];
+}
+
+describe("AWS plugin - STS dedicated route", () => {
+  let app: Hono<AppEnv>;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  describe("AssumeRole", () => {
+    it("returns 200 with synthetic credentials for an unseeded role ARN", async () => {
+      const roleArn = "arn:aws:iam::000000000000:role/nirva-upload";
+      const res = await app.request(`${base}/sts/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: `Action=AssumeRole&RoleArn=${encodeURIComponent(roleArn)}&RoleSessionName=test-session&Version=2011-06-15`,
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain("<AssumeRoleResponse");
+      expect(text).toContain("<AccessKeyId>");
+      expect(text).toContain("<SecretAccessKey>");
+      expect(text).toContain("<SessionToken>");
+      expect(text).toContain("<Expiration>");
+
+      const accessKeyId = xmlValue(text, "AccessKeyId");
+      expect(accessKeyId).toBeDefined();
+      expect(accessKeyId!.startsWith("ASIA")).toBe(true);
+
+      const expiration = xmlValue(text, "Expiration");
+      expect(expiration).toBeDefined();
+      expect(Number.isFinite(Date.parse(expiration!))).toBe(true);
+
+      const arn = xmlValue(text, "Arn");
+      expect(arn).toBe(`${roleArn}/test-session`);
+    });
+
+    it("honors an in-range DurationSeconds", async () => {
+      const before = Date.now();
+      const res = await app.request(`${base}/sts/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body:
+          "Action=AssumeRole" +
+          "&RoleArn=" +
+          encodeURIComponent("arn:aws:iam::000000000000:role/short") +
+          "&RoleSessionName=quick" +
+          "&DurationSeconds=900",
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      const expiration = Date.parse(xmlValue(text, "Expiration") ?? "");
+      // 900s is the STS minimum; expiration should be ~15 minutes from now.
+      const minutes = (expiration - before) / 60000;
+      expect(minutes).toBeGreaterThanOrEqual(14.5);
+      expect(minutes).toBeLessThanOrEqual(15.5);
+    });
+
+    it("rejects out-of-range DurationSeconds with a ValidationError", async () => {
+      // AWS rejects out-of-range durations rather than clamping them, so a
+      // caller asking for less than 900s or more than 43200s gets a 400.
+      const assume = (duration: string) =>
+        app.request(`${base}/sts/`, {
+          method: "POST",
+          headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+          body:
+            "Action=AssumeRole" +
+            "&RoleArn=" +
+            encodeURIComponent("arn:aws:iam::000000000000:role/short") +
+            "&RoleSessionName=quick" +
+            `&DurationSeconds=${duration}`,
+        });
+
+      const tooLow = await assume("60");
+      expect(tooLow.status).toBe(400);
+      expect(await tooLow.text()).toContain("ValidationError");
+
+      const tooHigh = await assume("99999");
+      expect(tooHigh.status).toBe(400);
+      const tooHighText = await tooHigh.text();
+      expect(tooHighText).toContain("ValidationError");
+      expect(tooHighText).toContain("43200");
+
+      const notInteger = await assume("abc");
+      expect(notInteger.status).toBe(400);
+      expect(await notInteger.text()).toContain("ValidationError");
+
+      // Boundary values are accepted.
+      const minOk = await assume("900");
+      expect(minOk.status).toBe(200);
+      const maxOk = await assume("43200");
+      expect(maxOk.status).toBe(200);
+    });
+
+    it("rejects missing RoleArn / RoleSessionName", async () => {
+      const res = await app.request(`${base}/sts/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: "Action=AssumeRole",
+      });
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain("ValidationError");
+    });
+
+    it("works at the AWS-SDK wire-format root path POST /", async () => {
+      const roleArn = "arn:aws:iam::000000000000:role/sdk-style";
+      const res = await app.request(`${base}/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: `Action=AssumeRole&RoleArn=${encodeURIComponent(roleArn)}&RoleSessionName=sdk-test&Version=2011-06-15`,
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain("<AssumeRoleResponse");
+      expect(xmlValue(text, "AccessKeyId")).toMatch(/^ASIA/);
+    });
+  });
+
+  describe("GetCallerIdentity", () => {
+    it("returns the synthetic caller envelope at /sts/", async () => {
+      const res = await app.request(`${base}/sts/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: "Action=GetCallerIdentity&Version=2011-06-15",
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain("<GetCallerIdentityResponse");
+      expect(xmlValue(text, "Account")).toBe("123456789012");
+      expect(xmlValue(text, "Arn")).toBe("arn:aws:iam::123456789012:user/admin");
+      expect(xmlValue(text, "UserId")).toBeDefined();
+    });
+
+    it("works at the AWS-SDK wire-format root path POST /", async () => {
+      const res = await app.request(`${base}/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: "Action=GetCallerIdentity&Version=2011-06-15",
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain("<GetCallerIdentityResponse");
+    });
+  });
+
+  describe("Action validation", () => {
+    it("returns InvalidAction for unknown actions on /sts/", async () => {
+      const res = await app.request(`${base}/sts/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: "Action=DoesNotExist",
+      });
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain("InvalidAction");
+    });
+
+    it("does not hijack non-STS POST / requests", async () => {
+      // POST / with no STS action should not be claimed by STS dispatch.
+      const res = await app.request(`${base}/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: "Action=ListBuckets",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("does not hijack POST / with non-form content types", async () => {
+      const res = await app.request(`${base}/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        body: '{"Action":"AssumeRole"}',
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("Boto3-style response parsing", () => {
+    it("AssumeRole XML parses into the structure boto3 expects", async () => {
+      const res = await app.request(`${base}/`, {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
+        body: `Action=AssumeRole&RoleArn=${encodeURIComponent("arn:aws:iam::000000000000:role/p")}&RoleSessionName=p-session`,
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+
+      // Mirror the dict shape boto3 surfaces from the AWS XML response. Boto3's
+      // botocore parser maps these tags into Credentials.{AccessKeyId,
+      // SecretAccessKey, SessionToken, Expiration} and AssumedRoleUser.{Arn,
+      // AssumedRoleId}.
+      const credentials = {
+        AccessKeyId: xmlValue(text, "AccessKeyId"),
+        SecretAccessKey: xmlValue(text, "SecretAccessKey"),
+        SessionToken: xmlValue(text, "SessionToken"),
+        Expiration: xmlValue(text, "Expiration"),
+      };
+      expect(credentials.AccessKeyId).toBeTruthy();
+      expect(credentials.SecretAccessKey).toBeTruthy();
+      expect(credentials.SessionToken).toBeTruthy();
+      expect(credentials.Expiration).toBeTruthy();
+    });
+  });
+});

--- a/packages/@emulators/aws/src/index.ts
+++ b/packages/@emulators/aws/src/index.ts
@@ -5,6 +5,7 @@ import { getAccountId, getDefaultRegion, generateAwsId } from "./helpers.js";
 import { s3Routes } from "./routes/s3.js";
 import { sqsRoutes } from "./routes/sqs.js";
 import { iamRoutes } from "./routes/iam.js";
+import { stsRoutes } from "./routes/sts.js";
 import { inspectorRoutes } from "./routes/inspector.js";
 
 export { getAwsStore, type AwsStore } from "./store.js";
@@ -183,6 +184,7 @@ export const awsPlugin: ServicePlugin = {
     inspectorRoutes(ctx);
     sqsRoutes(ctx);
     iamRoutes(ctx);
+    stsRoutes(ctx);
     s3Routes(ctx);
   },
   seed(store: Store, baseUrl: string): void {

--- a/packages/@emulators/aws/src/routes/iam.ts
+++ b/packages/@emulators/aws/src/routes/iam.ts
@@ -51,22 +51,6 @@ export function iamRoutes(ctx: RouteContext): void {
     }
   });
 
-  // STS endpoints
-  app.post("/sts/", async (c) => {
-    const body = await c.req.text();
-    const params = parseQueryString(body);
-    const action = params["Action"] ?? c.req.query("Action") ?? "";
-
-    switch (action) {
-      case "GetCallerIdentity":
-        return getCallerIdentity(c);
-      case "AssumeRole":
-        return assumeRole(c, params);
-      default:
-        return awsErrorXml(c, "InvalidAction", `The action ${action} is not valid for this endpoint.`, 400);
-    }
-  });
-
   function createUser(c: Context, params: Record<string, string>) {
     const userName = params["UserName"] ?? "";
     if (!userName) {
@@ -365,60 +349,4 @@ ${rolesXml}
     return awsXmlResponse(c, xml);
   }
 
-  function getCallerIdentity(c: Context) {
-    const authUser = c.get("authUser") as { login?: string } | undefined;
-    const userName = authUser?.login ?? "admin";
-    const arn = `arn:aws:iam::${accountId}:user/${userName}`;
-
-    // Return stable UserId from the IAM store when available
-    const user = aws().iamUsers.findOneBy("user_name", userName);
-    const userId = user?.user_id ?? generateAwsId("AIDA");
-
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<GetCallerIdentityResponse>
-  <GetCallerIdentityResult>
-    <Arn>${escapeXml(arn)}</Arn>
-    <UserId>${userId}</UserId>
-    <Account>${accountId}</Account>
-  </GetCallerIdentityResult>
-  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
-</GetCallerIdentityResponse>`;
-    return awsXmlResponse(c, xml);
-  }
-
-  function assumeRole(c: Context, params: Record<string, string>) {
-    const roleArn = params["RoleArn"] ?? "";
-    const sessionName = params["RoleSessionName"] ?? "session";
-
-    // Find the role by ARN
-    const role = aws()
-      .iamRoles.all()
-      .find((r) => r.arn === roleArn);
-    if (!role) {
-      return awsErrorXml(c, "NoSuchEntity", `The role specified cannot be found.`, 404);
-    }
-
-    const accessKeyId = "ASIA" + randomBytes(8).toString("hex").toUpperCase();
-    const secretAccessKey = randomBytes(30).toString("base64");
-    const sessionToken = randomBytes(64).toString("base64");
-    const expiration = new Date(Date.now() + 3600 * 1000).toISOString();
-
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<AssumeRoleResponse>
-  <AssumeRoleResult>
-    <Credentials>
-      <AccessKeyId>${accessKeyId}</AccessKeyId>
-      <SecretAccessKey>${secretAccessKey}</SecretAccessKey>
-      <SessionToken>${sessionToken}</SessionToken>
-      <Expiration>${expiration}</Expiration>
-    </Credentials>
-    <AssumedRoleUser>
-      <Arn>${roleArn}/${sessionName}</Arn>
-      <AssumedRoleId>${role.role_id}:${sessionName}</AssumedRoleId>
-    </AssumedRoleUser>
-  </AssumeRoleResult>
-  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
-</AssumeRoleResponse>`;
-    return awsXmlResponse(c, xml);
-  }
 }

--- a/packages/@emulators/aws/src/routes/sts.ts
+++ b/packages/@emulators/aws/src/routes/sts.ts
@@ -1,0 +1,161 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { getAwsStore } from "../store.js";
+import {
+  awsXmlResponse,
+  awsErrorXml,
+  escapeXml,
+  generateAwsId,
+  generateMessageId,
+  getAccountId,
+  parseQueryString,
+} from "../helpers.js";
+import { randomBytes } from "crypto";
+
+export function stsRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+  const aws = () => getAwsStore(store);
+  const accountId = getAccountId();
+
+  const handleStsAction = async (c: Context) => {
+    const body = await c.req.text();
+    const params = parseQueryString(body);
+    const action = params["Action"] ?? c.req.query("Action") ?? "";
+
+    switch (action) {
+      case "AssumeRole":
+        return assumeRole(c, params);
+      case "GetCallerIdentity":
+        return getCallerIdentity(c);
+      default:
+        return awsErrorXml(c, "InvalidAction", `The action ${action} is not valid for this endpoint.`, 400);
+    }
+  };
+
+  // Path-prefix routes (legacy convention used by other emulate AWS routes).
+  app.post("/sts", handleStsAction);
+  app.post("/sts/", handleStsAction);
+
+  // AWS SDK wire format: STS targets `POST /` with form-encoded body. We
+  // dispatch only when the body looks like an STS form (contains
+  // `Action=AssumeRole|GetCallerIdentity`) so that S3 wildcards remain
+  // unaffected. S3 has no `POST /` handler today, so this is safe.
+  const handleRootStsDispatch = async (c: Context) => {
+    const contentType = c.req.header("content-type") ?? "";
+    if (!contentType.includes("application/x-www-form-urlencoded")) {
+      return c.notFound();
+    }
+    const body = await c.req.text();
+    const params = parseQueryString(body);
+    const action = params["Action"] ?? "";
+    if (action !== "AssumeRole" && action !== "GetCallerIdentity") {
+      return c.notFound();
+    }
+    if (action === "AssumeRole") {
+      return assumeRole(c, params);
+    }
+    return getCallerIdentity(c);
+  };
+  app.post("/", handleRootStsDispatch);
+
+  function assumeRole(c: Context, params: Record<string, string>) {
+    const roleArn = params["RoleArn"] ?? "";
+    const sessionName = params["RoleSessionName"] ?? "session";
+    if (!roleArn) {
+      return awsErrorXml(c, "ValidationError", "The request must contain the parameter RoleArn.", 400);
+    }
+    if (!params["RoleSessionName"]) {
+      return awsErrorXml(c, "ValidationError", "The request must contain the parameter RoleSessionName.", 400);
+    }
+
+    // Synthetic credentials: emulate does not enforce IAM. If the role exists
+    // in the in-memory IAM store we reuse its role_id for stability; otherwise
+    // we mint a fresh AROA-prefixed id so callers can still parse the response
+    // shape. This matches LocalStack-style behavior.
+    const existingRole = aws()
+      .iamRoles.all()
+      .find((r) => r.arn === roleArn);
+    const roleId = existingRole?.role_id ?? generateAwsId("AROA");
+
+    // DurationSeconds must be within STS limits: 900s (15m) .. 43200s (12h).
+    // AWS rejects out-of-range values with a ValidationError rather than
+    // silently clamping, so we mirror that. Defaults to 3600s when omitted.
+    const MIN_DURATION_SEC = 900;
+    const MAX_DURATION_SEC = 43200;
+    let durationSec = 3600;
+    const rawDuration = params["DurationSeconds"];
+    if (rawDuration !== undefined && rawDuration !== "") {
+      const requestedDuration = Number(rawDuration);
+      if (!Number.isInteger(requestedDuration)) {
+        return awsErrorXml(
+          c,
+          "ValidationError",
+          `1 validation error detected: Value '${rawDuration}' at 'durationSeconds' failed to satisfy constraint: Member must be a valid integer.`,
+          400,
+        );
+      }
+      if (requestedDuration < MIN_DURATION_SEC) {
+        return awsErrorXml(
+          c,
+          "ValidationError",
+          `1 validation error detected: Value '${rawDuration}' at 'durationSeconds' failed to satisfy constraint: Member must have value greater than or equal to ${MIN_DURATION_SEC}.`,
+          400,
+        );
+      }
+      if (requestedDuration > MAX_DURATION_SEC) {
+        return awsErrorXml(
+          c,
+          "ValidationError",
+          `1 validation error detected: Value '${rawDuration}' at 'durationSeconds' failed to satisfy constraint: Member must have value less than or equal to ${MAX_DURATION_SEC}.`,
+          400,
+        );
+      }
+      durationSec = requestedDuration;
+    }
+
+    const accessKeyId = "ASIA" + randomBytes(8).toString("hex").toUpperCase();
+    const secretAccessKey = randomBytes(30).toString("base64");
+    const sessionToken = randomBytes(64).toString("base64");
+    const expiration = new Date(Date.now() + durationSec * 1000).toISOString();
+    const assumedRoleArn = `${roleArn}/${sessionName}`;
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>${accessKeyId}</AccessKeyId>
+      <SecretAccessKey>${escapeXml(secretAccessKey)}</SecretAccessKey>
+      <SessionToken>${escapeXml(sessionToken)}</SessionToken>
+      <Expiration>${expiration}</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>${escapeXml(assumedRoleArn)}</Arn>
+      <AssumedRoleId>${roleId}:${escapeXml(sessionName)}</AssumedRoleId>
+    </AssumedRoleUser>
+    <PackedPolicySize>0</PackedPolicySize>
+  </AssumeRoleResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</AssumeRoleResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function getCallerIdentity(c: Context) {
+    const authUser = c.get("authUser") as { login?: string } | undefined;
+    const userName = authUser?.login ?? "admin";
+    const arn = `arn:aws:iam::${accountId}:user/${userName}`;
+
+    // Prefer the stable UserId from the IAM store when available.
+    const user = aws().iamUsers.findOneBy("user_name", userName);
+    const userId = user?.user_id ?? generateAwsId("AIDA");
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+    <Arn>${escapeXml(arn)}</Arn>
+    <UserId>${userId}</UserId>
+    <Account>${accountId}</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</GetCallerIdentityResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+}


### PR DESCRIPTION
## Summary

Promotes the inline STS stub (previously buried in `routes/iam.ts`) into its own `routes/sts.ts`, and hardens it so the official AWS SDK / boto3 work against it.

## What changed

- **AWS SDK wire-format dispatch.** The SDK sends STS calls as `POST /` with a form-encoded body (not `/sts/`). This now dispatches STS only when the request is a urlencoded STS form (`Action=AssumeRole|GetCallerIdentity`), leaving S3's wildcard routes untouched. The legacy `POST /sts/` path still works.
- **`DurationSeconds` support + validation.** `AssumeRole` honors `DurationSeconds` (default 3600) and validates it against STS limits (900..43200), returning a `ValidationError` for out-of-range or non-integer values instead of silently clamping — matching real STS.
- **Stable identities.** Mints `ASIA`-prefixed credentials and reuses the IAM store's `role_id` / `user_id` when the principal already exists.
- Removes the now-duplicated STS code from `routes/iam.ts`.

## Known limitations (intentional)

Consistent with LocalStack / Moto defaults:

- Credentials are **synthetic and not persisted** — credentials returned by `AssumeRole` are not recognized on subsequent requests, and `GetCallerIdentity` reports the authenticated bearer user rather than an assumed-role principal.
- **SigV4 signatures are accepted but not verified** (an emulator has no real secret to validate against).

These are noted so the auth model is explicit; closing them would require persisting issued credentials and parsing the SigV4 access key — out of scope here.

## Tests

New `sts.test.ts` covers `AssumeRole` / `GetCallerIdentity` over both `/sts/` and the SDK `POST /` path, `DurationSeconds` validation (too low / too high / non-integer / boundary), unknown-action handling, and that a non-STS `POST /` is **not** hijacked. `pnpm --filter @emulators/aws test` → all green; `type-check` clean. No new dependencies.