### PR TITLE
feat(aws/sns): add SNS service + S3 ObjectCreated notifications

### DIFF
--- a/packages/@emulators/aws/README.md
+++ b/packages/@emulators/aws/README.md
@@ -1,6 +1,6 @@
 # @emulators/aws
 
-S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/IAM/STS endpoints. All responses use AWS-compatible XML.
+S3, SQS, SNS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/SNS/IAM/STS endpoints. Query responses use AWS-compatible XML.
 
 Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
 
@@ -26,12 +26,28 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 - `GET /:bucket/:key` — get object
 - `HEAD /:bucket/:key` — head object
 - `DELETE /:bucket/:key` — delete object
+- `PUT /:bucket?notification` — set bucket notification XML with `TopicConfiguration`
+- `GET /:bucket?notification` — get bucket notification XML
 
 ### SQS
 All operations via `POST /sqs/` with `Action` parameter:
 - `CreateQueue`, `ListQueues`, `GetQueueUrl`, `GetQueueAttributes`
 - `SendMessage`, `ReceiveMessage`, `DeleteMessage`
 - `PurgeQueue`, `DeleteQueue`
+
+### SNS
+All operations via `POST /sns/` with `Action` parameter:
+- `CreateTopic`, `ListTopics`, `DeleteTopic`
+- `Subscribe`, `Unsubscribe`
+- `Publish`
+- `GetTopicAttributes`, `SetTopicAttributes`
+- `GetSubscriptionAttributes`, `SetSubscriptionAttributes`
+
+SNS supports `sqs`, `http`, and `https` subscriptions. SQS subscriptions receive either the SNS notification envelope JSON or the raw message when `RawMessageDelivery` is `true`. HTTP and HTTPS subscriptions receive an SNS-shaped JSON notification body with fake signature fields; the emulator does not implement AWS-real signature verification fidelity.
+
+For HTTP delivery failures, a subscription `RedrivePolicy` with `deadLetterTargetArn` sends the failed notification envelope immediately to the target SQS queue. The emulator does not schedule AWS-style retry backoff.
+
+S3 bucket notifications can fan out `s3:ObjectCreated:Put` events to SNS topic configurations, including simple prefix and suffix filters.
 
 ### IAM
 All operations via `POST /iam/` with `Action` parameter:
@@ -60,6 +76,9 @@ aws:
     queues:
       - name: my-app-events
       - name: my-app-dlq
+  sns:
+    topics:
+      - name: my-app-object-created
   iam:
     users:
       - user_name: developer

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1031.0",
+    "@aws-sdk/client-sns": "^3.1042.0",
     "@aws-sdk/s3-presigned-post": "^3.1031.0",
     "tsup": "^8",
     "typescript": "^5.7",

--- a/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
@@ -13,7 +13,18 @@ import {
   DeleteObjectCommand,
   CopyObjectCommand,
   ListObjectsV2Command,
+  PutBucketNotificationConfigurationCommand,
 } from "@aws-sdk/client-s3";
+import {
+  SNSClient,
+  CreateTopicCommand,
+  DeleteTopicCommand,
+  GetTopicAttributesCommand,
+  ListTopicsCommand,
+  PublishCommand,
+  SetTopicAttributesCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { createTestApp } from "./helpers.js";
 
@@ -49,9 +60,33 @@ async function streamToString(stream: unknown): Promise<string> {
   return Buffer.concat(chunks).toString();
 }
 
+async function sqsAction(endpoint: string, params: Record<string, string>): Promise<string> {
+  const res = await fetch(`${endpoint}/sqs/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(params),
+  });
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+function xmlValue(xml: string, tagName: string): string {
+  return decodeXml(xml.match(new RegExp(`<${tagName}>([\\s\\S]*?)<\\/${tagName}>`))?.[1] ?? "");
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+}
+
 describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
   let emulator: EmulatorHandle;
   let s3: S3Client;
+  let sns: SNSClient;
 
   beforeAll(async () => {
     emulator = await startEmulator();
@@ -61,10 +96,16 @@ describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
       forcePathStyle: true,
       credentials: { accessKeyId: "AKIA", secretAccessKey: "secret" },
     });
+    sns = new SNSClient({
+      endpoint: `${emulator.url}/sns/`,
+      region: "us-east-1",
+      credentials: { accessKeyId: "AKIA", secretAccessKey: "secret" },
+    });
   });
 
   afterAll(async () => {
     s3.destroy();
+    sns.destroy();
     await emulator.close();
   });
 
@@ -242,5 +283,188 @@ describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
     const res = await fetch(post.url, { method: "POST", body: form });
     expect(res.status).toBe(400);
     expect(await res.text()).toContain("EntityTooLarge");
+  });
+
+  it("SNS CreateTopic, ListTopics, attributes, and DeleteTopic roundtrip through the SDK", async () => {
+    const created = await sns.send(new CreateTopicCommand({ Name: "sdk-e2e-topic" }));
+    expect(created.TopicArn).toMatch(/arn:aws:sns:us-east-1:123456789012:sdk-e2e-topic/);
+
+    await sns.send(
+      new SetTopicAttributesCommand({
+        TopicArn: created.TopicArn,
+        AttributeName: "DisplayName",
+        AttributeValue: "SDK Topic",
+      }),
+    );
+
+    const attrs = await sns.send(new GetTopicAttributesCommand({ TopicArn: created.TopicArn }));
+    expect(attrs.Attributes?.DisplayName).toBe("SDK Topic");
+
+    const listed = await sns.send(new ListTopicsCommand({}));
+    expect((listed.Topics ?? []).map((topic) => topic.TopicArn)).toContain(created.TopicArn);
+
+    await sns.send(new DeleteTopicCommand({ TopicArn: created.TopicArn }));
+    const afterDelete = await sns.send(new ListTopicsCommand({}));
+    expect((afterDelete.Topics ?? []).map((topic) => topic.TopicArn)).not.toContain(created.TopicArn);
+  });
+
+  it("delivers SNS envelope and raw messages to SQS subscriptions", async () => {
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sdk-e2e-sqs-topic" }));
+    const queueUrl = xmlValue(
+      await sqsAction(emulator.url, { Action: "CreateQueue", QueueName: "sns-envelope-queue" }),
+      "QueueUrl",
+    );
+    const rawQueueUrl = xmlValue(
+      await sqsAction(emulator.url, { Action: "CreateQueue", QueueName: "sns-raw-queue" }),
+      "QueueUrl",
+    );
+    const queueArn = xmlValue(
+      await sqsAction(emulator.url, { Action: "GetQueueAttributes", QueueUrl: queueUrl }),
+      "Value",
+    );
+    const rawQueueArn = xmlValue(
+      await sqsAction(emulator.url, { Action: "GetQueueAttributes", QueueUrl: rawQueueUrl }),
+      "Value",
+    );
+
+    await sns.send(new SubscribeCommand({ TopicArn: topic.TopicArn, Protocol: "sqs", Endpoint: queueArn }));
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn,
+        Protocol: "sqs",
+        Endpoint: rawQueueArn,
+        Attributes: { RawMessageDelivery: "true" },
+      }),
+    );
+
+    await sns.send(new PublishCommand({ TopicArn: topic.TopicArn, Message: "worker payload", Subject: "Test" }));
+
+    const received = await sqsAction(emulator.url, {
+      Action: "ReceiveMessage",
+      QueueUrl: queueUrl,
+      MaxNumberOfMessages: "1",
+    });
+    const envelope = JSON.parse(xmlValue(received, "Body")) as { Type: string; Subject: string; Message: string };
+    expect(envelope.Type).toBe("Notification");
+    expect(envelope.Subject).toBe("Test");
+    expect(envelope.Message).toBe("worker payload");
+
+    const rawReceived = await sqsAction(emulator.url, {
+      Action: "ReceiveMessage",
+      QueueUrl: rawQueueUrl,
+      MaxNumberOfMessages: "1",
+    });
+    expect(xmlValue(rawReceived, "Body")).toBe("worker payload");
+  });
+
+  it("POSTs SNS envelopes to HTTP subscriptions and sends failed HTTP deliveries to an SQS DLQ", async () => {
+    const deliveredBodies: string[] = [];
+    const httpServer = serve({
+      port: 0,
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        if (url.pathname === "/fail") {
+          return new Response("nope", { status: 500 });
+        }
+        deliveredBodies.push(await req.text());
+        return new Response("ok");
+      },
+    });
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once("listening", () => resolve());
+      httpServer.once("error", reject);
+    });
+    const { port } = httpServer.address() as AddressInfo;
+    const httpBase = `http://127.0.0.1:${port}`;
+
+    try {
+      const topic = await sns.send(new CreateTopicCommand({ Name: "sdk-e2e-http-topic" }));
+      const dlqUrl = xmlValue(await sqsAction(emulator.url, { Action: "CreateQueue", QueueName: "sns-http-dlq" }), "QueueUrl");
+      const dlqArn = xmlValue(await sqsAction(emulator.url, { Action: "GetQueueAttributes", QueueUrl: dlqUrl }), "Value");
+
+      await sns.send(new SubscribeCommand({ TopicArn: topic.TopicArn, Protocol: "http", Endpoint: `${httpBase}/ok` }));
+      await sns.send(
+        new SubscribeCommand({
+          TopicArn: topic.TopicArn,
+          Protocol: "http",
+          Endpoint: `${httpBase}/fail`,
+          Attributes: {
+            RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlqArn }),
+          },
+        }),
+      );
+
+      await sns.send(new PublishCommand({ TopicArn: topic.TopicArn, Message: "https worker body" }));
+
+      expect(deliveredBodies).toHaveLength(1);
+      const delivered = JSON.parse(deliveredBodies[0]) as { Type: string; Message: string };
+      expect(delivered.Type).toBe("Notification");
+      expect(delivered.Message).toBe("https worker body");
+
+      const dlqReceived = await sqsAction(emulator.url, {
+        Action: "ReceiveMessage",
+        QueueUrl: dlqUrl,
+        MaxNumberOfMessages: "1",
+      });
+      const dlqEnvelope = JSON.parse(xmlValue(dlqReceived, "Body")) as { Type: string; Message: string };
+      expect(dlqEnvelope.Type).toBe("Notification");
+      expect(dlqEnvelope.Message).toBe("https worker body");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+
+  it("fans out S3 ObjectCreated:Put notifications to SNS subscribers", async () => {
+    await s3.send(new CreateBucketCommand({ Bucket: "sdk-e2e-s3-sns" }));
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sdk-e2e-s3-topic" }));
+    const queueUrl = xmlValue(await sqsAction(emulator.url, { Action: "CreateQueue", QueueName: "s3-sns-events" }), "QueueUrl");
+    const queueArn = xmlValue(await sqsAction(emulator.url, { Action: "GetQueueAttributes", QueueUrl: queueUrl }), "Value");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn,
+        Protocol: "sqs",
+        Endpoint: queueArn,
+        Attributes: { RawMessageDelivery: "true" },
+      }),
+    );
+
+    await s3.send(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "sdk-e2e-s3-sns",
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            {
+              Id: "object-created-put",
+              TopicArn: topic.TopicArn,
+              Events: ["s3:ObjectCreated:Put"],
+            },
+          ],
+        },
+      }),
+    );
+
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: "sdk-e2e-s3-sns",
+        Key: "uploads/from-s3.txt",
+        Body: "fanout",
+        ContentType: "text/plain",
+      }),
+    );
+
+    const received = await sqsAction(emulator.url, {
+      Action: "ReceiveMessage",
+      QueueUrl: queueUrl,
+      MaxNumberOfMessages: "1",
+    });
+    const s3Event = JSON.parse(xmlValue(received, "Body")) as {
+      Records: Array<{ eventName: string; s3: { bucket: { name: string }; object: { key: string } } }>;
+    };
+    expect(s3Event.Records[0].eventName).toBe("ObjectCreated:Put");
+    expect(s3Event.Records[0].s3.bucket.name).toBe("sdk-e2e-s3-sns");
+    expect(s3Event.Records[0].s3.object.key).toBe("uploads/from-s3.txt");
   });
 });

--- a/packages/@emulators/aws/src/__tests__/aws.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws.test.ts
@@ -204,6 +204,35 @@ describe("AWS plugin - S3 Objects", () => {
     const body = await getRes.text();
     expect(body).toBe("copy me");
   });
+
+  it("round-trips a binary object byte-for-byte", async () => {
+    // Bytes that are NOT valid UTF-8 (0x80, 0xff, 0xfe) plus a NUL and PNG
+    // magic. The old handler called `.text()`, which decodes the body as
+    // UTF-8 and replaces every non-UTF-8 byte with U+FFFD (EF BF BD) — so
+    // binary uploads (audio, images, gzip, …) came back corrupted and longer
+    // than they went in. Storing the body base64 round-trips any byte exactly.
+    const binary = new Uint8Array([0x00, 0x01, 0x02, 0x80, 0xff, 0xfe, 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+
+    const putRes = await app.request(`${base}/emulate-default/audio.bin`, {
+      method: "PUT",
+      headers: { ...authHeaders(), "Content-Type": "application/octet-stream" },
+      body: binary,
+    });
+    expect(putRes.status).toBe(200);
+
+    const getRes = await app.request(`${base}/emulate-default/audio.bin`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    expect(getRes.status).toBe(200);
+    expect(getRes.headers.get("Content-Type")).toBe("application/octet-stream");
+
+    const received = new Uint8Array(await getRes.arrayBuffer());
+    expect(Array.from(received)).toEqual(Array.from(binary));
+    // Content-Length must reflect the raw byte count, not the inflated
+    // U+FFFD-substituted or base64 length.
+    expect(getRes.headers.get("Content-Length")).toBe(String(binary.byteLength));
+  });
 });
 
 describe("AWS plugin - S3 ListObjectsV2 pagination", () => {

--- a/packages/@emulators/aws/src/__tests__/aws.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws.test.ts
@@ -827,7 +827,7 @@ describe("AWS plugin - STS", () => {
 });
 
 describe("AWS plugin - seedFromConfig", () => {
-  it("seeds custom buckets, queues, users, and roles", () => {
+  it("seeds custom buckets, queues, topics, users, and roles", () => {
     const store = new Store();
     const webhooks = new WebhookDispatcher();
     const app = new Hono();
@@ -840,6 +840,9 @@ describe("AWS plugin - seedFromConfig", () => {
       },
       sqs: {
         queues: [{ name: "my-queue" }, { name: "orders.fifo", fifo: true }],
+      },
+      sns: {
+        topics: [{ name: "my-topic", attributes: { DisplayName: "My Topic" } }],
       },
       iam: {
         users: [{ user_name: "alice", create_access_key: true }],
@@ -859,6 +862,11 @@ describe("AWS plugin - seedFromConfig", () => {
     const queues = aws.sqsQueues.all();
     expect(queues.length).toBe(3);
     expect(queues.find((q) => q.queue_name === "orders.fifo")?.fifo).toBe(true);
+
+    const topics = aws.snsTopics.all();
+    expect(topics.length).toBe(1);
+    expect(topics[0].topic_name).toBe("my-topic");
+    expect(topics[0].attributes.DisplayName).toBe("My Topic");
 
     // Default admin + alice
     const users = aws.iamUsers.all();

--- a/packages/@emulators/aws/src/__tests__/helpers.ts
+++ b/packages/@emulators/aws/src/__tests__/helpers.ts
@@ -19,7 +19,7 @@ export function createTestApp(baseUrl: string = testBaseUrl) {
   tokenMap.set("test-aws-token", {
     login: "admin",
     id: 1,
-    scopes: ["s3:*", "sqs:*", "iam:*", "sts:*"],
+    scopes: ["s3:*", "sqs:*", "sns:*", "iam:*", "sts:*"],
   });
 
   const app = new Hono<AppEnv>();

--- a/packages/@emulators/aws/src/entities.ts
+++ b/packages/@emulators/aws/src/entities.ts
@@ -11,6 +11,7 @@ export interface S3Bucket extends Entity {
 export interface S3Object extends Entity {
   bucket_name: string;
   key: string;
+  /** Object bytes, base64-encoded (binary-safe — see s3.ts handlePutObject). */
   body: string;
   content_type: string;
   content_length: number;

--- a/packages/@emulators/aws/src/entities.ts
+++ b/packages/@emulators/aws/src/entities.ts
@@ -8,6 +8,18 @@ export interface S3Bucket extends Entity {
   versioning_enabled: boolean;
 }
 
+export interface S3TopicNotificationConfiguration {
+  id?: string;
+  topic_arn: string;
+  events: string[];
+  filter_rules: Array<{ name: "prefix" | "suffix"; value: string }>;
+}
+
+export interface S3BucketNotification extends Entity {
+  bucket_name: string;
+  topic_configurations: S3TopicNotificationConfiguration[];
+}
+
 export interface S3Object extends Entity {
   bucket_name: string;
   key: string;
@@ -44,6 +56,20 @@ export interface SqsMessage extends Entity {
   visible_after: number;
   sent_timestamp: number;
   receive_count: number;
+}
+
+export interface SnsTopic extends Entity {
+  topic_name: string;
+  arn: string;
+  attributes: Record<string, string>;
+}
+
+export interface SnsSubscription extends Entity {
+  subscription_arn: string;
+  topic_arn: string;
+  protocol: string;
+  endpoint: string;
+  attributes: Record<string, string>;
 }
 
 export interface IamUser extends Entity {

--- a/packages/@emulators/aws/src/helpers.ts
+++ b/packages/@emulators/aws/src/helpers.ts
@@ -23,7 +23,7 @@ export function generateReceiptHandle(): string {
   return randomBytes(48).toString("base64url");
 }
 
-export function md5(content: string): string {
+export function md5(content: string | Buffer | Uint8Array): string {
   return createHash("md5").update(content).digest("hex");
 }
 

--- a/packages/@emulators/aws/src/index.ts
+++ b/packages/@emulators/aws/src/index.ts
@@ -4,6 +4,7 @@ import { getAwsStore } from "./store.js";
 import { getAccountId, getDefaultRegion, generateAwsId } from "./helpers.js";
 import { s3Routes } from "./routes/s3.js";
 import { sqsRoutes } from "./routes/sqs.js";
+import { snsRoutes } from "./routes/sns.js";
 import { iamRoutes } from "./routes/iam.js";
 import { inspectorRoutes } from "./routes/inspector.js";
 
@@ -25,6 +26,12 @@ export interface AwsSeedConfig {
       name: string;
       fifo?: boolean;
       visibility_timeout?: number;
+    }>;
+  };
+  sns?: {
+    topics?: Array<{
+      name: string;
+      attributes?: Record<string, string>;
     }>;
   };
   iam?: {
@@ -127,6 +134,19 @@ export function seedFromConfig(store: Store, baseUrl: string, config: AwsSeedCon
     }
   }
 
+  if (config.sns?.topics) {
+    for (const t of config.sns.topics) {
+      const existing = aws.snsTopics.findOneBy("topic_name", t.name);
+      if (existing) continue;
+
+      aws.snsTopics.insert({
+        topic_name: t.name,
+        arn: `arn:aws:sns:${region}:${accountId}:${t.name}`,
+        attributes: t.attributes ?? {},
+      });
+    }
+  }
+
   if (config.iam?.users) {
     for (const u of config.iam.users) {
       const existing = aws.iamUsers.findOneBy("user_name", u.user_name);
@@ -182,6 +202,7 @@ export const awsPlugin: ServicePlugin = {
     // then S3 last since its routes use wildcard path params (/:bucket, /:bucket/:key)
     inspectorRoutes(ctx);
     sqsRoutes(ctx);
+    snsRoutes(ctx);
     iamRoutes(ctx);
     s3Routes(ctx);
   },

--- a/packages/@emulators/aws/src/routes/s3.ts
+++ b/packages/@emulators/aws/src/routes/s3.ts
@@ -231,11 +231,13 @@ ${prefixesXml}
       }
     }
 
-    // Store the object
-    const fileContent = await file.text();
+    // Store the object. Read as raw bytes and persist base64 so binary
+    // payloads (audio/images/etc.) survive — `.text()` would UTF-8-mangle them.
+    const fileBuf = Buffer.from(await file.arrayBuffer());
+    const fileContent = fileBuf.toString("base64");
     const contentType = (body["Content-Type"] as string) ?? file.type ?? "application/octet-stream";
-    const etag = md5(fileContent);
-    const contentLength = new TextEncoder().encode(fileContent).byteLength;
+    const etag = md5(fileBuf);
+    const contentLength = fileBuf.byteLength;
 
     const existing = aws()
       .s3Objects.findBy("bucket_name", bucketName)
@@ -347,9 +349,15 @@ ${prefixesXml}
       });
     }
 
-    const body = await c.req.text();
+    // Read the raw request bytes and store them base64-encoded. Using
+    // `c.req.text()` here would decode the body as UTF-8 and replace every
+    // non-UTF-8 byte with U+FFFD (EF BF BD), corrupting binary uploads
+    // (audio, images, gzip, …). base64 round-trips any byte exactly.
+    const bodyBuf = Buffer.from(await c.req.arrayBuffer());
+    const body = bodyBuf.toString("base64");
+    const contentLength = bodyBuf.byteLength;
     const contentType = c.req.header("Content-Type") ?? "application/octet-stream";
-    const etag = md5(body);
+    const etag = md5(bodyBuf);
 
     // Extract user metadata (x-amz-meta-*)
     const metadata: Record<string, string> = {};
@@ -367,7 +375,7 @@ ${prefixesXml}
       aws().s3Objects.update(existing.id, {
         body,
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: contentLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -378,7 +386,7 @@ ${prefixesXml}
         key,
         body,
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: contentLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -415,7 +423,9 @@ ${prefixesXml}
       headers[`x-amz-meta-${k}`] = v;
     }
 
-    return c.text(obj.body, 200, headers);
+    // obj.body is base64 (see handlePutObject); decode back to raw bytes so
+    // binary objects stream out byte-for-byte. c.body sends a Uint8Array as-is.
+    return c.body(Buffer.from(obj.body, "base64"), 200, headers);
   };
 
   const handleHeadObject = (c: S3ObjectContext) => {

--- a/packages/@emulators/aws/src/routes/s3.ts
+++ b/packages/@emulators/aws/src/routes/s3.ts
@@ -1,7 +1,9 @@
 import type { Context } from "@emulators/core";
 import type { AppEnv, RouteContext } from "@emulators/core";
+import type { S3TopicNotificationConfiguration } from "../entities.js";
 import { getAwsStore } from "../store.js";
 import { awsXmlResponse, awsErrorXml, md5, escapeXml } from "../helpers.js";
+import { publishToSnsTopic } from "./sns.js";
 
 // Handlers are reused across multiple routes (root paths + legacy `/s3/` aliases,
 // with and without trailing slashes). Parameterizing on the bucket/key path pattern
@@ -40,7 +42,11 @@ ${bucketXml}
     return awsXmlResponse(c, xml);
   };
 
-  const handleCreateBucket = (c: S3BucketContext) => {
+  const handleCreateBucket = async (c: S3BucketContext) => {
+    if (hasSubresource(c, "notification")) {
+      return handlePutBucketNotification(c);
+    }
+
     const bucketName = c.req.param("bucket");
     const existing = aws().s3Buckets.findOneBy("bucket_name", bucketName);
     if (existing) {
@@ -89,6 +95,10 @@ ${bucketXml}
   };
 
   const handleListObjects = (c: S3BucketContext) => {
+    if (hasSubresource(c, "notification")) {
+      return handleGetBucketNotification(c);
+    }
+
     const bucketName = c.req.param("bucket");
     const bucket = aws().s3Buckets.findOneBy("bucket_name", bucketName);
     if (!bucket) {
@@ -163,6 +173,57 @@ ${bucketXml}
 ${contentsXml}
 ${prefixesXml}
 </ListBucketResult>`;
+    return awsXmlResponse(c, xml);
+  };
+
+  const handlePutBucketNotification = async (c: S3BucketContext) => {
+    const bucketName = c.req.param("bucket");
+    const bucket = aws().s3Buckets.findOneBy("bucket_name", bucketName);
+    if (!bucket) {
+      return awsErrorXml(c, "NoSuchBucket", "The specified bucket does not exist.", 404);
+    }
+
+    const body = await c.req.text();
+    const topicConfigurations = parseTopicNotificationConfigurations(body);
+    const existing = aws().s3BucketNotifications.findOneBy("bucket_name", bucketName);
+    if (existing) {
+      aws().s3BucketNotifications.update(existing.id, {
+        topic_configurations: topicConfigurations,
+      });
+    } else {
+      aws().s3BucketNotifications.insert({
+        bucket_name: bucketName,
+        topic_configurations: topicConfigurations,
+      });
+    }
+
+    return c.text("", 200);
+  };
+
+  const handleGetBucketNotification = (c: S3BucketContext) => {
+    const bucketName = c.req.param("bucket");
+    const bucket = aws().s3Buckets.findOneBy("bucket_name", bucketName);
+    if (!bucket) {
+      return awsErrorXml(c, "NoSuchBucket", "The specified bucket does not exist.", 404);
+    }
+
+    const notification = aws().s3BucketNotifications.findOneBy("bucket_name", bucketName);
+    const topicConfigurationXml = (notification?.topic_configurations ?? [])
+      .map((config) => {
+        const idXml = config.id ? `    <Id>${escapeXml(config.id)}</Id>\n` : "";
+        const eventXml = config.events.map((event) => `    <Event>${escapeXml(event)}</Event>`).join("\n");
+        const filterXml = topicFilterXml(config);
+        return `  <TopicConfiguration>
+${idXml}    <Topic>${escapeXml(config.topic_arn)}</Topic>
+${eventXml}${filterXml}
+  </TopicConfiguration>`;
+      })
+      .join("\n");
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+${topicConfigurationXml}
+</NotificationConfiguration>`;
     return awsXmlResponse(c, xml);
   };
 
@@ -393,6 +454,8 @@ ${prefixesXml}
       });
     }
 
+    await publishS3ObjectCreatedPut(bucketName, key, etag, contentLength);
+
     return c.text("", 200, { ETag: `"${etag}"` });
   };
 
@@ -496,4 +559,129 @@ ${prefixesXml}
   app.get("/:bucket/:key{.+}", handleGetObject);
   app.on("HEAD", "/:bucket/:key{.+}", handleHeadObject);
   app.delete("/:bucket/:key{.+}", handleDeleteObject);
+
+  function hasSubresource(c: Context, name: string): boolean {
+    return new URL(c.req.url).searchParams.has(name);
+  }
+
+  function parseTopicNotificationConfigurations(xml: string): S3TopicNotificationConfiguration[] {
+    return [...xml.matchAll(/<TopicConfiguration\b[^>]*>([\s\S]*?)<\/TopicConfiguration>/g)].map((match) => {
+      const block = match[1] ?? "";
+      return {
+        id: readXmlText(block, "Id"),
+        topic_arn: readXmlText(block, "Topic") ?? readXmlText(block, "TopicArn") ?? "",
+        events: [...block.matchAll(/<Event>([\s\S]*?)<\/Event>/g)]
+          .map((eventMatch) => unescapeBasicXml(eventMatch[1] ?? ""))
+          .filter(Boolean),
+        filter_rules: parseNotificationFilterRules(block),
+      };
+    });
+  }
+
+  function readXmlText(xml: string, tagName: string): string | undefined {
+    const match = xml.match(new RegExp(`<${tagName}>([\\s\\S]*?)<\\/${tagName}>`));
+    return match ? unescapeBasicXml(match[1] ?? "") : undefined;
+  }
+
+  function parseNotificationFilterRules(xml: string): Array<{ name: "prefix" | "suffix"; value: string }> {
+    return [...xml.matchAll(/<FilterRule\b[^>]*>([\s\S]*?)<\/FilterRule>/g)]
+      .map((match) => {
+        const block = match[1] ?? "";
+        const name = readXmlText(block, "Name");
+        const value = readXmlText(block, "Value") ?? "";
+        if (name !== "prefix" && name !== "suffix") {
+          return undefined;
+        }
+        return { name, value };
+      })
+      .filter((rule): rule is { name: "prefix" | "suffix"; value: string } => Boolean(rule));
+  }
+
+  function topicFilterXml(config: S3TopicNotificationConfiguration): string {
+    if (config.filter_rules.length === 0) {
+      return "\n";
+    }
+
+    const rulesXml = config.filter_rules
+      .map(
+        (rule) => `          <FilterRule>
+            <Name>${escapeXml(rule.name)}</Name>
+            <Value>${escapeXml(rule.value)}</Value>
+          </FilterRule>`,
+      )
+      .join("\n");
+
+    return `
+    <Filter>
+      <S3Key>
+${rulesXml}
+      </S3Key>
+    </Filter>
+`;
+  }
+
+  function unescapeBasicXml(value: string): string {
+    return value
+      .replace(/&apos;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&gt;/g, ">")
+      .replace(/&lt;/g, "<")
+      .replace(/&amp;/g, "&");
+  }
+
+  async function publishS3ObjectCreatedPut(
+    bucketName: string,
+    key: string,
+    etag: string,
+    contentLength: number,
+  ): Promise<void> {
+    const notification = aws().s3BucketNotifications.findOneBy("bucket_name", bucketName);
+    if (!notification) {
+      return;
+    }
+
+    const eventMessage = JSON.stringify({
+      Records: [
+        {
+          eventVersion: "2.1",
+          eventSource: "aws:s3",
+          awsRegion: "us-east-1",
+          eventTime: new Date().toISOString(),
+          eventName: "ObjectCreated:Put",
+          s3: {
+            bucket: { name: bucketName },
+            object: {
+              key,
+              size: contentLength,
+              eTag: etag,
+            },
+          },
+        },
+      ],
+    });
+
+    for (const config of notification.topic_configurations) {
+      if (!topicConfigMatches(config, key, "s3:ObjectCreated:Put")) {
+        continue;
+      }
+      await publishToSnsTopic(store, baseUrl, {
+        topicArn: config.topic_arn,
+        message: eventMessage,
+      });
+    }
+  }
+
+  function topicConfigMatches(config: S3TopicNotificationConfiguration, key: string, eventName: string): boolean {
+    const eventMatches = config.events.some((event) => event === eventName || event === "s3:ObjectCreated:*");
+    if (!eventMatches) {
+      return false;
+    }
+
+    return config.filter_rules.every((rule) => {
+      if (rule.name === "prefix") {
+        return key.startsWith(rule.value);
+      }
+      return key.endsWith(rule.value);
+    });
+  }
 }

--- a/packages/@emulators/aws/src/routes/sns.ts
+++ b/packages/@emulators/aws/src/routes/sns.ts
@@ -1,0 +1,543 @@
+import type { Context, RouteContext, Store } from "@emulators/core";
+import type { SnsSubscription, SqsQueue } from "../entities.js";
+import { getAwsStore } from "../store.js";
+import {
+  awsXmlResponse,
+  awsErrorXml,
+  escapeXml,
+  generateMessageId,
+  generateReceiptHandle,
+  getAccountId,
+  getDefaultRegion,
+  md5,
+  parseQueryString,
+} from "../helpers.js";
+
+interface SnsPublishInput {
+  topicArn: string;
+  message: string;
+  subject?: string;
+  messageAttributes?: Record<string, { Type: string; Value: string }>;
+}
+
+interface SnsEnvelope {
+  Type: "Notification";
+  MessageId: string;
+  TopicArn: string;
+  Subject?: string;
+  Message: string;
+  Timestamp: string;
+  SignatureVersion: "1";
+  Signature: string;
+  SigningCertURL: string;
+  UnsubscribeURL: string;
+  MessageAttributes?: Record<string, { Type: string; Value: string }>;
+}
+
+export function snsRoutes(ctx: RouteContext): void {
+  const { app, store, baseUrl } = ctx;
+  const aws = () => getAwsStore(store);
+  const accountId = getAccountId();
+  const region = getDefaultRegion();
+
+  const handleSnsAction = async (c: Context) => {
+    const body = await c.req.text();
+    const params = parseQueryString(body);
+    const action = params["Action"] ?? c.req.query("Action") ?? "";
+
+    switch (action) {
+      case "CreateTopic":
+        return createTopic(c, params);
+      case "ListTopics":
+        return listTopics(c);
+      case "DeleteTopic":
+        return deleteTopic(c, params);
+      case "Subscribe":
+        return subscribe(c, params);
+      case "Unsubscribe":
+        return unsubscribe(c, params);
+      case "Publish":
+        return publish(c, params);
+      case "GetTopicAttributes":
+        return getTopicAttributes(c, params);
+      case "SetTopicAttributes":
+        return setTopicAttributes(c, params);
+      case "GetSubscriptionAttributes":
+        return getSubscriptionAttributes(c, params);
+      case "SetSubscriptionAttributes":
+        return setSubscriptionAttributes(c, params);
+      default:
+        return awsErrorXml(c, "InvalidAction", `The action ${action} is not valid for this endpoint.`, 400);
+    }
+  };
+
+  app.post("/sns", handleSnsAction);
+  app.post("/sns/", handleSnsAction);
+
+  function createTopic(c: Context, params: Record<string, string>) {
+    const topicName = params["Name"] ?? "";
+    if (!topicName) {
+      return awsErrorXml(c, "MissingParameter", "The request must contain the parameter Name.", 400);
+    }
+
+    const existing = aws().snsTopics.findOneBy("topic_name", topicName);
+    if (existing) {
+      return createTopicResponse(c, existing.arn);
+    }
+
+    const attrs = parseAttributeMap(params, "Attributes");
+    const arn = `arn:aws:sns:${region}:${accountId}:${topicName}`;
+    aws().snsTopics.insert({
+      topic_name: topicName,
+      arn,
+      attributes: attrs,
+    });
+
+    return createTopicResponse(c, arn);
+  }
+
+  function createTopicResponse(c: Context, topicArn: string) {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<CreateTopicResponse>
+  <CreateTopicResult>
+    <TopicArn>${escapeXml(topicArn)}</TopicArn>
+  </CreateTopicResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</CreateTopicResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function listTopics(c: Context) {
+    const topicsXml = aws()
+      .snsTopics.all()
+      .map(
+        (topic) => `      <member>
+        <TopicArn>${escapeXml(topic.arn)}</TopicArn>
+      </member>`,
+      )
+      .join("\n");
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListTopicsResponse>
+  <ListTopicsResult>
+    <Topics>
+${topicsXml}
+    </Topics>
+  </ListTopicsResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</ListTopicsResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function deleteTopic(c: Context, params: Record<string, string>) {
+    const topicArn = params["TopicArn"] ?? "";
+    const topic = aws().snsTopics.findOneBy("arn", topicArn);
+    if (topic) {
+      for (const subscription of aws().snsSubscriptions.findBy("topic_arn", topicArn)) {
+        aws().snsSubscriptions.delete(subscription.id);
+      }
+      aws().snsTopics.delete(topic.id);
+    }
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<DeleteTopicResponse>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</DeleteTopicResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function subscribe(c: Context, params: Record<string, string>) {
+    const topicArn = params["TopicArn"] ?? "";
+    const protocol = (params["Protocol"] ?? "").toLowerCase();
+    const endpoint = params["Endpoint"] ?? "";
+    if (!topicArn || !protocol || !endpoint) {
+      return awsErrorXml(c, "MissingParameter", "TopicArn, Protocol, and Endpoint are required.", 400);
+    }
+
+    const topic = aws().snsTopics.findOneBy("arn", topicArn);
+    if (!topic) {
+      return awsErrorXml(c, "NotFound", "Topic does not exist.", 404);
+    }
+
+    const existing = aws()
+      .snsSubscriptions.findBy("topic_arn", topicArn)
+      .find((subscription) => subscription.protocol === protocol && subscription.endpoint === endpoint);
+    if (existing) {
+      return subscribeResponse(c, existing.subscription_arn);
+    }
+
+    const attributes = parseAttributeMap(params, "Attributes");
+    const subscriptionArn = `${topicArn}:${generateMessageId()}`;
+    aws().snsSubscriptions.insert({
+      subscription_arn: subscriptionArn,
+      topic_arn: topicArn,
+      protocol,
+      endpoint,
+      attributes,
+    });
+
+    return subscribeResponse(c, subscriptionArn);
+  }
+
+  function subscribeResponse(c: Context, subscriptionArn: string) {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<SubscribeResponse>
+  <SubscribeResult>
+    <SubscriptionArn>${escapeXml(subscriptionArn)}</SubscriptionArn>
+  </SubscribeResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</SubscribeResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function unsubscribe(c: Context, params: Record<string, string>) {
+    const subscriptionArn = params["SubscriptionArn"] ?? "";
+    const subscription = aws().snsSubscriptions.findOneBy("subscription_arn", subscriptionArn);
+    if (subscription) {
+      aws().snsSubscriptions.delete(subscription.id);
+    }
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<UnsubscribeResponse>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</UnsubscribeResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  async function publish(c: Context, params: Record<string, string>) {
+    const topicArn = params["TopicArn"] ?? "";
+    const message = params["Message"] ?? "";
+    if (!topicArn || !message) {
+      return awsErrorXml(c, "MissingParameter", "TopicArn and Message are required.", 400);
+    }
+
+    const topic = aws().snsTopics.findOneBy("arn", topicArn);
+    if (!topic) {
+      return awsErrorXml(c, "NotFound", "Topic does not exist.", 404);
+    }
+
+    const messageId = await publishToSnsTopic(store, baseUrl, {
+      topicArn,
+      message,
+      subject: params["Subject"],
+      messageAttributes: parseMessageAttributes(params),
+    });
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<PublishResponse>
+  <PublishResult>
+    <MessageId>${messageId}</MessageId>
+  </PublishResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</PublishResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function getTopicAttributes(c: Context, params: Record<string, string>) {
+    const topicArn = params["TopicArn"] ?? "";
+    const topic = aws().snsTopics.findOneBy("arn", topicArn);
+    if (!topic) {
+      return awsErrorXml(c, "NotFound", "Topic does not exist.", 404);
+    }
+
+    const subscriptions = aws().snsSubscriptions.findBy("topic_arn", topicArn);
+    const attrs: Record<string, string> = {
+      TopicArn: topic.arn,
+      Owner: accountId,
+      SubscriptionsPending: "0",
+      SubscriptionsConfirmed: String(subscriptions.length),
+      SubscriptionsDeleted: "0",
+      DisplayName: topic.attributes["DisplayName"] ?? "",
+      ...topic.attributes,
+    };
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<GetTopicAttributesResponse>
+  <GetTopicAttributesResult>
+    <Attributes>
+${attributesXml(attrs)}
+    </Attributes>
+  </GetTopicAttributesResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</GetTopicAttributesResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function setTopicAttributes(c: Context, params: Record<string, string>) {
+    const topicArn = params["TopicArn"] ?? "";
+    const attributeName = params["AttributeName"] ?? "";
+    const attributeValue = params["AttributeValue"] ?? "";
+    const topic = aws().snsTopics.findOneBy("arn", topicArn);
+    if (!topic) {
+      return awsErrorXml(c, "NotFound", "Topic does not exist.", 404);
+    }
+    if (!attributeName) {
+      return awsErrorXml(c, "MissingParameter", "AttributeName is required.", 400);
+    }
+
+    aws().snsTopics.update(topic.id, {
+      attributes: {
+        ...topic.attributes,
+        [attributeName]: attributeValue,
+      },
+    });
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<SetTopicAttributesResponse>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</SetTopicAttributesResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function getSubscriptionAttributes(c: Context, params: Record<string, string>) {
+    const subscriptionArn = params["SubscriptionArn"] ?? "";
+    const subscription = aws().snsSubscriptions.findOneBy("subscription_arn", subscriptionArn);
+    if (!subscription) {
+      return awsErrorXml(c, "NotFound", "Subscription does not exist.", 404);
+    }
+
+    const attrs: Record<string, string> = {
+      SubscriptionArn: subscription.subscription_arn,
+      TopicArn: subscription.topic_arn,
+      Protocol: subscription.protocol,
+      Endpoint: subscription.endpoint,
+      Owner: accountId,
+      PendingConfirmation: "false",
+      RawMessageDelivery: subscription.attributes["RawMessageDelivery"] ?? "false",
+      ...subscription.attributes,
+    };
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<GetSubscriptionAttributesResponse>
+  <GetSubscriptionAttributesResult>
+    <Attributes>
+${attributesXml(attrs)}
+    </Attributes>
+  </GetSubscriptionAttributesResult>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</GetSubscriptionAttributesResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+
+  function setSubscriptionAttributes(c: Context, params: Record<string, string>) {
+    const subscriptionArn = params["SubscriptionArn"] ?? "";
+    const attributeName = params["AttributeName"] ?? "";
+    const attributeValue = params["AttributeValue"] ?? "";
+    const subscription = aws().snsSubscriptions.findOneBy("subscription_arn", subscriptionArn);
+    if (!subscription) {
+      return awsErrorXml(c, "NotFound", "Subscription does not exist.", 404);
+    }
+    if (!attributeName) {
+      return awsErrorXml(c, "MissingParameter", "AttributeName is required.", 400);
+    }
+
+    aws().snsSubscriptions.update(subscription.id, {
+      attributes: {
+        ...subscription.attributes,
+        [attributeName]: attributeValue,
+      },
+    });
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<SetSubscriptionAttributesResponse>
+  <ResponseMetadata><RequestId>${generateMessageId()}</RequestId></ResponseMetadata>
+</SetSubscriptionAttributesResponse>`;
+    return awsXmlResponse(c, xml);
+  }
+}
+
+export async function publishToSnsTopic(store: Store, baseUrl: string, input: SnsPublishInput): Promise<string> {
+  const aws = getAwsStore(store);
+  const topic = aws.snsTopics.findOneBy("arn", input.topicArn);
+  const messageId = generateMessageId();
+  if (!topic) {
+    return messageId;
+  }
+
+  const envelope = buildEnvelope(baseUrl, {
+    ...input,
+    messageId,
+  });
+
+  const subscriptions = aws.snsSubscriptions.findBy("topic_arn", input.topicArn);
+  for (const subscription of subscriptions) {
+    await deliverToSubscription(store, subscription, envelope);
+  }
+
+  return messageId;
+}
+
+function buildEnvelope(
+  baseUrl: string,
+  input: SnsPublishInput & {
+    messageId: string;
+  },
+): SnsEnvelope {
+  const envelope: SnsEnvelope = {
+    Type: "Notification",
+    MessageId: input.messageId,
+    TopicArn: input.topicArn,
+    Message: input.message,
+    Timestamp: new Date().toISOString(),
+    SignatureVersion: "1",
+    Signature: "emulate-fake-signature",
+    SigningCertURL: `${baseUrl}/sns/fake-signing-cert.pem`,
+    UnsubscribeURL: `${baseUrl}/sns/?Action=Unsubscribe&SubscriptionArn=emulate`,
+  };
+
+  if (input.subject) {
+    envelope.Subject = input.subject;
+  }
+  if (input.messageAttributes && Object.keys(input.messageAttributes).length > 0) {
+    envelope.MessageAttributes = input.messageAttributes;
+  }
+
+  return envelope;
+}
+
+async function deliverToSubscription(store: Store, subscription: SnsSubscription, envelope: SnsEnvelope): Promise<void> {
+  switch (subscription.protocol) {
+    case "sqs":
+      deliverToSqs(store, subscription, envelope);
+      return;
+    case "http":
+    case "https":
+      await deliverToHttp(store, subscription, envelope);
+      return;
+    default:
+      return;
+  }
+}
+
+function deliverToSqs(store: Store, subscription: SnsSubscription, envelope: SnsEnvelope): void {
+  const queue = findQueueByEndpoint(store, subscription.endpoint);
+  if (!queue) {
+    return;
+  }
+
+  const rawMessageDelivery = subscription.attributes["RawMessageDelivery"]?.toLowerCase() === "true";
+  enqueueSqsMessage(store, queue, rawMessageDelivery ? envelope.Message : JSON.stringify(envelope));
+}
+
+async function deliverToHttp(store: Store, subscription: SnsSubscription, envelope: SnsEnvelope): Promise<void> {
+  let delivered = false;
+  try {
+    const res = await fetch(subscription.endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain; charset=UTF-8",
+        "x-amz-sns-message-type": envelope.Type,
+        "x-amz-sns-topic-arn": envelope.TopicArn,
+        "x-amz-sns-message-id": envelope.MessageId,
+      },
+      body: JSON.stringify(envelope),
+    });
+    delivered = res.ok;
+  } catch {
+    delivered = false;
+  }
+
+  if (!delivered) {
+    deliverHttpFailureToDlq(store, subscription, envelope);
+  }
+}
+
+function deliverHttpFailureToDlq(store: Store, subscription: SnsSubscription, envelope: SnsEnvelope): void {
+  const redrivePolicy = subscription.attributes["RedrivePolicy"];
+  if (!redrivePolicy) {
+    return;
+  }
+
+  let deadLetterTargetArn: string | undefined;
+  try {
+    const parsed = JSON.parse(redrivePolicy) as { deadLetterTargetArn?: unknown };
+    if (typeof parsed.deadLetterTargetArn === "string") {
+      deadLetterTargetArn = parsed.deadLetterTargetArn;
+    }
+  } catch {
+    return;
+  }
+
+  if (!deadLetterTargetArn) {
+    return;
+  }
+
+  const queue = findQueueByEndpoint(store, deadLetterTargetArn);
+  if (queue) {
+    enqueueSqsMessage(store, queue, JSON.stringify(envelope));
+  }
+}
+
+function findQueueByEndpoint(store: Store, endpoint: string): SqsQueue | undefined {
+  const aws = getAwsStore(store);
+  return aws.sqsQueues.findOneBy("arn", endpoint) ?? aws.sqsQueues.findOneBy("queue_url", endpoint);
+}
+
+function enqueueSqsMessage(store: Store, queue: SqsQueue, body: string): void {
+  const aws = getAwsStore(store);
+  const now = Date.now();
+  aws.sqsMessages.insert({
+    queue_name: queue.queue_name,
+    message_id: generateMessageId(),
+    receipt_handle: generateReceiptHandle(),
+    body,
+    md5_of_body: md5(body),
+    attributes: {
+      SentTimestamp: String(now),
+      ApproximateReceiveCount: "0",
+      ApproximateFirstReceiveTimestamp: "",
+      SenderId: getAccountId(),
+    },
+    message_attributes: {},
+    visible_after: now + queue.delay_seconds * 1000,
+    sent_timestamp: now,
+    receive_count: 0,
+  });
+}
+
+function parseAttributeMap(params: Record<string, string>, prefix: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+
+  for (let i = 1; params[`Attribute.${i}.Name`]; i++) {
+    const name = params[`Attribute.${i}.Name`];
+    if (name) {
+      attrs[name] = params[`Attribute.${i}.Value`] ?? "";
+    }
+  }
+
+  for (let i = 1; params[`${prefix}.entry.${i}.key`] || params[`${prefix}.entry.${i}.Key`]; i++) {
+    const key = params[`${prefix}.entry.${i}.key`] ?? params[`${prefix}.entry.${i}.Key`];
+    if (key) {
+      attrs[key] = params[`${prefix}.entry.${i}.value`] ?? params[`${prefix}.entry.${i}.Value`] ?? "";
+    }
+  }
+
+  return attrs;
+}
+
+function parseMessageAttributes(params: Record<string, string>): Record<string, { Type: string; Value: string }> {
+  const attrs: Record<string, { Type: string; Value: string }> = {};
+  for (let i = 1; params[`MessageAttributes.entry.${i}.Name`]; i++) {
+    const name = params[`MessageAttributes.entry.${i}.Name`];
+    const type = params[`MessageAttributes.entry.${i}.Value.DataType`] ?? "String";
+    const value =
+      params[`MessageAttributes.entry.${i}.Value.StringValue`] ??
+      params[`MessageAttributes.entry.${i}.Value.BinaryValue`] ??
+      "";
+    if (name) {
+      attrs[name] = { Type: type, Value: value };
+    }
+  }
+  return attrs;
+}
+
+function attributesXml(attrs: Record<string, string>): string {
+  return Object.entries(attrs)
+    .map(
+      ([key, value]) => `      <entry>
+        <key>${escapeXml(key)}</key>
+        <value>${escapeXml(value)}</value>
+      </entry>`,
+    )
+    .join("\n");
+}

--- a/packages/@emulators/aws/src/store.ts
+++ b/packages/@emulators/aws/src/store.ts
@@ -1,11 +1,24 @@
 import { Store, type Collection } from "@emulators/core";
-import type { S3Bucket, S3Object, SqsQueue, SqsMessage, IamUser, IamRole } from "./entities.js";
+import type {
+  S3Bucket,
+  S3BucketNotification,
+  S3Object,
+  SqsQueue,
+  SqsMessage,
+  SnsTopic,
+  SnsSubscription,
+  IamUser,
+  IamRole,
+} from "./entities.js";
 
 export interface AwsStore {
   s3Buckets: Collection<S3Bucket>;
+  s3BucketNotifications: Collection<S3BucketNotification>;
   s3Objects: Collection<S3Object>;
   sqsQueues: Collection<SqsQueue>;
   sqsMessages: Collection<SqsMessage>;
+  snsTopics: Collection<SnsTopic>;
+  snsSubscriptions: Collection<SnsSubscription>;
   iamUsers: Collection<IamUser>;
   iamRoles: Collection<IamRole>;
 }
@@ -13,9 +26,16 @@ export interface AwsStore {
 export function getAwsStore(store: Store): AwsStore {
   return {
     s3Buckets: store.collection<S3Bucket>("aws.s3_buckets", ["bucket_name"]),
+    s3BucketNotifications: store.collection<S3BucketNotification>("aws.s3_bucket_notifications", ["bucket_name"]),
     s3Objects: store.collection<S3Object>("aws.s3_objects", ["key", "bucket_name"]),
     sqsQueues: store.collection<SqsQueue>("aws.sqs_queues", ["queue_name", "queue_url"]),
     sqsMessages: store.collection<SqsMessage>("aws.sqs_messages", ["message_id", "queue_name"]),
+    snsTopics: store.collection<SnsTopic>("aws.sns_topics", ["topic_name", "arn"]),
+    snsSubscriptions: store.collection<SnsSubscription>("aws.sns_subscriptions", [
+      "subscription_arn",
+      "topic_arn",
+      "endpoint",
+    ]),
     iamUsers: store.collection<IamUser>("aws.iam_users", ["user_name", "user_id"]),
     iamRoles: store.collection<IamRole>("aws.iam_roles", ["role_name", "role_id"]),
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1031.0
         version: 3.1031.0
+      '@aws-sdk/client-sns':
+        specifier: ^3.1042.0
+        version: 3.1054.0
       '@aws-sdk/s3-presigned-post':
         specifier: ^3.1031.0
         version: 3.1031.0
@@ -732,8 +735,16 @@ packages:
     resolution: {integrity: sha512-HflwKSpDl2pwPiH116n9dy1pKW+5yEoiGFor6NO1yADgge+QY5LqluBiHscD7k/o9ib+dgxf6Vg4WsctcRT3OA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sns@3.1054.0':
+    resolution: {integrity: sha512-8Befe/r+dyKneJkqLBcO9dEwSNsrf1FRPUHGaVN535gq8jGTSv45ybNT4SWSWU76mxR8oGTbvNGWoJGvlMGjcQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.0':
     resolution: {integrity: sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.14':
+    resolution: {integrity: sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.7':
@@ -744,32 +755,64 @@ packages:
     resolution: {integrity: sha512-WBHAMxyPdgeJY6ZGLvq9mJwzZ+GaNUROQbfdVshtMsDVBrZTj5ZuFjKclSjSHvKSHJ4Y4O2yvI/aA/hrJbYfng==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.40':
+    resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.28':
     resolution: {integrity: sha512-+1DwCjjpo1WoiZTN08yGitI3nUwZUSQWVWFrW4C46HqZwACjcUQ7C66tnKPBTVxrEYYDOP11A6Afmu1L6ylt3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.30':
     resolution: {integrity: sha512-Fg1oJcoijwOZjTxdbx+ubqbQl8YEQ4Cwhjw6TWzQjuDEvQYNhnCXW2pN7eKtdTrdE4a6+5TVKGSm2I+i2BKIQg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.30':
     resolution: {integrity: sha512-nchIrrI/7dgjG1bW/DEWOJc00K9n+kkl6B8Mk0KO6d4GfWBOXlVr9uHp7CJR9FIrjmov5SGjHXG2q9XAtkRw6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.31':
     resolution: {integrity: sha512-99OHVQ6eZ5DTxiOWgHdjBMvLqv7xoY4jLK6nZ1NcNSQbAnYZkQNIHi/VqInc9fnmg7of9si/z+waE6YL9OQIlw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.45':
+    resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.26':
     resolution: {integrity: sha512-jibxNld3m+vbmQwn98hcQ+fLIVrx3cQuhZlSs1/hix48SjDS5/pjMLwpmtLD/lFnd6ve1AL4o1bZg3X1WRa2SQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.30':
     resolution: {integrity: sha512-honYIM17F/+QSWJRE84T4u//ofqEi7rLbnwmIpu7fgFX5PML78wbtdSAy5Xwyve3TLpE9/f9zQx0aBVxSjAOPw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.30':
     resolution: {integrity: sha512-CyL4oWUlONQRN2SsYMVrA9Z3i3QfLWTQctI8tuKbjNGCVVDCnJf/yMbSJCOZgpPFRtxh7dgQwvpqwmJm+iytmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
@@ -816,6 +859,10 @@ packages:
     resolution: {integrity: sha512-bzPdsNQnCh6TvvUmTHLZlL8qgyME6mNiUErcRMyJPywIl1BEu2VZRShel3mUoSh89bOBEXEWtjocDMolFxd/9A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.12':
+    resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.12':
     resolution: {integrity: sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==}
     engines: {node: '>=20.0.0'}
@@ -828,12 +875,24 @@ packages:
     resolution: {integrity: sha512-qDwhXw+SIM5vMAMgflA8LPRa7xP+/wgXYr++llzCOwp7kkM2v7GGGWzoRW8e1CACaO4ljZd/NSQbsRLKm1sMWw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1031.0':
     resolution: {integrity: sha512-zj/PvnbQK/2KJNln5K2QRI9HSsy+B4emz2gbQyUHkk6l7Lidu83P/9tfmC2cJXkcC3vdmyKH2DP3Iw/FDfKQuQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1054.0':
+    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -866,6 +925,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.18':
     resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1513,6 +1576,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2525,8 +2591,16 @@ packages:
     resolution: {integrity: sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.4':
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.4':
+    resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.14':
@@ -2551,6 +2625,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.17':
     resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.4':
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -2609,6 +2687,10 @@ packages:
     resolution: {integrity: sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.4':
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.14':
     resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
@@ -2637,12 +2719,20 @@ packages:
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.4':
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.11':
     resolution: {integrity: sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.14':
@@ -4056,8 +4146,15 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastq@1.20.1:
@@ -5046,6 +5143,10 @@ packages:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -5532,6 +5633,9 @@ packages:
   strnum@2.2.1:
     resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
@@ -5970,6 +6074,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -6146,6 +6254,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-sns@3.1054.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.0':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6162,6 +6283,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
       '@smithy/types': 4.14.1
@@ -6175,6 +6307,14 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.28':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6186,6 +6326,16 @@ snapshots:
       '@smithy/smithy-client': 4.12.11
       '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.5.23
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.30':
@@ -6207,6 +6357,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-login': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.30':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6219,6 +6385,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.31':
     dependencies:
@@ -6237,6 +6412,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.45':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-ini': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.26':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6244,6 +6433,14 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.30':
@@ -6259,6 +6456,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/token-providers': 3.1054.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.30':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6270,6 +6477,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
     dependencies:
@@ -6409,6 +6625,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.12':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.12':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6440,6 +6669,13 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1031.0':
     dependencies:
       '@aws-sdk/core': 3.974.0
@@ -6452,9 +6688,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1054.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.8':
     dependencies:
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -6500,6 +6750,12 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -7066,6 +7322,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.0':
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8056,12 +8314,24 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.14':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.14':
@@ -8100,6 +8370,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -8197,6 +8473,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.14':
     dependencies:
       '@smithy/types': 4.14.1
@@ -8238,6 +8520,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.11':
     dependencies:
       '@smithy/core': 3.23.15
@@ -8249,6 +8537,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -9904,11 +10196,23 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.0
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
   fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
       strnum: 2.2.1
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -11252,6 +11556,8 @@ snapshots:
 
   path-expression-matcher@1.2.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -11967,6 +12273,8 @@ snapshots:
 
   strnum@2.2.1: {}
 
+  strnum@2.3.0: {}
+
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -12443,6 +12751,8 @@ snapshots:
 
   wrappy@1.0.2:
     optional: true
+
+  xml-naming@0.1.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

Adds an **SNS** emulator and wires **S3 event notifications** into it, so the common flow — *upload an object to S3 → S3 fires an `ObjectCreated` event → SNS fans it out → a subscriber receives a request* — works locally.

> [!IMPORTANT]
> **Stacked on #168.** This branch is built on top of `fix/s3-binary-safe-objects` (#168) because S3→SNS fan-out depends on objects round-tripping correctly. **Please merge #168 first** — until then, this PR's diff includes #168's changes (`helpers.ts`, the binary-safe `s3.ts` PUT/GET, and the binary round-trip test). After #168 merges, this diff will show SNS only.

## What's added

**SNS** (`POST /sns/`, query-style):
- `CreateTopic`, `ListTopics`, `DeleteTopic`
- `Subscribe`, `Unsubscribe` (`sqs`, `http`, `https` protocols)
- `Publish` — SNS envelope JSON, or the raw message when `RawMessageDelivery=true`
- `Get`/`SetTopicAttributes`, `Get`/`SetSubscriptionAttributes`
- HTTP/HTTPS subscriptions receive an SNS-shaped JSON body; a subscription `RedrivePolicy` with `deadLetterTargetArn` delivers failed HTTP notifications to the target SQS queue (no AWS-style retry backoff).

**S3 → SNS:**
- `PUT`/`GET /:bucket?notification` to configure a `TopicConfiguration`
- `s3:ObjectCreated:Put` events fan out to matching topic configurations, with simple prefix/suffix filtering.

## Known limitation (intentional)

Consistent with LocalStack / Moto: HTTP/HTTPS notification bodies carry **fake signature fields** — the emulator does not implement AWS-real SNS signature verification.

## Tests

Real `@aws-sdk/client-sns` E2E coverage: topic lifecycle, SQS + HTTP subscription delivery (including DLQ), and S3 `ObjectCreated` fan-out, plus `seedFromConfig` topic seeding. Adds `@aws-sdk/client-sns` as a dev dependency (lockfile change is purely additive). `pnpm --filter @emulators/aws test` → all green; `type-check` clean.