### PR TITLE
fix(slack): enforce message size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,8 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/chat.scheduledMessages.list` - list pending scheduled messages
 - `POST /api/chat.meMessage` - /me message
 
+Chat writes and incoming webhooks apply Slack-compatible message limits: top-level `text` is truncated at 40,000 characters with a `message_truncated` warning, while oversized rich payloads such as too many blocks or overlong block text return Slack-style errors.
+
 ### Conversations
 - `POST /api/conversations.list` - list conversations (cursor pagination, `types`, `exclude_archived`)
 - `POST /api/conversations.info` - get channel info

--- a/apps/web/app/docs/slack/page.mdx
+++ b/apps/web/app/docs/slack/page.mdx
@@ -20,6 +20,8 @@ Scope checks are relaxed by default for local development. Set `slack.strict_sco
 - `POST /api/chat.scheduledMessages.list` - list pending scheduled messages
 - `POST /api/chat.meMessage` - /me message
 
+Slack message limits are enforced on chat writes and incoming webhooks. Top-level `text` longer than 40,000 characters is truncated and Web API responses include `response_metadata.warnings: ["message_truncated"]`. Message payloads with more than 50 blocks, oversized section/context/header/markdown block text, or more than 100 attachments return Slack-style errors such as `msg_blocks_too_long` or `too_many_attachments`.
+
 ## Conversations
 
 - `POST /api/conversations.list` - list conversations (cursor pagination, `types`, `exclude_archived`)

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -24,6 +24,8 @@ npm install @emulators/slack
 - `POST /api/chat.scheduledMessages.list` — list pending scheduled messages
 - `POST /api/chat.meMessage` — /me message
 
+Chat writes and incoming webhooks apply Slack-compatible message limits: top-level `text` is truncated at 40,000 characters with a `message_truncated` warning, while oversized rich payloads such as too many blocks or overlong block text return Slack-style errors.
+
 ### Conversations
 - `POST /api/conversations.list` — list conversations (cursor pagination, `types`, `exclude_archived`)
 - `POST /api/conversations.info` — get channel info

--- a/packages/@emulators/slack/src/__tests__/slack-sdk.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack-sdk.test.ts
@@ -137,6 +137,19 @@ describe("Slack plugin - real @slack/web-api WebClient baseline", () => {
     expect(deleted.ok).toBe(true);
   });
 
+  it("truncates a 10 MB chat message through the Slack SDK", async () => {
+    expect(emulator).toBeDefined();
+    const channel = getSlackStore(emulator!.store).channels.findOneBy("name", "general")!.channel_id;
+    const text = "x".repeat(10 * 1024 * 1024);
+
+    const posted = await client.chat.postMessage({ channel, text });
+
+    expect(posted.ok).toBe(true);
+    expect(posted.message?.text).toHaveLength(40_000);
+    expect(posted.response_metadata?.warnings).toEqual(["message_truncated"]);
+    expect(getSlackStore(emulator!.store).messages.findOneBy("ts", posted.ts!)?.text).toHaveLength(40_000);
+  });
+
   it("round trips rich chat messages through the Slack SDK", async () => {
     expect(emulator).toBeDefined();
     const channel = getSlackStore(emulator!.store).channels.findOneBy("name", "general")!.channel_id;

--- a/packages/@emulators/slack/src/__tests__/slack.test.ts
+++ b/packages/@emulators/slack/src/__tests__/slack.test.ts
@@ -253,6 +253,37 @@ describe("Slack plugin - chat.postMessage", () => {
     expect(body.ok).toBe(false);
     expect(body.error).toBe("invalid_blocks");
   });
+
+  it("rejects message block payloads over Slack limits", async () => {
+    const ss = getSlackStore(store);
+    const ch = ss.channels.all()[0];
+
+    const tooManyBlocks = Array.from({ length: 51 }, (_, index) => ({
+      type: "section",
+      text: { type: "plain_text", text: `block ${index}` },
+    }));
+    const tooManyBlocksRes = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ channel: ch.channel_id, text: "too many blocks", blocks: tooManyBlocks }),
+    });
+    const tooManyBlocksBody = (await tooManyBlocksRes.json()) as any;
+    expect(tooManyBlocksBody.ok).toBe(false);
+    expect(tooManyBlocksBody.error).toBe("msg_blocks_too_long");
+
+    const oversizedSectionRes = await app.request(`${base}/api/chat.postMessage`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        channel: ch.channel_id,
+        text: "oversized section",
+        blocks: [{ type: "section", text: { type: "mrkdwn", text: "x".repeat(3_001) } }],
+      }),
+    });
+    const oversizedSectionBody = (await oversizedSectionRes.json()) as any;
+    expect(oversizedSectionBody.ok).toBe(false);
+    expect(oversizedSectionBody.error).toBe("msg_blocks_too_long");
+  });
 });
 
 describe("Slack plugin - chat.update", () => {

--- a/packages/@emulators/slack/src/helpers.ts
+++ b/packages/@emulators/slack/src/helpers.ts
@@ -40,6 +40,11 @@ export interface SlackRichMessageParseResult {
   error?: string;
 }
 
+export interface SlackTextLimitResult {
+  responseMetadata?: SlackJsonObject;
+  text: string;
+}
+
 interface ParsedField<T> {
   value?: T;
   error?: string;
@@ -61,6 +66,34 @@ export function slackOk<T extends Record<string, unknown>>(c: Context, data: T) 
 
 export function slackError(c: Context, error: string, status: ContentfulStatusCode = 200) {
   return c.json({ ok: false, error }, status);
+}
+
+export const SLACK_MESSAGE_TEXT_MAX_CHARS = 40_000;
+export const SLACK_MESSAGE_MAX_BLOCKS = 50;
+export const SLACK_SECTION_TEXT_MAX_CHARS = 3_000;
+export const SLACK_SECTION_FIELD_TEXT_MAX_CHARS = 2_000;
+export const SLACK_MARKDOWN_BLOCK_TEXT_MAX_CHARS = 12_000;
+export const SLACK_CONTEXT_TEXT_MAX_CHARS = 3_000;
+export const SLACK_HEADER_TEXT_MAX_CHARS = 150;
+export const SLACK_MAX_ATTACHMENTS = 100;
+
+export function applySlackTextLimit(text: string): SlackTextLimitResult {
+  if (text.length <= SLACK_MESSAGE_TEXT_MAX_CHARS) return { text };
+  return {
+    text: text.slice(0, SLACK_MESSAGE_TEXT_MAX_CHARS),
+    responseMetadata: {
+      messages: [
+        `[WARN] Your message was truncated but still posted. The \`text\` field accepts up to ${SLACK_MESSAGE_TEXT_MAX_CHARS.toLocaleString()} characters.`,
+      ],
+      warnings: ["message_truncated"],
+    },
+  };
+}
+
+export function validateSlackRichMessageLimits(fields: SlackRichMessageFields): string | undefined {
+  if ((fields.attachments?.length ?? 0) > SLACK_MAX_ATTACHMENTS) return "too_many_attachments";
+  if (hasOversizedSlackBlocks(fields.blocks)) return "msg_blocks_too_long";
+  return undefined;
 }
 
 export function isSlackStrictScopes(store: Store): boolean {
@@ -356,6 +389,39 @@ function hasBodyField(body: Record<string, unknown>, field: string): boolean {
 
 function isSlackJsonObject(value: unknown): value is SlackJsonObject {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOversizedSlackBlocks(blocks: SlackJsonObject[] | undefined): boolean {
+  if (!blocks) return false;
+  if (blocks.length > SLACK_MESSAGE_MAX_BLOCKS) return true;
+  return blocks.some((block) => {
+    const type = typeof block.type === "string" ? block.type : "";
+    if (type === "section") {
+      return (
+        slackTextObjectLength(block.text) > SLACK_SECTION_TEXT_MAX_CHARS ||
+        slackTextObjectArrayTooLong(block.fields, SLACK_SECTION_FIELD_TEXT_MAX_CHARS)
+      );
+    }
+    if (type === "markdown") return stringField(block.text).length > SLACK_MARKDOWN_BLOCK_TEXT_MAX_CHARS;
+    if (type === "context") return slackTextObjectArrayTooLong(block.elements, SLACK_CONTEXT_TEXT_MAX_CHARS);
+    if (type === "header") return slackTextObjectLength(block.text) > SLACK_HEADER_TEXT_MAX_CHARS;
+    return false;
+  });
+}
+
+function slackTextObjectArrayTooLong(value: unknown, maxChars: number): boolean {
+  if (!Array.isArray(value)) return false;
+  return value.some((item) => slackTextObjectLength(item) > maxChars);
+}
+
+function slackTextObjectLength(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  if (!isSlackJsonObject(value)) return 0;
+  return stringField(value.text).length;
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
 function parseSlackJsonString(value: string): ParsedField<unknown> {

--- a/packages/@emulators/slack/src/routes/chat.ts
+++ b/packages/@emulators/slack/src/routes/chat.ts
@@ -10,12 +10,14 @@ import {
   generateTs,
   getSlackConversationOpenState,
   hasSlackMessageContent,
+  applySlackTextLimit,
   parseSlackBody,
   parseSlackRichMessageFields,
   requireSlackScopes,
   setSlackConversationOpenState,
   slackError,
   slackOk,
+  validateSlackRichMessageLimits,
 } from "../helpers.js";
 
 export function chatRoutes(ctx: RouteContext): void {
@@ -121,10 +123,13 @@ export function chatRoutes(ctx: RouteContext): void {
 
     const body = await parseSlackBody(c);
     const channel = typeof body.channel === "string" ? body.channel : "";
-    const text = typeof body.text === "string" ? body.text : "";
+    const textLimit = applySlackTextLimit(typeof body.text === "string" ? body.text : "");
+    const text = textLimit.text;
     const thread_ts = typeof body.thread_ts === "string" ? body.thread_ts : undefined;
     const richMessage = parseSlackRichMessageFields(body);
     if (richMessage.error) return slackError(c, richMessage.error);
+    const limitError = validateSlackRichMessageLimits(richMessage.fields);
+    if (limitError) return slackError(c, limitError);
 
     if (!channel) return slackError(c, "channel_not_found");
     if (!hasSlackMessageContent(text, richMessage.fields)) return slackError(c, "no_text");
@@ -183,6 +188,7 @@ export function chatRoutes(ctx: RouteContext): void {
       channel: ch.channel_id,
       ts,
       message: formatSlackMessage(msg),
+      ...(textLimit.responseMetadata ? { response_metadata: textLimit.responseMetadata } : {}),
     });
   });
 
@@ -196,10 +202,13 @@ export function chatRoutes(ctx: RouteContext): void {
     const body = await parseSlackBody(c);
     const channel = typeof body.channel === "string" ? body.channel : "";
     const user = typeof body.user === "string" ? body.user : "";
-    const text = typeof body.text === "string" ? body.text : "";
+    const textLimit = applySlackTextLimit(typeof body.text === "string" ? body.text : "");
+    const text = textLimit.text;
     const thread_ts = typeof body.thread_ts === "string" ? body.thread_ts : undefined;
     const richMessage = parseSlackRichMessageFields(body);
     if (richMessage.error) return slackError(c, richMessage.error);
+    const limitError = validateSlackRichMessageLimits(richMessage.fields);
+    if (limitError) return slackError(c, limitError);
 
     if (!channel) return slackError(c, "channel_not_found");
     if (!user) return slackError(c, "user_not_found");
@@ -230,7 +239,10 @@ export function chatRoutes(ctx: RouteContext): void {
       reactions: [],
     });
 
-    return slackOk(c, { message_ts: ts });
+    return slackOk(c, {
+      message_ts: ts,
+      ...(textLimit.responseMetadata ? { response_metadata: textLimit.responseMetadata } : {}),
+    });
   });
 
   // chat.update
@@ -244,9 +256,12 @@ export function chatRoutes(ctx: RouteContext): void {
     const channel = typeof body.channel === "string" ? body.channel : "";
     const ts = typeof body.ts === "string" ? body.ts : "";
     const hasText = typeof body.text === "string";
-    const text = hasText ? (body.text as string) : "";
+    const textLimit = applySlackTextLimit(hasText ? (body.text as string) : "");
+    const text = textLimit.text;
     const richMessage = parseSlackRichMessageFields(body);
     if (richMessage.error) return slackError(c, richMessage.error);
+    const limitError = validateSlackRichMessageLimits(richMessage.fields);
+    if (limitError) return slackError(c, limitError);
 
     if (!channel || !ts) return slackError(c, "message_not_found");
 
@@ -301,6 +316,7 @@ export function chatRoutes(ctx: RouteContext): void {
       ts,
       text: updated.text,
       message: formatSlackMessage(updated),
+      ...(textLimit.responseMetadata ? { response_metadata: textLimit.responseMetadata } : {}),
     });
   });
 
@@ -391,11 +407,14 @@ export function chatRoutes(ctx: RouteContext): void {
 
     const body = await parseSlackBody(c);
     const channel = typeof body.channel === "string" ? body.channel : "";
-    const text = typeof body.text === "string" ? body.text : "";
+    const textLimit = applySlackTextLimit(typeof body.text === "string" ? body.text : "");
+    const text = textLimit.text;
     const postAt = Number(body.post_at);
     const thread_ts = typeof body.thread_ts === "string" ? body.thread_ts : undefined;
     const richMessage = parseSlackRichMessageFields(body);
     if (richMessage.error) return slackError(c, richMessage.error);
+    const limitError = validateSlackRichMessageLimits(richMessage.fields);
+    if (limitError) return slackError(c, limitError);
 
     if (!channel) return slackError(c, "channel_not_found");
     if (!hasSlackMessageContent(text, richMessage.fields)) return slackError(c, "no_text");
@@ -430,6 +449,7 @@ export function chatRoutes(ctx: RouteContext): void {
       scheduled_message_id: scheduled.scheduled_message_id,
       post_at: scheduled.post_at,
       message: formatSlackScheduledMessage(scheduled),
+      ...(textLimit.responseMetadata ? { response_metadata: textLimit.responseMetadata } : {}),
     });
   });
 
@@ -528,7 +548,8 @@ export function chatRoutes(ctx: RouteContext): void {
 
     const body = await parseSlackBody(c);
     const channel = typeof body.channel === "string" ? body.channel : "";
-    const text = typeof body.text === "string" ? body.text : "";
+    const textLimit = applySlackTextLimit(typeof body.text === "string" ? body.text : "");
+    const text = textLimit.text;
 
     if (!channel) return slackError(c, "channel_not_found");
 
@@ -551,7 +572,11 @@ export function chatRoutes(ctx: RouteContext): void {
       reactions: [],
     });
 
-    return slackOk(c, { channel: ch.channel_id, ts });
+    return slackOk(c, {
+      channel: ch.channel_id,
+      ts,
+      ...(textLimit.responseMetadata ? { response_metadata: textLimit.responseMetadata } : {}),
+    });
   });
 }
 

--- a/packages/@emulators/slack/src/routes/webhooks.ts
+++ b/packages/@emulators/slack/src/routes/webhooks.ts
@@ -1,6 +1,13 @@
 import type { RouteContext } from "@emulators/core";
 import { getSlackStore } from "../store.js";
-import { formatSlackMessage, generateTs, hasSlackMessageContent, parseSlackRichMessageFields } from "../helpers.js";
+import {
+  applySlackTextLimit,
+  formatSlackMessage,
+  generateTs,
+  hasSlackMessageContent,
+  parseSlackRichMessageFields,
+  validateSlackRichMessageLimits,
+} from "../helpers.js";
 
 export function webhookRoutes(ctx: RouteContext): void {
   const { app, store, webhooks } = ctx;
@@ -39,12 +46,17 @@ export function webhookRoutes(ctx: RouteContext): void {
       }
     }
 
-    const text = typeof body.text === "string" ? body.text : "";
+    const textLimit = applySlackTextLimit(typeof body.text === "string" ? body.text : "");
+    const text = textLimit.text;
     const channelName = typeof body.channel === "string" ? body.channel : "";
     const threadTs = typeof body.thread_ts === "string" ? body.thread_ts : undefined;
     const richMessage = parseSlackRichMessageFields(body);
     if (richMessage.error) {
       return c.text(richMessage.error, 400);
+    }
+    const limitError = validateSlackRichMessageLimits(richMessage.fields);
+    if (limitError) {
+      return c.text(limitError, 400);
     }
 
     if (!hasSlackMessageContent(text, richMessage.fields)) {

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -40,6 +40,8 @@ Requests without a token return `not_authed`. In relaxed scope mode, any non-emp
 
 Scope checks are relaxed by default for local development. Set `slack.strict_scopes: true` in seed config when you need supported Web API methods to return Slack-style `missing_scope` errors with `needed` and `provided` fields. Strict mode checks `chat:write`, `channels:read`, `channels:history`, `channels:join`, `channels:manage`, `channels:write`, `groups:read`, `groups:history`, `groups:write`, `im:read`, `im:history`, `im:write`, `mpim:read`, `mpim:history`, `mpim:write`, `users:read`, `users:read.email`, `users.profile:read`, `users.profile:write`, `users:write`, `files:read`, `files:write`, `pins:read`, `pins:write`, `bookmarks:read`, `bookmarks:write`, `reactions:read`, `reactions:write`, and `team:read`. Slack lists no method-specific scopes for `views.publish`, `views.open`, `views.update`, or `views.push`, so the emulator requires auth but does not add strict-scope checks for those methods.
 
+Chat writes and incoming webhooks apply Slack-compatible message limits: top-level `text` is truncated at 40,000 characters with a `message_truncated` warning, while oversized rich payloads such as too many blocks or overlong block text return Slack-style errors.
+
 ## Pointing Your App at the Emulator
 
 ### Environment Variable


### PR DESCRIPTION
Summary
- Add Slack-compatible top-level text truncation for chat writes and incoming webhooks at 40,000 characters.
- Return `response_metadata.warnings: ["message_truncated"]` on Web API chat responses when text is truncated.
- Reject oversized rich payloads, including more than 50 blocks, overlong section/context/header/markdown block text, and more than 100 attachments.
- Add a 10 MB `@slack/web-api` regression test for `chat.postMessage`.

Tests
- `pnpm --filter @emulators/slack test`
- `pnpm --filter @emulators/slack type-check`
- `pnpm --filter @emulators/slack lint`
- `git diff --check`
- `pnpm exec prettier --check apps/web/app/docs/slack/page.mdx packages/@emulators/slack/src/helpers.ts packages/@emulators/slack/src/routes/chat.ts packages/@emulators/slack/src/routes/webhooks.ts packages/@emulators/slack/src/__tests__/slack-sdk.test.ts packages/@emulators/slack/src/__tests__/slack.test.ts`