### PR TITLE
feat: add Polar.sh emulator support

### DIFF
--- a/packages/@emulators/polar/README.md
+++ b/packages/@emulators/polar/README.md
@@ -1,0 +1,50 @@
+# @emulators/polar
+
+Polar.sh API emulation with organizations, products, prices, checkouts, and subscriptions.
+
+Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
+
+## Install
+
+```bash
+npm install @emulators/polar
+```
+
+## Endpoints
+
+### Organizations
+- `GET /v1/organizations` — list organizations
+- `GET /v1/organizations/:id` — retrieve organization
+
+### Products
+- `GET /v1/products` — list products
+- `GET /v1/products/:id` — retrieve product
+
+### Checkouts
+- `POST /v1/checkouts` — create checkout session
+- `GET /v1/checkouts/:id` — retrieve checkout session
+
+### Subscriptions
+- `GET /v1/subscriptions` — list subscriptions
+- `GET /v1/subscriptions/:id` — retrieve subscription
+
+## Seed Configuration
+
+```yaml
+polar:
+  organizations:
+    - name: My Project
+      slug: my-project
+  products:
+    - name: Pro Tier
+      description: Support our project with a monthly subscription
+      organization_slug: my-project
+      prices:
+        - amount: 1000
+          currency: usd
+```
+
+## Links
+
+- [Full documentation](https://emulate.dev)
+- [GitHub](https://github.com/vercel-labs/emulate)

--- a/packages/@emulators/polar/package.json
+++ b/packages/@emulators/polar/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@emulators/polar",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/polar"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/polar/src/__tests__/polar.test.ts
+++ b/packages/@emulators/polar/src/__tests__/polar.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "@emulators/core";
+import {
+  Store,
+  WebhookDispatcher,
+  authMiddleware,
+  createApiErrorHandler,
+  createErrorHandler,
+  type TokenMap,
+} from "@emulators/core";
+import { polarPlugin } from "../index.js";
+
+const base = "http://localhost:15000";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("polar_test_token", {
+    login: "test-account",
+    id: 1,
+    scopes: [],
+  });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap));
+  polarPlugin.register(app as any, store, webhooks, base, tokenMap);
+  polarPlugin.seed?.(store, base);
+
+  return { app, store, webhooks, tokenMap };
+}
+
+function auth(): Record<string, string> {
+  return {
+    Authorization: "Bearer polar_test_token",
+    "Content-Type": "application/json",
+  };
+}
+
+describe("Polar plugin", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    const ctx = createTestApp();
+    app = ctx.app;
+  });
+
+  describe("products", () => {
+    it("lists seeded products", async () => {
+      const res = await app.request(`${base}/v1/products`, { headers: auth() });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.items.length).toBeGreaterThan(0);
+      expect(body.items[0].name).toBe("Test Product");
+    });
+  });
+
+  describe("organizations", () => {
+    it("lists seeded organizations", async () => {
+      const res = await app.request(`${base}/v1/organizations`, { headers: auth() });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.items.length).toBeGreaterThan(0);
+      expect(body.items[0].slug).toBe("test-org");
+    });
+  });
+
+  describe("checkouts", () => {
+    it("creates and retrieves a checkout session", async () => {
+      // Get a product first
+      const prodRes = await app.request(`${base}/v1/products`, { headers: auth() });
+      const { items } = await prodRes.json();
+      const productId = items[0].polar_id;
+
+      const createRes = await app.request(`${base}/v1/checkouts`, {
+        method: "POST",
+        headers: auth(),
+        body: JSON.stringify({ product_id: productId, success_url: "https://example.com/success" }),
+      });
+      expect(createRes.status).toBe(201);
+      const checkout = await createRes.json();
+      expect(checkout.polar_id).toMatch(/^ch_/);
+      expect(checkout.product_id).toBe(productId);
+
+      const getRes = await app.request(`${base}/v1/checkouts/${checkout.polar_id}`, { headers: auth() });
+      expect(getRes.status).toBe(200);
+      const fetched = await getRes.json();
+      expect(fetched.polar_id).toBe(checkout.polar_id);
+    });
+  });
+});

--- a/packages/@emulators/polar/src/entities.ts
+++ b/packages/@emulators/polar/src/entities.ts
@@ -1,0 +1,59 @@
+import type { Entity } from "@emulators/core";
+
+export interface PolarOrganization extends Entity {
+  polar_id: string;
+  name: string;
+  slug: string;
+  avatar_url: string | null;
+}
+
+export interface PolarProduct extends Entity {
+  polar_id: string;
+  name: string;
+  description: string | null;
+  organization_id: string;
+  is_recurring: boolean;
+  is_archived: boolean;
+}
+
+export interface PolarPrice extends Entity {
+  polar_id: string;
+  product_id: string;
+  amount_type: "fixed";
+  price_currency: string;
+  price_amount: number;
+  recurring_interval: "month" | "year" | null;
+}
+
+export interface PolarCheckout extends Entity {
+  polar_id: string;
+  status: "open" | "confirmed" | "expired";
+  payment_processor: "stripe";
+  client_secret: string;
+  url: string;
+  success_url: string;
+  embed_origin: string | null;
+  organization_id: string;
+  product_id: string;
+  price_id: string;
+  customer_id: string | null;
+  customer_name: string | null;
+  customer_email: string | null;
+  metadata: Record<string, string | number | boolean>;
+}
+
+export interface PolarSubscription extends Entity {
+  polar_id: string;
+  status: "active" | "canceled" | "incomplete" | "incomplete_expired" | "past_due" | "unpaid";
+  current_period_start: string;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+  canceled_at: string | null;
+  started_at: string | null;
+  user_id: string;
+  organization_id: string;
+  product_id: string;
+  price_id: string;
+  checkout_id: string | null;
+  metadata: Record<string, string | number | boolean>;
+}

--- a/packages/@emulators/polar/src/helpers.ts
+++ b/packages/@emulators/polar/src/helpers.ts
@@ -1,0 +1,5 @@
+import { randomBytes } from "node:crypto";
+
+export function polarId(prefix: string): string {
+  return `${prefix}_${randomBytes(12).toString("hex")}`;
+}

--- a/packages/@emulators/polar/src/index.ts
+++ b/packages/@emulators/polar/src/index.ts
@@ -1,0 +1,112 @@
+import type { Hono } from "@emulators/core";
+import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@emulators/core";
+import { getPolarStore } from "./store.js";
+import { polarId } from "./helpers.js";
+import { checkoutRoutes } from "./routes/checkouts.js";
+import { productRoutes } from "./routes/products.js";
+import { organizationRoutes } from "./routes/organizations.js";
+import { subscriptionRoutes } from "./routes/subscriptions.js";
+
+export { getPolarStore, type PolarStore } from "./store.js";
+export * from "./entities.js";
+
+export interface PolarSeedConfig {
+  organizations?: Array<{
+    id?: string;
+    name: string;
+    slug: string;
+  }>;
+  products?: Array<{
+    id?: string;
+    name: string;
+    description?: string;
+    organization_slug: string;
+    prices: Array<{
+      id?: string;
+      amount: number;
+      currency?: string;
+    }>;
+  }>;
+}
+
+function seedDefaults(store: Store): void {
+  const ps = getPolarStore(store);
+
+  const org = ps.organizations.insert({
+    polar_id: polarId("org"),
+    name: "Test Organization",
+    slug: "test-org",
+    avatar_url: null,
+  });
+
+  ps.products.insert({
+    polar_id: polarId("prod"),
+    name: "Test Product",
+    description: "A test product for emulation",
+    organization_id: org.polar_id,
+    is_recurring: false,
+    is_archived: false,
+  });
+}
+
+export function seedFromConfig(
+  store: Store,
+  _baseUrl: string,
+  config: PolarSeedConfig,
+): void {
+  const ps = getPolarStore(store);
+
+  if (config.organizations) {
+    for (const o of config.organizations) {
+      ps.organizations.insert({
+        polar_id: o.id ?? polarId("org"),
+        name: o.name,
+        slug: o.slug,
+        avatar_url: null,
+      });
+    }
+  }
+
+  if (config.products) {
+    for (const p of config.products) {
+      const org = ps.organizations.findOneBy("slug", p.organization_slug);
+      if (!org) continue;
+
+      const product = ps.products.insert({
+        polar_id: p.id ?? polarId("prod"),
+        name: p.name,
+        description: p.description ?? null,
+        organization_id: org.polar_id,
+        is_recurring: p.prices.some(pr => pr.amount > 0), // Simple heuristic
+        is_archived: false,
+      });
+
+      for (const pr of p.prices) {
+        ps.prices.insert({
+          polar_id: pr.id ?? polarId("price"),
+          product_id: product.polar_id,
+          amount_type: "fixed",
+          price_currency: pr.currency ?? "usd",
+          price_amount: pr.amount,
+          recurring_interval: null,
+        });
+      }
+    }
+  }
+}
+
+export const polarPlugin: ServicePlugin = {
+  name: "polar",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    checkoutRoutes(ctx);
+    productRoutes(ctx);
+    organizationRoutes(ctx);
+    subscriptionRoutes(ctx);
+  },
+  seed(store: Store): void {
+    seedDefaults(store);
+  },
+};
+
+export default polarPlugin;

--- a/packages/@emulators/polar/src/routes/checkouts.ts
+++ b/packages/@emulators/polar/src/routes/checkouts.ts
@@ -1,0 +1,46 @@
+import type { RouteContext } from "@emulators/core";
+import { getPolarStore } from "../store.js";
+import { polarId } from "../helpers.js";
+
+export function checkoutRoutes({ app, store, baseUrl }: RouteContext): void {
+  const polar = getPolarStore(store);
+
+  app.post("/v1/checkouts", async (c) => {
+    const body = await c.req.json();
+    const product_id = body.product_id;
+    
+    // Find product to ensure it exists
+    const product = polar.products.findOneBy("polar_id", product_id);
+    if (!product) {
+      return c.json({ error: "Product not found" }, 404);
+    }
+
+    const checkout = polar.checkouts.insert({
+      polar_id: polarId("ch"),
+      status: "open",
+      payment_processor: "stripe",
+      client_secret: `secret_${polarId("cs")}`,
+      url: `${baseUrl}/checkout/${polarId("ch")}`,
+      success_url: body.success_url ?? `${baseUrl}/success`,
+      embed_origin: body.embed_origin ?? null,
+      organization_id: product.organization_id,
+      product_id: product.polar_id,
+      price_id: body.price_id ?? "",
+      customer_id: null,
+      customer_name: body.customer_name ?? null,
+      customer_email: body.customer_email ?? null,
+      metadata: body.metadata ?? {},
+    });
+
+    return c.json(checkout, 201);
+  });
+
+  app.get("/v1/checkouts/:id", (c) => {
+    const id = c.req.param("id");
+    const checkout = polar.checkouts.findOneBy("polar_id", id);
+    if (!checkout) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    return c.json(checkout);
+  });
+}

--- a/packages/@emulators/polar/src/routes/organizations.ts
+++ b/packages/@emulators/polar/src/routes/organizations.ts
@@ -1,0 +1,26 @@
+import type { RouteContext } from "@emulators/core";
+import { getPolarStore } from "../store.js";
+
+export function organizationRoutes({ app, store }: RouteContext): void {
+  const polar = getPolarStore(store);
+
+  app.get("/v1/organizations", (c) => {
+    const orgs = polar.organizations.all();
+    return c.json({
+      items: orgs,
+      pagination: {
+        total_count: orgs.length,
+        max_page: 1,
+      }
+    });
+  });
+
+  app.get("/v1/organizations/:id", (c) => {
+    const id = c.req.param("id");
+    const org = polar.organizations.findOneBy("polar_id", id);
+    if (!org) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    return c.json(org);
+  });
+}

--- a/packages/@emulators/polar/src/routes/products.ts
+++ b/packages/@emulators/polar/src/routes/products.ts
@@ -1,0 +1,30 @@
+import type { RouteContext } from "@emulators/core";
+import { getPolarStore } from "../store.js";
+
+export function productRoutes({ app, store }: RouteContext): void {
+  const polar = getPolarStore(store);
+
+  app.get("/v1/products", (c) => {
+    const org_id = c.req.query("organization_id");
+    let products = polar.products.all();
+    if (org_id) {
+      products = products.filter(p => p.organization_id === org_id);
+    }
+    return c.json({
+      items: products,
+      pagination: {
+        total_count: products.length,
+        max_page: 1,
+      }
+    });
+  });
+
+  app.get("/v1/products/:id", (c) => {
+    const id = c.req.param("id");
+    const product = polar.products.findOneBy("polar_id", id);
+    if (!product) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    return c.json(product);
+  });
+}

--- a/packages/@emulators/polar/src/routes/subscriptions.ts
+++ b/packages/@emulators/polar/src/routes/subscriptions.ts
@@ -1,0 +1,31 @@
+import type { RouteContext } from "@emulators/core";
+import { getPolarStore } from "../store.js";
+import { polarId } from "../helpers.js";
+
+export function subscriptionRoutes({ app, store }: RouteContext): void {
+  const polar = getPolarStore(store);
+
+  app.get("/v1/subscriptions", (c) => {
+    const org_id = c.req.query("organization_id");
+    let subs = polar.subscriptions.all();
+    if (org_id) {
+      subs = subs.filter(s => s.organization_id === org_id);
+    }
+    return c.json({
+      items: subs,
+      pagination: {
+        total_count: subs.length,
+        max_page: 1,
+      }
+    });
+  });
+
+  app.get("/v1/subscriptions/:id", (c) => {
+    const id = c.req.param("id");
+    const sub = polar.subscriptions.findOneBy("polar_id", id);
+    if (!sub) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    return c.json(sub);
+  });
+}

--- a/packages/@emulators/polar/src/store.ts
+++ b/packages/@emulators/polar/src/store.ts
@@ -1,0 +1,26 @@
+import { Store, type Collection } from "@emulators/core";
+import type {
+  PolarOrganization,
+  PolarProduct,
+  PolarPrice,
+  PolarCheckout,
+  PolarSubscription,
+} from "./entities.js";
+
+export interface PolarStore {
+  organizations: Collection<PolarOrganization>;
+  products: Collection<PolarProduct>;
+  prices: Collection<PolarPrice>;
+  checkouts: Collection<PolarCheckout>;
+  subscriptions: Collection<PolarSubscription>;
+}
+
+export function getPolarStore(store: Store): PolarStore {
+  return {
+    organizations: store.collection<PolarOrganization>("polar.organizations", ["polar_id", "slug"]),
+    products: store.collection<PolarProduct>("polar.products", ["polar_id", "organization_id"]),
+    prices: store.collection<PolarPrice>("polar.prices", ["polar_id", "product_id"]),
+    checkouts: store.collection<PolarCheckout>("polar.checkouts", ["polar_id", "organization_id"]),
+    subscriptions: store.collection<PolarSubscription>("polar.subscriptions", ["polar_id", "organization_id", "user_id"]),
+  };
+}

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -70,6 +70,7 @@
     "@emulators/resend": "workspace:*",
     "@emulators/stripe": "workspace:*",
     "@emulators/clerk": "workspace:*",
+    "@emulators/polar": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -27,11 +27,36 @@ const SERVICE_NAME_LIST = [
   "stripe",
   "mongoatlas",
   "clerk",
+  "polar",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
 
 export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
+  polar: {
+    label: "Polar.sh open source funding emulator",
+    endpoints: "products, prices, checkouts, subscriptions, organizations, webhooks",
+    async load() {
+      const mod = await import("@emulators/polar");
+      return { plugin: mod.polarPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback() {
+      return { login: "polar_test_admin", id: 1, scopes: [] };
+    },
+    initConfig: {
+      polar: {
+        organizations: [{ name: "My Project", slug: "my-project" }],
+        products: [
+          {
+            name: "Pro Tier",
+            description: "Support our project with a monthly subscription",
+            organization_slug: "my-project",
+            prices: [{ amount: 1000, currency: "usd" }],
+          },
+        ],
+      },
+    },
+  },
   vercel: {
     label: "Vercel REST API emulator",
     endpoints: "projects, deployments, domains, env vars, users, teams, file uploads, protection bypass",


### PR DESCRIPTION
This PR adds a new emulator for Polar.sh, including support for organizations, products, prices, checkouts, and subscriptions. Fixes #46.