### PR TITLE
feat(github): support git clone over smart HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ github:
       name: hello-world
       language: JavaScript
       auto_init: true
+    - owner: octocat
+      name: cloneable
+      files:
+        README.md: "# cloneable\n"
+        src/index.js: "console.log('hi');\n"
 
 google:
   users:
@@ -595,6 +600,21 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - Trees: get (with recursive), create (with inline content)
 - Blobs: get, create
 - Tags: get, create
+
+### Git over HTTP (clone)
+
+Repos can be cloned with a real `git` client through the smart HTTP protocol:
+
+```bash
+git clone http://x-access-token:$TOKEN@localhost:4001/octocat/hello-world.git
+```
+
+- `GET /:owner/:repo/info/refs?service=git-upload-pack` - ref advertisement
+- `POST /:owner/:repo/git-upload-pack` - clone and full fetch
+- Seed file contents with `files` on a repo fixture (path to content map); without `files`, `auto_init` repos serve their generated README
+- A presented token must be one the emulator knows: seeded through config or minted at runtime (for example by `POST /app/installations/:installation_id/access_tokens`). Unknown tokens get a 401 even where REST routes would fall back to the default user
+- Public repos clone anonymously; private repos require a token with access
+- Read only: push (`git-receive-pack`), shallow clones (`--depth`), and partial fetches are not supported
 
 ### Organizations & Teams
 - Orgs: get, update, list

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -82,6 +82,21 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - Blobs: get, create
 - Tags: get, create
 
+## Git over HTTP (clone)
+
+Repos can be cloned with a real `git` client through the smart HTTP protocol:
+
+```bash
+git clone http://x-access-token:$TOKEN@localhost:4001/octocat/hello-world.git
+```
+
+- `GET /:owner/:repo/info/refs?service=git-upload-pack` - ref advertisement
+- `POST /:owner/:repo/git-upload-pack` - clone and full fetch
+- Seed file contents with `files` on a repo fixture (path to content map); without `files`, `auto_init` repos serve their generated README
+- A presented token must be seeded through config or minted at runtime (for example by `POST /app/installations/:installation_id/access_tokens`); unknown tokens get a 401
+- Public repos clone anonymously; private repos require a token with access
+- Read only: push (`git-receive-pack`), shallow clones (`--depth`), and partial fetches are not supported
+
 ## Organizations & Teams
 
 - Orgs: get, update, list

--- a/packages/@emulators/github/src/__tests__/git-http.test.ts
+++ b/packages/@emulators/github/src/__tests__/git-http.test.ts
@@ -14,6 +14,7 @@ import {
   type TokenMap,
 } from "@emulators/core";
 import { getGitHubStore, githubPlugin, seedFromConfig } from "../index.js";
+import { serializeCommit } from "../git-objects.js";
 
 const base = "http://localhost:4000";
 
@@ -163,12 +164,15 @@ describe("git smart HTTP endpoints", () => {
     expect(res.status).toBe(200);
   });
 
-  it("advertises an empty repo with the zero id capabilities line", async () => {
+  it("advertises an empty repo with the zero id capabilities line and symref", async () => {
     const { app } = createTestApp();
     const res = await fetchAdvertisement(app, "octocat/empty-repo");
     expect(res.status).toBe(200);
     const body = Buffer.from(await res.arrayBuffer()).toString("utf8");
     expect(body).toContain(`${"0".repeat(40)} capabilities^{}`);
+    // Without the symref, clones fall back to the client's init.defaultBranch
+    // and local HEAD can disagree with the repo's REST default_branch.
+    expect(body).toContain("symref=HEAD:refs/heads/main");
   });
 
   it("responds to upload-pack with NAK followed by a version 2 packfile", async () => {
@@ -303,6 +307,22 @@ describe("git smart HTTP endpoints", () => {
         repos: [{ owner: "octocat", name: "bad3", files: { a: "file", "a/b": "dir clash" } }],
       }),
     ).toThrow(/both a file and a directory|uses "a" as a directory/);
+  });
+
+  it("rejects invalid commit dates instead of minting epoch timestamps", () => {
+    expect(() =>
+      serializeCommit({
+        treeSha: "0".repeat(40),
+        parentShas: [],
+        authorName: "octocat",
+        authorEmail: "octocat@example.com",
+        authorDate: "not-a-date",
+        committerName: "octocat",
+        committerEmail: "octocat@example.com",
+        committerDate: "not-a-date",
+        message: "bad date",
+      }),
+    ).toThrow(/Invalid commit date/);
   });
 });
 

--- a/packages/@emulators/github/src/__tests__/git-http.test.ts
+++ b/packages/@emulators/github/src/__tests__/git-http.test.ts
@@ -1,0 +1,422 @@
+import { randomBytes } from "crypto";
+import { spawn, spawnSync } from "child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { gzipSync } from "zlib";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Hono, Store, WebhookDispatcher, serve } from "@emulators/core";
+import {
+  authMiddleware,
+  createApiErrorHandler,
+  createErrorHandler,
+  type AuthFallback,
+  type TokenMap,
+} from "@emulators/core";
+import { getGitHubStore, githubPlugin, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4000";
+
+const FIXTURE_FILES: Record<string, string> = {
+  "README.md": "# private-fixture\n\nHello from the emulator.\n",
+  "src/index.ts": 'export const answer = 42;\nconsole.log("hi");\n',
+  "docs/guide/intro.md": "Deeply nested file.\n",
+  "docs/guide/copy.md": "Deeply nested file.\n",
+};
+
+function createTestApp(options: { fallbackUser?: AuthFallback } = {}) {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("test-token", { login: "octocat", id: 1, scopes: ["repo", "user", "admin:org"] });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap, undefined, options.fallbackUser));
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ login: "octocat" }],
+    repos: [
+      { owner: "octocat", name: "private-fixture", private: true, files: FIXTURE_FILES },
+      { owner: "octocat", name: "public-fixture" },
+      { owner: "octocat", name: "empty-repo", auto_init: false },
+    ],
+  });
+
+  return { app, store, tokenMap };
+}
+
+/**
+ * Records a token the same way POST /app/installations/:id/access_tokens does
+ * (see routes/apps.ts). Minting over HTTP requires an App JWT, whose
+ * verification is currently broken (#96); once that is fixed this helper can
+ * be replaced with a real request to the endpoint.
+ */
+function mintInstallationToken(tokenMap: TokenMap): string {
+  const token = "ghs_" + randomBytes(20).toString("base64url");
+  tokenMap.set(token, { login: "octocat", id: 1, scopes: ["contents:read"] });
+  return token;
+}
+
+function basicAuth(token: string): string {
+  return `Basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`;
+}
+
+async function fetchAdvertisement(app: Hono, repoPath: string, token?: string) {
+  return app.request(`${base}/${repoPath}/info/refs?service=git-upload-pack`, {
+    headers: token ? { Authorization: basicAuth(token) } : {},
+  });
+}
+
+async function fetchHeadSha(app: Hono, repoPath: string, token: string): Promise<string> {
+  const adv = await fetchAdvertisement(app, repoPath, token);
+  return /([0-9a-f]{40}) HEAD\0/.exec(await adv.text())![1];
+}
+
+// Framed by hand on purpose so the requests stay independent of pktLine in the
+// code under test.
+function uploadPackBody(wantSha: string, extraLines: string[] = []): Buffer {
+  const frame = (payload: string) => (payload.length + 4).toString(16).padStart(4, "0") + payload;
+  return Buffer.from([frame(`want ${wantSha}\n`), ...extraLines.map(frame), "0000", frame("done\n")].join(""));
+}
+
+describe("git smart HTTP endpoints", () => {
+  it("advertises refs with the service header, symref, and capabilities", async () => {
+    const { app, tokenMap } = createTestApp();
+    const token = mintInstallationToken(tokenMap);
+    const res = await fetchAdvertisement(app, "octocat/private-fixture.git", token);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/x-git-upload-pack-advertisement");
+    const body = Buffer.from(await res.arrayBuffer()).toString("utf8");
+    expect(body.startsWith("001e# service=git-upload-pack\n0000")).toBe(true);
+    expect(body).toContain("symref=HEAD:refs/heads/main");
+    expect(body).toMatch(/[0-9a-f]{40} HEAD\0/);
+    expect(body).toMatch(/[0-9a-f]{40} refs\/heads\/main\n/);
+    expect(body.endsWith("0000")).toBe(true);
+  });
+
+  it("serves the same advertisement with and without the .git suffix", async () => {
+    const { app, tokenMap } = createTestApp();
+    const token = mintInstallationToken(tokenMap);
+    const withSuffix = await fetchAdvertisement(app, "octocat/private-fixture.git", token);
+    const withoutSuffix = await fetchAdvertisement(app, "octocat/private-fixture", token);
+    expect(await withSuffix.text()).toBe(await withoutSuffix.text());
+  });
+
+  it("rejects git-receive-pack since push is unsupported", async () => {
+    const { app } = createTestApp();
+    const res = await app.request(`${base}/octocat/public-fixture/info/refs?service=git-receive-pack`);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects dumb protocol requests without the service parameter", async () => {
+    const { app } = createTestApp();
+    const res = await app.request(`${base}/octocat/public-fixture/info/refs`);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown repos", async () => {
+    const { app } = createTestApp();
+    const res = await fetchAdvertisement(app, "octocat/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+
+  it("challenges anonymous access to private repos with WWW-Authenticate", async () => {
+    const { app } = createTestApp();
+    const res = await fetchAdvertisement(app, "octocat/private-fixture");
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(/^Basic/);
+  });
+
+  it("rejects tokens that were never minted, even for public repos", async () => {
+    const { app } = createTestApp();
+    const res = await fetchAdvertisement(app, "octocat/public-fixture", "ghs_never_minted");
+    expect(res.status).toBe(401);
+  });
+
+  it("stays strict when the REST fallback user is configured", async () => {
+    const fallbackUser = { login: "octocat", id: 1, scopes: ["repo"] };
+    const { app } = createTestApp({ fallbackUser });
+
+    const rest = await app.request(`${base}/repos/octocat/private-fixture`, {
+      headers: { Authorization: "Bearer ghs_never_minted" },
+    });
+    expect(rest.status).toBe(200);
+
+    const git = await fetchAdvertisement(app, "octocat/private-fixture", "ghs_never_minted");
+    expect(git.status).toBe(401);
+  });
+
+  it("hides private repos from minted tokens without access", async () => {
+    const { app, tokenMap } = createTestApp();
+    tokenMap.set("ghs_other_user", { login: "someone-else", id: 99, scopes: ["contents:read"] });
+    const res = await fetchAdvertisement(app, "octocat/private-fixture", "ghs_other_user");
+    expect(res.status).toBe(404);
+  });
+
+  it("allows anonymous advertisement for public repos", async () => {
+    const { app } = createTestApp();
+    const res = await fetchAdvertisement(app, "octocat/public-fixture");
+    expect(res.status).toBe(200);
+  });
+
+  it("advertises an empty repo with the zero id capabilities line", async () => {
+    const { app } = createTestApp();
+    const res = await fetchAdvertisement(app, "octocat/empty-repo");
+    expect(res.status).toBe(200);
+    const body = Buffer.from(await res.arrayBuffer()).toString("utf8");
+    expect(body).toContain(`${"0".repeat(40)} capabilities^{}`);
+  });
+
+  it("responds to upload-pack with NAK followed by a version 2 packfile", async () => {
+    const { app, tokenMap } = createTestApp();
+    const token = mintInstallationToken(tokenMap);
+    const headSha = await fetchHeadSha(app, "octocat/private-fixture", token);
+
+    const res = await app.request(`${base}/octocat/private-fixture.git/git-upload-pack`, {
+      method: "POST",
+      headers: { Authorization: basicAuth(token), "Content-Type": "application/x-git-upload-pack-request" },
+      body: uploadPackBody(headSha),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/x-git-upload-pack-result");
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.subarray(0, 8).toString("utf8")).toBe("0008NAK\n");
+    expect(body.subarray(8, 12).toString("utf8")).toBe("PACK");
+    expect(body.readUInt32BE(12)).toBe(2);
+    // 1 commit, 4 trees (root, src, docs, docs/guide), 3 blobs (one is content-deduplicated).
+    expect(body.readUInt32BE(16)).toBe(8);
+  });
+
+  it("accepts gzip-encoded upload-pack request bodies", async () => {
+    const { app, tokenMap } = createTestApp();
+    const token = mintInstallationToken(tokenMap);
+    const headSha = await fetchHeadSha(app, "octocat/private-fixture", token);
+
+    const res = await app.request(`${base}/octocat/private-fixture/git-upload-pack`, {
+      method: "POST",
+      headers: { Authorization: basicAuth(token), "Content-Encoding": "gzip" },
+      body: gzipSync(uploadPackBody(headSha)),
+    });
+
+    expect(res.status).toBe(200);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.subarray(8, 12).toString("utf8")).toBe("PACK");
+  });
+
+  it("answers wants for unknown shas with an ERR packet", async () => {
+    const { app, tokenMap } = createTestApp();
+    const token = mintInstallationToken(tokenMap);
+    const res = await app.request(`${base}/octocat/private-fixture/git-upload-pack`, {
+      method: "POST",
+      headers: { Authorization: basicAuth(token) },
+      body: uploadPackBody("a".repeat(40)),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("ERR upload-pack: not our ref");
+  });
+
+  it("rejects malformed pkt-line bodies", async () => {
+    const { app, tokenMap } = createTestApp();
+    const token = mintInstallationToken(tokenMap);
+    const res = await app.request(`${base}/octocat/private-fixture/git-upload-pack`, {
+      method: "POST",
+      headers: { Authorization: basicAuth(token) },
+      body: "zzzzwant nothing",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects shallow fetches, which are not advertised", async () => {
+    const { app, tokenMap } = createTestApp();
+    const token = mintInstallationToken(tokenMap);
+    const headSha = await fetchHeadSha(app, "octocat/private-fixture", token);
+    const res = await app.request(`${base}/octocat/private-fixture/git-upload-pack`, {
+      method: "POST",
+      headers: { Authorization: basicAuth(token) },
+      body: uploadPackBody(headSha, ["deepen 1\n"]),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("Shallow");
+  });
+
+  it("keeps the REST git data API consistent with the served objects", async () => {
+    const { app } = createTestApp();
+    const headers = { Authorization: "Bearer test-token" };
+
+    const ref = await app.request(`${base}/repos/octocat/private-fixture/git/ref/heads/main`, { headers });
+    const refJson = (await ref.json()) as { object: { sha: string } };
+    const commit = await app.request(`${base}/repos/octocat/private-fixture/git/commits/${refJson.object.sha}`, {
+      headers,
+    });
+    const commitJson = (await commit.json()) as { commit: { tree: { sha: string } } };
+    const tree = await app.request(
+      `${base}/repos/octocat/private-fixture/git/trees/${commitJson.commit.tree.sha}?recursive=1`,
+      { headers },
+    );
+    const treeJson = (await tree.json()) as { tree: Array<{ path: string; type: string; sha: string }> };
+
+    const blobPaths = treeJson.tree.filter((e) => e.type === "blob").map((e) => e.path);
+    expect(blobPaths.sort()).toEqual(Object.keys(FIXTURE_FILES).sort());
+
+    const readmeEntry = treeJson.tree.find((e) => e.path === "README.md")!;
+    const blob = await app.request(`${base}/repos/octocat/private-fixture/git/blobs/${readmeEntry.sha}`, { headers });
+    const blobJson = (await blob.json()) as { content: string };
+    expect(Buffer.from(blobJson.content, "base64").toString("utf8")).toBe(FIXTURE_FILES["README.md"]);
+  });
+
+  it("produces identical shas across instances for the same fixture", async () => {
+    const first = createTestApp();
+    const second = createTestApp();
+    const [a, b] = await Promise.all([
+      fetchAdvertisement(first.app, "octocat/public-fixture"),
+      fetchAdvertisement(second.app, "octocat/public-fixture"),
+    ]);
+    expect(await a.text()).toBe(await b.text());
+  });
+
+  it("rejects fixture file paths with traversal or .git segments", () => {
+    const { store } = createTestApp();
+
+    expect(() =>
+      seedFromConfig(store, base, {
+        users: [{ login: "octocat" }],
+        repos: [{ owner: "octocat", name: "bad", files: { "../escape.txt": "no" } }],
+      }),
+    ).toThrow(/path/);
+    expect(getGitHubStore(store).repos.findOneBy("full_name", "octocat/bad")).toBeUndefined();
+
+    expect(() =>
+      seedFromConfig(store, base, {
+        users: [{ login: "octocat" }],
+        repos: [{ owner: "octocat", name: "bad2", files: { ".git/config": "no" } }],
+      }),
+    ).toThrow(/\.git/);
+
+    expect(() =>
+      seedFromConfig(store, base, {
+        users: [{ login: "octocat" }],
+        repos: [{ owner: "octocat", name: "bad3", files: { a: "file", "a/b": "dir clash" } }],
+      }),
+    ).toThrow(/both a file and a directory|uses "a" as a directory/);
+  });
+});
+
+const hasGit = spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
+
+describe.skipIf(!hasGit)("git clone integration", () => {
+  let server: ReturnType<typeof serve>;
+  let port: number;
+  let tokenMap: TokenMap;
+  let app: Hono;
+  let work: string;
+  let gitEnv: Record<string, string>;
+
+  beforeAll(async () => {
+    const created = createTestApp();
+    app = created.app;
+    tokenMap = created.tokenMap;
+    server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    if (address == null || typeof address === "string") throw new Error("expected a TCP address");
+    port = address.port;
+
+    work = await mkdtemp(join(tmpdir(), "emulate-git-"));
+    const home = join(work, "home");
+    await mkdir(home);
+    await writeFile(join(home, ".gitconfig"), "[init]\n\tdefaultBranch = main\n");
+    gitEnv = {
+      PATH: process.env.PATH ?? "",
+      HOME: home,
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_CONFIG_NOSYSTEM: "1",
+    };
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(work, { recursive: true, force: true });
+  });
+
+  // The server runs inside this test process, so git must be spawned
+  // asynchronously; a sync spawn would block the event loop and deadlock.
+  function git(args: string[], cwd?: string): Promise<{ status: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+      const child = spawn("git", args, { cwd, env: gitEnv, timeout: 60000 });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => (stdout += chunk));
+      child.stderr.on("data", (chunk) => (stderr += chunk));
+      child.on("close", (status) => resolve({ status, stdout, stderr }));
+    });
+  }
+
+  function cloneUrl(repo: string, token?: string): string {
+    const auth = token ? `x-access-token:${token}@` : "";
+    return `http://${auth}127.0.0.1:${port}/octocat/${repo}.git`;
+  }
+
+  it("clones a private fixture repo with a minted installation token", { timeout: 60000 }, async () => {
+    const token = mintInstallationToken(tokenMap);
+    const dir = join(work, "private-clone");
+    const clone = await git(["clone", cloneUrl("private-fixture", token), dir]);
+    expect(clone.status, clone.stderr).toBe(0);
+
+    for (const [path, content] of Object.entries(FIXTURE_FILES)) {
+      expect(await readFile(join(dir, path), "utf8")).toBe(content);
+    }
+
+    const fsck = await git(["fsck", "--strict"], dir);
+    expect(fsck.status, fsck.stderr).toBe(0);
+
+    const log = await git(["log", "--format=%s|%an|%ae", "-n1"], dir);
+    expect(log.stdout.trim()).toBe("Initial commit|octocat|octocat@localhost");
+
+    const branch = await git(["branch", "--show-current"], dir);
+    expect(branch.stdout.trim()).toBe("main");
+
+    const head = await git(["rev-parse", "HEAD"], dir);
+    const ref = await fetch(`http://127.0.0.1:${port}/repos/octocat/private-fixture/git/ref/heads/main`, {
+      headers: { Authorization: "Bearer test-token" },
+    });
+    const refJson = (await ref.json()) as { object: { sha: string } };
+    expect(head.stdout.trim()).toBe(refJson.object.sha);
+  });
+
+  it("fails to clone with a token that was never minted", { timeout: 60000 }, async () => {
+    const clone = await git(["clone", cloneUrl("private-fixture", "ghs_never_minted"), join(work, "denied")]);
+    expect(clone.status).not.toBe(0);
+    expect(clone.stderr).toMatch(/Authentication failed|401/);
+  });
+
+  it("fails to clone a private repo anonymously", { timeout: 60000 }, async () => {
+    const clone = await git(["clone", cloneUrl("private-fixture"), join(work, "anonymous")]);
+    expect(clone.status).not.toBe(0);
+  });
+
+  it("clones a public fixture repo anonymously", { timeout: 60000 }, async () => {
+    const dir = join(work, "public-clone");
+    const clone = await git(["clone", cloneUrl("public-fixture"), dir]);
+    expect(clone.status, clone.stderr).toBe(0);
+    expect(await readFile(join(dir, "README.md"), "utf8")).toBe("# public-fixture\n");
+  });
+
+  it("clones a repo created at runtime through the REST API", { timeout: 60000 }, async () => {
+    const create = await fetch(`http://127.0.0.1:${port}/user/repos`, {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "made-at-runtime", auto_init: true }),
+    });
+    expect(create.status).toBe(201);
+
+    const dir = join(work, "runtime-clone");
+    const clone = await git(["clone", cloneUrl("made-at-runtime", "test-token"), dir]);
+    expect(clone.status, clone.stderr).toBe(0);
+    expect(await readFile(join(dir, "README.md"), "utf8")).toBe("# made-at-runtime\n");
+  });
+});

--- a/packages/@emulators/github/src/__tests__/git-http.test.ts
+++ b/packages/@emulators/github/src/__tests__/git-http.test.ts
@@ -39,10 +39,12 @@ function createTestApp(options: { fallbackUser?: AuthFallback } = {}) {
   githubPlugin.seed?.(store, base);
   seedFromConfig(store, base, {
     users: [{ login: "octocat" }],
+    orgs: [{ login: "acme" }],
     repos: [
       { owner: "octocat", name: "private-fixture", private: true, files: FIXTURE_FILES },
       { owner: "octocat", name: "public-fixture" },
       { owner: "octocat", name: "empty-repo", auto_init: false },
+      { owner: "acme", name: "org-private", private: true },
     ],
   });
 
@@ -158,6 +160,21 @@ describe("git smart HTTP endpoints", () => {
     expect(res.status).toBe(404);
   });
 
+  it("authorizes org installation tokens by account id and login", async () => {
+    const { app, store, tokenMap } = createTestApp();
+    const org = getGitHubStore(store).orgs.findOneBy("login", "acme")!;
+
+    // What POST /app/installations/:id/access_tokens records for an org install.
+    tokenMap.set("ghs_org_install", { login: org.login, id: org.id, scopes: ["contents:read"] });
+    const allowed = await fetchAdvertisement(app, "acme/org-private", "ghs_org_install");
+    expect(allowed.status).toBe(200);
+
+    // Same login with a different id is not the installation principal.
+    tokenMap.set("ghs_imposter", { login: org.login, id: org.id + 1000, scopes: ["contents:read"] });
+    const denied = await fetchAdvertisement(app, "acme/org-private", "ghs_imposter");
+    expect(denied.status).toBe(404);
+  });
+
   it("allows anonymous advertisement for public repos", async () => {
     const { app } = createTestApp();
     const res = await fetchAdvertisement(app, "octocat/public-fixture");
@@ -271,6 +288,34 @@ describe("git smart HTTP endpoints", () => {
     const blob = await app.request(`${base}/repos/octocat/private-fixture/git/blobs/${readmeEntry.sha}`, { headers });
     const blobJson = (await blob.json()) as { content: string };
     expect(Buffer.from(blobJson.content, "base64").toString("utf8")).toBe(FIXTURE_FILES["README.md"]);
+  });
+
+  it("skips refs whose rows cannot serialize instead of failing the advertisement", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const repo = gh.repos.findOneBy("full_name", "octocat/public-fixture")!;
+    gh.commits.insert({
+      repo_id: repo.id,
+      sha: "f".repeat(40),
+      node_id: "",
+      message: "bad",
+      author_name: "x",
+      author_email: "x@localhost",
+      author_date: "not-a-date",
+      committer_name: "x",
+      committer_email: "x@localhost",
+      committer_date: "not-a-date",
+      tree_sha: "e".repeat(40),
+      parent_shas: [],
+      user_id: null,
+    } as any);
+    gh.refs.insert({ repo_id: repo.id, ref: "refs/heads/broken", sha: "f".repeat(40), node_id: "" } as any);
+
+    const res = await fetchAdvertisement(app, "octocat/public-fixture");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).not.toContain("refs/heads/broken");
+    expect(body).toContain("refs/heads/main");
   });
 
   it("produces identical shas across instances for the same fixture", async () => {

--- a/packages/@emulators/github/src/git-data.ts
+++ b/packages/@emulators/github/src/git-data.ts
@@ -1,0 +1,286 @@
+import type { GitHubBlob, GitHubBranch, GitHubCommit, GitHubRef, GitHubRepo, GitHubTree } from "./entities.js";
+import type { GitHubStore } from "./store.js";
+import { generateNodeId } from "./helpers.js";
+import {
+  compareTreeEntries,
+  gitObjectSha,
+  serializeBlob,
+  serializeCommit,
+  serializeTree,
+  type GitObject,
+  type GitTreeEntry,
+} from "./git-objects.js";
+
+/**
+ * Bridges the REST-facing store rows (blobs, trees, commits, refs) and real
+ * git objects. Repos materialized here use canonical git shas, so the same
+ * history can be served both through the REST API and through the git smart
+ * HTTP endpoints.
+ */
+
+/** Fixed commit date for seeded fixtures so their shas are stable across emulator restarts. */
+export const FIXTURE_COMMIT_DATE = "2024-01-01T00:00:00.000Z";
+
+export interface MaterializeOptions {
+  authorName: string;
+  authorEmail: string;
+  commitDate: string;
+  pushedAt: string;
+  message: string;
+  userId: number | null;
+}
+
+export function defaultReadmeFiles(title: string): Record<string, string> {
+  return { "README.md": `# ${title}\n` };
+}
+
+/** REST tree rows name entries `path`; the wire format calls the same field `name`. */
+function toGitEntry(entry: { mode: string; path: string; sha: string }): GitTreeEntry {
+  return { mode: entry.mode, name: entry.path, sha: entry.sha };
+}
+
+interface DirNode {
+  files: Map<string, string>;
+  dirs: Map<string, DirNode>;
+}
+
+function newDirNode(): DirNode {
+  return { files: new Map(), dirs: new Map() };
+}
+
+function validateSegment(segment: string, fullPath: string): void {
+  if (!segment || segment === "." || segment === "..") {
+    throw new Error(`Invalid repo file path "${fullPath}": empty, "." and ".." path segments are not allowed`);
+  }
+  if (segment.toLowerCase() === ".git") {
+    throw new Error(`Invalid repo file path "${fullPath}": ".git" path segments are not allowed`);
+  }
+  if (segment.includes("\0")) {
+    throw new Error(`Invalid repo file path "${fullPath}": null bytes are not allowed`);
+  }
+}
+
+function buildFileTree(files: Record<string, string>): DirNode {
+  const root = newDirNode();
+  for (const [path, content] of Object.entries(files)) {
+    const segments = path.split("/");
+    for (const segment of segments) {
+      validateSegment(segment, path);
+    }
+    let node = root;
+    for (const segment of segments.slice(0, -1)) {
+      if (node.files.has(segment)) {
+        throw new Error(`Invalid repo files: "${path}" uses "${segment}" as a directory but it is also a file`);
+      }
+      let child = node.dirs.get(segment);
+      if (!child) {
+        child = newDirNode();
+        node.dirs.set(segment, child);
+      }
+      node = child;
+    }
+    const name = segments[segments.length - 1];
+    if (node.dirs.has(name)) {
+      throw new Error(`Invalid repo files: "${path}" is both a file and a directory`);
+    }
+    node.files.set(name, content);
+  }
+  return root;
+}
+
+/** Validates fixture file paths without writing anything, so callers can fail before creating rows. */
+export function validateRepoFiles(files: Record<string, string>): void {
+  buildFileTree(files);
+}
+
+/**
+ * Creates blob, tree, commit, branch, and ref rows for a freshly created repo
+ * from a path-to-content map. All shas are canonical git object ids, which
+ * makes the repo cloneable through the git smart HTTP endpoints.
+ */
+export function materializeRepoGit(
+  gh: GitHubStore,
+  repo: GitHubRepo,
+  files: Record<string, string>,
+  options: MaterializeOptions,
+): { totalBytes: number } {
+  const root = buildFileTree(files);
+  const insertedBlobs = new Set<string>();
+  const insertedTrees = new Set<string>();
+  let totalBytes = 0;
+
+  const insertBlob = (content: string): { sha: string; size: number } => {
+    const obj = serializeBlob(content, "utf-8");
+    const sha = gitObjectSha(obj);
+    const size = obj.data.length;
+    if (!insertedBlobs.has(sha)) {
+      insertedBlobs.add(sha);
+      totalBytes += size;
+      const blob = gh.blobs.insert({
+        repo_id: repo.id,
+        sha,
+        node_id: "",
+        content,
+        encoding: "utf-8",
+        size,
+      } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
+      gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
+    }
+    return { sha, size };
+  };
+
+  const insertTree = (node: DirNode): string => {
+    const entries: GitHubTree["tree"] = [];
+    for (const [name, child] of node.dirs) {
+      entries.push({ path: name, mode: "040000", type: "tree", sha: insertTree(child) });
+    }
+    for (const [name, content] of node.files) {
+      const { sha, size } = insertBlob(content);
+      entries.push({ path: name, mode: "100644", type: "blob", sha, size });
+    }
+    entries.sort((a, b) => compareTreeEntries(toGitEntry(a), toGitEntry(b)));
+    const obj = serializeTree(entries.map(toGitEntry));
+    const sha = gitObjectSha(obj);
+    if (!insertedTrees.has(sha)) {
+      insertedTrees.add(sha);
+      const tree = gh.trees.insert({
+        repo_id: repo.id,
+        sha,
+        node_id: "",
+        tree: entries,
+        truncated: false,
+      } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
+      gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
+    }
+    return sha;
+  };
+
+  const treeSha = insertTree(root);
+
+  const commitMeta = {
+    treeSha,
+    parentShas: [],
+    authorName: options.authorName,
+    authorEmail: options.authorEmail,
+    authorDate: options.commitDate,
+    committerName: options.authorName,
+    committerEmail: options.authorEmail,
+    committerDate: options.commitDate,
+    message: options.message,
+  };
+  const commitSha = gitObjectSha(serializeCommit(commitMeta));
+
+  const commit = gh.commits.insert({
+    repo_id: repo.id,
+    sha: commitSha,
+    node_id: "",
+    message: options.message,
+    author_name: options.authorName,
+    author_email: options.authorEmail,
+    author_date: options.commitDate,
+    committer_name: options.authorName,
+    committer_email: options.authorEmail,
+    committer_date: options.commitDate,
+    tree_sha: treeSha,
+    parent_shas: [],
+    user_id: options.userId,
+  } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
+  gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
+
+  gh.branches.insert({
+    repo_id: repo.id,
+    name: repo.default_branch,
+    sha: commitSha,
+    protected: false,
+  } as Omit<GitHubBranch, "id" | "created_at" | "updated_at">);
+
+  const ref = gh.refs.insert({
+    repo_id: repo.id,
+    ref: `refs/heads/${repo.default_branch}`,
+    sha: commitSha,
+    node_id: "",
+  } as Omit<GitHubRef, "id" | "created_at" | "updated_at">);
+  gh.refs.update(ref.id, { node_id: generateNodeId("Ref", ref.id) });
+
+  gh.repos.update(repo.id, { size: totalBytes, pushed_at: options.pushedAt });
+
+  return { totalBytes };
+}
+
+/**
+ * Returns a resolver that collects every object reachable from a commit,
+ * verifying that each row still serializes to its recorded sha. The resolver
+ * returns null when any reachable object is missing or was created with a
+ * synthetic (non-git) sha, for example by the plain REST git data endpoints.
+ */
+export function createRepoObjectSource(
+  gh: GitHubStore,
+  repoId: number,
+): (tipSha: string) => Map<string, GitObject> | null {
+  const bySha = <T extends { sha: string }>(rows: T[]): Map<string, T> => new Map(rows.map((row) => [row.sha, row]));
+  const commits = bySha(gh.commits.findBy("repo_id", repoId));
+  const trees = bySha(gh.trees.findBy("repo_id", repoId));
+  const blobs = bySha(gh.blobs.findBy("repo_id", repoId));
+
+  const verified = new Map<string, GitObject>();
+  const verifiedObject = (sha: string, build: () => GitObject): GitObject | null => {
+    let obj = verified.get(sha);
+    if (!obj) {
+      obj = build();
+      if (gitObjectSha(obj) !== sha) return null;
+      verified.set(sha, obj);
+    }
+    return obj;
+  };
+
+  const resolveCommit = (sha: string, out: Map<string, GitObject>): boolean => {
+    if (out.has(sha)) return true;
+    const row = commits.get(sha);
+    if (!row) return false;
+    const obj = verifiedObject(sha, () =>
+      serializeCommit({
+        treeSha: row.tree_sha,
+        parentShas: row.parent_shas,
+        authorName: row.author_name,
+        authorEmail: row.author_email,
+        authorDate: row.author_date,
+        committerName: row.committer_name,
+        committerEmail: row.committer_email,
+        committerDate: row.committer_date,
+        message: row.message,
+      }),
+    );
+    if (!obj) return false;
+    out.set(sha, obj);
+    return resolveTree(row.tree_sha, out) && row.parent_shas.every((parent) => resolveCommit(parent, out));
+  };
+
+  const resolveTree = (sha: string, out: Map<string, GitObject>): boolean => {
+    if (out.has(sha)) return true;
+    const row = trees.get(sha);
+    if (!row) return false;
+    const obj = verifiedObject(sha, () => serializeTree(row.tree.map(toGitEntry)));
+    if (!obj) return false;
+    out.set(sha, obj);
+    for (const entry of row.tree) {
+      const ok = entry.type === "tree" ? resolveTree(entry.sha, out) : resolveBlob(entry.sha, out);
+      if (!ok) return false;
+    }
+    return true;
+  };
+
+  const resolveBlob = (sha: string, out: Map<string, GitObject>): boolean => {
+    if (out.has(sha)) return true;
+    const row = blobs.get(sha);
+    if (!row) return false;
+    const obj = verifiedObject(sha, () => serializeBlob(row.content, row.encoding));
+    if (!obj) return false;
+    out.set(sha, obj);
+    return true;
+  };
+
+  return (tipSha) => {
+    const out = new Map<string, GitObject>();
+    return resolveCommit(tipSha, out) ? out : null;
+  };
+}

--- a/packages/@emulators/github/src/git-data.ts
+++ b/packages/@emulators/github/src/git-data.ts
@@ -226,7 +226,13 @@ export function createRepoObjectSource(
   const verifiedObject = (sha: string, build: () => GitObject): GitObject | null => {
     let obj = verified.get(sha);
     if (!obj) {
-      obj = build();
+      try {
+        obj = build();
+      } catch {
+        // Rows the REST API accepts but git cannot represent (for example an
+        // unparseable commit date) are simply not materialized.
+        return null;
+      }
       if (gitObjectSha(obj) !== sha) return null;
       verified.set(sha, obj);
     }

--- a/packages/@emulators/github/src/git-objects.ts
+++ b/packages/@emulators/github/src/git-objects.ts
@@ -1,0 +1,165 @@
+import { createHash } from "crypto";
+import { deflateSync } from "zlib";
+
+/**
+ * Minimal pure-TypeScript git object model used by the smart HTTP endpoints.
+ * Builds loose objects (blob, tree, commit), computes their canonical object
+ * ids, and assembles version 2 packfiles. No git binary, filesystem access, or
+ * external dependency is involved; everything is derived from in-memory data.
+ */
+
+export type GitObjectType = "commit" | "tree" | "blob";
+
+export interface GitObject {
+  type: GitObjectType;
+  data: Buffer;
+}
+
+export const ZERO_SHA = "0".repeat(40);
+
+const PACK_TYPE_NUMBERS: Record<GitObjectType, number> = { commit: 1, tree: 2, blob: 3 };
+
+export function gitObjectSha(obj: GitObject): string {
+  return createHash("sha1").update(`${obj.type} ${obj.data.length}\0`).update(obj.data).digest("hex");
+}
+
+export interface GitTreeEntry {
+  mode: string;
+  name: string;
+  sha: string;
+}
+
+/** Tree entry modes as stored in the REST-facing rows ("040000") vs the on-wire tree object ("40000"). */
+function wireMode(mode: string): string {
+  return mode === "040000" ? "40000" : mode;
+}
+
+function treeSortKey(entry: GitTreeEntry): Buffer {
+  const isTree = wireMode(entry.mode) === "40000";
+  return Buffer.from(isTree ? `${entry.name}/` : entry.name, "utf8");
+}
+
+/** Canonical git tree order: byte-wise by name, with directories compared as "name/". */
+export function compareTreeEntries(a: GitTreeEntry, b: GitTreeEntry): number {
+  return Buffer.compare(treeSortKey(a), treeSortKey(b));
+}
+
+export function serializeTree(entries: GitTreeEntry[]): GitObject {
+  const sorted = [...entries].sort(compareTreeEntries);
+  const data = Buffer.concat(
+    sorted.flatMap((entry) => [Buffer.from(`${wireMode(entry.mode)} ${entry.name}\0`, "utf8"), shaToBytes(entry.sha)]),
+  );
+  return { type: "tree", data };
+}
+
+function shaToBytes(sha: string): Buffer {
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`invalid object id: ${sha}`);
+  }
+  return Buffer.from(sha, "hex");
+}
+
+export interface GitCommitMeta {
+  treeSha: string;
+  parentShas: string[];
+  authorName: string;
+  authorEmail: string;
+  authorDate: string;
+  committerName: string;
+  committerEmail: string;
+  committerDate: string;
+  message: string;
+}
+
+export function serializeCommit(meta: GitCommitMeta): GitObject {
+  const lines = [`tree ${meta.treeSha}`];
+  for (const parent of meta.parentShas) {
+    lines.push(`parent ${parent}`);
+  }
+  lines.push(`author ${identityLine(meta.authorName, meta.authorEmail, meta.authorDate)}`);
+  lines.push(`committer ${identityLine(meta.committerName, meta.committerEmail, meta.committerDate)}`);
+  const message = meta.message.endsWith("\n") ? meta.message : `${meta.message}\n`;
+  return { type: "commit", data: Buffer.from(`${lines.join("\n")}\n\n${message}`, "utf8") };
+}
+
+export function serializeBlob(content: string, encoding: "base64" | "utf-8"): GitObject {
+  return { type: "blob", data: Buffer.from(content, encoding) };
+}
+
+function identityLine(name: string, email: string, isoDate: string): string {
+  const millis = Date.parse(isoDate);
+  const seconds = Number.isFinite(millis) ? Math.floor(millis / 1000) : 0;
+  return `${sanitizeIdentity(name) || "emulate"} <${sanitizeIdentity(email)}> ${seconds} +0000`;
+}
+
+function sanitizeIdentity(value: string): string {
+  return value.replace(/[<>\n]/g, "").trim();
+}
+
+export function buildPackfile(objects: GitObject[]): Buffer {
+  const header = Buffer.alloc(12);
+  header.write("PACK", 0, "ascii");
+  header.writeUInt32BE(2, 4);
+  header.writeUInt32BE(objects.length, 8);
+
+  const chunks: Buffer[] = [header];
+  for (const obj of objects) {
+    chunks.push(packEntryHeader(PACK_TYPE_NUMBERS[obj.type], obj.data.length), deflateSync(obj.data));
+  }
+  const trailer = createHash("sha1");
+  for (const chunk of chunks) {
+    trailer.update(chunk);
+  }
+  return Buffer.concat([...chunks, trailer.digest()]);
+}
+
+function packEntryHeader(typeNumber: number, size: number): Buffer {
+  const bytes: number[] = [];
+  let current = (typeNumber << 4) | (size & 0x0f);
+  let remaining = Math.floor(size / 16);
+  while (remaining > 0) {
+    bytes.push(current | 0x80);
+    current = remaining & 0x7f;
+    remaining = Math.floor(remaining / 128);
+  }
+  bytes.push(current);
+  return Buffer.from(bytes);
+}
+
+export const FLUSH_PKT = Buffer.from("0000", "ascii");
+
+export function pktLine(payload: string | Buffer): Buffer {
+  const data = typeof payload === "string" ? Buffer.from(payload, "utf8") : payload;
+  if (data.length + 4 > 0xffff) {
+    throw new Error("pkt-line payload too large");
+  }
+  const length = (data.length + 4).toString(16).padStart(4, "0");
+  return Buffer.concat([Buffer.from(length, "ascii"), data]);
+}
+
+/** Parses a pkt-line stream into payload strings. Flush pkts are skipped; malformed lengths throw. */
+export function parsePktLines(body: Buffer): string[] {
+  const lines: string[] = [];
+  let offset = 0;
+  while (offset < body.length) {
+    if (offset + 4 > body.length) {
+      throw new Error("truncated pkt-line stream");
+    }
+    const lengthHex = body.subarray(offset, offset + 4).toString("ascii");
+    if (!/^[0-9a-fA-F]{4}$/.test(lengthHex)) {
+      throw new Error("invalid pkt-line length");
+    }
+    const length = parseInt(lengthHex, 16);
+    if (length === 0) {
+      offset += 4;
+      continue;
+    }
+    if (length < 4 || offset + length > body.length) {
+      throw new Error("invalid pkt-line length");
+    }
+    const payload = body.subarray(offset + 4, offset + length).toString("utf8");
+    lines.push(payload.endsWith("\n") ? payload.slice(0, -1) : payload);
+    offset += length;
+  }
+  return lines;
+}

--- a/packages/@emulators/github/src/git-objects.ts
+++ b/packages/@emulators/github/src/git-objects.ts
@@ -88,7 +88,12 @@ export function serializeBlob(content: string, encoding: "base64" | "utf-8"): Gi
 
 function identityLine(name: string, email: string, isoDate: string): string {
   const millis = Date.parse(isoDate);
-  const seconds = Number.isFinite(millis) ? Math.floor(millis / 1000) : 0;
+  if (!Number.isFinite(millis)) {
+    // A silent epoch fallback would bake 1970 timestamps into sha-stable
+    // commits; force callers to pass a real date.
+    throw new Error(`Invalid commit date "${isoDate}": expected an ISO-8601 timestamp`);
+  }
+  const seconds = Math.floor(millis / 1000);
   return `${sanitizeIdentity(name) || "emulate"} <${sanitizeIdentity(email)}> ${seconds} +0000`;
 }
 

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -4,7 +4,8 @@ import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteCo
 import { getGitHubStore } from "./store.js";
 import type { GitHubStore } from "./store.js";
 import type { GitHubAppInstallation } from "./entities.js";
-import { generateNodeId, generateSha } from "./helpers.js";
+import { generateNodeId } from "./helpers.js";
+import { defaultReadmeFiles, FIXTURE_COMMIT_DATE, materializeRepoGit, validateRepoFiles } from "./git-data.js";
 import { usersRoutes } from "./routes/users.js";
 import { reposRoutes } from "./routes/repos.js";
 import { issuesRoutes } from "./routes/issues.js";
@@ -23,6 +24,7 @@ import { rateLimitRoutes } from "./routes/rate-limit.js";
 import { metaRoutes } from "./routes/meta.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { appsRoutes } from "./routes/apps.js";
+import { gitHttpRoutes } from "./routes/git-http.js";
 
 export { getGitHubStore, type GitHubStore } from "./store.js";
 export * from "./entities.js";
@@ -56,6 +58,7 @@ export interface GitHubSeedConfig {
     topics?: string[];
     default_branch?: string;
     auto_init?: boolean;
+    files?: Record<string, string>;
   }>;
   oauth_apps?: Array<{
     client_id: string;
@@ -202,6 +205,9 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
       const existing = gh.repos.findOneBy("full_name", fullName);
       if (existing) continue;
 
+      // Fail on bad fixture paths before any rows for this repo are created.
+      if (r.files) validateRepoFiles(r.files);
+
       const ownerType = ownerUser ? "User" : "Organization";
       const defaultBranch = r.default_branch ?? "main";
 
@@ -246,52 +252,17 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
       });
       gh.repos.update(repo.id, { node_id: generateNodeId("Repository", repo.id) });
 
-      if (r.auto_init !== false) {
-        const sha = generateSha();
-        const treeSha = generateSha();
-
-        const commit = gh.commits.insert({
-          repo_id: repo.id,
-          sha,
-          node_id: "",
+      if (r.files || r.auto_init !== false) {
+        // Real git objects with canonical shas, deterministic across restarts,
+        // so the repo can be cloned through the git smart HTTP endpoints.
+        materializeRepoGit(gh, gh.repos.get(repo.id)!, r.files ?? defaultReadmeFiles(r.name), {
+          authorName: r.owner,
+          authorEmail: `${r.owner}@localhost`,
+          commitDate: FIXTURE_COMMIT_DATE,
+          pushedAt: repo.created_at,
           message: "Initial commit",
-          author_name: r.owner,
-          author_email: `${r.owner}@localhost`,
-          author_date: repo.created_at,
-          committer_name: r.owner,
-          committer_email: `${r.owner}@localhost`,
-          committer_date: repo.created_at,
-          tree_sha: treeSha,
-          parent_shas: [],
-          user_id: owner.id,
+          userId: owner.id,
         });
-        gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
-
-        const tree = gh.trees.insert({
-          repo_id: repo.id,
-          sha: treeSha,
-          node_id: "",
-          tree: [{ path: "README.md", mode: "100644", type: "blob", sha: generateSha(), size: 20 }],
-          truncated: false,
-        });
-        gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
-
-        gh.branches.insert({
-          repo_id: repo.id,
-          name: defaultBranch,
-          sha,
-          protected: false,
-        });
-
-        const refRow = gh.refs.insert({
-          repo_id: repo.id,
-          ref: `refs/heads/${defaultBranch}`,
-          sha,
-          node_id: "",
-        });
-        gh.refs.update(refRow.id, { node_id: generateNodeId("Ref", refRow.id) });
-
-        gh.repos.update(repo.id, { pushed_at: repo.created_at, size: 1 });
       }
 
       if (ownerType === "User") {
@@ -493,6 +464,8 @@ export const githubPlugin: ServicePlugin = {
     metaRoutes(ctx);
     oauthRoutes(ctx);
     appsRoutes(ctx);
+    // Registered last so explicit REST paths always win over /:owner/:repo.
+    gitHttpRoutes(ctx);
   },
   seed(store: Store, baseUrl: string): void {
     seedDefaults(store, baseUrl);

--- a/packages/@emulators/github/src/routes/git-http.ts
+++ b/packages/@emulators/github/src/routes/git-http.ts
@@ -4,7 +4,7 @@ import { debug } from "@emulators/core";
 import { getGitHubStore } from "../store.js";
 import type { GitHubStore } from "../store.js";
 import type { GitHubRepo } from "../entities.js";
-import { canAccessRepo, ownerLoginOf } from "../route-helpers.js";
+import { canAccessRepo } from "../route-helpers.js";
 import { lookupRepo } from "../helpers.js";
 import { createRepoObjectSource } from "../git-data.js";
 import { buildPackfile, FLUSH_PKT, parsePktLines, pktLine, ZERO_SHA, type GitObject } from "../git-objects.js";
@@ -84,8 +84,10 @@ function authorizeGitRequest(c: Context, gh: GitHubStore, tokenMap: TokenMap | u
 
   if (repo.private) {
     if (!user) return unauthorized(c);
-    const allowed = user.login === ownerLoginOf(gh, repo) || canAccessRepo(gh, user, repo);
-    if (!allowed) return repoNotFound(c);
+    // canAccessRepo compares by user id (owner, org member, collaborator) —
+    // no login-string fast path, which would trust a token whose login
+    // merely collides with the owner's.
+    if (!canAccessRepo(gh, user, repo)) return repoNotFound(c);
   }
   return repo;
 }
@@ -149,10 +151,13 @@ export function gitHttpRoutes({ app, store, tokenMap }: RouteContext): void {
 
     const chunks: Buffer[] = [pktLine("# service=git-upload-pack\n"), FLUSH_PKT];
     if (refs.length === 0) {
+      // Real GitHub advertises symref=HEAD for empty repos too, so clones
+      // initialize local HEAD from the server's default branch instead of
+      // the client's init.defaultBranch.
       chunks.push(
         hasRefs
           ? pktLine(`ERR ${repo.full_name} has refs but no materialized git objects to serve`)
-          : pktLine(`${ZERO_SHA} capabilities^{}\0${UPLOAD_PACK_CAPS}\n`),
+          : pktLine(`${ZERO_SHA} capabilities^{}\0symref=HEAD:refs/heads/${repo.default_branch} ${UPLOAD_PACK_CAPS}\n`),
       );
     } else {
       let caps = UPLOAD_PACK_CAPS;

--- a/packages/@emulators/github/src/routes/git-http.ts
+++ b/packages/@emulators/github/src/routes/git-http.ts
@@ -87,9 +87,22 @@ function authorizeGitRequest(c: Context, gh: GitHubStore, tokenMap: TokenMap | u
     // canAccessRepo compares by user id (owner, org member, collaborator) —
     // no login-string fast path, which would trust a token whose login
     // merely collides with the owner's.
-    if (!canAccessRepo(gh, user, repo)) return repoNotFound(c);
+    if (!canAccessRepo(gh, user, repo) && !isOrgInstallationPrincipal(gh, user, repo)) {
+      return repoNotFound(c);
+    }
   }
   return repo;
+}
+
+/**
+ * Installation tokens for org accounts carry the org's login and id (see the
+ * access_tokens route) and have no users row, so canAccessRepo cannot resolve
+ * them. Matching both id and login keeps a mere login collision insufficient.
+ */
+function isOrgInstallationPrincipal(gh: GitHubStore, user: AuthUser, repo: GitHubRepo): boolean {
+  if (repo.owner_type !== "Organization") return false;
+  const org = gh.orgs.get(repo.owner_id);
+  return org != null && user.id === org.id && user.login === org.login;
 }
 
 function loadServeableRefs(

--- a/packages/@emulators/github/src/routes/git-http.ts
+++ b/packages/@emulators/github/src/routes/git-http.ts
@@ -1,0 +1,253 @@
+import { gunzipSync } from "zlib";
+import type { Context, RouteContext, TokenMap, AuthUser } from "@emulators/core";
+import { debug } from "@emulators/core";
+import { getGitHubStore } from "../store.js";
+import type { GitHubStore } from "../store.js";
+import type { GitHubRepo } from "../entities.js";
+import { canAccessRepo, ownerLoginOf } from "../route-helpers.js";
+import { lookupRepo } from "../helpers.js";
+import { createRepoObjectSource } from "../git-data.js";
+import { buildPackfile, FLUSH_PKT, parsePktLines, pktLine, ZERO_SHA, type GitObject } from "../git-objects.js";
+
+/**
+ * Read side of the git smart HTTP protocol (protocol v0), enough for a real
+ * `git clone ${baseUrl}/{owner}/{repo}.git` against fixture repos. Push
+ * (git-receive-pack), shallow clones, and partial fetches are not supported.
+ *
+ * Unlike the REST routes, these endpoints do not fall back to a default user
+ * for unknown tokens: a presented token must be one this emulator instance
+ * knows, either seeded through config or minted at runtime (for example by
+ * POST /app/installations/:id/access_tokens). That keeps clone tests honest.
+ */
+
+const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+const MAX_INFLATED_BODY_BYTES = 4 * 1024 * 1024;
+const UPLOAD_PACK_CAPS = "agent=emulate";
+
+const ADVERTISEMENT_TYPE = "application/x-git-upload-pack-advertisement";
+const RESULT_TYPE = "application/x-git-upload-pack-result";
+
+function stripGitSuffix(repoName: string): string {
+  return repoName.endsWith(".git") ? repoName.slice(0, -4) : repoName;
+}
+
+function resolveGitUser(c: Context, tokenMap: TokenMap | undefined): { provided: boolean; user: AuthUser | null } {
+  const header = c.req.header("Authorization")?.trim();
+  if (!header) return { provided: false, user: null };
+
+  const candidates: string[] = [];
+  const basic = /^Basic\s+(.+)$/i.exec(header);
+  if (basic) {
+    // Buffer.from tolerates malformed base64; garbage decodes to garbage and
+    // simply will not match any known token.
+    const decoded = Buffer.from(basic[1], "base64").toString("utf8");
+    const separator = decoded.indexOf(":");
+    const username = separator === -1 ? decoded : decoded.slice(0, separator);
+    const password = separator === -1 ? "" : decoded.slice(separator + 1);
+    // git sends the token as the password (x-access-token:TOKEN), but URLs
+    // like http://TOKEN@host put it in the username, so check both.
+    if (password) candidates.push(password);
+    if (username) candidates.push(username);
+  } else {
+    const bearer = /^(?:Bearer|token)\s+(.+)$/i.exec(header);
+    if (bearer) candidates.push(bearer[1].trim());
+  }
+
+  for (const candidate of candidates) {
+    const user = tokenMap?.get(candidate);
+    if (user) return { provided: true, user };
+  }
+  return { provided: true, user: null };
+}
+
+function unauthorized(c: Context): Response {
+  c.header("WWW-Authenticate", 'Basic realm="GitHub"');
+  return c.text("Authentication required", 401);
+}
+
+function repoNotFound(c: Context): Response {
+  return c.text("Repository not found.", 404);
+}
+
+function authorizeGitRequest(c: Context, gh: GitHubStore, tokenMap: TokenMap | undefined): GitHubRepo | Response {
+  const owner = c.req.param("owner");
+  const repoName = c.req.param("repo");
+  // Exact name first so a repo literally named "x.git" stays reachable.
+  const repo = lookupRepo(gh, owner, repoName) ?? lookupRepo(gh, owner, stripGitSuffix(repoName));
+
+  const { provided, user } = resolveGitUser(c, tokenMap);
+  if (provided && !user) {
+    // A token was presented but was never minted or seeded by this instance.
+    return unauthorized(c);
+  }
+  if (!repo) return repoNotFound(c);
+
+  if (repo.private) {
+    if (!user) return unauthorized(c);
+    const allowed = user.login === ownerLoginOf(gh, repo) || canAccessRepo(gh, user, repo);
+    if (!allowed) return repoNotFound(c);
+  }
+  return repo;
+}
+
+function loadServeableRefs(
+  gh: GitHubStore,
+  repo: GitHubRepo,
+): { refs: Array<{ name: string; sha: string }>; headSha: string | null; hasRefs: boolean } {
+  const resolve = createRepoObjectSource(gh, repo.id);
+  const rows = gh.refs.findBy("repo_id", repo.id);
+  const refs: Array<{ name: string; sha: string }> = [];
+  for (const row of rows) {
+    if (resolve(row.sha)) {
+      refs.push({ name: row.ref, sha: row.sha });
+    } else {
+      debug("github:git", `skipping ${row.ref} in ${repo.full_name}: objects for ${row.sha} are not materialized`);
+    }
+  }
+  refs.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const head = refs.find((r) => r.name === `refs/heads/${repo.default_branch}`);
+  return { refs, headSha: head?.sha ?? null, hasRefs: rows.length > 0 };
+}
+
+function noCache(c: Context): void {
+  c.header("Cache-Control", "no-cache, max-age=0, must-revalidate");
+  c.header("Pragma", "no-cache");
+}
+
+/** Reads the request body, aborting (null) as soon as it exceeds the limit instead of buffering it all. */
+async function readBodyWithLimit(c: Context, limit: number): Promise<Buffer | null> {
+  const stream = c.req.raw.body;
+  if (!stream) return Buffer.alloc(0);
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const piece = Buffer.from(chunk as Uint8Array);
+    total += piece.length;
+    if (total > limit) return null;
+    chunks.push(piece);
+  }
+  return Buffer.concat(chunks);
+}
+
+export function gitHttpRoutes({ app, store, tokenMap }: RouteContext): void {
+  const gh = getGitHubStore(store);
+
+  app.get("/:owner/:repo/info/refs", (c) => {
+    const service = c.req.query("service");
+    if (service === "git-receive-pack") {
+      return c.text("The emulator does not support git push", 403);
+    }
+    if (service !== "git-upload-pack") {
+      return c.text("Smart HTTP is required: use service=git-upload-pack", 400);
+    }
+
+    const repo = authorizeGitRequest(c, gh, tokenMap);
+    if (repo instanceof Response) return repo;
+
+    const { refs, headSha, hasRefs } = loadServeableRefs(gh, repo);
+    noCache(c);
+
+    const chunks: Buffer[] = [pktLine("# service=git-upload-pack\n"), FLUSH_PKT];
+    if (refs.length === 0) {
+      chunks.push(
+        hasRefs
+          ? pktLine(`ERR ${repo.full_name} has refs but no materialized git objects to serve`)
+          : pktLine(`${ZERO_SHA} capabilities^{}\0${UPLOAD_PACK_CAPS}\n`),
+      );
+    } else {
+      let caps = UPLOAD_PACK_CAPS;
+      const lines: string[] = [];
+      if (headSha) {
+        caps = `symref=HEAD:refs/heads/${repo.default_branch} ${caps}`;
+        lines.push(`${headSha} HEAD`);
+      }
+      for (const ref of refs) {
+        lines.push(`${ref.sha} ${ref.name}`);
+      }
+      lines.forEach((line, index) => {
+        chunks.push(pktLine(index === 0 ? `${line}\0${caps}\n` : `${line}\n`));
+      });
+    }
+    chunks.push(FLUSH_PKT);
+    return c.body(Buffer.concat(chunks), 200, { "Content-Type": ADVERTISEMENT_TYPE });
+  });
+
+  app.post("/:owner/:repo/git-upload-pack", async (c) => {
+    const repo = authorizeGitRequest(c, gh, tokenMap);
+    if (repo instanceof Response) return repo;
+
+    let body = await readBodyWithLimit(c, MAX_REQUEST_BODY_BYTES);
+    if (body === null) {
+      return c.text("Request body too large", 413);
+    }
+    const encoding = c.req.header("Content-Encoding")?.toLowerCase();
+    if (encoding === "gzip" || encoding === "x-gzip") {
+      try {
+        body = gunzipSync(body, { maxOutputLength: MAX_INFLATED_BODY_BYTES });
+      } catch {
+        return c.text("Invalid gzip request body", 400);
+      }
+    }
+
+    let lines: string[];
+    try {
+      lines = parsePktLines(body);
+    } catch {
+      return c.text("Invalid pkt-line request body", 400);
+    }
+
+    const wants = new Set<string>();
+    let done = false;
+    for (const line of lines) {
+      const want = /^want ([0-9a-f]{40})(?: |$)/.exec(line);
+      if (want) {
+        wants.add(want[1]);
+        continue;
+      }
+      if (line === "done") {
+        done = true;
+        continue;
+      }
+      if (/^(deepen|shallow|filter)/.test(line)) {
+        return c.text("Shallow and filtered fetches are not supported by the emulator", 400);
+      }
+      // "have" lines and anything else are ignored: the emulator always sends
+      // a full pack, which is a valid (if unoptimized) response.
+    }
+    if (wants.size === 0) {
+      return c.text("No want lines in request", 400);
+    }
+
+    const tips = new Set(gh.refs.findBy("repo_id", repo.id).map((r) => r.sha));
+    noCache(c);
+
+    for (const want of wants) {
+      if (!tips.has(want)) {
+        return c.body(pktLine(`ERR upload-pack: not our ref ${want}`), 200, { "Content-Type": RESULT_TYPE });
+      }
+    }
+
+    if (!done) {
+      // Stateless negotiation round: nothing in common yet, ask the client to
+      // continue. A fresh clone always sends "done" in its first request.
+      return c.body(pktLine("NAK\n"), 200, { "Content-Type": RESULT_TYPE });
+    }
+
+    const resolve = createRepoObjectSource(gh, repo.id);
+    const objects = new Map<string, GitObject>();
+    for (const want of wants) {
+      const resolved = resolve(want);
+      if (!resolved) {
+        return c.body(pktLine(`ERR ${repo.full_name} has refs but no materialized git objects to serve`), 200, {
+          "Content-Type": RESULT_TYPE,
+        });
+      }
+      for (const [sha, obj] of resolved) {
+        objects.set(sha, obj);
+      }
+    }
+
+    const pack = buildPackfile([...objects.values()]);
+    return c.body(Buffer.concat([pktLine("NAK\n"), pack]), 200, { "Content-Type": RESULT_TYPE });
+  });
+}

--- a/packages/@emulators/github/src/routes/repos.ts
+++ b/packages/@emulators/github/src/routes/repos.ts
@@ -10,19 +10,10 @@ import {
   ownerLoginOf,
 } from "../route-helpers.js";
 import type { GitHubStore } from "../store.js";
-import type {
-  GitHubBlob,
-  GitHubBranch,
-  GitHubCollaborator,
-  GitHubCommit,
-  GitHubRef,
-  GitHubRepo,
-  GitHubTag,
-  GitHubTree,
-  GitHubUser,
-} from "../entities.js";
+import type { GitHubCollaborator, GitHubRepo, GitHubTag, GitHubUser } from "../entities.js";
 import type { Collection, Entity } from "@emulators/core";
-import { formatRepo, formatUser, generateNodeId, generateSha, lookupOwner, lookupRepo, timestamp } from "../helpers.js";
+import { formatRepo, formatUser, generateNodeId, lookupOwner, lookupRepo, timestamp } from "../helpers.js";
+import { defaultReadmeFiles, materializeRepoGit } from "../git-data.js";
 
 const LICENSE_TEMPLATES: Record<string, { key: string; name: string; spdx_id: string }> = {
   mit: { key: "mit", name: "MIT License", spdx_id: "MIT" },
@@ -53,71 +44,23 @@ function validateRepoName(name: unknown): string {
 }
 
 function seedInitialGit(gh: GitHubStore, repo: GitHubRepo, actor: GitHubUser | null, readmeTitle?: string) {
-  const repoId = repo.id;
-  const readme = `# ${readmeTitle ?? repo.name}\n`;
-  const size = Buffer.byteLength(readme, "utf8");
-
-  const blob = gh.blobs.insert({
-    repo_id: repoId,
-    sha: generateSha(),
-    node_id: "",
-    content: readme,
-    encoding: "utf-8",
-    size,
-  } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
-  gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
-
-  const tree = gh.trees.insert({
-    repo_id: repoId,
-    sha: generateSha(),
-    node_id: "",
-    tree: [{ path: "README.md", mode: "100644", type: "blob", sha: blob.sha }],
-    truncated: false,
-  } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
-  gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
-
   const authorName = actor?.name ?? actor?.login ?? "User";
   const login = actor?.login ?? "user";
   const email = actor?.email ?? `${login}@users.noreply.github.com`;
   const now = timestamp();
 
-  const commit = gh.commits.insert({
-    repo_id: repoId,
-    sha: generateSha(),
-    node_id: "",
+  const { totalBytes } = materializeRepoGit(gh, repo, defaultReadmeFiles(readmeTitle ?? repo.name), {
+    authorName,
+    authorEmail: email,
+    commitDate: now,
+    pushedAt: now,
     message: "Initial commit",
-    author_name: authorName,
-    author_email: email,
-    author_date: now,
-    committer_name: authorName,
-    committer_email: email,
-    committer_date: now,
-    tree_sha: tree.sha,
-    parent_shas: [],
-    user_id: actor?.id ?? null,
-  } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
-  gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
-
-  gh.branches.insert({
-    repo_id: repoId,
-    name: repo.default_branch,
-    sha: commit.sha,
-    protected: false,
-  } as Omit<GitHubBranch, "id" | "created_at" | "updated_at">);
-
-  const ref = gh.refs.insert({
-    repo_id: repoId,
-    ref: `refs/heads/${repo.default_branch}`,
-    sha: commit.sha,
-    node_id: "",
-  } as Omit<GitHubRef, "id" | "created_at" | "updated_at">);
-  gh.refs.update(ref.id, { node_id: generateNodeId("Ref", ref.id) });
+    userId: actor?.id ?? null,
+  });
 
   gh.repos.update(repo.id, {
-    size,
-    pushed_at: now,
     language: "Markdown",
-    languages: { Markdown: size },
+    languages: { Markdown: totalBytes },
   });
 }
 

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -63,7 +63,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   github: {
     label: "GitHub REST API emulator",
     endpoints:
-      "users, repos, issues, PRs, comments, reviews, labels, milestones, branches, git data, orgs, teams, releases, webhooks, search, actions, checks, rate limit",
+      "users, repos, issues, PRs, comments, reviews, labels, milestones, branches, git data, git clone (smart HTTP), orgs, teams, releases, webhooks, search, actions, checks, rate limit",
     async load() {
       const mod = await import("@emulators/github");
       return {

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -160,7 +160,27 @@ github:
         - http://localhost:3000/api/auth/callback/github
 ```
 
-Repos are auto-initialized with a commit, branch, and README unless `auto_init: false` is set.
+Repos are auto-initialized with a commit, branch, and README unless `auto_init: false` is set. A repo fixture can also declare file contents, which are materialized as real git objects:
+
+```yaml
+github:
+  repos:
+    - owner: octocat
+      name: cloneable
+      files:
+        README.md: "# cloneable\n"
+        src/index.js: "console.log('hi');\n"
+```
+
+## Git clone
+
+Seeded repos can be cloned with a real `git` client over smart HTTP. The token must be one the emulator knows (seeded in config or minted at runtime, for example through the installation access token endpoint); unknown tokens are rejected with a 401:
+
+```bash
+git clone "http://x-access-token:$TOKEN@localhost:4001/octocat/cloneable.git"
+```
+
+Public repos clone anonymously. Push, shallow clones, and partial fetches are not supported.
 
 ## Pagination
 


### PR DESCRIPTION
Adds the read side of the git smart HTTP protocol to the GitHub emulator, so a
real `git` client can clone fixture repos:

```bash
git clone http://x-access-token:$TOKEN@localhost:4001/octocat/hello-world.git
```

### Why

The emulator covers GitHub's REST surface, but anything exercising an actual
clone/fetch (CI harnesses, agents that do real repo work) currently needs a
separate fake git server next to emulate — splitting fixture state and token
auth across two processes. This closes that gap: the same seeded repos and the
same minted/seeded tokens now serve both REST and the git wire protocol.

### How
- GET /:owner/:repo/info/refs?service=git-upload-pack (ref advertisement) and
POST /:owner/:repo/git-upload-pack (clone / full fetch), protocol v0.
- Pure TypeScript object + packfile generation (git-objects.ts, git-data.ts) —
no git binary or filesystem dependency; everything resolves through the
in-memory store, and repos materialize with canonical git SHAs so REST git-data
responses and served packfiles agree. Fixture SHAs are deterministic across
restarts.
- Repo fixtures gain a files map (path → content); auto_init repos serve
their generated README.
- Auth is stricter than the REST routes on purpose: a presented token must be
one this instance seeded or minted (e.g. via
- `POST /app/installations/:id/access_tokens)` — unknown tokens get a 401 rather
than falling back to a default user, so clone tests can't pass vacuously.
- Public repos clone anonymously; private repos require a token with access.
- Request bodies are size-limited both compressed and inflated; fixture paths
reject .., .git, and null-byte segments.
- Out of scope / for follow up(rejected with clear errors): push (git-receive-pack), shallow
clones, partial fetches.

