### PR TITLE
Add Vercel Blob emulator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,24 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `PATCH /v9/projects/:idOrName/env/:id` - update env var
 - `DELETE /v9/projects/:idOrName/env/:id` - delete env var
 
+### Blob
+Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`).
+
+- `PUT /api/blob?pathname=<path>` - upload a blob (honors `x-add-random-suffix`, `x-allow-overwrite`, `x-content-type`, `x-cache-control-max-age`, `x-if-match` headers)
+- `GET /api/blob?url=<urlOrPathname>` - blob metadata (`head()`)
+- `GET /api/blob?prefix=&limit=&cursor=&mode=` - list blobs (`list()`, including folded mode)
+- `POST /api/blob/delete` - delete blobs (`del()`)
+- `GET /blob/:storeId/<pathname>` - serve blob content (public, no auth; `?download=1` adds an attachment disposition)
+
+Point the SDK at the emulator with two environment variables:
+
+```bash
+VERCEL_BLOB_API_URL=http://localhost:4000/api/blob
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_mystore_secret
+```
+
+Any token of the form `vercel_blob_rw_<storeId>_<secret>` is accepted; the store id is parsed from the token. Multipart uploads and client (browser) uploads are not supported yet.
+
 ## GitHub API
 
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.

--- a/apps/web/app/docs/vercel/page.mdx
+++ b/apps/web/app/docs/vercel/page.mdx
@@ -51,3 +51,22 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `GET /v10/projects/:idOrName/env/:id` - get env var
 - `PATCH /v9/projects/:idOrName/env/:id` - update env var
 - `DELETE /v9/projects/:idOrName/env/:id` - delete env var
+
+## Blob
+
+Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`).
+
+- `PUT /api/blob?pathname=<path>` - upload a blob (honors `x-add-random-suffix`, `x-allow-overwrite`, `x-content-type`, `x-cache-control-max-age`, `x-if-match` headers)
+- `GET /api/blob?url=<urlOrPathname>` - blob metadata (`head()`)
+- `GET /api/blob?prefix=&limit=&cursor=&mode=` - list blobs (`list()`, including folded mode)
+- `POST /api/blob/delete` - delete blobs (`del()`)
+- `GET /blob/:storeId/<pathname>` - serve blob content (public, no auth; `?download=1` adds an attachment disposition)
+
+Point the SDK at the emulator with two environment variables:
+
+```bash
+VERCEL_BLOB_API_URL=http://localhost:4000/api/blob
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_mystore_secret
+```
+
+Any token of the form `vercel_blob_rw_<storeId>_<secret>` is accepted; the store id is parsed from the token. Multipart uploads and client (browser) uploads are not supported yet.

--- a/packages/@emulators/vercel/package.json
+++ b/packages/@emulators/vercel/package.json
@@ -38,6 +38,7 @@
     "@emulators/core": "workspace:*"
   },
   "devDependencies": {
+    "@vercel/blob": "^2.4.0",
     "tsup": "^8",
     "typescript": "^5.7",
     "vitest": "^4.1.0"

--- a/packages/@emulators/vercel/src/__tests__/blob.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/blob.test.ts
@@ -123,6 +123,19 @@ describe("Vercel Blob via the @vercel/blob SDK", () => {
     expect(meta.pathname).toBe("meta/env-token.txt");
   });
 
+  it("put accepts SDK OIDC auth with an explicit storeId", async () => {
+    const uploaded = await put("auth/oidc.txt", "oidc token", {
+      access: "public",
+      oidcToken: "local-oidc-token",
+      storeId,
+    });
+
+    expect(uploaded.url).toBe(`${emulatorUrl}/blob/${storeId}/auth/oidc.txt`);
+    const res = await fetch(uploaded.url);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("oidc token");
+  });
+
   it("list filters by prefix and returns metadata", async () => {
     await put("listing/a.txt", "a", { access: "public", token });
     await put("listing/b.txt", "b", { access: "public", token });

--- a/packages/@emulators/vercel/src/__tests__/blob.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/blob.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { randomBytes } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import { Hono, serve } from "@emulators/core";
+import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
+import { put, head, list, del, BlobNotFoundError, BlobAccessError } from "@vercel/blob";
+import { vercelPlugin } from "../index.js";
+
+const token = "vercel_blob_rw_teststore_secret";
+const storeId = "teststore";
+
+let emulatorUrl: string;
+let apiUrl: string;
+let closeServer: () => Promise<void>;
+
+beforeAll(async () => {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  const app = new Hono();
+  app.use("*", authMiddleware(tokenMap));
+
+  const server = serve({ fetch: app.fetch, port: 0 });
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", () => resolve());
+    server.once("error", reject);
+  });
+  const { port } = server.address() as AddressInfo;
+  emulatorUrl = `http://127.0.0.1:${port}`;
+  apiUrl = `${emulatorUrl}/api/blob`;
+
+  // Blob URLs embed the base URL, so register routes after the port is known.
+  vercelPlugin.register(app as any, store, webhooks, emulatorUrl, tokenMap);
+  vercelPlugin.seed?.(store, emulatorUrl);
+
+  process.env.VERCEL_BLOB_API_URL = apiUrl;
+  process.env.BLOB_READ_WRITE_TOKEN = token;
+
+  closeServer = () =>
+    new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+afterAll(async () => {
+  delete process.env.VERCEL_BLOB_API_URL;
+  delete process.env.BLOB_READ_WRITE_TOKEN;
+  await closeServer();
+});
+
+describe("Vercel Blob via the @vercel/blob SDK", () => {
+  it("put uploads bytes and the returned url serves them back", async () => {
+    const data = randomBytes(1024);
+    const result = await put("round-trip/data.bin", data, { access: "public", token });
+
+    expect(result.pathname).toBe("round-trip/data.bin");
+    expect(result.url).toBe(`${emulatorUrl}/blob/${storeId}/round-trip/data.bin`);
+    expect(result.contentType).toBe("application/octet-stream");
+    expect(result.contentDisposition).toBe('attachment; filename="data.bin"');
+
+    const res = await fetch(result.url);
+    expect(res.status).toBe(200);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(data)).toBe(true);
+    expect(res.headers.get("etag")).toBe(result.etag);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=31536000");
+  });
+
+  it("put with addRandomSuffix appends a suffix before the extension", async () => {
+    const result = await put("suffix/report.txt", "hello suffix", {
+      access: "public",
+      token,
+      addRandomSuffix: true,
+    });
+
+    expect(result.pathname).toMatch(/^suffix\/report-[a-z0-9]+\.txt$/);
+    expect(result.pathname).not.toBe("suffix/report.txt");
+
+    const res = await fetch(result.url);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello suffix");
+    expect(res.headers.get("content-type")).toContain("text/plain");
+  });
+
+  it("put with allowOverwrite: false rejects when the blob already exists", async () => {
+    await put("conflict/file.txt", "first", { access: "public", token });
+    await expect(
+      put("conflict/file.txt", "second", { access: "public", token, allowOverwrite: false }),
+    ).rejects.toThrow(/allowOverwrite/);
+
+    // The original content is untouched and allowOverwrite: true replaces it.
+    const before = await fetch(`${emulatorUrl}/blob/${storeId}/conflict/file.txt`);
+    expect(await before.text()).toBe("first");
+
+    await put("conflict/file.txt", "second", { access: "public", token, allowOverwrite: true });
+    const after = await fetch(`${emulatorUrl}/blob/${storeId}/conflict/file.txt`);
+    expect(await after.text()).toBe("second");
+  });
+
+  it("head returns blob metadata", async () => {
+    const uploaded = await put("meta/info.json", JSON.stringify({ ok: true }), {
+      access: "public",
+      token,
+      cacheControlMaxAge: 60,
+    });
+
+    const meta = await head(uploaded.url, { token });
+    expect(meta.pathname).toBe("meta/info.json");
+    expect(meta.url).toBe(uploaded.url);
+    expect(meta.downloadUrl).toBe(uploaded.downloadUrl);
+    expect(meta.size).toBe(Buffer.byteLength(JSON.stringify({ ok: true })));
+    expect(meta.contentType).toBe("application/json");
+    expect(meta.contentDisposition).toBe('attachment; filename="info.json"');
+    expect(meta.cacheControl).toBe("public, max-age=60");
+    expect(meta.etag).toBe(uploaded.etag);
+    expect(meta.uploadedAt).toBeInstanceOf(Date);
+    expect(Number.isNaN(meta.uploadedAt.getTime())).toBe(false);
+  });
+
+  it("head falls back to BLOB_READ_WRITE_TOKEN when no token option is given", async () => {
+    const uploaded = await put("meta/env-token.txt", "env token", { access: "public", token });
+    const meta = await head(uploaded.url);
+    expect(meta.pathname).toBe("meta/env-token.txt");
+  });
+
+  it("list filters by prefix and returns metadata", async () => {
+    await put("listing/a.txt", "a", { access: "public", token });
+    await put("listing/b.txt", "b", { access: "public", token });
+    await put("other/c.txt", "c", { access: "public", token });
+
+    const result = await list({ prefix: "listing/", token });
+    const pathnames = result.blobs.map((b) => b.pathname);
+    expect(pathnames).toEqual(["listing/a.txt", "listing/b.txt"]);
+    expect(result.hasMore).toBe(false);
+    for (const blob of result.blobs) {
+      expect(blob.url).toBe(`${emulatorUrl}/blob/${storeId}/${blob.pathname}`);
+      expect(blob.size).toBe(1);
+      expect(blob.uploadedAt).toBeInstanceOf(Date);
+      expect(blob.etag).toMatch(/^"[0-9a-f]{64}"$/);
+    }
+  });
+
+  it("list paginates with limit and cursor", async () => {
+    await put("paging/1.txt", "1", { access: "public", token });
+    await put("paging/2.txt", "2", { access: "public", token });
+    await put("paging/3.txt", "3", { access: "public", token });
+
+    const first = await list({ prefix: "paging/", limit: 2, token });
+    expect(first.blobs.map((b) => b.pathname)).toEqual(["paging/1.txt", "paging/2.txt"]);
+    expect(first.hasMore).toBe(true);
+    expect(first.cursor).toBeDefined();
+
+    const second = await list({ prefix: "paging/", cursor: first.cursor, token });
+    expect(second.blobs.map((b) => b.pathname)).toEqual(["paging/3.txt"]);
+    expect(second.hasMore).toBe(false);
+  });
+
+  it("del removes a blob and head then rejects with BlobNotFoundError", async () => {
+    const uploaded = await put("deletion/gone.txt", "bye", { access: "public", token });
+    await del(uploaded.url, { token });
+
+    await expect(head(uploaded.url, { token })).rejects.toBeInstanceOf(BlobNotFoundError);
+    const res = await fetch(uploaded.url);
+    expect(res.status).toBe(404);
+  });
+
+  it("downloadUrl serves the content with an attachment disposition", async () => {
+    const uploaded = await put("downloads/manual.txt", "download me", { access: "public", token });
+
+    const res = await fetch(uploaded.downloadUrl);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-disposition")).toBe('attachment; filename="manual.txt"');
+    expect(await res.text()).toBe("download me");
+
+    // The plain url has no attachment disposition.
+    const inline = await fetch(uploaded.url);
+    expect(inline.headers.get("content-disposition")).toBeNull();
+  });
+
+  it("a bad token surfaces as BlobAccessError", async () => {
+    await expect(list({ token: "not-a-blob-token" })).rejects.toBeInstanceOf(BlobAccessError);
+  });
+});
+
+describe("Vercel Blob direct HTTP error shapes", () => {
+  it("returns a 403 forbidden JSON body for a bad token", async () => {
+    const res = await fetch(apiUrl, { headers: { authorization: "Bearer wrong" } });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("forbidden");
+    expect(typeof body.error.message).toBe("string");
+  });
+
+  it("returns a 404 not_found JSON body when head misses", async () => {
+    const res = await fetch(`${apiUrl}?url=${encodeURIComponent("missing/never-uploaded.txt")}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("not_found");
+    expect(body.error.message).toBe("The requested blob does not exist");
+  });
+});

--- a/packages/@emulators/vercel/src/__tests__/blob.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/blob.test.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import { Hono, serve } from "@emulators/core";
 import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
-import { put, head, list, del, BlobNotFoundError, BlobAccessError } from "@vercel/blob";
+import { put, head, list, del, copy, BlobNotFoundError, BlobAccessError } from "@vercel/blob";
 import { vercelPlugin } from "../index.js";
 
 const token = "vercel_blob_rw_teststore_secret";
@@ -63,7 +63,7 @@ describe("Vercel Blob via the @vercel/blob SDK", () => {
     const body = Buffer.from(await res.arrayBuffer());
     expect(body.equals(data)).toBe(true);
     expect(res.headers.get("etag")).toBe(result.etag);
-    expect(res.headers.get("cache-control")).toBe("public, max-age=31536000");
+    expect(res.headers.get("cache-control")).toBe("public, max-age=2592000");
   });
 
   it("put with addRandomSuffix appends a suffix before the extension", async () => {
@@ -136,6 +136,20 @@ describe("Vercel Blob via the @vercel/blob SDK", () => {
     expect(await res.text()).toBe("oidc token");
   });
 
+  it("copy duplicates source content into the destination blob", async () => {
+    const source = await put("copy/source.txt", "copy me", { access: "public", token });
+    const copied = await copy(source.url, "copy/dest.txt", { access: "public", token });
+
+    expect(copied.pathname).toBe("copy/dest.txt");
+    const res = await fetch(copied.url);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("copy me");
+
+    const meta = await head(copied.url, { token });
+    expect(meta.size).toBe("copy me".length);
+    expect(meta.etag).toBe(source.etag);
+  });
+
   it("list filters by prefix and returns metadata", async () => {
     await put("listing/a.txt", "a", { access: "public", token });
     await put("listing/b.txt", "b", { access: "public", token });
@@ -175,6 +189,22 @@ describe("Vercel Blob via the @vercel/blob SDK", () => {
     await expect(head(uploaded.url, { token })).rejects.toBeInstanceOf(BlobNotFoundError);
     const res = await fetch(uploaded.url);
     expect(res.status).toBe(404);
+  });
+
+  it("full blob URLs cannot target a different authenticated store", async () => {
+    const otherToken = "vercel_blob_rw_otherstore_secret";
+    const own = await put("store-scope/shared.txt", "own", { access: "public", token });
+    const other = await put("store-scope/shared.txt", "other", { access: "public", token: otherToken });
+
+    await expect(head(other.url, { token })).rejects.toBeInstanceOf(BlobNotFoundError);
+
+    await del(other.url, { token });
+    const ownRes = await fetch(own.url);
+    const otherRes = await fetch(other.url);
+    expect(ownRes.status).toBe(200);
+    expect(await ownRes.text()).toBe("own");
+    expect(otherRes.status).toBe(200);
+    expect(await otherRes.text()).toBe("other");
   });
 
   it("downloadUrl serves the content with an attachment disposition", async () => {

--- a/packages/@emulators/vercel/src/entities.ts
+++ b/packages/@emulators/vercel/src/entities.ts
@@ -236,6 +236,18 @@ export interface VercelApiKey extends Entity {
   tokenString: string;
 }
 
+export interface VercelBlob extends Entity {
+  pathname: string;
+  storeId: string;
+  contentType: string;
+  contentDisposition: string;
+  cacheControl: string;
+  size: number;
+  etag: string;
+  uploadedAt: string;
+  dataBase64: string;
+}
+
 export interface VercelIntegration extends Entity {
   client_id: string;
   client_secret: string;

--- a/packages/@emulators/vercel/src/helpers.ts
+++ b/packages/@emulators/vercel/src/helpers.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import type { Context } from "@emulators/core";
 import type {
   VercelUser,
@@ -15,6 +15,17 @@ import type { VercelStore } from "./store.js";
 export function generateUid(prefix = ""): string {
   const id = randomBytes(12).toString("base64url").slice(0, 20);
   return prefix ? `${prefix}_${id}` : id;
+}
+
+/**
+ * Deterministic uid for seeded entities. Seeded identities must be stable
+ * across emulator restarts: downstream apps key accounts on the OIDC sub,
+ * and a regenerated uid for the same seeded user creates a duplicate
+ * account in the app after every restart.
+ */
+export function stableUid(prefix: string, seedKey: string): string {
+  const id = createHash("sha256").update(seedKey).digest("base64url").slice(0, 20);
+  return `${prefix}_${id}`;
 }
 
 export function generateSecret(): string {

--- a/packages/@emulators/vercel/src/index.ts
+++ b/packages/@emulators/vercel/src/index.ts
@@ -2,7 +2,7 @@ import type { Hono } from "@emulators/core";
 import type { AppEnv, RouteContext, ServicePlugin, Store, WebhookDispatcher, TokenMap } from "@emulators/core";
 import type { VercelEnvVar } from "./entities.js";
 import { getVercelStore } from "./store.js";
-import { generateUid, nowMs } from "./helpers.js";
+import { generateUid, nowMs, stableUid } from "./helpers.js";
 import { userRoutes } from "./routes/user.js";
 import { projectsRoutes } from "./routes/projects.js";
 import { deploymentsRoutes } from "./routes/deployments.js";
@@ -10,6 +10,7 @@ import { domainsRoutes } from "./routes/domains.js";
 import { envRoutes } from "./routes/env.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { apiKeysRoutes } from "./routes/api-keys.js";
+import { blobRoutes } from "./routes/blob.js";
 
 export { getVercelStore, type VercelStore } from "./store.js";
 export * from "./entities.js";
@@ -53,7 +54,7 @@ function seedDefaults(store: Store, _baseUrl: string): void {
   const vs = getVercelStore(store);
 
   vs.users.insert({
-    uid: generateUid("user"),
+    uid: stableUid("user", "vercel.user.admin"),
     email: "admin@localhost",
     username: "admin",
     name: "Admin",
@@ -75,7 +76,7 @@ export function seedFromConfig(store: Store, baseUrl: string, config: VercelSeed
       const existing = vs.users.findOneBy("username", u.username);
       if (existing) continue;
       vs.users.insert({
-        uid: generateUid("user"),
+        uid: stableUid("user", `vercel.user.${u.username}`),
         email: u.email ?? `${u.username}@localhost`,
         username: u.username,
         name: u.name ?? null,
@@ -218,6 +219,7 @@ export const vercelPlugin: ServicePlugin = {
     domainsRoutes(ctx);
     envRoutes(ctx);
     apiKeysRoutes(ctx);
+    blobRoutes(ctx);
   },
   seed(store: Store, baseUrl: string): void {
     seedDefaults(store, baseUrl);

--- a/packages/@emulators/vercel/src/routes/blob.ts
+++ b/packages/@emulators/vercel/src/routes/blob.ts
@@ -44,22 +44,21 @@ function forbidden(c: Context): Response {
   return blobErr(c, 403, "forbidden", "Access denied");
 }
 
-/**
- * Parses the store id from a read-write token of the form
- * vercel_blob_rw_<storeId>_<random>, falling back to the
- * x-vercel-blob-store-id header. Returns null when the request
- * carries no well-formed token.
- */
 function resolveStoreId(c: Context): string | null {
   const authHeader = c.req.header("authorization") ?? "";
   const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
   if (!match) return null;
   const token = match[1];
-  if (!token.startsWith("vercel_blob_rw_")) return null;
-  const parts = token.split("_");
-  if (parts.length < 5 || parts[4] === "") return null;
-  const storeId = parts[3] || c.req.header("x-vercel-blob-store-id") || "";
-  return storeId === "" ? null : storeId;
+  if (token.startsWith("vercel_blob_rw_")) {
+    const parts = token.split("_");
+    if (parts.length >= 5 && parts[3] !== "" && parts[4] !== "") {
+      return parts[3];
+    }
+    return null;
+  }
+
+  const storeId = c.req.header("x-vercel-blob-store-id")?.trim();
+  return storeId ? storeId : null;
 }
 
 function inferContentType(pathname: string): string {
@@ -151,8 +150,7 @@ function headResponse(baseUrl: string, blob: VercelBlob): Record<string, unknown
 export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
   const vs = getVercelStore(store);
 
-  // ---------- Upload ----------
-  // The SDK sends PUT <api>/?pathname=<pathname> with the raw bytes as body.
+  // Upload. The SDK sends PUT <api>/?pathname=<pathname> with the raw bytes as body.
 
   const handlePut = async (c: Context): Promise<Response> => {
     const storeId = resolveStoreId(c);
@@ -223,7 +221,7 @@ export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
     });
   };
 
-  // ---------- Head and list ----------
+  // Head and list.
   // The SDK sends GET <api>?url=<urlOrPathname> for head and
   // GET <api>?prefix=&limit=&cursor=&mode= for list.
 
@@ -297,7 +295,7 @@ export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
   app.get("/api/blob", handleGet);
   app.get("/api/blob/", handleGet);
 
-  // ---------- Delete ----------
+  // Delete.
 
   app.post("/api/blob/delete", async (c) => {
     const storeId = resolveStoreId(c);
@@ -327,14 +325,14 @@ export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
     return c.json(null);
   });
 
-  // ---------- Multipart uploads (not supported) ----------
+  // Multipart uploads are not supported yet.
 
   const handleMpu = (c: Context): Response =>
     blobErr(c, 400, "bad_request", "Multipart uploads are not supported by the emulator yet");
   app.post("/api/blob/mpu", handleMpu);
   app.put("/api/blob/mpu", handleMpu);
 
-  // ---------- Public content serving ----------
+  // Public content serving.
   // Blob URLs point here. Public access, no authentication.
 
   app.get("/blob/:storeId/:pathname{.+}", (c) => {

--- a/packages/@emulators/vercel/src/routes/blob.ts
+++ b/packages/@emulators/vercel/src/routes/blob.ts
@@ -5,7 +5,7 @@ import { getVercelStore } from "../store.js";
 import type { VercelStore } from "../store.js";
 import type { VercelBlob } from "../entities.js";
 
-const DEFAULT_CACHE_MAX_AGE = 31536000;
+const DEFAULT_CACHE_MAX_AGE = 2592000;
 const DEFAULT_LIST_LIMIT = 1000;
 
 const MIME_TYPES: Record<string, string> = {
@@ -109,27 +109,40 @@ function contentDispositionFor(pathname: string): string {
   return `attachment; filename="${basename}"`;
 }
 
-/**
- * Accepts either a full blob URL (as returned by the upload endpoint)
- * or a bare pathname and resolves it to a store pathname.
- */
-function resolvePathname(urlOrPathname: string): string {
+interface BlobRef {
+  pathname: string;
+  storeId?: string;
+}
+
+function resolveBlobRef(urlOrPathname: string): BlobRef {
   if (!/^https?:\/\//i.test(urlOrPathname)) {
-    return urlOrPathname;
+    return { pathname: urlOrPathname };
   }
-  let path: string;
+  let url: URL;
   try {
-    path = decodeURIComponent(new URL(urlOrPathname).pathname);
+    url = new URL(urlOrPathname);
   } catch {
-    return urlOrPathname;
+    return { pathname: urlOrPathname };
   }
-  const match = /^\/blob\/[^/]+\/(.+)$/.exec(path);
-  if (match) return match[1];
-  return path.replace(/^\//, "");
+  const path = decodeURIComponent(url.pathname);
+  const match = /^\/blob\/([^/]+)\/(.+)$/.exec(path);
+  if (match) {
+    return { storeId: match[1], pathname: match[2] };
+  }
+  const vercelHost = /^([^.]+)\.(?:public|private)\.blob\.vercel-storage\.com$/i.exec(url.hostname);
+  if (vercelHost) {
+    return { storeId: vercelHost[1], pathname: path.replace(/^\//, "") };
+  }
+  return { pathname: path.replace(/^\//, "") };
 }
 
 function findBlob(vs: VercelStore, storeId: string, pathname: string): VercelBlob | undefined {
   return vs.blobs.findBy("pathname", pathname).find((b) => b.storeId === storeId);
+}
+
+function findBlobRef(vs: VercelStore, storeId: string, ref: BlobRef): VercelBlob | undefined {
+  if (ref.storeId && ref.storeId !== storeId) return undefined;
+  return findBlob(vs, storeId, ref.pathname);
 }
 
 function headResponse(baseUrl: string, blob: VercelBlob): Record<string, unknown> {
@@ -171,7 +184,6 @@ export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
 
     const pathname = c.req.header("x-add-random-suffix") === "1" ? withRandomSuffix(rawPathname) : rawPathname;
 
-    const body = Buffer.from(await c.req.arrayBuffer());
     const existing = findBlob(vs, storeId, pathname);
 
     const ifMatch = c.req.header("x-if-match");
@@ -184,6 +196,13 @@ export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
       return blobErr(c, 400, "bad_request", "This blob already exists, use allowOverwrite: true to overwrite it");
     }
 
+    const fromUrl = c.req.query("fromUrl");
+    const source = fromUrl === undefined ? undefined : findBlobRef(vs, storeId, resolveBlobRef(fromUrl));
+    if (fromUrl !== undefined && !source) {
+      return blobErr(c, 404, "not_found", "The requested blob does not exist");
+    }
+
+    const body = source ? Buffer.from(source.dataBase64, "base64") : Buffer.from(await c.req.arrayBuffer());
     const contentType = c.req.header("x-content-type") || inferContentType(pathname);
     const maxAgeHeader = c.req.header("x-cache-control-max-age");
     const maxAge = maxAgeHeader ? parseInt(maxAgeHeader, 10) : NaN;
@@ -231,7 +250,7 @@ export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
 
     const urlParam = c.req.query("url");
     if (urlParam !== undefined) {
-      const blob = findBlob(vs, storeId, resolvePathname(urlParam));
+      const blob = findBlobRef(vs, storeId, resolveBlobRef(urlParam));
       if (!blob) {
         return blobErr(c, 404, "not_found", "The requested blob does not exist");
       }
@@ -311,7 +330,7 @@ export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
 
     const ifMatch = c.req.header("x-if-match");
     for (const urlOrPathname of urls) {
-      const blob = findBlob(vs, storeId, resolvePathname(urlOrPathname));
+      const blob = findBlobRef(vs, storeId, resolveBlobRef(urlOrPathname));
       if (!blob) continue;
       if (ifMatch) {
         const normalized = ifMatch.startsWith('"') ? ifMatch : `"${ifMatch}"`;

--- a/packages/@emulators/vercel/src/routes/blob.ts
+++ b/packages/@emulators/vercel/src/routes/blob.ts
@@ -1,0 +1,363 @@
+import { createHash, randomBytes } from "crypto";
+import type { Context, RouteContext } from "@emulators/core";
+import type { ContentfulStatusCode } from "@emulators/core";
+import { getVercelStore } from "../store.js";
+import type { VercelStore } from "../store.js";
+import type { VercelBlob } from "../entities.js";
+
+const DEFAULT_CACHE_MAX_AGE = 31536000;
+const DEFAULT_LIST_LIMIT = 1000;
+
+const MIME_TYPES: Record<string, string> = {
+  avif: "image/avif",
+  css: "text/css",
+  csv: "text/csv",
+  gif: "image/gif",
+  gz: "application/gzip",
+  html: "text/html",
+  ico: "image/x-icon",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  js: "text/javascript",
+  json: "application/json",
+  md: "text/markdown",
+  mp3: "audio/mpeg",
+  mp4: "video/mp4",
+  pdf: "application/pdf",
+  png: "image/png",
+  svg: "image/svg+xml",
+  txt: "text/plain",
+  wasm: "application/wasm",
+  webm: "video/webm",
+  webp: "image/webp",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  xml: "application/xml",
+  zip: "application/zip",
+};
+
+function blobErr(c: Context, status: ContentfulStatusCode, code: string, message: string): Response {
+  return c.json({ error: { code, message } }, status);
+}
+
+function forbidden(c: Context): Response {
+  return blobErr(c, 403, "forbidden", "Access denied");
+}
+
+/**
+ * Parses the store id from a read-write token of the form
+ * vercel_blob_rw_<storeId>_<random>, falling back to the
+ * x-vercel-blob-store-id header. Returns null when the request
+ * carries no well-formed token.
+ */
+function resolveStoreId(c: Context): string | null {
+  const authHeader = c.req.header("authorization") ?? "";
+  const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
+  if (!match) return null;
+  const token = match[1];
+  if (!token.startsWith("vercel_blob_rw_")) return null;
+  const parts = token.split("_");
+  if (parts.length < 5 || parts[4] === "") return null;
+  const storeId = parts[3] || c.req.header("x-vercel-blob-store-id") || "";
+  return storeId === "" ? null : storeId;
+}
+
+function inferContentType(pathname: string): string {
+  const basename = pathname.split("/").pop() ?? "";
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0) return "application/octet-stream";
+  const ext = basename.slice(dot + 1).toLowerCase();
+  return MIME_TYPES[ext] ?? "application/octet-stream";
+}
+
+function randomSuffix(): string {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+  const bytes = randomBytes(8);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += alphabet[bytes[i] % alphabet.length];
+  }
+  return out;
+}
+
+function withRandomSuffix(pathname: string): string {
+  const suffix = randomSuffix();
+  const slash = pathname.lastIndexOf("/");
+  const dot = pathname.lastIndexOf(".");
+  if (dot > slash + 1) {
+    return `${pathname.slice(0, dot)}-${suffix}${pathname.slice(dot)}`;
+  }
+  return `${pathname}-${suffix}`;
+}
+
+function encodePathname(pathname: string): string {
+  return pathname
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function blobUrl(baseUrl: string, storeId: string, pathname: string): string {
+  return `${baseUrl}/blob/${encodeURIComponent(storeId)}/${encodePathname(pathname)}`;
+}
+
+function downloadUrl(url: string): string {
+  return `${url}?download=1`;
+}
+
+function contentDispositionFor(pathname: string): string {
+  const basename = (pathname.split("/").pop() ?? pathname).replace(/"/g, "");
+  return `attachment; filename="${basename}"`;
+}
+
+/**
+ * Accepts either a full blob URL (as returned by the upload endpoint)
+ * or a bare pathname and resolves it to a store pathname.
+ */
+function resolvePathname(urlOrPathname: string): string {
+  if (!/^https?:\/\//i.test(urlOrPathname)) {
+    return urlOrPathname;
+  }
+  let path: string;
+  try {
+    path = decodeURIComponent(new URL(urlOrPathname).pathname);
+  } catch {
+    return urlOrPathname;
+  }
+  const match = /^\/blob\/[^/]+\/(.+)$/.exec(path);
+  if (match) return match[1];
+  return path.replace(/^\//, "");
+}
+
+function findBlob(vs: VercelStore, storeId: string, pathname: string): VercelBlob | undefined {
+  return vs.blobs.findBy("pathname", pathname).find((b) => b.storeId === storeId);
+}
+
+function headResponse(baseUrl: string, blob: VercelBlob): Record<string, unknown> {
+  const url = blobUrl(baseUrl, blob.storeId, blob.pathname);
+  return {
+    url,
+    downloadUrl: downloadUrl(url),
+    pathname: blob.pathname,
+    size: blob.size,
+    contentType: blob.contentType,
+    contentDisposition: blob.contentDisposition,
+    cacheControl: blob.cacheControl,
+    uploadedAt: blob.uploadedAt,
+    etag: blob.etag,
+  };
+}
+
+export function blobRoutes({ app, store, baseUrl }: RouteContext): void {
+  const vs = getVercelStore(store);
+
+  // ---------- Upload ----------
+  // The SDK sends PUT <api>/?pathname=<pathname> with the raw bytes as body.
+
+  const handlePut = async (c: Context): Promise<Response> => {
+    const storeId = resolveStoreId(c);
+    if (!storeId) return forbidden(c);
+
+    const rawPathname = c.req.query("pathname");
+    if (!rawPathname) {
+      return blobErr(c, 400, "bad_request", "pathname is required");
+    }
+    if (rawPathname.includes("//")) {
+      return blobErr(c, 400, "bad_request", "pathname cannot contain //");
+    }
+
+    const access = c.req.header("x-vercel-blob-access") ?? "public";
+    if (access !== "public") {
+      return blobErr(c, 400, "bad_request", "Only access: public is supported by the emulator");
+    }
+
+    const pathname = c.req.header("x-add-random-suffix") === "1" ? withRandomSuffix(rawPathname) : rawPathname;
+
+    const body = Buffer.from(await c.req.arrayBuffer());
+    const existing = findBlob(vs, storeId, pathname);
+
+    const ifMatch = c.req.header("x-if-match");
+    if (ifMatch) {
+      const normalized = ifMatch.startsWith('"') ? ifMatch : `"${ifMatch}"`;
+      if (!existing || existing.etag !== normalized) {
+        return blobErr(c, 412, "precondition_failed", "Precondition failed: ETag mismatch.");
+      }
+    } else if (existing && c.req.header("x-allow-overwrite") !== "1") {
+      return blobErr(c, 400, "bad_request", "This blob already exists, use allowOverwrite: true to overwrite it");
+    }
+
+    const contentType = c.req.header("x-content-type") || inferContentType(pathname);
+    const maxAgeHeader = c.req.header("x-cache-control-max-age");
+    const maxAge = maxAgeHeader ? parseInt(maxAgeHeader, 10) : NaN;
+    const cacheControl = `public, max-age=${Number.isFinite(maxAge) ? maxAge : DEFAULT_CACHE_MAX_AGE}`;
+    const contentDisposition = contentDispositionFor(pathname);
+    const etag = `"${createHash("sha256").update(body).digest("hex")}"`;
+    const uploadedAt = new Date().toISOString();
+
+    const fields = {
+      pathname,
+      storeId,
+      contentType,
+      contentDisposition,
+      cacheControl,
+      size: body.byteLength,
+      etag,
+      uploadedAt,
+      dataBase64: body.toString("base64"),
+    };
+
+    if (existing) {
+      vs.blobs.update(existing.id, fields);
+    } else {
+      vs.blobs.insert(fields);
+    }
+
+    const url = blobUrl(baseUrl, storeId, pathname);
+    return c.json({
+      url,
+      downloadUrl: downloadUrl(url),
+      pathname,
+      contentType,
+      contentDisposition,
+      etag,
+    });
+  };
+
+  // ---------- Head and list ----------
+  // The SDK sends GET <api>?url=<urlOrPathname> for head and
+  // GET <api>?prefix=&limit=&cursor=&mode= for list.
+
+  const handleGet = (c: Context): Response => {
+    const storeId = resolveStoreId(c);
+    if (!storeId) return forbidden(c);
+
+    const urlParam = c.req.query("url");
+    if (urlParam !== undefined) {
+      const blob = findBlob(vs, storeId, resolvePathname(urlParam));
+      if (!blob) {
+        return blobErr(c, 404, "not_found", "The requested blob does not exist");
+      }
+      return c.json(headResponse(baseUrl, blob));
+    }
+
+    const prefix = c.req.query("prefix") ?? "";
+    const limitParam = parseInt(c.req.query("limit") ?? "", 10);
+    const limit = Number.isFinite(limitParam) && limitParam > 0 ? limitParam : DEFAULT_LIST_LIMIT;
+    const cursor = c.req.query("cursor");
+    const folded = c.req.query("mode") === "folded";
+
+    let items = vs.blobs
+      .findBy("storeId", storeId)
+      .filter((b) => b.pathname.startsWith(prefix))
+      .sort((a, b) => (a.pathname < b.pathname ? -1 : a.pathname > b.pathname ? 1 : 0));
+
+    const folders = new Set<string>();
+    if (folded) {
+      items = items.filter((b) => {
+        const rest = b.pathname.slice(prefix.length);
+        const slash = rest.indexOf("/");
+        if (slash === -1) return true;
+        folders.add(prefix + rest.slice(0, slash + 1));
+        return false;
+      });
+    }
+
+    if (cursor) {
+      items = items.filter((b) => b.pathname > cursor);
+    }
+
+    const hasMore = items.length > limit;
+    const page = items.slice(0, limit);
+
+    const result: Record<string, unknown> = {
+      blobs: page.map((b) => {
+        const url = blobUrl(baseUrl, b.storeId, b.pathname);
+        return {
+          url,
+          downloadUrl: downloadUrl(url),
+          pathname: b.pathname,
+          size: b.size,
+          uploadedAt: b.uploadedAt,
+          etag: b.etag,
+        };
+      }),
+      hasMore,
+    };
+    if (hasMore && page.length > 0) {
+      result.cursor = page[page.length - 1].pathname;
+    }
+    if (folded) {
+      result.folders = [...folders].sort();
+    }
+    return c.json(result);
+  };
+
+  app.put("/api/blob", handlePut);
+  app.put("/api/blob/", handlePut);
+  app.get("/api/blob", handleGet);
+  app.get("/api/blob/", handleGet);
+
+  // ---------- Delete ----------
+
+  app.post("/api/blob/delete", async (c) => {
+    const storeId = resolveStoreId(c);
+    if (!storeId) return forbidden(c);
+
+    let body: { urls?: unknown };
+    try {
+      body = (await c.req.json()) as { urls?: unknown };
+    } catch {
+      body = {};
+    }
+    const urls = Array.isArray(body.urls) ? body.urls.filter((u): u is string => typeof u === "string") : [];
+
+    const ifMatch = c.req.header("x-if-match");
+    for (const urlOrPathname of urls) {
+      const blob = findBlob(vs, storeId, resolvePathname(urlOrPathname));
+      if (!blob) continue;
+      if (ifMatch) {
+        const normalized = ifMatch.startsWith('"') ? ifMatch : `"${ifMatch}"`;
+        if (blob.etag !== normalized) {
+          return blobErr(c, 412, "precondition_failed", "Precondition failed: ETag mismatch.");
+        }
+      }
+      vs.blobs.delete(blob.id);
+    }
+
+    return c.json(null);
+  });
+
+  // ---------- Multipart uploads (not supported) ----------
+
+  const handleMpu = (c: Context): Response =>
+    blobErr(c, 400, "bad_request", "Multipart uploads are not supported by the emulator yet");
+  app.post("/api/blob/mpu", handleMpu);
+  app.put("/api/blob/mpu", handleMpu);
+
+  // ---------- Public content serving ----------
+  // Blob URLs point here. Public access, no authentication.
+
+  app.get("/blob/:storeId/:pathname{.+}", (c) => {
+    const storeId = c.req.param("storeId");
+    const pathname = c.req.param("pathname");
+    const blob = findBlob(vs, storeId, pathname);
+    if (!blob) {
+      return blobErr(c, 404, "not_found", "The requested blob does not exist");
+    }
+
+    const headers: Record<string, string> = {
+      etag: blob.etag,
+      "cache-control": blob.cacheControl,
+    };
+
+    if (c.req.header("if-none-match") === blob.etag) {
+      return c.body(null, 304, headers);
+    }
+
+    headers["content-type"] = blob.contentType;
+    if (c.req.query("download") === "1") {
+      headers["content-disposition"] = blob.contentDisposition;
+    }
+    return c.body(Buffer.from(blob.dataBase64, "base64"), 200, headers);
+  });
+}

--- a/packages/@emulators/vercel/src/store.ts
+++ b/packages/@emulators/vercel/src/store.ts
@@ -15,6 +15,7 @@ import type {
   VercelProtectionBypass,
   VercelIntegration,
   VercelApiKey,
+  VercelBlob,
 } from "./entities.js";
 
 export interface VercelStore {
@@ -33,6 +34,7 @@ export interface VercelStore {
   protectionBypasses: Collection<VercelProtectionBypass>;
   apiKeys: Collection<VercelApiKey>;
   integrations: Collection<VercelIntegration>;
+  blobs: Collection<VercelBlob>;
 }
 
 export function getVercelStore(store: Store): VercelStore {
@@ -55,5 +57,6 @@ export function getVercelStore(store: Store): VercelStore {
     protectionBypasses: store.collection<VercelProtectionBypass>("vercel.protection_bypasses", ["projectId"]),
     apiKeys: store.collection<VercelApiKey>("vercel.api_keys", ["uid", "teamId", "userId"]),
     integrations: store.collection<VercelIntegration>("vercel.integrations", ["client_id"]),
+    blobs: store.collection<VercelBlob>("vercel.blobs", ["pathname", "storeId"]),
   };
 }

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -34,7 +34,7 @@ export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
 export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   vercel: {
     label: "Vercel REST API emulator",
-    endpoints: "projects, deployments, domains, env vars, users, teams, file uploads, protection bypass",
+    endpoints: "projects, deployments, domains, env vars, users, teams, file uploads, protection bypass, blob storage",
     async load() {
       const mod = await import("@emulators/vercel");
       return { plugin: mod.vercelPlugin, seedFromConfig: mod.seedFromConfig };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@vercel/blob':
+        specifier: ^2.4.0
+        version: 2.4.0
       tsup:
         specifier: ^8
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
@@ -3198,6 +3201,10 @@ packages:
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
+  '@vercel/blob@2.4.0':
+    resolution: {integrity: sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==}
+    engines: {node: '>=20.0.0'}
+
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
@@ -3322,6 +3329,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -4343,6 +4353,10 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
@@ -4394,6 +4408,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -5750,6 +5767,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -8814,6 +8835,14 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  '@vercel/blob@2.4.0':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.26.0
+
   '@vercel/oidc@3.1.0': {}
 
   '@vitest/expect@4.1.3':
@@ -8974,6 +9003,10 @@ snapshots:
   astring@1.9.0: {}
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   asynckit@0.4.0: {}
 
@@ -10272,6 +10305,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.7.4
@@ -10320,6 +10355,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -12212,6 +12249,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@6.26.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel
-description: Emulated Vercel REST API for local development and testing. Use when the user needs to interact with Vercel API endpoints locally, test Vercel integrations, emulate projects/deployments/domains, set up Vercel OAuth flows, manage environment variables, create API keys, configure protection bypass, or test without hitting the real Vercel API. Triggers include "Vercel API", "emulate Vercel", "mock Vercel", "test Vercel OAuth", "Vercel integration", "local Vercel", or any task requiring a local Vercel API.
+description: Emulated Vercel REST API for local development and testing. Use when the user needs to interact with Vercel API endpoints locally, test Vercel integrations, emulate projects/deployments/domains, set up Vercel OAuth flows, manage environment variables, create API keys, configure protection bypass, emulate Vercel Blob storage, or test without hitting the real Vercel API. Triggers include "Vercel API", "emulate Vercel", "mock Vercel", "test Vercel OAuth", "Vercel integration", "Vercel Blob", "local Vercel", or any task requiring a local Vercel API.
 allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
 ---
 
@@ -342,6 +342,58 @@ curl -X DELETE http://localhost:4000/v9/projects/my-app/env/env_abc123 \
 ```
 
 Env var types: `system`, `encrypted`, `plain`, `secret`, `sensitive`.
+
+### Blob
+
+Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`). Point the SDK at the emulator with two environment variables:
+
+```bash
+VERCEL_BLOB_API_URL=http://localhost:4000/api/blob
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_mystore_secret
+```
+
+Any token of the form `vercel_blob_rw_<storeId>_<secret>` is accepted; the store id is parsed from the token.
+
+```typescript
+import { put, head, list, del } from '@vercel/blob'
+
+const blob = await put('avatars/user.png', data, { access: 'public' })
+// blob.url serves the bytes from the emulator
+await head(blob.url)
+await list({ prefix: 'avatars/' })
+await del(blob.url)
+```
+
+Direct HTTP:
+
+```bash
+BLOB_TOKEN="vercel_blob_rw_mystore_secret"
+
+# Upload (honors x-add-random-suffix, x-allow-overwrite, x-content-type,
+#   x-cache-control-max-age, x-if-match headers)
+curl -X PUT "http://localhost:4000/api/blob?pathname=docs/readme.txt" \
+  -H "Authorization: Bearer $BLOB_TOKEN" \
+  --data-binary @readme.txt
+
+# Metadata (head)
+curl "http://localhost:4000/api/blob?url=docs/readme.txt" \
+  -H "Authorization: Bearer $BLOB_TOKEN"
+
+# List (prefix, limit, cursor, mode=folded)
+curl "http://localhost:4000/api/blob?prefix=docs/" \
+  -H "Authorization: Bearer $BLOB_TOKEN"
+
+# Delete
+curl -X POST http://localhost:4000/api/blob/delete \
+  -H "Authorization: Bearer $BLOB_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"urls": ["docs/readme.txt"]}'
+
+# Serve content (public, no auth; ?download=1 forces attachment)
+curl http://localhost:4000/blob/mystore/docs/readme.txt
+```
+
+Multipart uploads and client (browser) uploads are not supported yet.
 
 ### API Keys
 


### PR DESCRIPTION
- Add stateful Vercel Blob emulation for put, head, list, delete, and public object serving
- Cover Blob SDK behavior with @vercel/blob tests and register blob storage in service metadata
- Document Blob configuration and make seeded Vercel user IDs stable