### PR TITLE
Add Linear emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,8 @@ Stateful Linear GraphQL API emulation with seeded organizations, users, teams, w
 - `POST /oauth/token` - authorization code, refresh token, and client credentials grants
 - `POST /oauth/revoke` - revoke access or refresh tokens
 
+OAuth app `actor` config is authoritative. Apps configured with `actor: user` use authorization code flows. Apps configured with `actor: app` use the app install flow and can request client credentials tokens.
+
 ### Webhooks And Inspector
 
 - `webhookCreate` / `webhookDelete` manage local webhook subscriptions

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ All services start with sensible defaults. No config file needed:
 - **Slack** on `http://localhost:4003`
 - **Apple** on `http://localhost:4004`
 - **Microsoft** on `http://localhost:4005`
-- **AWS** on `http://localhost:4006`
+- **Okta** on `http://localhost:4006`
+- **AWS** on `http://localhost:4007`
+- **Resend** on `http://localhost:4008`
+- **Stripe** on `http://localhost:4009`
+- **MongoDB Atlas** on `http://localhost:4010`
+- **Clerk** on `http://localhost:4011`
+- **Linear** on `http://localhost:4012`
 
 ## CLI
 
@@ -141,7 +147,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, or `'linear'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -332,6 +338,51 @@ slack:
         - team:read
   strict_scopes: false
 
+linear:
+  organization:
+    name: Acme
+    url_key: acme
+  users:
+    - email: admin@example.com
+      name: Admin User
+      admin: true
+    - email: dev@example.com
+      name: Developer
+  teams:
+    - key: ENG
+      name: Engineering
+      states:
+        - name: Backlog
+          type: backlog
+        - name: Todo
+          type: unstarted
+        - name: In Progress
+          type: started
+        - name: Done
+          type: completed
+  labels:
+    - name: Bug
+      color: "#d92d20"
+      team: ENG
+  issues:
+    - team: ENG
+      title: Fix local checkout test
+      state: Todo
+      assignee: dev@example.com
+      labels: [Bug]
+  oauth_apps:
+    - client_id: lin_example_client_id
+      client_secret: example_client_secret
+      name: My Linear App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/linear
+      scopes: [read, write, issues:create, comments:create]
+  tokens:
+    - token: lin_test_admin
+      user: admin@example.com
+      scopes: [read, write, issues:create, comments:create, admin]
+  strict_scopes: false
+
 apple:
   users:
     - email: testuser@icloud.com
@@ -445,6 +496,20 @@ slack:
       name: "My Slack App"
       redirect_uris:
         - "http://localhost:3000/api/auth/callback/slack"
+```
+
+### Linear OAuth Apps
+
+```yaml
+linear:
+  oauth_apps:
+    - client_id: "lin_example_client_id"
+      client_secret: "example_client_secret"
+      name: "My Linear App"
+      redirect_uris:
+        - "http://localhost:3000/api/auth/callback/linear"
+      scopes: [read, write, issues:create, comments:create]
+      actor: user
 ```
 
 ### Apple OAuth Clients
@@ -771,6 +836,33 @@ Slack scope checks are relaxed by default so local tests can use simple bearer t
 
 Current Slack limits: Slack Connect, Enterprise Grid admin APIs, Audit Logs API, SCIM, Legal Holds, Socket Mode, slash command and interaction simulation, user groups, reminders, stars, calls, canvases, lists, functions, workflows, chat streaming, legacy `files.upload`, exact rate limiting, and paid-plan behavior are not implemented.
 
+## Linear API
+
+Stateful Linear GraphQL API emulation with seeded organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and basic agent sessions. GraphQL reads and writes mutate in-memory state and use Relay-style connections with opaque cursors. OAuth supports authorization code, PKCE, refresh token, revoke, client credentials, and `actor=app` tokens for local app-actor tests. Supported writes dispatch Linear-shaped webhook payloads with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers when webhooks are configured.
+
+### GraphQL
+
+- `POST /graphql` - GraphQL endpoint for queries and mutations
+- `GET /graphql` - query-string GraphQL endpoint for tooling
+- Queries: `viewer`, `organization`, `users`, `user`, `teams`, `team`, `workflowStates`, `workflowState`, `issues`, `issue`, `comments`, `comment`, `issueLabels`, `issueLabel`, `projects`, `project`, `cycles`, `cycle`, `webhooks`, `webhook`, `agentSessions`, `agentSession`
+- Mutations: `issueCreate`, `issueUpdate`, `issueDelete`, `issueArchive`, `issueUnarchive`, `commentCreate`, `commentUpdate`, `commentDelete`, `issueLabelCreate`, `issueLabelUpdate`, `issueLabelDelete`, `issueAddLabel`, `issueRemoveLabel`, `webhookCreate`, `webhookDelete`, `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`, `agentActivityCreate`
+
+### OAuth
+
+- `GET /oauth/authorize` - authorization endpoint with local user picker
+- `POST /oauth/authorize/callback` - local user picker callback that creates an authorization code
+- `POST /oauth/token` - authorization code, refresh token, and client credentials grants
+- `POST /oauth/revoke` - revoke access or refresh tokens
+
+### Webhooks And Inspector
+
+- `webhookCreate` / `webhookDelete` manage local webhook subscriptions
+- `GET /` - tabbed local inspector for issues, teams, users, projects, agents, auth records, webhook subscriptions, and deliveries
+
+Linear scope checks are relaxed by default so local tests can use simple bearer tokens or the seeded `lin_test_admin` token. Set `linear.strict_scopes: true` in seed config to require `read`, `write`, `issues:create`, `comments:create`, or `admin` on supported GraphQL operations.
+
+Current Linear limits: full schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and production agent behavior are not implemented. Agent support is a focused local-test subset.
+
 ## Apple Sign In
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
@@ -954,6 +1046,7 @@ packages/
     github/         # GitHub API service
     google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, Drive
     slack/          # Slack Web API, OAuth v2, incoming webhooks
+    linear/         # Linear GraphQL API, OAuth, webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
@@ -974,6 +1067,8 @@ Tokens are configured in the seed config and map to users. Pass them as `Authori
 **Google**: Standard OAuth 2.0 authorization code flow. Configure clients in the seed config.
 
 **Slack**: All Web API endpoints require `Authorization: Bearer <token>`. Seeded OAuth apps create local installation records, and OAuth v2 flow with user picker UI creates scoped bot tokens. Optional strict scope mode returns `missing_scope` when a token lacks a required method scope.
+
+**Linear**: GraphQL accepts `Authorization: Bearer <token>` or a bare personal API key value. Seeded Linear tokens map to users or app actors, OAuth apps support local authorization code and client credentials flows, and optional strict scope mode checks supported GraphQL operations.
 
 **Apple**: OIDC authorization code flow with RS256 ID tokens. On first auth per user/client pair, a `user` JSON blob is included.
 

--- a/apps/web/app/api/docs-chat/route.ts
+++ b/apps/web/app/api/docs-chat/route.ts
@@ -12,7 +12,7 @@ export const maxDuration = 60;
 
 const DEFAULT_MODEL = "anthropic/claude-haiku-4.5";
 
-const SYSTEM_PROMPT = `You are a helpful documentation assistant for emulate, a local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, MongoDB Atlas, Resend, and Stripe APIs used in CI and no-network sandboxes.
+const SYSTEM_PROMPT = `You are a helpful documentation assistant for emulate, a local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, and Linear APIs used in CI and no-network sandboxes.
 
 emulate provides fully stateful, production-fidelity API emulation, not mocks. The CLI is installed as the "emulate" npm package and run via "npx emulate". It also supports a programmatic API via createEmulator and a Next.js adapter (@emulators/adapter-next) for embedding emulators in your app.
 

--- a/apps/web/app/docs/architecture/page.mdx
+++ b/apps/web/app/docs/architecture/page.mdx
@@ -10,6 +10,7 @@ packages/
     github/         # GitHub API service
     google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, Drive
     slack/          # Slack Web API, OAuth v2, incoming webhooks
+    linear/         # Linear GraphQL API, OAuth, webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
@@ -17,6 +18,7 @@ packages/
     mongoatlas/     # MongoDB Atlas Admin API + Data API
     resend/         # Resend email API
     stripe/         # Stripe billing and payments API
+    clerk/          # Clerk Backend API and OAuth
 apps/
   web/              # Documentation site (Next.js)
 ```

--- a/apps/web/app/docs/linear/layout.tsx
+++ b/apps/web/app/docs/linear/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("linear");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/linear/page.mdx
+++ b/apps/web/app/docs/linear/page.mdx
@@ -64,7 +64,7 @@ Scope checks are relaxed by default. Set `linear.strict_scopes: true` to require
 - `POST /oauth/token` - authorization code, refresh token, and client credentials grants
 - `POST /oauth/revoke` - revoke access or refresh tokens
 
-OAuth apps can use `actor: user` or `actor: app`. App actor support is intended for local agent and service-account tests.
+OAuth apps can use `actor: user` or `actor: app`. The configured actor is authoritative. User actor apps use authorization code flows. App actor apps use the app install flow and can request client credentials tokens.
 
 ## Seed Config
 

--- a/apps/web/app/docs/linear/page.mdx
+++ b/apps/web/app/docs/linear/page.mdx
@@ -1,0 +1,117 @@
+# Linear API
+
+Stateful Linear GraphQL API emulation with organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and basic agent sessions.
+
+## Start
+
+```bash
+npx emulate --service linear
+```
+
+When Linear is the only enabled service, it starts on `http://localhost:4000`. When all services are started, it uses `http://localhost:4012`.
+
+## URL Mapping
+
+| Real Linear URL | Emulator URL |
+|-----------------|--------------|
+| `https://api.linear.app/graphql` | `$LINEAR_EMULATOR_URL/graphql` |
+| `https://linear.app/oauth/authorize` | `$LINEAR_EMULATOR_URL/oauth/authorize` |
+| `https://api.linear.app/oauth/token` | `$LINEAR_EMULATOR_URL/oauth/token` |
+| `https://api.linear.app/oauth/revoke` | `$LINEAR_EMULATOR_URL/oauth/revoke` |
+
+## GraphQL
+
+- `POST /graphql` - GraphQL endpoint for queries and mutations
+- `GET /graphql` - query-string GraphQL endpoint for tooling
+
+Supported queries:
+
+- `viewer`
+- `organization`
+- `users`, `user`
+- `teams`, `team`
+- `workflowStates`, `workflowState`
+- `issues`, `issue`
+- `comments`, `comment`
+- `issueLabels`, `issueLabel`
+- `projects`, `project`
+- `cycles`, `cycle`
+- `webhooks`, `webhook`
+- `agentSessions`, `agentSession`
+
+Supported mutations:
+
+- `issueCreate`, `issueUpdate`, `issueDelete`, `issueArchive`, `issueUnarchive`
+- `commentCreate`, `commentUpdate`, `commentDelete`
+- `issueLabelCreate`, `issueLabelUpdate`, `issueLabelDelete`
+- `issueAddLabel`, `issueRemoveLabel`
+- `webhookCreate`, `webhookDelete`
+- `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`
+- `agentActivityCreate`
+
+Connections use Relay-style cursors with `nodes`, `edges`, and `pageInfo`.
+
+## Auth
+
+GraphQL accepts `Authorization: Bearer <token>` or a bare personal API key value. The default seeded token is `lin_test_admin`.
+
+Scope checks are relaxed by default. Set `linear.strict_scopes: true` to require supported operation scopes such as `read`, `write`, `issues:create`, `comments:create`, and `admin`.
+
+## OAuth
+
+- `GET /oauth/authorize` - authorization endpoint with local user picker
+- `POST /oauth/authorize/callback` - local callback used by the user picker
+- `POST /oauth/token` - authorization code, refresh token, and client credentials grants
+- `POST /oauth/revoke` - revoke access or refresh tokens
+
+OAuth apps can use `actor: user` or `actor: app`. App actor support is intended for local agent and service-account tests.
+
+## Seed Config
+
+```yaml
+linear:
+  organization:
+    name: Acme
+    url_key: acme
+  users:
+    - email: admin@example.com
+      name: Admin User
+      admin: true
+    - email: dev@example.com
+      name: Developer
+  teams:
+    - key: ENG
+      name: Engineering
+  issues:
+    - team: ENG
+      title: Fix local checkout test
+      state: Todo
+      assignee: dev@example.com
+  oauth_apps:
+    - client_id: lin_example_client_id
+      client_secret: example_client_secret
+      name: My Linear App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/linear
+      scopes: [read, write, issues:create, comments:create]
+  tokens:
+    - token: lin_test_admin
+      user: admin@example.com
+      scopes: [read, write, issues:create, comments:create, admin]
+```
+
+## Webhooks
+
+Create local webhook subscriptions through `webhookCreate` or seed config. Supported writes dispatch Linear-shaped payloads with these headers:
+
+- `Linear-Delivery`
+- `Linear-Event`
+- `Linear-Signature`
+
+## Inspector
+
+- `GET /` - tabbed inspector for issues, teams, users, projects, agent sessions, OAuth apps, tokens, webhook subscriptions, and webhook deliveries
+
+## Current Limits
+
+Full Linear schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and full production agent behavior are not implemented.

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -1,6 +1,6 @@
 # Getting Started
 
-Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Okta, MongoDB Atlas, Resend, and Stripe APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
+Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, and Linear APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
 
 ## Quick Start
 
@@ -16,11 +16,13 @@ All services start with sensible defaults. No config file needed:
 - **Slack** on `http://localhost:4003`
 - **Apple** on `http://localhost:4004`
 - **Microsoft** on `http://localhost:4005`
-- **AWS** on `http://localhost:4006`
-- **Okta** on `http://localhost:4007`
-- **MongoDB Atlas** on `http://localhost:4008`
-- **Resend** on `http://localhost:4009`
-- **Stripe** on `http://localhost:4010`
+- **Okta** on `http://localhost:4006`
+- **AWS** on `http://localhost:4007`
+- **Resend** on `http://localhost:4008`
+- **Stripe** on `http://localhost:4009`
+- **MongoDB Atlas** on `http://localhost:4010`
+- **Clerk** on `http://localhost:4011`
+- **Linear** on `http://localhost:4012`
 
 ## CLI
 

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -59,7 +59,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>service</code></td>
       <td><em>(required)</em></td>
-      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'aws'</code>, <code>'okta'</code>, <code>'mongoatlas'</code>, <code>'resend'</code>, or <code>'stripe'</code></td>
+      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, <code>'clerk'</code>, or <code>'linear'</code></td>
     </tr>
     <tr>
       <td><code>port</code></td>
@@ -109,7 +109,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 Each emulator is published as its own `@emulators/*` package. Install only the ones you need:
 
 ```bash
-npm install @emulators/github @emulators/google @emulators/stripe
+npm install @emulators/github @emulators/google @emulators/linear
 ```
 
 ### Available packages
@@ -126,6 +126,7 @@ npm install @emulators/github @emulators/google @emulators/stripe
     <tr><td><code>@emulators/github</code></td><td>GitHub API</td></tr>
     <tr><td><code>@emulators/google</code></td><td>Google OAuth, Gmail, Calendar, Drive</td></tr>
     <tr><td><code>@emulators/slack</code></td><td>Slack Web API, OAuth v2, webhooks</td></tr>
+    <tr><td><code>@emulators/linear</code></td><td>Linear GraphQL API, OAuth, webhooks</td></tr>
     <tr><td><code>@emulators/apple</code></td><td>Apple Sign In / OIDC</td></tr>
     <tr><td><code>@emulators/microsoft</code></td><td>Microsoft Entra ID, Graph API</td></tr>
     <tr><td><code>@emulators/aws</code></td><td>AWS S3, SQS, IAM, STS</td></tr>
@@ -133,6 +134,7 @@ npm install @emulators/github @emulators/google @emulators/stripe
     <tr><td><code>@emulators/mongoatlas</code></td><td>MongoDB Atlas Admin API + Data API</td></tr>
     <tr><td><code>@emulators/resend</code></td><td>Resend email API</td></tr>
     <tr><td><code>@emulators/stripe</code></td><td>Stripe billing and payments API</td></tr>
+    <tr><td><code>@emulators/clerk</code></td><td>Clerk Backend API and OAuth</td></tr>
     <tr><td><code>@emulators/core</code></td><td>Shared store, middleware, and utilities</td></tr>
     <tr><td><code>@emulators/adapter-next</code></td><td>Next.js App Router integration</td></tr>
   </tbody>

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -26,6 +26,7 @@ const sections: NavSection[] = [
       { href: "/docs/github", label: "GitHub" },
       { href: "/docs/google", label: "Google" },
       { href: "/docs/slack", label: "Slack" },
+      { href: "/docs/linear", label: "Linear" },
       { href: "/docs/apple", label: "Apple" },
       { href: "/docs/microsoft", label: "Microsoft Entra ID" },
       { href: "/docs/aws", label: "AWS" },

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -24,6 +24,7 @@ const sections: NavSection[] = [
       { href: "/docs/github", label: "GitHub" },
       { href: "/docs/google", label: "Google" },
       { href: "/docs/slack", label: "Slack" },
+      { href: "/docs/linear", label: "Linear" },
       { href: "/docs/apple", label: "Apple" },
       { href: "/docs/microsoft", label: "Microsoft Entra ID" },
       { href: "/docs/aws", label: "AWS" },

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -12,6 +12,7 @@ export const allDocsPages: NavItem[] = [
   { name: "GitHub API", href: "/docs/github" },
   { name: "Google API", href: "/docs/google" },
   { name: "Slack API", href: "/docs/slack" },
+  { name: "Linear API", href: "/docs/linear" },
   { name: "Apple Sign In", href: "/docs/apple" },
   { name: "Microsoft Entra ID", href: "/docs/microsoft" },
   { name: "AWS", href: "/docs/aws" },

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -7,6 +7,7 @@ export const PAGE_TITLES: Record<string, string> = {
   github: "GitHub API",
   google: "Google API",
   slack: "Slack API",
+  linear: "Linear API",
   apple: "Apple Sign In",
   microsoft: "Microsoft Entra ID",
   aws: "AWS",

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -10,6 +10,7 @@ const oldDocsSlugs = [
   "github",
   "google",
   "slack",
+  "linear",
   "apple",
   "microsoft",
   "aws",

--- a/packages/@emulators/linear/README.md
+++ b/packages/@emulators/linear/README.md
@@ -26,4 +26,6 @@ npx emulate --service linear
 - Linear-shaped webhook delivery with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers.
 - Local inspector at `/`.
 
+OAuth app `actor` config is authoritative. Apps configured with `actor: user` use authorization code flows. Apps configured with `actor: app` use the app install flow and can request client credentials tokens.
+
 This is not a complete Linear clone. Unsupported GraphQL fields return GraphQL errors.

--- a/packages/@emulators/linear/README.md
+++ b/packages/@emulators/linear/README.md
@@ -1,0 +1,29 @@
+# @emulators/linear
+
+Stateful Linear GraphQL API emulator for local development and CI.
+
+Part of [emulate](https://github.com/vercel-labs/emulate), local drop-in replacement services for CI and no-network sandboxes.
+
+## Install
+
+```sh
+npm install @emulators/linear
+```
+
+Most users should run it through the main CLI:
+
+```sh
+npx emulate --service linear
+```
+
+## Supported Surface
+
+- `POST /graphql` for a focused Linear GraphQL subset.
+- Queries for viewer, organization, users, teams, workflow states, issues, comments, labels, projects, cycles, webhooks, and agent sessions.
+- Mutations for issues, comments, labels, webhooks, and basic agent sessions and activities.
+- OAuth authorize, token, refresh, revoke, PKCE, client credentials, and app actor tokens.
+- Personal API key and OAuth bearer token auth.
+- Linear-shaped webhook delivery with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers.
+- Local inspector at `/`.
+
+This is not a complete Linear clone. Unsupported GraphQL fields return GraphQL errors.

--- a/packages/@emulators/linear/package.json
+++ b/packages/@emulators/linear/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@emulators/linear",
+  "version": "0.6.1",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/linear"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*",
+    "graphql": "^17.0.0"
+  },
+  "devDependencies": {
+    "@linear/sdk": "^86.0.0",
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -160,6 +160,28 @@ describe("Linear emulator", () => {
     expect(tokenBody.access_token).toMatch(/^lin_/);
     expect(tokenBody.refresh_token).toMatch(/^lin_refresh_/);
     expect(tokenBody.scope).toBe("read write");
+
+    const accessGraphql = await app.request(`${base}/graphql`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tokenBody.access_token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query: "{ viewer { email } }" }),
+    });
+    expect(accessGraphql.status).toBe(200);
+
+    const refreshGraphql = await app.request(`${base}/graphql`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tokenBody.refresh_token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query: "{ viewer { email } }" }),
+    });
+    expect(refreshGraphql.status).toBe(401);
+    const refreshBody = (await refreshGraphql.json()) as { message: string };
+    expect(refreshBody.message).toContain("refresh tokens");
   });
 
   it("stores webhook deliveries for issue mutations", async () => {

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -1,0 +1,323 @@
+import { createHash } from "node:crypto";
+import { LinearClient } from "@linear/sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono, Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
+import { getLinearStore, linearPlugin, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4300";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  const app = new Hono();
+  app.use("*", authMiddleware(tokenMap));
+  linearPlugin.register(app as any, store, webhooks, base, tokenMap);
+  linearPlugin.seed?.(store, base);
+  return { app, store, tokenMap };
+}
+
+async function gql(app: Hono, query: string, variables?: Record<string, unknown>) {
+  return app.request(`${base}/graphql`, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer lin_test_admin",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+}
+
+describe("Linear emulator", () => {
+  let app: Hono;
+  let store: Store;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    const setup = createTestApp();
+    app = setup.app;
+    store = setup.store;
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("serves viewer, teams, and seeded issues through GraphQL", async () => {
+    const res = await gql(
+      app,
+      `query {
+        viewer { email admin }
+        teams { nodes { key name states { nodes { name type } } } }
+        issues { nodes { identifier title team { key } state { name } comments { nodes { body } } } }
+      }`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.errors).toBeUndefined();
+    expect(body.data.viewer.email).toBe("admin@linear.local");
+    expect(body.data.teams.nodes[0].key).toBe("ENG");
+    expect(body.data.issues.nodes[0].identifier).toBe("ENG-1");
+    expect(body.data.issues.nodes[0].comments.nodes[0].body).toContain("seeded");
+  });
+
+  it("creates issues and comments that can be read back", async () => {
+    const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
+    const state = getLinearStore(store).workflowStates.findOneBy("name", "Todo")!;
+
+    const createIssue = await gql(
+      app,
+      `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue { id identifier title state { name } }
+        }
+      }`,
+      {
+        input: {
+          teamId: team.linear_id,
+          stateId: state.linear_id,
+          title: "Write Linear tests",
+          description: "Cover the local GraphQL flow.",
+          priority: 2,
+        },
+      },
+    );
+    expect(createIssue.status).toBe(200);
+    const issueBody = (await createIssue.json()) as any;
+    expect(issueBody.errors).toBeUndefined();
+    expect(issueBody.data.issueCreate.issue.identifier).toBe("ENG-2");
+
+    const issueId = issueBody.data.issueCreate.issue.id;
+    const createComment = await gql(
+      app,
+      `mutation CreateComment($input: CommentCreateInput!) {
+        commentCreate(input: $input) {
+          success
+          comment { id body issue { identifier } }
+        }
+      }`,
+      { input: { issueId, body: "Done locally." } },
+    );
+    const commentBody = (await createComment.json()) as any;
+    expect(commentBody.errors).toBeUndefined();
+    expect(commentBody.data.commentCreate.comment.issue.identifier).toBe("ENG-2");
+
+    const readBack = await gql(app, `query { issue(id: "${issueId}") { title comments { nodes { body } } } }`);
+    const readBody = (await readBack.json()) as any;
+    expect(readBody.data.issue.comments.nodes[0].body).toBe("Done locally.");
+  });
+
+  it("supports OAuth authorization code exchange with PKCE", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [
+        {
+          client_id: "pkce-client",
+          client_secret: "pkce-secret",
+          name: "PKCE App",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read", "write"],
+        },
+      ],
+    });
+    const user = getLinearStore(store).users.findOneBy("email", "admin@linear.local")!;
+    const verifier = "linear-pkce-verifier";
+    const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+    const codeRes = await app.request(`${base}/oauth/authorize/callback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        user_ref: user.linear_id,
+        actor: "user",
+        redirect_uri: "http://localhost:3000/callback",
+        scope: "read write",
+        state: "state-1",
+        client_id: "pkce-client",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }).toString(),
+    });
+    expect(codeRes.status).toBe(302);
+    const location = new URL(codeRes.headers.get("location") ?? "");
+    expect(location.searchParams.get("state")).toBe("state-1");
+
+    const tokenRes = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: location.searchParams.get("code") ?? "",
+        client_id: "pkce-client",
+        client_secret: "pkce-secret",
+        redirect_uri: "http://localhost:3000/callback",
+        code_verifier: verifier,
+      }).toString(),
+    });
+    expect(tokenRes.status).toBe(200);
+    const tokenBody = (await tokenRes.json()) as any;
+    expect(tokenBody.access_token).toMatch(/^lin_/);
+    expect(tokenBody.refresh_token).toMatch(/^lin_refresh_/);
+    expect(tokenBody.scope).toBe("read write");
+  });
+
+  it("stores webhook deliveries for issue mutations", async () => {
+    seedFromConfig(store, base, {
+      webhooks: [
+        {
+          label: "Local receiver",
+          url: "http://127.0.0.1:1/linear",
+          resource_types: ["Issue"],
+          all_public_teams: true,
+          secret: "local-secret",
+        },
+      ],
+    });
+    const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
+
+    const res = await gql(
+      app,
+      `mutation($input: IssueCreateInput!) {
+        issueCreate(input: $input) { success issue { identifier } }
+      }`,
+      { input: { teamId: team.linear_id, title: "Trigger webhook" } },
+    );
+    expect(res.status).toBe(200);
+    const deliveries = getLinearStore(store).webhookDeliveries.all();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].event).toBe("Issue");
+    expect(deliveries[0].action).toBe("create");
+    expect(deliveries[0].headers["Linear-Signature"]).toBeDefined();
+  });
+
+  it("renders the shared inspector", async () => {
+    const res = await app.request(`${base}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Linear Inspector");
+    expect(html).toContain("ENG-1");
+  });
+
+  it("works through the official Linear SDK endpoint override", async () => {
+    seedFromConfig(store, base, {
+      tokens: [
+        {
+          token: "lin_oauth_sdk",
+          type: "oauth_access",
+          user: "admin@linear.local",
+          scopes: ["read", "write", "issues:create", "comments:create"],
+        },
+      ],
+    });
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.startsWith(`${base}/graphql`)) {
+        return app.request(url, init);
+      }
+      return originalFetch(input, init);
+    };
+
+    const client = new LinearClient({
+      apiKey: "lin_test_admin",
+      apiUrl: `${base}/graphql`,
+    });
+
+    const viewer = await client.viewer;
+    expect(viewer.email).toBe("admin@linear.local");
+    expect(viewer.isMe).toBe(true);
+
+    const oauthClient = new LinearClient({
+      accessToken: "lin_oauth_sdk",
+      apiUrl: `${base}/graphql`,
+    });
+    const oauthViewer = await oauthClient.viewer;
+    expect(oauthViewer.email).toBe("admin@linear.local");
+
+    const teams = await client.client.rawRequest<
+      { teams: { nodes: Array<{ id: string; key: string; name: string }> } },
+      Record<string, never>
+    >(`query { teams { nodes { id key name } } }`);
+    expect(teams.data?.teams.nodes[0].key).toBe("ENG");
+
+    const teamId = teams.data!.teams.nodes[0].id;
+    const createIssue = await client.client.rawRequest<
+      { issueCreate: { success: boolean; issue: { id: string; identifier: string; title: string } } },
+      { input: { teamId: string; title: string } }
+    >(
+      `mutation($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue { id identifier title }
+        }
+      }`,
+      { input: { teamId, title: "Created from SDK" } },
+    );
+    expect(createIssue.data?.issueCreate.issue.identifier).toBe("ENG-2");
+
+    const issueId = createIssue.data!.issueCreate.issue.id;
+    const updateIssue = await client.client.rawRequest<
+      { issueUpdate: { success: boolean; issue: { id: string; title: string; priority: number } } },
+      { input: { id: string; title: string; priority: number } }
+    >(
+      `mutation($input: IssueUpdateInput!) {
+        issueUpdate(input: $input) {
+          success
+          issue { id title priority }
+        }
+      }`,
+      { input: { id: issueId, title: "Updated from SDK", priority: 1 } },
+    );
+    expect(updateIssue.data?.issueUpdate.issue.title).toBe("Updated from SDK");
+    expect(updateIssue.data?.issueUpdate.issue.priority).toBe(1);
+
+    const firstIssuePage = await client.client.rawRequest<
+      {
+        issues: {
+          nodes: Array<{ id: string; identifier: string }>;
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        };
+      },
+      { first: number }
+    >(
+      `query($first: Int) {
+        issues(first: $first) {
+          nodes { id identifier }
+          pageInfo { hasNextPage endCursor }
+        }
+      }`,
+      { first: 1 },
+    );
+    expect(firstIssuePage.data?.issues.nodes[0].identifier).toBe("ENG-1");
+    expect(firstIssuePage.data?.issues.pageInfo.hasNextPage).toBe(true);
+
+    const nextIssuePage = await client.client.rawRequest<
+      { issues: { nodes: Array<{ id: string; identifier: string }>; pageInfo: { hasNextPage: boolean } } },
+      { first: number; after: string }
+    >(
+      `query($first: Int, $after: String) {
+        issues(first: $first, after: $after) {
+          nodes { id identifier }
+          pageInfo { hasNextPage }
+        }
+      }`,
+      { first: 1, after: firstIssuePage.data!.issues.pageInfo.endCursor! },
+    );
+    expect(nextIssuePage.data?.issues.nodes[0].identifier).toBe("ENG-2");
+    expect(nextIssuePage.data?.issues.pageInfo.hasNextPage).toBe(false);
+
+    const createComment = await client.client.rawRequest<
+      { commentCreate: { success: boolean; comment: { id: string; body: string; issue: { identifier: string } } } },
+      { input: { issueId: string; body: string } }
+    >(
+      `mutation($input: CommentCreateInput!) {
+        commentCreate(input: $input) {
+          success
+          comment { id body issue { identifier } }
+        }
+      }`,
+      { input: { issueId, body: "Commented from SDK" } },
+    );
+    expect(createComment.data?.commentCreate.comment.issue.identifier).toBe("ENG-2");
+  });
+});

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -163,6 +163,97 @@ describe("Linear emulator", () => {
     expect(linearStore.agentActivities.findBy("session_id", sessionId)).toEqual([]);
   });
 
+  it("deletes comment-scoped agent sessions with the comment", async () => {
+    const issue = getLinearStore(store).issues.findOneBy("identifier", "ENG-1")!;
+    const commentRes = await gql(
+      app,
+      `mutation CreateComment($input: CommentCreateInput!) {
+        commentCreate(input: $input) { comment { id } }
+      }`,
+      { input: { issueId: issue.linear_id, body: "Start an agent session." } },
+    );
+    const commentBody = (await commentRes.json()) as any;
+    const commentId = commentBody.data.commentCreate.comment.id;
+
+    const sessionRes = await gql(
+      app,
+      `mutation CreateSession($input: AgentSessionCreateOnCommentInput!) {
+        agentSessionCreateOnComment(input: $input) { agentSession { id } }
+      }`,
+      { input: { commentId, plan: "Handle the comment." } },
+    );
+    const sessionBody = (await sessionRes.json()) as any;
+    const sessionId = sessionBody.data.agentSessionCreateOnComment.agentSession.id;
+
+    await gql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) { agentActivity { id } }
+      }`,
+      { input: { sessionId, type: "response", body: "Done." } },
+    );
+
+    const deleteComment = await gql(
+      app,
+      `mutation DeleteComment($id: String!) {
+        commentDelete(id: $id) { success }
+      }`,
+      { id: commentId },
+    );
+    expect(deleteComment.status).toBe(200);
+    const deleteBody = (await deleteComment.json()) as any;
+    expect(deleteBody.errors).toBeUndefined();
+
+    const linearStore = getLinearStore(store);
+    expect(linearStore.agentSessions.findBy("comment_id", commentId)).toEqual([]);
+    expect(linearStore.agentActivities.findBy("session_id", sessionId)).toEqual([]);
+
+    const readSessions = await gql(app, `{ agentSessions { nodes { id comment { id } } } }`);
+    const readBody = (await readSessions.json()) as any;
+    expect(readBody.errors).toBeUndefined();
+  });
+
+  it("clears stale issue lifecycle timestamps when moving between workflow states", async () => {
+    const linearStore = getLinearStore(store);
+    const team = linearStore.teams.findOneBy("key", "ENG")!;
+    const todo = linearStore.workflowStates.findOneBy("name", "Todo")!;
+    const done = linearStore.workflowStates.findOneBy("name", "Done")!;
+
+    const createIssue = await gql(
+      app,
+      `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) { issue { id completedAt canceledAt startedAt } }
+      }`,
+      { input: { teamId: team.linear_id, stateId: todo.linear_id, title: "Move lifecycle states" } },
+    );
+    const issueBody = (await createIssue.json()) as any;
+    const issueId = issueBody.data.issueCreate.issue.id;
+
+    const complete = await gql(
+      app,
+      `mutation UpdateIssue($input: IssueUpdateInput!) {
+        issueUpdate(input: $input) { issue { completedAt canceledAt startedAt state { name } } }
+      }`,
+      { input: { id: issueId, stateId: done.linear_id } },
+    );
+    const completeBody = (await complete.json()) as any;
+    expect(completeBody.data.issueUpdate.issue.state.name).toBe("Done");
+    expect(completeBody.data.issueUpdate.issue.completedAt).toBeTruthy();
+
+    const reopen = await gql(
+      app,
+      `mutation UpdateIssue($input: IssueUpdateInput!) {
+        issueUpdate(input: $input) { issue { completedAt canceledAt startedAt state { name } } }
+      }`,
+      { input: { id: issueId, stateId: todo.linear_id } },
+    );
+    const reopenBody = (await reopen.json()) as any;
+    expect(reopenBody.data.issueUpdate.issue.state.name).toBe("Todo");
+    expect(reopenBody.data.issueUpdate.issue.completedAt).toBeNull();
+    expect(reopenBody.data.issueUpdate.issue.canceledAt).toBeNull();
+    expect(reopenBody.data.issueUpdate.issue.startedAt).toBeNull();
+  });
+
   it("honors issue filter or clauses", async () => {
     const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
     await gql(
@@ -295,6 +386,55 @@ describe("Linear emulator", () => {
     expect(refreshBody.message).toContain("refresh tokens");
   });
 
+  it("enforces the OAuth app actor configuration", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [
+        {
+          client_id: "user-actor-client",
+          client_secret: "user-actor-secret",
+          name: "User Actor App",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read"],
+          actor: "user",
+        },
+        {
+          client_id: "app-actor-client",
+          client_secret: "app-actor-secret",
+          name: "App Actor App",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read"],
+          actor: "app",
+        },
+      ],
+    });
+
+    const userActorGrant = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: "user-actor-client",
+        client_secret: "user-actor-secret",
+        scope: "read",
+      }).toString(),
+    });
+    expect(userActorGrant.status).toBe(400);
+    const userActorBody = (await userActorGrant.json()) as any;
+    expect(userActorBody.error).toBe("unauthorized_client");
+
+    const appActorAuthorize = await app.request(
+      `${base}/oauth/authorize?client_id=app-actor-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=read`,
+    );
+    expect(appActorAuthorize.status).toBe(200);
+    expect(await appActorAuthorize.text()).toContain("Install App Actor App");
+
+    const actorMismatch = await app.request(
+      `${base}/oauth/authorize?client_id=app-actor-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=read&actor=user`,
+    );
+    expect(actorMismatch.status).toBe(400);
+    expect(await actorMismatch.text()).toContain("Invalid actor");
+  });
+
   it("requires read scope for queries in strict mode", async () => {
     seedFromConfig(store, base, {
       strict_scopes: true,
@@ -363,6 +503,7 @@ describe("Linear emulator", () => {
           name: "Read Only App",
           redirect_uris: ["http://localhost:3000/callback"],
           scopes: ["read"],
+          actor: "app",
         },
       ],
     });
@@ -373,7 +514,7 @@ describe("Linear emulator", () => {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
         user_ref: user.linear_id,
-        actor: "user",
+        actor: "app",
         redirect_uri: "http://localhost:3000/callback",
         scope: "admin",
         state: "state-1",
@@ -500,6 +641,51 @@ describe("Linear emulator", () => {
     expect(deliveries[0].event).toBe("Issue");
     expect(deliveries[0].action).toBe("create");
     expect(deliveries[0].headers["Linear-Signature"]).toBeDefined();
+  });
+
+  it("stores webhook deliveries for issue label mutations", async () => {
+    seedFromConfig(store, base, {
+      webhooks: [
+        {
+          label: "Issue receiver",
+          url: "http://127.0.0.1:1/linear",
+          resource_types: ["Issue"],
+          all_public_teams: true,
+        },
+      ],
+    });
+    const linearStore = getLinearStore(store);
+    const issue = linearStore.issues.findOneBy("identifier", "ENG-1")!;
+    const bug = linearStore.issueLabels.findOneBy("name", "Bug")!;
+    const feature = linearStore.issueLabels.findOneBy("name", "Feature")!;
+
+    const addLabel = await gql(
+      app,
+      `mutation AddLabel($id: String!, $labelId: String!) {
+        issueAddLabel(id: $id, labelId: $labelId) { issue { identifier labels { nodes { name } } } }
+      }`,
+      { id: issue.linear_id, labelId: feature.linear_id },
+    );
+    expect(addLabel.status).toBe(200);
+    const addBody = (await addLabel.json()) as any;
+    expect(addBody.errors).toBeUndefined();
+
+    const removeLabel = await gql(
+      app,
+      `mutation RemoveLabel($id: String!, $labelId: String!) {
+        issueRemoveLabel(id: $id, labelId: $labelId) { issue { identifier labels { nodes { name } } } }
+      }`,
+      { id: issue.linear_id, labelId: feature.linear_id },
+    );
+    expect(removeLabel.status).toBe(200);
+    const removeBody = (await removeLabel.json()) as any;
+    expect(removeBody.errors).toBeUndefined();
+
+    const deliveries = linearStore.webhookDeliveries.all();
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries.map((delivery) => delivery.event)).toEqual(["Issue", "Issue"]);
+    expect(deliveries.map((delivery) => delivery.action)).toEqual(["update", "update"]);
+    expect((deliveries[0].payload as any).updatedFrom.labels).toEqual([{ id: bug.linear_id, name: "Bug" }]);
   });
 
   it("does not send all public team webhooks for private team events", async () => {

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -507,6 +507,39 @@ describe("Linear emulator", () => {
     expect(await actorMismatch.text()).toContain("Invalid actor");
   });
 
+  it("accepts OAuth client credentials from a Basic header with colons in the secret", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [
+        {
+          client_id: "basic-client",
+          client_secret: "secret:with:colons",
+          name: "Basic App",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read"],
+          actor: "app",
+        },
+      ],
+    });
+
+    const credentials = Buffer.from("basic-client:secret:with:colons", "utf8").toString("base64");
+    const res = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        scope: "read",
+      }).toString(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.access_token).toMatch(/^lin_/);
+    expect(body.scope).toBe("read");
+  });
+
   it("lets seed config override the default test token", async () => {
     seedFromConfig(store, base, {
       strict_scopes: true,

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -109,6 +109,47 @@ describe("Linear emulator", () => {
     expect(readBody.data.issue.comments.nodes[0].body).toBe("Done locally.");
   });
 
+  it("rejects issue creation with an unknown workflow state", async () => {
+    const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
+
+    const res = await gql(
+      app,
+      `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) { issue { identifier state { name } } }
+      }`,
+      { input: { teamId: team.linear_id, stateId: "missing-state", title: "Bad state" } },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.errors[0].message).toContain("Workflow state not found: missing-state");
+    expect(getLinearStore(store).issues.findOneBy("title", "Bad state")).toBeUndefined();
+  });
+
+  it("rejects adding an issue label from another team", async () => {
+    seedFromConfig(store, base, {
+      teams: [{ key: "SEC", name: "Security" }],
+      labels: [{ name: "Security", color: "#111827", team: "SEC" }],
+    });
+    const linearStore = getLinearStore(store);
+    const issue = linearStore.issues.findOneBy("identifier", "ENG-1")!;
+    const securityLabel = linearStore.issueLabels.findOneBy("name", "Security")!;
+    const beforeLabelIds = [...issue.label_ids];
+
+    const res = await gql(
+      app,
+      `mutation AddLabel($id: String!, $labelId: String!) {
+        issueAddLabel(id: $id, labelId: $labelId) { issue { labels { nodes { name } } } }
+      }`,
+      { id: issue.linear_id, labelId: securityLabel.linear_id },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.errors[0].message).toContain("Issue label not found for team");
+    expect(linearStore.issues.findOneBy("linear_id", issue.linear_id)?.label_ids).toEqual(beforeLabelIds);
+  });
+
   it("deletes issue comments and agent sessions with the issue", async () => {
     const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
     const createIssue = await gql(

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -435,6 +435,96 @@ describe("Linear emulator", () => {
     expect(await actorMismatch.text()).toContain("Invalid actor");
   });
 
+  it("lets seed config override the default test token", async () => {
+    seedFromConfig(store, base, {
+      strict_scopes: true,
+      users: [
+        {
+          email: "admin@example.com",
+          name: "Config Admin",
+          admin: true,
+        },
+      ],
+      tokens: [
+        {
+          token: "lin_test_admin",
+          user: "admin@example.com",
+          scopes: ["read"],
+        },
+      ],
+    });
+
+    const viewer = await gql(app, "{ viewer { email name } }");
+    expect(viewer.status).toBe(200);
+    const viewerBody = (await viewer.json()) as any;
+    expect(viewerBody.errors).toBeUndefined();
+    expect(viewerBody.data.viewer).toEqual({ email: "admin@example.com", name: "Config Admin" });
+
+    const adminOnly = await gql(
+      app,
+      `mutation($input: WebhookCreateInput!) {
+        webhookCreate(input: $input) { success webhook { id } }
+      }`,
+      { input: { url: "http://127.0.0.1:1/linear" } },
+    );
+    expect(adminOnly.status).toBe(400);
+    const adminBody = (await adminOnly.json()) as any;
+    expect(adminBody.errors[0].message).toContain("admin");
+  });
+
+  it("lets seed config override the default OAuth app", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [
+        {
+          client_id: "lin_example_client_id",
+          client_secret: "configured-secret",
+          name: "Configured App",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read"],
+          actor: "app",
+        },
+      ],
+    });
+    const oauthApp = getLinearStore(store).oauthApps.findOneBy("client_id", "lin_example_client_id")!;
+    expect(oauthApp.name).toBe("Configured App");
+    expect(oauthApp.scopes).toEqual(["read"]);
+    expect(oauthApp.actor).toBe("app");
+    expect(oauthApp.app_user_id).toBeTruthy();
+
+    const invalidScope = await app.request(
+      `${base}/oauth/authorize?client_id=lin_example_client_id&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=admin`,
+    );
+    expect(invalidScope.status).toBe(400);
+    expect(await invalidScope.text()).toContain("Invalid scope");
+
+    const oldSecret = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: "lin_example_client_id",
+        client_secret: "example_client_secret",
+        scope: "read",
+      }).toString(),
+    });
+    expect(oldSecret.status).toBe(400);
+
+    const clientCredentials = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: "lin_example_client_id",
+        client_secret: "configured-secret",
+        scope: "read",
+      }).toString(),
+    });
+    expect(clientCredentials.status).toBe(200);
+    const tokenBody = (await clientCredentials.json()) as any;
+    expect(tokenBody.access_token).toMatch(/^lin_/);
+    expect(tokenBody.scope).toBe("read");
+  });
+
   it("requires read scope for queries in strict mode", async () => {
     seedFromConfig(store, base, {
       strict_scopes: true,

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -109,6 +109,44 @@ describe("Linear emulator", () => {
     expect(readBody.data.issue.comments.nodes[0].body).toBe("Done locally.");
   });
 
+  it("honors issue filter or clauses", async () => {
+    const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
+    await gql(
+      app,
+      `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) { issue { identifier } }
+      }`,
+      { input: { teamId: team.linear_id, title: "Review Linear filter logic" } },
+    );
+
+    const missing = await gql(
+      app,
+      `query Issues($filter: IssueFilter) {
+        issues(filter: $filter) { nodes { identifier title } }
+      }`,
+      { filter: { or: [{ title: { eq: "Definitely missing" } }] } },
+    );
+    expect(missing.status).toBe(200);
+    const missingBody = (await missing.json()) as any;
+    expect(missingBody.errors).toBeUndefined();
+    expect(missingBody.data.issues.nodes).toEqual([]);
+
+    const matching = await gql(
+      app,
+      `query Issues($filter: IssueFilter) {
+        issues(filter: $filter) { nodes { identifier title } }
+      }`,
+      {
+        filter: {
+          or: [{ title: { eq: "Definitely missing" } }, { title: { eq: "Review Linear filter logic" } }],
+        },
+      },
+    );
+    const matchingBody = (await matching.json()) as any;
+    expect(matchingBody.errors).toBeUndefined();
+    expect(matchingBody.data.issues.nodes).toEqual([{ identifier: "ENG-2", title: "Review Linear filter logic" }]);
+  });
+
   it("supports OAuth authorization code exchange with PKCE", async () => {
     seedFromConfig(store, base, {
       oauth_apps: [

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -17,11 +17,11 @@ function createTestApp() {
   return { app, store, tokenMap };
 }
 
-async function gql(app: Hono, query: string, variables?: Record<string, unknown>) {
+async function gql(app: Hono, query: string, variables?: Record<string, unknown>, token = "lin_test_admin") {
   return app.request(`${base}/graphql`, {
     method: "POST",
     headers: {
-      Authorization: "Bearer lin_test_admin",
+      Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ query, variables }),
@@ -182,6 +182,184 @@ describe("Linear emulator", () => {
     expect(refreshGraphql.status).toBe(401);
     const refreshBody = (await refreshGraphql.json()) as { message: string };
     expect(refreshBody.message).toContain("refresh tokens");
+  });
+
+  it("requires read scope for queries in strict mode", async () => {
+    seedFromConfig(store, base, {
+      strict_scopes: true,
+      tokens: [
+        {
+          token: "lin_no_scopes",
+          user: "admin@linear.local",
+          scopes: [],
+        },
+        {
+          token: "lin_read_only",
+          user: "admin@linear.local",
+          scopes: ["read"],
+        },
+      ],
+    });
+
+    const missingRead = await gql(
+      app,
+      "{ viewer { email } issues { nodes { identifier } } }",
+      undefined,
+      "lin_no_scopes",
+    );
+    expect(missingRead.status).toBe(400);
+    const missingBody = (await missingRead.json()) as any;
+    expect(missingBody.errors[0].message).toContain("read");
+
+    const read = await gql(app, "{ viewer { email } issues { nodes { identifier } } }", undefined, "lin_read_only");
+    expect(read.status).toBe(200);
+    const readBody = (await read.json()) as any;
+    expect(readBody.errors).toBeUndefined();
+    expect(readBody.data.viewer.email).toBe("admin@linear.local");
+  });
+
+  it("does not let write scope satisfy admin in strict mode", async () => {
+    seedFromConfig(store, base, {
+      strict_scopes: true,
+      tokens: [
+        {
+          token: "lin_write_only",
+          user: "admin@linear.local",
+          scopes: ["write"],
+        },
+      ],
+    });
+
+    const res = await gql(
+      app,
+      `mutation($input: WebhookCreateInput!) {
+        webhookCreate(input: $input) { success webhook { id } }
+      }`,
+      { input: { url: "http://127.0.0.1:1/linear" } },
+      "lin_write_only",
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.errors[0].message).toContain("admin");
+  });
+
+  it("rejects OAuth scopes that are not registered on the app", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [
+        {
+          client_id: "read-only-client",
+          client_secret: "read-only-secret",
+          name: "Read Only App",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read"],
+        },
+      ],
+    });
+    const user = getLinearStore(store).users.findOneBy("email", "admin@linear.local")!;
+
+    const codeRes = await app.request(`${base}/oauth/authorize/callback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        user_ref: user.linear_id,
+        actor: "user",
+        redirect_uri: "http://localhost:3000/callback",
+        scope: "admin",
+        state: "state-1",
+        client_id: "read-only-client",
+      }).toString(),
+    });
+    expect(codeRes.status).toBe(400);
+    expect(await codeRes.text()).toContain("Invalid scope");
+
+    const clientCredentialsRes = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: "read-only-client",
+        client_secret: "read-only-secret",
+        scope: "admin",
+      }).toString(),
+    });
+    expect(clientCredentialsRes.status).toBe(400);
+    const tokenBody = (await clientCredentialsRes.json()) as any;
+    expect(tokenBody.error).toBe("invalid_scope");
+  });
+
+  it("binds refresh tokens to the OAuth client that received them", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [
+        {
+          client_id: "client-a",
+          client_secret: "secret-a",
+          name: "Client A",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read"],
+        },
+        {
+          client_id: "client-b",
+          client_secret: "secret-b",
+          name: "Client B",
+          redirect_uris: ["http://localhost:3000/callback"],
+          scopes: ["read"],
+        },
+      ],
+    });
+    const user = getLinearStore(store).users.findOneBy("email", "admin@linear.local")!;
+
+    const codeRes = await app.request(`${base}/oauth/authorize/callback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        user_ref: user.linear_id,
+        actor: "user",
+        redirect_uri: "http://localhost:3000/callback",
+        scope: "read",
+        client_id: "client-a",
+      }).toString(),
+    });
+    const location = new URL(codeRes.headers.get("location") ?? "");
+
+    const tokenRes = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: location.searchParams.get("code") ?? "",
+        client_id: "client-a",
+        client_secret: "secret-a",
+        redirect_uri: "http://localhost:3000/callback",
+      }).toString(),
+    });
+    expect(tokenRes.status).toBe(200);
+    const issued = (await tokenRes.json()) as any;
+
+    const wrongClient = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: issued.refresh_token,
+        client_id: "client-b",
+        client_secret: "secret-b",
+      }).toString(),
+    });
+    expect(wrongClient.status).toBe(400);
+    const wrongClientBody = (await wrongClient.json()) as any;
+    expect(wrongClientBody.error).toBe("invalid_grant");
+
+    const rightClient = await app.request(`${base}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: issued.refresh_token,
+        client_id: "client-a",
+        client_secret: "secret-a",
+      }).toString(),
+    });
+    expect(rightClient.status).toBe(200);
   });
 
   it("stores webhook deliveries for issue mutations", async () => {

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -131,6 +131,7 @@ describe("Linear emulator", () => {
     const team = linearStore.teams.findOneBy("key", "ENG")!;
     const issue = linearStore.issues.findOneBy("identifier", "ENG-1")!;
     const originalAssignee = issue.assignee_id;
+    const originalSequence = team.issue_sequence;
 
     const createWithUnknownLabel = await gql(
       app,
@@ -143,6 +144,19 @@ describe("Linear emulator", () => {
     const createBody = (await createWithUnknownLabel.json()) as any;
     expect(createBody.errors[0].message).toContain("Issue label not found for team: missing-label");
     expect(linearStore.issues.findOneBy("title", "Bad label")).toBeUndefined();
+    expect(linearStore.teams.findOneBy("linear_id", team.linear_id)?.issue_sequence).toBe(originalSequence);
+
+    const createAfterFailure = await gql(
+      app,
+      `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) { issue { identifier } }
+      }`,
+      { input: { teamId: team.linear_id, title: "Valid after failed create" } },
+    );
+    expect(createAfterFailure.status).toBe(200);
+    const createAfterFailureBody = (await createAfterFailure.json()) as any;
+    expect(createAfterFailureBody.errors).toBeUndefined();
+    expect(createAfterFailureBody.data.issueCreate.issue.identifier).toBe("ENG-2");
 
     const updateWithUnknownAssignee = await gql(
       app,
@@ -155,6 +169,66 @@ describe("Linear emulator", () => {
     const updateBody = (await updateWithUnknownAssignee.json()) as any;
     expect(updateBody.errors[0].message).toContain("User not found for assigneeId: missing-user");
     expect(linearStore.issues.findOneBy("linear_id", issue.linear_id)?.assignee_id).toBe(originalAssignee);
+  });
+
+  it("rejects scoped resources with unknown team IDs", async () => {
+    const linearStore = getLinearStore(store);
+    const labelCount = linearStore.issueLabels.all().length;
+    const webhookCount = linearStore.webhooks.all().length;
+
+    const labelRes = await gql(
+      app,
+      `mutation CreateLabel($input: IssueLabelCreateInput!) {
+        issueLabelCreate(input: $input) { issueLabel { id } }
+      }`,
+      { input: { teamId: "missing-team", name: "Bad team label" } },
+    );
+    expect(labelRes.status).toBe(400);
+    const labelBody = (await labelRes.json()) as any;
+    expect(labelBody.errors[0].message).toContain("Team not found: missing-team");
+    expect(linearStore.issueLabels.all()).toHaveLength(labelCount);
+
+    const webhookRes = await gql(
+      app,
+      `mutation CreateWebhook($input: WebhookCreateInput!) {
+        webhookCreate(input: $input) { webhook { id } }
+      }`,
+      { input: { teamId: "missing-team", url: "http://127.0.0.1:1/linear" } },
+    );
+    expect(webhookRes.status).toBe(400);
+    const webhookBody = (await webhookRes.json()) as any;
+    expect(webhookBody.errors[0].message).toContain("Team not found: missing-team");
+    expect(linearStore.webhooks.all()).toHaveLength(webhookCount);
+  });
+
+  it("rejects explicit unknown agent user IDs", async () => {
+    const linearStore = getLinearStore(store);
+    const issue = linearStore.issues.findOneBy("identifier", "ENG-1")!;
+    const comment = linearStore.comments.findBy("issue_id", issue.linear_id)[0]!;
+    const sessionCount = linearStore.agentSessions.all().length;
+
+    const issueSession = await gql(
+      app,
+      `mutation CreateSession($input: AgentSessionCreateOnIssue!) {
+        agentSessionCreateOnIssue(input: $input) { agentSession { id } }
+      }`,
+      { input: { issueId: issue.linear_id, agentUserId: "missing-user" } },
+    );
+    expect(issueSession.status).toBe(400);
+    const issueSessionBody = (await issueSession.json()) as any;
+    expect(issueSessionBody.errors[0].message).toContain("User not found: missing-user");
+
+    const commentSession = await gql(
+      app,
+      `mutation CreateSession($input: AgentSessionCreateOnComment!) {
+        agentSessionCreateOnComment(input: $input) { agentSession { id } }
+      }`,
+      { input: { commentId: comment.linear_id, agentUserId: "missing-user" } },
+    );
+    expect(commentSession.status).toBe(400);
+    const commentSessionBody = (await commentSession.json()) as any;
+    expect(commentSessionBody.errors[0].message).toContain("User not found: missing-user");
+    expect(linearStore.agentSessions.all()).toHaveLength(sessionCount);
   });
 
   it("rejects adding an issue label from another team", async () => {

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -109,6 +109,60 @@ describe("Linear emulator", () => {
     expect(readBody.data.issue.comments.nodes[0].body).toBe("Done locally.");
   });
 
+  it("deletes issue comments and agent sessions with the issue", async () => {
+    const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
+    const createIssue = await gql(
+      app,
+      `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) { issue { id } }
+      }`,
+      { input: { teamId: team.linear_id, title: "Delete child records" } },
+    );
+    const issueBody = (await createIssue.json()) as any;
+    const issueId = issueBody.data.issueCreate.issue.id;
+
+    await gql(
+      app,
+      `mutation CreateComment($input: CommentCreateInput!) {
+        commentCreate(input: $input) { comment { id } }
+      }`,
+      { input: { issueId, body: "Remove me with the issue." } },
+    );
+    const sessionRes = await gql(
+      app,
+      `mutation CreateSession($input: AgentSessionCreateOnIssueInput!) {
+        agentSessionCreateOnIssue(input: $input) { agentSession { id } }
+      }`,
+      { input: { issueId, plan: "Clean up child records" } },
+    );
+    const sessionBody = (await sessionRes.json()) as any;
+    const sessionId = sessionBody.data.agentSessionCreateOnIssue.agentSession.id;
+
+    await gql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) { agentActivity { id } }
+      }`,
+      { input: { sessionId, type: "response", body: "Done." } },
+    );
+
+    const deleteIssue = await gql(
+      app,
+      `mutation DeleteIssue($id: String!) {
+        issueDelete(id: $id) { success }
+      }`,
+      { id: issueId },
+    );
+    expect(deleteIssue.status).toBe(200);
+    const deleteBody = (await deleteIssue.json()) as any;
+    expect(deleteBody.errors).toBeUndefined();
+
+    const linearStore = getLinearStore(store);
+    expect(linearStore.comments.findBy("issue_id", issueId)).toEqual([]);
+    expect(linearStore.agentSessions.findBy("issue_id", issueId)).toEqual([]);
+    expect(linearStore.agentActivities.findBy("session_id", sessionId)).toEqual([]);
+  });
+
   it("honors issue filter or clauses", async () => {
     const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
     await gql(
@@ -145,6 +199,25 @@ describe("Linear emulator", () => {
     const matchingBody = (await matching.json()) as any;
     expect(matchingBody.errors).toBeUndefined();
     expect(matchingBody.data.issues.nodes).toEqual([{ identifier: "ENG-2", title: "Review Linear filter logic" }]);
+  });
+
+  it("applies negative issue filters across aliases", async () => {
+    const res = await gql(
+      app,
+      `query Issues($teamFilter: IssueFilter, $labelFilter: IssueFilter) {
+        byTeam: issues(filter: $teamFilter) { nodes { identifier } }
+        byLabel: issues(filter: $labelFilter) { nodes { identifier } }
+      }`,
+      {
+        teamFilter: { team: { neq: "ENG" } },
+        labelFilter: { labels: { neq: "Bug" } },
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.errors).toBeUndefined();
+    expect(body.data.byTeam.nodes).toEqual([]);
+    expect(body.data.byLabel.nodes).toEqual([]);
   });
 
   it("supports OAuth authorization code exchange with PKCE", async () => {
@@ -427,6 +500,31 @@ describe("Linear emulator", () => {
     expect(deliveries[0].event).toBe("Issue");
     expect(deliveries[0].action).toBe("create");
     expect(deliveries[0].headers["Linear-Signature"]).toBeDefined();
+  });
+
+  it("does not send all public team webhooks for private team events", async () => {
+    seedFromConfig(store, base, {
+      teams: [{ key: "SEC", name: "Security", private: true }],
+      webhooks: [
+        {
+          label: "Public teams only",
+          url: "http://127.0.0.1:1/linear",
+          resource_types: ["Issue"],
+          all_public_teams: true,
+        },
+      ],
+    });
+    const team = getLinearStore(store).teams.findOneBy("key", "SEC")!;
+
+    const res = await gql(
+      app,
+      `mutation($input: IssueCreateInput!) {
+        issueCreate(input: $input) { success issue { identifier } }
+      }`,
+      { input: { teamId: team.linear_id, title: "Private team webhook" } },
+    );
+    expect(res.status).toBe(200);
+    expect(getLinearStore(store).webhookDeliveries.all()).toHaveLength(0);
   });
 
   it("renders the shared inspector", async () => {

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -126,6 +126,37 @@ describe("Linear emulator", () => {
     expect(getLinearStore(store).issues.findOneBy("title", "Bad state")).toBeUndefined();
   });
 
+  it("rejects issue mutations with unknown relation IDs", async () => {
+    const linearStore = getLinearStore(store);
+    const team = linearStore.teams.findOneBy("key", "ENG")!;
+    const issue = linearStore.issues.findOneBy("identifier", "ENG-1")!;
+    const originalAssignee = issue.assignee_id;
+
+    const createWithUnknownLabel = await gql(
+      app,
+      `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) { issue { identifier } }
+      }`,
+      { input: { teamId: team.linear_id, title: "Bad label", labelIds: ["missing-label"] } },
+    );
+    expect(createWithUnknownLabel.status).toBe(400);
+    const createBody = (await createWithUnknownLabel.json()) as any;
+    expect(createBody.errors[0].message).toContain("Issue label not found for team: missing-label");
+    expect(linearStore.issues.findOneBy("title", "Bad label")).toBeUndefined();
+
+    const updateWithUnknownAssignee = await gql(
+      app,
+      `mutation UpdateIssue($input: IssueUpdateInput!) {
+        issueUpdate(input: $input) { issue { id } }
+      }`,
+      { input: { id: issue.linear_id, assigneeId: "missing-user" } },
+    );
+    expect(updateWithUnknownAssignee.status).toBe(400);
+    const updateBody = (await updateWithUnknownAssignee.json()) as any;
+    expect(updateBody.errors[0].message).toContain("User not found for assigneeId: missing-user");
+    expect(linearStore.issues.findOneBy("linear_id", issue.linear_id)?.assignee_id).toBe(originalAssignee);
+  });
+
   it("rejects adding an issue label from another team", async () => {
     seedFromConfig(store, base, {
       teams: [{ key: "SEC", name: "Security" }],
@@ -171,7 +202,7 @@ describe("Linear emulator", () => {
     );
     const sessionRes = await gql(
       app,
-      `mutation CreateSession($input: AgentSessionCreateOnIssueInput!) {
+      `mutation CreateSession($input: AgentSessionCreateOnIssue!) {
         agentSessionCreateOnIssue(input: $input) { agentSession { id } }
       }`,
       { input: { issueId, plan: "Clean up child records" } },
@@ -218,7 +249,7 @@ describe("Linear emulator", () => {
 
     const sessionRes = await gql(
       app,
-      `mutation CreateSession($input: AgentSessionCreateOnCommentInput!) {
+      `mutation CreateSession($input: AgentSessionCreateOnComment!) {
         agentSessionCreateOnComment(input: $input) { agentSession { id } }
       }`,
       { input: { commentId, plan: "Handle the comment." } },
@@ -901,20 +932,25 @@ describe("Linear emulator", () => {
     expect(createIssue.issueId).toBeTruthy();
     const issueId = createIssue.issueId!;
     expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.identifier).toBe("ENG-2");
-    const updateIssue = await client.client.rawRequest<
-      { issueUpdate: { success: boolean; issue: { id: string; title: string; priority: number } } },
-      { input: { id: string; title: string; priority: number } }
-    >(
-      `mutation($input: IssueUpdateInput!) {
-        issueUpdate(input: $input) {
-          success
-          issue { id title priority }
-        }
-      }`,
-      { input: { id: issueId, title: "Updated from SDK", priority: 1 } },
-    );
-    expect(updateIssue.data?.issueUpdate.issue.title).toBe("Updated from SDK");
-    expect(updateIssue.data?.issueUpdate.issue.priority).toBe(1);
+    const updateIssue = await client.updateIssue(issueId, { title: "Updated from SDK", priority: 1 });
+    expect(updateIssue.success).toBe(true);
+    expect(updateIssue.issueId).toBe(issueId);
+    expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.title).toBe("Updated from SDK");
+    expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.priority).toBe(1);
+
+    const createAgentSession = await client.agentSessionCreateOnIssue({ issueId });
+    expect(createAgentSession.success).toBe(true);
+    expect(createAgentSession.agentSessionId).toBeTruthy();
+
+    const createLabel = await client.createIssueLabel({ teamId, name: "SDK Label", color: "#0f766e" });
+    expect(createLabel.success).toBe(true);
+    const labelId = createLabel.issueLabelId!;
+    const updateLabel = await client.updateIssueLabel(labelId, { name: "SDK Label Updated" });
+    expect(updateLabel.success).toBe(true);
+    expect(getLinearStore(store).issueLabels.findOneBy("linear_id", labelId)?.name).toBe("SDK Label Updated");
+    const deleteLabel = await client.deleteIssueLabel(labelId);
+    expect(deleteLabel.success).toBe(true);
+    expect(deleteLabel.entityId).toBe(labelId);
 
     const firstIssuePage = await client.client.rawRequest<
       {
@@ -956,5 +992,27 @@ describe("Linear emulator", () => {
     expect(getLinearStore(store).comments.findOneBy("linear_id", createComment.commentId!)?.body).toBe(
       "Commented from SDK",
     );
+    const commentId = createComment.commentId!;
+    const updateComment = await client.updateComment(commentId, { body: "Updated comment from SDK" });
+    expect(updateComment.success).toBe(true);
+    expect(getLinearStore(store).comments.findOneBy("linear_id", commentId)?.body).toBe("Updated comment from SDK");
+    const deleteComment = await client.deleteComment(commentId);
+    expect(deleteComment.success).toBe(true);
+    expect(deleteComment.entityId).toBe(commentId);
+
+    const archiveIssue = await client.archiveIssue(issueId);
+    expect(archiveIssue.success).toBe(true);
+    expect(archiveIssue.entityId).toBe(issueId);
+    expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.archived_at).toBeTruthy();
+
+    const unarchiveIssue = await client.unarchiveIssue(issueId);
+    expect(unarchiveIssue.success).toBe(true);
+    expect(unarchiveIssue.entityId).toBe(issueId);
+    expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.archived_at).toBeNull();
+
+    const deleteIssue = await client.deleteIssue(issueId);
+    expect(deleteIssue.success).toBe(true);
+    expect(deleteIssue.entityId).toBe(issueId);
+    expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)).toBeUndefined();
   });
 });

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -825,7 +825,11 @@ describe("Linear emulator", () => {
     globalThis.fetch = async (input, init) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.startsWith(`${base}/graphql`)) {
-        return app.request(url, init);
+        return app.request(url, {
+          method: init?.method,
+          headers: init?.headers,
+          body: init?.body,
+        });
       }
       return originalFetch(input, init);
     };
@@ -846,28 +850,16 @@ describe("Linear emulator", () => {
     const oauthViewer = await oauthClient.viewer;
     expect(oauthViewer.email).toBe("admin@linear.local");
 
-    const teams = await client.client.rawRequest<
-      { teams: { nodes: Array<{ id: string; key: string; name: string }> } },
-      Record<string, never>
-    >(`query { teams { nodes { id key name } } }`);
-    expect(teams.data?.teams.nodes[0].key).toBe("ENG");
+    const teams = await client.teams();
+    expect(teams.nodes[0].key).toBe("ENG");
 
-    const teamId = teams.data!.teams.nodes[0].id;
-    const createIssue = await client.client.rawRequest<
-      { issueCreate: { success: boolean; issue: { id: string; identifier: string; title: string } } },
-      { input: { teamId: string; title: string } }
-    >(
-      `mutation($input: IssueCreateInput!) {
-        issueCreate(input: $input) {
-          success
-          issue { id identifier title }
-        }
-      }`,
-      { input: { teamId, title: "Created from SDK" } },
-    );
-    expect(createIssue.data?.issueCreate.issue.identifier).toBe("ENG-2");
+    const teamId = teams.nodes[0].id;
+    const createIssue = await client.createIssue({ teamId, title: "Created from SDK" });
+    expect(createIssue.success).toBe(true);
 
-    const issueId = createIssue.data!.issueCreate.issue.id;
+    expect(createIssue.issueId).toBeTruthy();
+    const issueId = createIssue.issueId!;
+    expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.identifier).toBe("ENG-2");
     const updateIssue = await client.client.rawRequest<
       { issueUpdate: { success: boolean; issue: { id: string; title: string; priority: number } } },
       { input: { id: string; title: string; priority: number } }
@@ -918,18 +910,10 @@ describe("Linear emulator", () => {
     expect(nextIssuePage.data?.issues.nodes[0].identifier).toBe("ENG-2");
     expect(nextIssuePage.data?.issues.pageInfo.hasNextPage).toBe(false);
 
-    const createComment = await client.client.rawRequest<
-      { commentCreate: { success: boolean; comment: { id: string; body: string; issue: { identifier: string } } } },
-      { input: { issueId: string; body: string } }
-    >(
-      `mutation($input: CommentCreateInput!) {
-        commentCreate(input: $input) {
-          success
-          comment { id body issue { identifier } }
-        }
-      }`,
-      { input: { issueId, body: "Commented from SDK" } },
+    const createComment = await client.createComment({ issueId, body: "Commented from SDK" });
+    expect(createComment.success).toBe(true);
+    expect(getLinearStore(store).comments.findOneBy("linear_id", createComment.commentId!)?.body).toBe(
+      "Commented from SDK",
     );
-    expect(createComment.data?.commentCreate.comment.issue.identifier).toBe("ENG-2");
   });
 });

--- a/packages/@emulators/linear/src/auth.ts
+++ b/packages/@emulators/linear/src/auth.ts
@@ -30,7 +30,7 @@ export function tokenScopes(store: Store, c: Context): string[] {
   const token = c.get("authToken");
   if (token) {
     const record = getLinearStore(store).tokens.findOneBy("token", token);
-    if (record && !record.revoked) return record.scopes;
+    if (record && record.type !== "oauth_refresh" && !record.revoked) return record.scopes;
   }
   return c.get("authScopes") ?? [];
 }

--- a/packages/@emulators/linear/src/auth.ts
+++ b/packages/@emulators/linear/src/auth.ts
@@ -1,0 +1,46 @@
+import type { Context, Store } from "@emulators/core";
+import { getLinearStore } from "./store.js";
+import { resolveUser } from "./index.js";
+
+export function currentUser(store: Store, c: Context) {
+  const ls = getLinearStore(store);
+  const authUser = c.get("authUser");
+  if (authUser) {
+    const byLogin = resolveUser(store, authUser.login);
+    if (byLogin) return byLogin;
+  }
+
+  const token = c.get("authToken");
+  if (token) {
+    const record = ls.tokens.findOneBy("token", token);
+    if (record?.user_id) {
+      const user = ls.users.findOneBy("linear_id", record.user_id);
+      if (user) return user;
+    }
+  }
+
+  return (
+    ls.users.all().find((user) => user.admin && !user.app) ??
+    ls.users.all().find((user) => !user.app) ??
+    ls.users.all()[0]
+  );
+}
+
+export function tokenScopes(store: Store, c: Context): string[] {
+  const token = c.get("authToken");
+  if (token) {
+    const record = getLinearStore(store).tokens.findOneBy("token", token);
+    if (record && !record.revoked) return record.scopes;
+  }
+  return c.get("authScopes") ?? [];
+}
+
+export function requireLinearScopes(store: Store, c: Context, scopes: string[]): void {
+  const strict = store.getData<boolean>("linear.strict_scopes") ?? false;
+  if (!strict || scopes.length === 0) return;
+  const provided = new Set(tokenScopes(store, c));
+  if (provided.has("admin") || provided.has("write")) return;
+  const missing = scopes.filter((scope) => !provided.has(scope));
+  if (missing.length === 0) return;
+  throw new Error(`Missing required Linear scope: ${missing.join(", ")}`);
+}

--- a/packages/@emulators/linear/src/auth.ts
+++ b/packages/@emulators/linear/src/auth.ts
@@ -39,8 +39,14 @@ export function requireLinearScopes(store: Store, c: Context, scopes: string[]):
   const strict = store.getData<boolean>("linear.strict_scopes") ?? false;
   if (!strict || scopes.length === 0) return;
   const provided = new Set(tokenScopes(store, c));
-  if (provided.has("admin") || provided.has("write")) return;
-  const missing = scopes.filter((scope) => !provided.has(scope));
+  if (provided.has("admin")) return;
+  const missing = scopes.filter((scope) => !hasLinearScope(provided, scope));
   if (missing.length === 0) return;
   throw new Error(`Missing required Linear scope: ${missing.join(", ")}`);
+}
+
+function hasLinearScope(provided: Set<string>, scope: string): boolean {
+  if (provided.has(scope)) return true;
+  if (scope === "issues:create" || scope === "comments:create") return provided.has("write");
+  return false;
 }

--- a/packages/@emulators/linear/src/entities.ts
+++ b/packages/@emulators/linear/src/entities.ts
@@ -1,0 +1,170 @@
+import type { Entity } from "@emulators/core";
+
+export type LinearWorkflowStateType = "backlog" | "unstarted" | "started" | "completed" | "canceled";
+export type LinearTokenType = "personal" | "oauth_access" | "oauth_refresh" | "client_credentials";
+export type LinearTokenActorType = "user" | "app";
+export type LinearIssuePriority = 0 | 1 | 2 | 3 | 4;
+export type LinearAgentActivityType = "thought" | "elicitation" | "action" | "response" | "error" | "prompt";
+
+export interface LinearOrganization extends Entity {
+  linear_id: string;
+  name: string;
+  url_key: string;
+  url: string;
+}
+
+export interface LinearUser extends Entity {
+  linear_id: string;
+  email: string;
+  name: string;
+  display_name: string;
+  avatar_url: string | null;
+  active: boolean;
+  admin: boolean;
+  app: boolean;
+}
+
+export interface LinearTeam extends Entity {
+  linear_id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  private: boolean;
+  url: string;
+  issue_sequence: number;
+}
+
+export interface LinearWorkflowState extends Entity {
+  linear_id: string;
+  team_id: string;
+  name: string;
+  type: LinearWorkflowStateType;
+  position: number;
+}
+
+export interface LinearIssueLabel extends Entity {
+  linear_id: string;
+  team_id: string | null;
+  name: string;
+  color: string;
+  description: string | null;
+}
+
+export interface LinearProject extends Entity {
+  linear_id: string;
+  team_id: string | null;
+  name: string;
+  description: string | null;
+  state: "planned" | "started" | "completed" | "canceled";
+}
+
+export interface LinearCycle extends Entity {
+  linear_id: string;
+  team_id: string;
+  name: string;
+  number: number;
+  starts_at: string | null;
+  ends_at: string | null;
+}
+
+export interface LinearIssue extends Entity {
+  linear_id: string;
+  identifier: string;
+  number: number;
+  team_id: string;
+  title: string;
+  description: string | null;
+  priority: LinearIssuePriority;
+  state_id: string;
+  assignee_id: string | null;
+  creator_id: string | null;
+  delegate_id: string | null;
+  project_id: string | null;
+  cycle_id: string | null;
+  label_ids: string[];
+  url: string;
+  archived_at: string | null;
+  canceled_at: string | null;
+  completed_at: string | null;
+  started_at: string | null;
+  due_date: string | null;
+  create_as_user: string | null;
+  display_icon_url: string | null;
+}
+
+export interface LinearComment extends Entity {
+  linear_id: string;
+  issue_id: string;
+  user_id: string | null;
+  body: string;
+  create_as_user: string | null;
+  display_icon_url: string | null;
+}
+
+export interface LinearOAuthApp extends Entity {
+  linear_id: string;
+  client_id: string;
+  client_secret: string;
+  name: string;
+  redirect_uris: string[];
+  scopes: string[];
+  actor: LinearTokenActorType;
+  assignable: boolean;
+  mentionable: boolean;
+  app_user_id: string | null;
+}
+
+export interface LinearToken extends Entity {
+  token: string;
+  type: LinearTokenType;
+  actor_type: LinearTokenActorType;
+  user_id: string | null;
+  app_id: string | null;
+  scopes: string[];
+  expires_at: string | null;
+  revoked: boolean;
+  refresh_token: string | null;
+}
+
+export interface LinearWebhook extends Entity {
+  linear_id: string;
+  label: string;
+  url: string;
+  enabled: boolean;
+  resource_types: string[];
+  team_id: string | null;
+  all_public_teams: boolean;
+  secret: string | null;
+  creator_id: string | null;
+}
+
+export interface LinearWebhookDelivery extends Entity {
+  linear_id: string;
+  webhook_id: string;
+  event: string;
+  action: string;
+  url: string;
+  status: number | null;
+  error: string | null;
+  payload: unknown;
+  headers: Record<string, string>;
+}
+
+export interface LinearAgentSession extends Entity {
+  linear_id: string;
+  issue_id: string | null;
+  comment_id: string | null;
+  agent_user_id: string;
+  state: "pending" | "active" | "completed" | "failed" | "canceled";
+  plan: string | null;
+  external_url: string | null;
+}
+
+export interface LinearAgentActivity extends Entity {
+  linear_id: string;
+  session_id: string;
+  user_id: string | null;
+  type: LinearAgentActivityType;
+  body: string;
+  ephemeral: boolean;
+}

--- a/packages/@emulators/linear/src/ids.ts
+++ b/packages/@emulators/linear/src/ids.ts
@@ -1,0 +1,16 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+export function linearId(): string {
+  return randomUUID();
+}
+
+export function token(prefix: string): string {
+  return `${prefix}_${randomBytes(24).toString("base64url")}`;
+}
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/packages/@emulators/linear/src/index.ts
+++ b/packages/@emulators/linear/src/index.ts
@@ -360,22 +360,34 @@ export function seedFromConfig(store: Store, baseUrl: string, config: LinearSeed
 
   if (config.oauth_apps) {
     for (const appCfg of config.oauth_apps) {
-      if (ls.oauthApps.findOneBy("client_id", appCfg.client_id)) continue;
-      let appUserId: string | null = null;
-      if (appCfg.actor === "app" || appCfg.assignable || appCfg.mentionable) {
-        appUserId = ensureAppUser(store, appCfg.name).linear_id;
+      const existing = ls.oauthApps.findOneBy("client_id", appCfg.client_id);
+      const actor = appCfg.actor ?? existing?.actor ?? "user";
+      const assignable = appCfg.assignable ?? existing?.assignable ?? false;
+      const mentionable = appCfg.mentionable ?? existing?.mentionable ?? false;
+      let appUserId = existing?.app_user_id ?? null;
+      if (actor === "app" || assignable || mentionable) {
+        appUserId = appUserId ?? ensureAppUser(store, appCfg.name).linear_id;
+      } else {
+        appUserId = null;
+      }
+      const oauthApp = {
+        client_secret: appCfg.client_secret,
+        name: appCfg.name,
+        redirect_uris: appCfg.redirect_uris,
+        scopes: normalizeScopes(appCfg.scopes, existing?.scopes ?? DEFAULT_SCOPES),
+        actor,
+        assignable,
+        mentionable,
+        app_user_id: appUserId,
+      };
+      if (existing) {
+        ls.oauthApps.update(existing.id, oauthApp);
+        continue;
       }
       ls.oauthApps.insert({
         linear_id: appCfg.id ?? linearId(),
         client_id: appCfg.client_id,
-        client_secret: appCfg.client_secret,
-        name: appCfg.name,
-        redirect_uris: appCfg.redirect_uris,
-        scopes: normalizeScopes(appCfg.scopes, DEFAULT_SCOPES),
-        actor: appCfg.actor ?? "user",
-        assignable: appCfg.assignable ?? false,
-        mentionable: appCfg.mentionable ?? false,
-        app_user_id: appUserId,
+        ...oauthApp,
       });
     }
   }
@@ -446,21 +458,28 @@ export function seedFromConfig(store: Store, baseUrl: string, config: LinearSeed
 
   if (config.tokens) {
     for (const tokenCfg of config.tokens) {
-      if (ls.tokens.findOneBy("token", tokenCfg.token)) continue;
+      const existing = ls.tokens.findOneBy("token", tokenCfg.token);
       const app = tokenCfg.app
         ? (ls.oauthApps.findOneBy("client_id", tokenCfg.app) ?? ls.oauthApps.findOneBy("linear_id", tokenCfg.app))
         : undefined;
       const user = tokenCfg.user ? resolveUser(store, tokenCfg.user) : undefined;
-      ls.tokens.insert({
-        token: tokenCfg.token,
-        type: tokenCfg.type ?? "personal",
-        actor_type: tokenCfg.actor ?? (app ? "app" : "user"),
-        user_id: user?.linear_id ?? app?.app_user_id ?? ls.users.all()[0]?.linear_id ?? null,
-        app_id: app?.linear_id ?? null,
-        scopes: normalizeScopes(tokenCfg.scopes, DEFAULT_SCOPES),
+      const tokenRecord = {
+        type: tokenCfg.type ?? existing?.type ?? "personal",
+        actor_type: tokenCfg.actor ?? (app ? "app" : (existing?.actor_type ?? "user")),
+        user_id: user?.linear_id ?? app?.app_user_id ?? existing?.user_id ?? ls.users.all()[0]?.linear_id ?? null,
+        app_id: tokenCfg.app ? (app?.linear_id ?? null) : (existing?.app_id ?? null),
+        scopes: normalizeScopes(tokenCfg.scopes, existing?.scopes ?? DEFAULT_SCOPES),
         expires_at: null,
         revoked: false,
         refresh_token: null,
+      };
+      if (existing) {
+        ls.tokens.update(existing.id, tokenRecord);
+        continue;
+      }
+      ls.tokens.insert({
+        token: tokenCfg.token,
+        ...tokenRecord,
       });
     }
   }

--- a/packages/@emulators/linear/src/index.ts
+++ b/packages/@emulators/linear/src/index.ts
@@ -1,0 +1,712 @@
+import type { Context, Hono } from "@emulators/core";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { getLinearStore } from "./store.js";
+import { linearId, slugify } from "./ids.js";
+import type { LinearIssuePriority, LinearTokenActorType, LinearWorkflowStateType } from "./entities.js";
+import { graphqlRoutes } from "./routes/graphql.js";
+import { oauthRoutes } from "./routes/oauth.js";
+import { inspectorRoutes } from "./routes/inspector.js";
+
+export { getLinearStore, type LinearStore } from "./store.js";
+export * from "./entities.js";
+
+export interface LinearSeedConfig {
+  port?: number;
+  baseUrl?: string;
+  organization?: {
+    name?: string;
+    url_key?: string;
+  };
+  users?: Array<{
+    id?: string;
+    email: string;
+    name?: string;
+    display_name?: string;
+    avatar_url?: string;
+    admin?: boolean;
+    active?: boolean;
+  }>;
+  teams?: Array<{
+    id?: string;
+    key: string;
+    name: string;
+    description?: string;
+    private?: boolean;
+    states?: Array<{
+      id?: string;
+      name: string;
+      type?: LinearWorkflowStateType;
+      position?: number;
+    }>;
+  }>;
+  labels?: Array<{
+    id?: string;
+    name: string;
+    color?: string;
+    description?: string;
+    team?: string;
+  }>;
+  projects?: Array<{
+    id?: string;
+    name: string;
+    description?: string;
+    state?: "planned" | "started" | "completed" | "canceled";
+    team?: string;
+  }>;
+  cycles?: Array<{
+    id?: string;
+    team: string;
+    name: string;
+    number?: number;
+    starts_at?: string;
+    ends_at?: string;
+  }>;
+  issues?: Array<{
+    id?: string;
+    team: string;
+    title: string;
+    description?: string;
+    priority?: LinearIssuePriority;
+    state?: string;
+    assignee?: string;
+    creator?: string;
+    delegate?: string;
+    project?: string;
+    cycle?: string;
+    labels?: string[];
+    due_date?: string;
+  }>;
+  comments?: Array<{
+    id?: string;
+    issue: string;
+    body: string;
+    user?: string;
+  }>;
+  oauth_apps?: Array<{
+    id?: string;
+    client_id: string;
+    client_secret: string;
+    name: string;
+    redirect_uris: string[];
+    scopes?: string[] | string;
+    actor?: LinearTokenActorType;
+    assignable?: boolean;
+    mentionable?: boolean;
+  }>;
+  tokens?: Array<{
+    token: string;
+    type?: "personal" | "oauth_access" | "client_credentials";
+    user?: string;
+    app?: string;
+    scopes?: string[] | string;
+    actor?: LinearTokenActorType;
+  }>;
+  webhooks?: Array<{
+    id?: string;
+    label?: string;
+    url: string;
+    resource_types?: string[] | string;
+    team?: string;
+    all_public_teams?: boolean;
+    secret?: string;
+    enabled?: boolean;
+  }>;
+  strict_scopes?: boolean;
+}
+
+const DEFAULT_SCOPES = ["read", "write", "issues:create", "comments:create", "admin"];
+
+function seedDefaults(store: Store, baseUrl: string): void {
+  const ls = getLinearStore(store);
+  if (!ls.organizations.all()[0]) {
+    ls.organizations.insert({
+      linear_id: linearId(),
+      name: "Emulate",
+      url_key: "emulate",
+      url: "https://linear.app/emulate",
+    });
+  }
+
+  let admin = ls.users.findOneBy("email", "admin@linear.local");
+  if (!admin) {
+    admin = ls.users.insert({
+      linear_id: linearId(),
+      email: "admin@linear.local",
+      name: "Admin User",
+      display_name: "Admin",
+      avatar_url: null,
+      active: true,
+      admin: true,
+      app: false,
+    });
+  }
+
+  let developer = ls.users.findOneBy("email", "dev@linear.local");
+  if (!developer) {
+    developer = ls.users.insert({
+      linear_id: linearId(),
+      email: "dev@linear.local",
+      name: "Developer",
+      display_name: "Developer",
+      avatar_url: null,
+      active: true,
+      admin: false,
+      app: false,
+    });
+  }
+
+  let team = ls.teams.findOneBy("key", "ENG");
+  if (!team) {
+    team = ls.teams.insert({
+      linear_id: linearId(),
+      key: "ENG",
+      name: "Engineering",
+      description: "Default engineering team",
+      private: false,
+      url: "https://linear.app/emulate/team/ENG",
+      issue_sequence: 0,
+    });
+  }
+
+  ensureDefaultStates(store, team.linear_id);
+  const todo = resolveState(store, "Todo", team.linear_id) ?? resolveState(store, "Todo");
+  const bug = ensureLabel(store, { name: "Bug", color: "#d92d20", teamId: team.linear_id });
+  ensureLabel(store, { name: "Feature", color: "#2563eb", teamId: team.linear_id });
+  const project = ensureProject(store, { name: "Local Project", teamId: team.linear_id });
+  const cycle = ensureCycle(store, { name: "Cycle 1", number: 1, teamId: team.linear_id });
+
+  if (ls.issues.all().length === 0 && todo) {
+    const number = nextIssueNumber(store, team.linear_id);
+    const issue = ls.issues.insert({
+      linear_id: linearId(),
+      identifier: `${team.key}-${number}`,
+      number,
+      team_id: team.linear_id,
+      title: "Ship Linear emulator",
+      description: "Use local Linear state in tests without calling the real Linear API.",
+      priority: 3,
+      state_id: todo.linear_id,
+      assignee_id: developer.linear_id,
+      creator_id: admin.linear_id,
+      delegate_id: null,
+      project_id: project.linear_id,
+      cycle_id: cycle.linear_id,
+      label_ids: [bug.linear_id],
+      url: `${baseUrl}/issue/${team.key}-${number}`,
+      archived_at: null,
+      canceled_at: null,
+      completed_at: null,
+      started_at: null,
+      due_date: null,
+      create_as_user: null,
+      display_icon_url: null,
+    });
+    ls.comments.insert({
+      linear_id: linearId(),
+      issue_id: issue.linear_id,
+      user_id: admin.linear_id,
+      body: "This issue was seeded by the Linear emulator.",
+      create_as_user: null,
+      display_icon_url: null,
+    });
+  }
+
+  if (!ls.oauthApps.findOneBy("client_id", "lin_example_client_id")) {
+    ls.oauthApps.insert({
+      linear_id: linearId(),
+      client_id: "lin_example_client_id",
+      client_secret: "example_client_secret",
+      name: "My Linear App",
+      redirect_uris: ["http://localhost:3000/api/auth/callback/linear"],
+      scopes: DEFAULT_SCOPES,
+      actor: "user",
+      assignable: false,
+      mentionable: false,
+      app_user_id: null,
+    });
+  }
+
+  if (!ls.tokens.findOneBy("token", "lin_test_admin")) {
+    ls.tokens.insert({
+      token: "lin_test_admin",
+      type: "personal",
+      actor_type: "user",
+      user_id: admin.linear_id,
+      app_id: null,
+      scopes: DEFAULT_SCOPES,
+      expires_at: null,
+      revoked: false,
+      refresh_token: null,
+    });
+  }
+}
+
+export function seedFromConfig(store: Store, baseUrl: string, config: LinearSeedConfig): void {
+  const ls = getLinearStore(store);
+
+  if (config.organization) {
+    const existing = ls.organizations.all()[0];
+    const name = config.organization.name ?? existing?.name ?? "Emulate";
+    const urlKey = config.organization.url_key ?? existing?.url_key ?? slugify(name);
+    if (existing) {
+      ls.organizations.update(existing.id, {
+        name,
+        url_key: urlKey,
+        url: `https://linear.app/${urlKey}`,
+      });
+    } else {
+      ls.organizations.insert({
+        linear_id: linearId(),
+        name,
+        url_key: urlKey,
+        url: `https://linear.app/${urlKey}`,
+      });
+    }
+  }
+
+  if (config.users) {
+    for (const userCfg of config.users) {
+      const existing = ls.users.findOneBy("email", userCfg.email);
+      if (existing) continue;
+      const name = userCfg.name ?? userCfg.display_name ?? userCfg.email.split("@")[0];
+      ls.users.insert({
+        linear_id: userCfg.id ?? linearId(),
+        email: userCfg.email,
+        name,
+        display_name: userCfg.display_name ?? name,
+        avatar_url: userCfg.avatar_url ?? null,
+        active: userCfg.active ?? true,
+        admin: userCfg.admin ?? false,
+        app: false,
+      });
+    }
+  }
+
+  if (config.teams) {
+    for (const teamCfg of config.teams) {
+      let team = ls.teams.findOneBy("key", teamCfg.key);
+      if (!team) {
+        team = ls.teams.insert({
+          linear_id: teamCfg.id ?? linearId(),
+          key: teamCfg.key,
+          name: teamCfg.name,
+          description: teamCfg.description ?? null,
+          private: teamCfg.private ?? false,
+          url: `https://linear.app/${ls.organizations.all()[0]?.url_key ?? "emulate"}/team/${teamCfg.key}`,
+          issue_sequence: 0,
+        });
+      }
+
+      if (teamCfg.states) {
+        for (let i = 0; i < teamCfg.states.length; i++) {
+          const stateCfg = teamCfg.states[i];
+          if (ls.workflowStates.findBy("team_id", team.linear_id).some((state) => state.name === stateCfg.name)) {
+            continue;
+          }
+          ls.workflowStates.insert({
+            linear_id: stateCfg.id ?? linearId(),
+            team_id: team.linear_id,
+            name: stateCfg.name,
+            type: stateCfg.type ?? inferStateType(stateCfg.name),
+            position: stateCfg.position ?? i + 1,
+          });
+        }
+      } else {
+        ensureDefaultStates(store, team.linear_id);
+      }
+    }
+  }
+
+  if (config.labels) {
+    for (const labelCfg of config.labels) {
+      const teamId = labelCfg.team ? (resolveTeam(store, labelCfg.team)?.linear_id ?? null) : null;
+      ensureLabel(store, {
+        id: labelCfg.id,
+        name: labelCfg.name,
+        color: labelCfg.color ?? "#64748b",
+        description: labelCfg.description,
+        teamId,
+      });
+    }
+  }
+
+  if (config.projects) {
+    for (const projectCfg of config.projects) {
+      const teamId = projectCfg.team ? (resolveTeam(store, projectCfg.team)?.linear_id ?? null) : null;
+      ensureProject(store, {
+        id: projectCfg.id,
+        name: projectCfg.name,
+        description: projectCfg.description,
+        state: projectCfg.state,
+        teamId,
+      });
+    }
+  }
+
+  if (config.cycles) {
+    for (const cycleCfg of config.cycles) {
+      const team = resolveTeam(store, cycleCfg.team);
+      if (!team) continue;
+      ensureCycle(store, {
+        id: cycleCfg.id,
+        name: cycleCfg.name,
+        number: cycleCfg.number,
+        teamId: team.linear_id,
+        startsAt: cycleCfg.starts_at,
+        endsAt: cycleCfg.ends_at,
+      });
+    }
+  }
+
+  if (config.oauth_apps) {
+    for (const appCfg of config.oauth_apps) {
+      if (ls.oauthApps.findOneBy("client_id", appCfg.client_id)) continue;
+      let appUserId: string | null = null;
+      if (appCfg.actor === "app" || appCfg.assignable || appCfg.mentionable) {
+        appUserId = ensureAppUser(store, appCfg.name).linear_id;
+      }
+      ls.oauthApps.insert({
+        linear_id: appCfg.id ?? linearId(),
+        client_id: appCfg.client_id,
+        client_secret: appCfg.client_secret,
+        name: appCfg.name,
+        redirect_uris: appCfg.redirect_uris,
+        scopes: normalizeScopes(appCfg.scopes, DEFAULT_SCOPES),
+        actor: appCfg.actor ?? "user",
+        assignable: appCfg.assignable ?? false,
+        mentionable: appCfg.mentionable ?? false,
+        app_user_id: appUserId,
+      });
+    }
+  }
+
+  if (config.issues) {
+    for (const issueCfg of config.issues) {
+      const team = resolveTeam(store, issueCfg.team);
+      if (!team) continue;
+      const existing = ls.issues
+        .all()
+        .find((issue) => issue.title === issueCfg.title && issue.team_id === team.linear_id);
+      if (existing) continue;
+      const state =
+        (issueCfg.state ? resolveState(store, issueCfg.state, team.linear_id) : undefined) ??
+        resolveState(store, "Todo", team.linear_id) ??
+        ls.workflowStates.findBy("team_id", team.linear_id)[0];
+      if (!state) continue;
+      const number = nextIssueNumber(store, team.linear_id);
+      const labelIds = (issueCfg.labels ?? [])
+        .map((label) => resolveLabel(store, label, team.linear_id)?.linear_id)
+        .filter((id): id is string => Boolean(id));
+      ls.issues.insert({
+        linear_id: issueCfg.id ?? linearId(),
+        identifier: `${team.key}-${number}`,
+        number,
+        team_id: team.linear_id,
+        title: issueCfg.title,
+        description: issueCfg.description ?? null,
+        priority: issueCfg.priority ?? 0,
+        state_id: state.linear_id,
+        assignee_id: issueCfg.assignee ? (resolveUser(store, issueCfg.assignee)?.linear_id ?? null) : null,
+        creator_id: issueCfg.creator
+          ? (resolveUser(store, issueCfg.creator)?.linear_id ?? null)
+          : (ls.users.all()[0]?.linear_id ?? null),
+        delegate_id: issueCfg.delegate ? (resolveUser(store, issueCfg.delegate)?.linear_id ?? null) : null,
+        project_id: issueCfg.project ? (resolveProject(store, issueCfg.project)?.linear_id ?? null) : null,
+        cycle_id: issueCfg.cycle ? (resolveCycle(store, issueCfg.cycle, team.linear_id)?.linear_id ?? null) : null,
+        label_ids: labelIds,
+        url: `${baseUrl}/issue/${team.key}-${number}`,
+        archived_at: null,
+        canceled_at: null,
+        completed_at: state.type === "completed" ? new Date().toISOString() : null,
+        started_at: state.type === "started" ? new Date().toISOString() : null,
+        due_date: issueCfg.due_date ?? null,
+        create_as_user: null,
+        display_icon_url: null,
+      });
+    }
+  }
+
+  if (config.comments) {
+    for (const commentCfg of config.comments) {
+      const issue = resolveIssue(store, commentCfg.issue);
+      if (!issue) continue;
+      ls.comments.insert({
+        linear_id: commentCfg.id ?? linearId(),
+        issue_id: issue.linear_id,
+        user_id: commentCfg.user
+          ? (resolveUser(store, commentCfg.user)?.linear_id ?? null)
+          : (ls.users.all()[0]?.linear_id ?? null),
+        body: commentCfg.body,
+        create_as_user: null,
+        display_icon_url: null,
+      });
+    }
+  }
+
+  if (config.tokens) {
+    for (const tokenCfg of config.tokens) {
+      if (ls.tokens.findOneBy("token", tokenCfg.token)) continue;
+      const app = tokenCfg.app
+        ? (ls.oauthApps.findOneBy("client_id", tokenCfg.app) ?? ls.oauthApps.findOneBy("linear_id", tokenCfg.app))
+        : undefined;
+      const user = tokenCfg.user ? resolveUser(store, tokenCfg.user) : undefined;
+      ls.tokens.insert({
+        token: tokenCfg.token,
+        type: tokenCfg.type ?? "personal",
+        actor_type: tokenCfg.actor ?? (app ? "app" : "user"),
+        user_id: user?.linear_id ?? app?.app_user_id ?? ls.users.all()[0]?.linear_id ?? null,
+        app_id: app?.linear_id ?? null,
+        scopes: normalizeScopes(tokenCfg.scopes, DEFAULT_SCOPES),
+        expires_at: null,
+        revoked: false,
+        refresh_token: null,
+      });
+    }
+  }
+
+  if (config.webhooks) {
+    for (const whCfg of config.webhooks) {
+      const team = whCfg.team ? resolveTeam(store, whCfg.team) : undefined;
+      ls.webhooks.insert({
+        linear_id: whCfg.id ?? linearId(),
+        label: whCfg.label ?? "Local webhook",
+        url: whCfg.url,
+        enabled: whCfg.enabled ?? true,
+        resource_types: normalizeScopes(whCfg.resource_types, ["Issue", "Comment"]),
+        team_id: team?.linear_id ?? null,
+        all_public_teams: whCfg.all_public_teams ?? !team,
+        secret: whCfg.secret ?? null,
+        creator_id: ls.users.all()[0]?.linear_id ?? null,
+      });
+    }
+  }
+
+  if (config.strict_scopes !== undefined) {
+    store.setData("linear.strict_scopes", config.strict_scopes);
+  }
+}
+
+export const linearPlugin: ServicePlugin = {
+  name: "linear",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    app.use("*", async (c, next) => {
+      applyLinearTokenAuth(c, store);
+      await next();
+    });
+
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    graphqlRoutes(ctx);
+    oauthRoutes(ctx);
+    inspectorRoutes(ctx);
+  },
+  seed(store: Store, baseUrl: string): void {
+    seedDefaults(store, baseUrl);
+  },
+};
+
+export default linearPlugin;
+
+export function normalizeScopes(value: string[] | string | undefined, fallback: string[] = []): string[] {
+  if (Array.isArray(value)) return value.map((scope) => scope.trim()).filter(Boolean);
+  if (typeof value === "string") {
+    return value
+      .split(/[,\s]+/)
+      .map((scope) => scope.trim())
+      .filter(Boolean);
+  }
+  return [...fallback];
+}
+
+export function resolveUser(store: Store, ref: string | undefined | null) {
+  if (!ref) return undefined;
+  const ls = getLinearStore(store);
+  return (
+    ls.users.findOneBy("linear_id", ref) ??
+    ls.users.findOneBy("email", ref) ??
+    ls.users.all().find((user) => user.name === ref || user.display_name === ref)
+  );
+}
+
+export function resolveTeam(store: Store, ref: string | undefined | null) {
+  if (!ref) return undefined;
+  const ls = getLinearStore(store);
+  return ls.teams.findOneBy("linear_id", ref) ?? ls.teams.findOneBy("key", ref) ?? ls.teams.findOneBy("name", ref);
+}
+
+export function resolveState(store: Store, ref: string | undefined | null, teamId?: string) {
+  if (!ref) return undefined;
+  const ls = getLinearStore(store);
+  const states = teamId ? ls.workflowStates.findBy("team_id", teamId) : ls.workflowStates.all();
+  return states.find((state) => state.linear_id === ref || state.name === ref || state.type === ref);
+}
+
+export function resolveIssue(store: Store, ref: string | undefined | null) {
+  if (!ref) return undefined;
+  const ls = getLinearStore(store);
+  return ls.issues.findOneBy("linear_id", ref) ?? ls.issues.findOneBy("identifier", ref);
+}
+
+export function resolveLabel(store: Store, ref: string | undefined | null, teamId?: string) {
+  if (!ref) return undefined;
+  const ls = getLinearStore(store);
+  const labels = teamId
+    ? ls.issueLabels.all().filter((label) => label.team_id === teamId || label.team_id === null)
+    : ls.issueLabels.all();
+  return labels.find((label) => label.linear_id === ref || label.name === ref);
+}
+
+export function resolveProject(store: Store, ref: string | undefined | null) {
+  if (!ref) return undefined;
+  const ls = getLinearStore(store);
+  return ls.projects.findOneBy("linear_id", ref) ?? ls.projects.findOneBy("name", ref);
+}
+
+export function resolveCycle(store: Store, ref: string | undefined | null, teamId?: string) {
+  if (!ref) return undefined;
+  const ls = getLinearStore(store);
+  const cycles = teamId ? ls.cycles.findBy("team_id", teamId) : ls.cycles.all();
+  return cycles.find((cycle) => cycle.linear_id === ref || cycle.name === ref || String(cycle.number) === ref);
+}
+
+export function nextIssueNumber(store: Store, teamId: string): number {
+  const ls = getLinearStore(store);
+  const team = ls.teams.findOneBy("linear_id", teamId);
+  if (!team) return 1;
+  const next = team.issue_sequence + 1;
+  ls.teams.update(team.id, { issue_sequence: next });
+  return next;
+}
+
+function applyLinearTokenAuth(c: Context, store: Store): void {
+  const requestToken = linearRequestToken(c);
+  if (!requestToken) return;
+
+  const record = getLinearStore(store).tokens.findOneBy("token", requestToken);
+  if (!record || record.revoked) return;
+  if (record.expires_at && new Date(record.expires_at).getTime() <= Date.now()) return;
+
+  const user = record.user_id ? getLinearStore(store).users.findOneBy("linear_id", record.user_id) : undefined;
+  c.set("authToken", record.token);
+  c.set("authScopes", record.scopes);
+  c.set("authUser", {
+    login: user?.email ?? record.user_id ?? record.app_id ?? "linear-app",
+    id: record.id,
+    scopes: record.scopes,
+  });
+}
+
+function linearRequestToken(c: Context): string | undefined {
+  const authHeader = c.req.header("Authorization");
+  if (!authHeader) return undefined;
+  const token = authHeader.replace(/^(Bearer|token)\s+/i, "").trim();
+  return token || undefined;
+}
+
+function ensureDefaultStates(store: Store, teamId: string): void {
+  const defaults: Array<{ name: string; type: LinearWorkflowStateType; position: number }> = [
+    { name: "Backlog", type: "backlog", position: 1 },
+    { name: "Todo", type: "unstarted", position: 2 },
+    { name: "In Progress", type: "started", position: 3 },
+    { name: "Done", type: "completed", position: 4 },
+  ];
+  const ls = getLinearStore(store);
+  for (const state of defaults) {
+    if (ls.workflowStates.findBy("team_id", teamId).some((existing) => existing.name === state.name)) continue;
+    ls.workflowStates.insert({
+      linear_id: linearId(),
+      team_id: teamId,
+      ...state,
+    });
+  }
+}
+
+function inferStateType(name: string): LinearWorkflowStateType {
+  const lower = name.toLowerCase();
+  if (lower.includes("backlog")) return "backlog";
+  if (lower.includes("progress") || lower.includes("started")) return "started";
+  if (lower.includes("done") || lower.includes("complete")) return "completed";
+  if (lower.includes("cancel")) return "canceled";
+  return "unstarted";
+}
+
+function ensureLabel(
+  store: Store,
+  input: { id?: string; name: string; color: string; description?: string; teamId: string | null },
+) {
+  const ls = getLinearStore(store);
+  const existing = ls.issueLabels
+    .all()
+    .find((label) => label.name === input.name && (label.team_id === input.teamId || label.team_id === null));
+  if (existing) return existing;
+  return ls.issueLabels.insert({
+    linear_id: input.id ?? linearId(),
+    team_id: input.teamId,
+    name: input.name,
+    color: input.color,
+    description: input.description ?? null,
+  });
+}
+
+function ensureProject(
+  store: Store,
+  input: {
+    id?: string;
+    name: string;
+    description?: string;
+    state?: "planned" | "started" | "completed" | "canceled";
+    teamId: string | null;
+  },
+) {
+  const ls = getLinearStore(store);
+  const existing = ls.projects.all().find((project) => project.name === input.name && project.team_id === input.teamId);
+  if (existing) return existing;
+  return ls.projects.insert({
+    linear_id: input.id ?? linearId(),
+    team_id: input.teamId,
+    name: input.name,
+    description: input.description ?? null,
+    state: input.state ?? "planned",
+  });
+}
+
+function ensureCycle(
+  store: Store,
+  input: {
+    id?: string;
+    name: string;
+    number?: number;
+    teamId: string;
+    startsAt?: string;
+    endsAt?: string;
+  },
+) {
+  const ls = getLinearStore(store);
+  const existing = ls.cycles.findBy("team_id", input.teamId).find((cycle) => cycle.name === input.name);
+  if (existing) return existing;
+  const number = input.number ?? ls.cycles.findBy("team_id", input.teamId).length + 1;
+  return ls.cycles.insert({
+    linear_id: input.id ?? linearId(),
+    team_id: input.teamId,
+    name: input.name,
+    number,
+    starts_at: input.startsAt ?? null,
+    ends_at: input.endsAt ?? null,
+  });
+}
+
+function ensureAppUser(store: Store, appName: string) {
+  const ls = getLinearStore(store);
+  const email = `${slugify(appName) || "linear-app"}@apps.linear.local`;
+  const existing = ls.users.findOneBy("email", email);
+  if (existing) return existing;
+  return ls.users.insert({
+    linear_id: linearId(),
+    email,
+    name: appName,
+    display_name: appName,
+    avatar_url: null,
+    active: true,
+    admin: false,
+    app: true,
+  });
+}

--- a/packages/@emulators/linear/src/index.ts
+++ b/packages/@emulators/linear/src/index.ts
@@ -397,6 +397,7 @@ export function seedFromConfig(store: Store, baseUrl: string, config: LinearSeed
       const labelIds = (issueCfg.labels ?? [])
         .map((label) => resolveLabel(store, label, team.linear_id)?.linear_id)
         .filter((id): id is string => Boolean(id));
+      const now = new Date().toISOString();
       ls.issues.insert({
         linear_id: issueCfg.id ?? linearId(),
         identifier: `${team.key}-${number}`,
@@ -416,9 +417,9 @@ export function seedFromConfig(store: Store, baseUrl: string, config: LinearSeed
         label_ids: labelIds,
         url: `${baseUrl}/issue/${team.key}-${number}`,
         archived_at: null,
-        canceled_at: null,
-        completed_at: state.type === "completed" ? new Date().toISOString() : null,
-        started_at: state.type === "started" ? new Date().toISOString() : null,
+        canceled_at: state.type === "canceled" ? now : null,
+        completed_at: state.type === "completed" ? now : null,
+        started_at: state.type === "started" ? now : null,
         due_date: issueCfg.due_date ?? null,
         create_as_user: null,
         display_icon_url: null,

--- a/packages/@emulators/linear/src/index.ts
+++ b/packages/@emulators/linear/src/index.ts
@@ -490,7 +490,8 @@ export const linearPlugin: ServicePlugin = {
   name: "linear",
   register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
     app.use("*", async (c, next) => {
-      applyLinearTokenAuth(c, store);
+      const authError = applyLinearTokenAuth(c, store);
+      if (authError) return authError;
       await next();
     });
 
@@ -577,13 +578,19 @@ export function nextIssueNumber(store: Store, teamId: string): number {
   return next;
 }
 
-function applyLinearTokenAuth(c: Context, store: Store): void {
+function applyLinearTokenAuth(c: Context, store: Store): Response | undefined {
   const requestToken = linearRequestToken(c);
   if (!requestToken) return;
 
   const record = getLinearStore(store).tokens.findOneBy("token", requestToken);
-  if (!record || record.revoked) return;
-  if (record.expires_at && new Date(record.expires_at).getTime() <= Date.now()) return;
+  if (!record) return;
+  if (record.type === "oauth_refresh") {
+    return linearAuthError(c, "OAuth refresh tokens cannot be used as Linear API access tokens.");
+  }
+  if (record.revoked) return linearAuthError(c, "Linear token has been revoked.");
+  if (record.expires_at && new Date(record.expires_at).getTime() <= Date.now()) {
+    return linearAuthError(c, "Linear token has expired.");
+  }
 
   const user = record.user_id ? getLinearStore(store).users.findOneBy("linear_id", record.user_id) : undefined;
   c.set("authToken", record.token);
@@ -593,6 +600,16 @@ function applyLinearTokenAuth(c: Context, store: Store): void {
     id: record.id,
     scopes: record.scopes,
   });
+}
+
+function linearAuthError(c: Context, message: string): Response {
+  return c.json(
+    {
+      message,
+      documentation_url: c.get("docsUrl") ?? "https://emulate.dev/linear",
+    },
+    401,
+  );
 }
 
 function linearRequestToken(c: Context): string | undefined {

--- a/packages/@emulators/linear/src/pagination.ts
+++ b/packages/@emulators/linear/src/pagination.ts
@@ -1,0 +1,53 @@
+export interface ConnectionArgs {
+  first?: number | null;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
+}
+
+export function connectionFromArray<T>(items: T[], args: ConnectionArgs = {}) {
+  const beforeIndex = args.before ? decodeCursor(args.before) : items.length;
+  const afterIndex = args.after ? decodeCursor(args.after) + 1 : 0;
+  let start = Math.max(0, afterIndex);
+  let end = Math.min(items.length, beforeIndex);
+
+  if (typeof args.first === "number") {
+    end = Math.min(end, start + Math.max(0, args.first));
+  } else if (typeof args.last === "number") {
+    start = Math.max(start, end - Math.max(0, args.last));
+  } else {
+    end = Math.min(end, start + 50);
+  }
+
+  const slice = items.slice(start, end);
+  const edges = slice.map((node, offset) => ({
+    node,
+    cursor: encodeCursor(start + offset),
+  }));
+
+  return {
+    nodes: slice,
+    edges,
+    pageInfo: {
+      hasNextPage: end < items.length,
+      hasPreviousPage: start > 0,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+}
+
+function encodeCursor(index: number): string {
+  return Buffer.from(`linear:${index}`, "utf-8").toString("base64url");
+}
+
+function decodeCursor(cursor: string): number {
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf-8");
+    const [, index] = decoded.split(":");
+    const parsed = Number(index);
+    return Number.isFinite(parsed) ? parsed : -1;
+  } catch {
+    return -1;
+  }
+}

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -1,0 +1,1690 @@
+import { buildSchema, graphql } from "graphql";
+import type { Context, RouteContext, Store } from "@emulators/core";
+import { getLinearStore } from "../store.js";
+import { linearId } from "../ids.js";
+import { connectionFromArray, type ConnectionArgs } from "../pagination.js";
+import { currentUser, requireLinearScopes } from "../auth.js";
+import {
+  nextIssueNumber,
+  resolveCycle,
+  resolveIssue,
+  resolveLabel,
+  resolveProject,
+  resolveState,
+  resolveTeam,
+  resolveUser,
+} from "../index.js";
+import type {
+  LinearAgentActivity,
+  LinearAgentActivityType,
+  LinearAgentSession,
+  LinearComment,
+  LinearCycle,
+  LinearIssue,
+  LinearIssueLabel,
+  LinearIssuePriority,
+  LinearProject,
+  LinearTeam,
+  LinearUser,
+  LinearWebhook,
+  LinearWorkflowState,
+} from "../entities.js";
+import { dispatchLinearWebhook } from "../webhooks.js";
+
+const schema = buildSchema(`
+  type Query {
+    viewer: User!
+    organization: Organization!
+    users(first: Int, after: String, last: Int, before: String, filter: UserFilter): UserConnection!
+    user(id: String!): User
+    teams(first: Int, after: String, last: Int, before: String): TeamConnection!
+    team(id: String!): Team
+    workflowStates(first: Int, after: String, last: Int, before: String): WorkflowStateConnection!
+    workflowState(id: String!): WorkflowState
+    issues(first: Int, after: String, last: Int, before: String, filter: IssueFilter, orderBy: String): IssueConnection!
+    issue(id: String!): Issue
+    comments(first: Int, after: String, last: Int, before: String): CommentConnection!
+    comment(id: String!): Comment
+    issueLabels(first: Int, after: String, last: Int, before: String): IssueLabelConnection!
+    issueLabel(id: String!): IssueLabel
+    projects(first: Int, after: String, last: Int, before: String): ProjectConnection!
+    project(id: String!): Project
+    cycles(first: Int, after: String, last: Int, before: String): CycleConnection!
+    cycle(id: String!): Cycle
+    webhooks(first: Int, after: String, last: Int, before: String): WebhookConnection!
+    webhook(id: String!): Webhook
+    agentSessions(first: Int, after: String, last: Int, before: String): AgentSessionConnection!
+    agentSession(id: String!): AgentSession
+  }
+
+  type Mutation {
+    issueCreate(input: IssueCreateInput!): IssuePayload!
+    issueUpdate(input: IssueUpdateInput!): IssuePayload!
+    issueDelete(id: String!): ArchivePayload!
+    issueArchive(id: String!): IssuePayload!
+    issueUnarchive(id: String!): IssuePayload!
+    commentCreate(input: CommentCreateInput!): CommentPayload!
+    commentUpdate(input: CommentUpdateInput!): CommentPayload!
+    commentDelete(id: String!): ArchivePayload!
+    issueLabelCreate(input: IssueLabelCreateInput!): IssueLabelPayload!
+    issueLabelUpdate(input: IssueLabelUpdateInput!): IssueLabelPayload!
+    issueLabelDelete(id: String!): ArchivePayload!
+    issueAddLabel(id: String!, labelId: String!): IssuePayload!
+    issueRemoveLabel(id: String!, labelId: String!): IssuePayload!
+    webhookCreate(input: WebhookCreateInput!): WebhookPayload!
+    webhookDelete(id: String!): ArchivePayload!
+    agentSessionCreateOnIssue(input: AgentSessionCreateOnIssueInput!): AgentSessionPayload!
+    agentSessionCreateOnComment(input: AgentSessionCreateOnCommentInput!): AgentSessionPayload!
+    agentSessionUpdate(input: AgentSessionUpdateInput!): AgentSessionPayload!
+    agentActivityCreate(input: AgentActivityCreateInput!): AgentActivityPayload!
+  }
+
+  type Organization {
+    id: String!
+    name: String!
+    urlKey: String!
+    url: String!
+    createdAt: String!
+    updatedAt: String!
+    users(first: Int, after: String, last: Int, before: String): UserConnection!
+    teams(first: Int, after: String, last: Int, before: String): TeamConnection!
+  }
+
+  type User {
+    id: String!
+    name: String!
+    displayName: String!
+    email: String!
+    description: String
+    avatarUrl: String
+    createdIssueCount: Int!
+    avatarBackgroundColor: String
+    statusUntilAt: String
+    statusEmoji: String
+    initials: String!
+    lastSeen: String
+    timezone: String
+    disableReason: String
+    statusLabel: String
+    archivedAt: String
+    gitHubUserId: String
+    title: String
+    url: String!
+    active: Boolean!
+    isAssignable: Boolean!
+    guest: Boolean!
+    admin: Boolean!
+    owner: Boolean!
+    app: Boolean!
+    isMentionable: Boolean!
+    isMe: Boolean!
+    supportsAgentSessions: Boolean!
+    canAccessAnyPublicTeam: Boolean!
+    calendarHash: String
+    inviteHash: String
+    createdAt: String!
+    updatedAt: String!
+    assignedIssues(first: Int, after: String, last: Int, before: String): IssueConnection!
+    createdIssues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Team {
+    id: String!
+    key: String!
+    name: String!
+    description: String
+    private: Boolean!
+    url: String!
+    createdAt: String!
+    updatedAt: String!
+    states(first: Int, after: String, last: Int, before: String): WorkflowStateConnection!
+    issues(first: Int, after: String, last: Int, before: String, filter: IssueFilter): IssueConnection!
+    labels(first: Int, after: String, last: Int, before: String): IssueLabelConnection!
+    projects(first: Int, after: String, last: Int, before: String): ProjectConnection!
+    cycles(first: Int, after: String, last: Int, before: String): CycleConnection!
+    webhooks(first: Int, after: String, last: Int, before: String): WebhookConnection!
+  }
+
+  type WorkflowState {
+    id: String!
+    name: String!
+    type: String!
+    position: Int!
+    createdAt: String!
+    updatedAt: String!
+    team: Team!
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Issue {
+    id: String!
+    identifier: String!
+    number: Int!
+    title: String!
+    description: String
+    priority: Int!
+    url: String!
+    createdAt: String!
+    updatedAt: String!
+    archivedAt: String
+    canceledAt: String
+    completedAt: String
+    startedAt: String
+    dueDate: String
+    createAsUser: String
+    displayIconUrl: String
+    team: Team!
+    state: WorkflowState!
+    assignee: User
+    creator: User
+    delegate: User
+    labels(first: Int, after: String, last: Int, before: String): IssueLabelConnection!
+    comments(first: Int, after: String, last: Int, before: String): CommentConnection!
+    project: Project
+    cycle: Cycle
+  }
+
+  type Comment {
+    id: String!
+    body: String!
+    createdAt: String!
+    updatedAt: String!
+    createAsUser: String
+    displayIconUrl: String
+    issue: Issue!
+    user: User
+  }
+
+  type IssueLabel {
+    id: String!
+    name: String!
+    color: String!
+    description: String
+    createdAt: String!
+    updatedAt: String!
+    team: Team
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Project {
+    id: String!
+    name: String!
+    description: String
+    state: String!
+    createdAt: String!
+    updatedAt: String!
+    team: Team
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Cycle {
+    id: String!
+    name: String!
+    number: Int!
+    startsAt: String
+    endsAt: String
+    createdAt: String!
+    updatedAt: String!
+    team: Team!
+    issues(first: Int, after: String, last: Int, before: String): IssueConnection!
+  }
+
+  type Webhook {
+    id: String!
+    label: String!
+    url: String!
+    enabled: Boolean!
+    resourceTypes: [String!]!
+    allPublicTeams: Boolean!
+    secret: String
+    createdAt: String!
+    updatedAt: String!
+    team: Team
+  }
+
+  type AgentSession {
+    id: String!
+    state: String!
+    plan: String
+    externalUrl: String
+    createdAt: String!
+    updatedAt: String!
+    issue: Issue
+    comment: Comment
+    agentUser: User!
+    activities(first: Int, after: String, last: Int, before: String): AgentActivityConnection!
+  }
+
+  type AgentActivity {
+    id: String!
+    type: String!
+    body: String!
+    ephemeral: Boolean!
+    createdAt: String!
+    updatedAt: String!
+    session: AgentSession!
+    user: User
+  }
+
+  type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+  }
+
+  type UserEdge { node: User! cursor: String! }
+  type TeamEdge { node: Team! cursor: String! }
+  type WorkflowStateEdge { node: WorkflowState! cursor: String! }
+  type IssueEdge { node: Issue! cursor: String! }
+  type CommentEdge { node: Comment! cursor: String! }
+  type IssueLabelEdge { node: IssueLabel! cursor: String! }
+  type ProjectEdge { node: Project! cursor: String! }
+  type CycleEdge { node: Cycle! cursor: String! }
+  type WebhookEdge { node: Webhook! cursor: String! }
+  type AgentSessionEdge { node: AgentSession! cursor: String! }
+  type AgentActivityEdge { node: AgentActivity! cursor: String! }
+
+  type UserConnection { nodes: [User!]! edges: [UserEdge!]! pageInfo: PageInfo! }
+  type TeamConnection { nodes: [Team!]! edges: [TeamEdge!]! pageInfo: PageInfo! }
+  type WorkflowStateConnection { nodes: [WorkflowState!]! edges: [WorkflowStateEdge!]! pageInfo: PageInfo! }
+  type IssueConnection { nodes: [Issue!]! edges: [IssueEdge!]! pageInfo: PageInfo! }
+  type CommentConnection { nodes: [Comment!]! edges: [CommentEdge!]! pageInfo: PageInfo! }
+  type IssueLabelConnection { nodes: [IssueLabel!]! edges: [IssueLabelEdge!]! pageInfo: PageInfo! }
+  type ProjectConnection { nodes: [Project!]! edges: [ProjectEdge!]! pageInfo: PageInfo! }
+  type CycleConnection { nodes: [Cycle!]! edges: [CycleEdge!]! pageInfo: PageInfo! }
+  type WebhookConnection { nodes: [Webhook!]! edges: [WebhookEdge!]! pageInfo: PageInfo! }
+  type AgentSessionConnection { nodes: [AgentSession!]! edges: [AgentSessionEdge!]! pageInfo: PageInfo! }
+  type AgentActivityConnection { nodes: [AgentActivity!]! edges: [AgentActivityEdge!]! pageInfo: PageInfo! }
+
+  type IssuePayload { success: Boolean! issue: Issue }
+  type CommentPayload { success: Boolean! comment: Comment }
+  type IssueLabelPayload { success: Boolean! issueLabel: IssueLabel }
+  type WebhookPayload { success: Boolean! webhook: Webhook }
+  type AgentSessionPayload { success: Boolean! agentSession: AgentSession }
+  type AgentActivityPayload { success: Boolean! agentActivity: AgentActivity }
+  type ArchivePayload { success: Boolean! }
+
+  input StringComparator {
+    eq: String
+    neq: String
+    in: [String!]
+    nin: [String!]
+    contains: String
+    startsWith: String
+    endsWith: String
+    eqIgnoreCase: String
+    neqIgnoreCase: String
+    null: Boolean
+  }
+
+  input IssueFilter {
+    id: StringComparator
+    identifier: StringComparator
+    title: StringComparator
+    team: StringComparator
+    state: StringComparator
+    assignee: StringComparator
+    creator: StringComparator
+    project: StringComparator
+    cycle: StringComparator
+    labels: StringComparator
+    or: [IssueFilter!]
+  }
+
+  input UserFilter {
+    id: StringComparator
+    email: StringComparator
+    name: StringComparator
+    active: Boolean
+    admin: Boolean
+  }
+
+  input IssueCreateInput {
+    teamId: String!
+    title: String!
+    description: String
+    priority: Int
+    stateId: String
+    assigneeId: String
+    delegateId: String
+    labelIds: [String!]
+    projectId: String
+    cycleId: String
+    createAsUser: String
+    displayIconUrl: String
+    dueDate: String
+  }
+
+  input IssueUpdateInput {
+    id: String!
+    title: String
+    description: String
+    priority: Int
+    stateId: String
+    assigneeId: String
+    delegateId: String
+    labelIds: [String!]
+    projectId: String
+    cycleId: String
+    archivedAt: String
+    dueDate: String
+  }
+
+  input CommentCreateInput {
+    issueId: String!
+    body: String!
+    createAsUser: String
+    displayIconUrl: String
+  }
+
+  input CommentUpdateInput {
+    id: String!
+    body: String!
+  }
+
+  input IssueLabelCreateInput {
+    name: String!
+    color: String
+    description: String
+    teamId: String
+  }
+
+  input IssueLabelUpdateInput {
+    id: String!
+    name: String
+    color: String
+    description: String
+  }
+
+  input WebhookCreateInput {
+    url: String!
+    label: String
+    resourceTypes: [String!]
+    teamId: String
+    allPublicTeams: Boolean
+    secret: String
+    enabled: Boolean
+  }
+
+  input AgentSessionCreateOnIssueInput {
+    issueId: String!
+    agentUserId: String
+    plan: String
+    externalUrl: String
+  }
+
+  input AgentSessionCreateOnCommentInput {
+    commentId: String!
+    agentUserId: String
+    plan: String
+    externalUrl: String
+  }
+
+  input AgentSessionUpdateInput {
+    id: String!
+    state: String
+    plan: String
+    externalUrl: String
+  }
+
+  input AgentActivityCreateInput {
+    sessionId: String!
+    type: String!
+    body: String!
+    ephemeral: Boolean
+  }
+`);
+
+interface LinearGraphQLContext {
+  store: Store;
+  c: Context;
+  baseUrl: string;
+}
+
+export function graphqlRoutes(ctx: RouteContext): void {
+  const { app, store, baseUrl } = ctx;
+
+  app.get("/graphql", async (c) => {
+    const result = await runGraphQL(c.req.query("query") ?? "", {
+      variables: parseVariables(c.req.query("variables")),
+      operationName: c.req.query("operationName") ?? undefined,
+      context: { store, c, baseUrl },
+    });
+    return c.json(result, result.errors ? 400 : 200);
+  });
+
+  app.post("/graphql", async (c) => {
+    const body = await readGraphQLBody(c);
+    const result = await runGraphQL(body.query, {
+      variables: body.variables,
+      operationName: body.operationName,
+      context: { store, c, baseUrl },
+    });
+    return c.json(result, result.errors ? 400 : 200);
+  });
+}
+
+async function runGraphQL(
+  query: string,
+  opts: { variables?: Record<string, unknown>; operationName?: string; context: LinearGraphQLContext },
+) {
+  if (!query) {
+    return { errors: [{ message: "GraphQL query is required" }] };
+  }
+
+  return graphql({
+    schema,
+    source: query,
+    rootValue: createRoot(opts.context),
+    contextValue: opts.context,
+    variableValues: opts.variables,
+    operationName: opts.operationName,
+  });
+}
+
+async function readGraphQLBody(c: Context): Promise<{
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string;
+}> {
+  const contentType = c.req.header("content-type") ?? "";
+  if (contentType.includes("application/x-www-form-urlencoded")) {
+    const body = await c.req.parseBody();
+    return {
+      query: bodyStr(body.query),
+      variables: parseVariables(bodyStr(body.variables)),
+      operationName: bodyStr(body.operationName) || undefined,
+    };
+  }
+  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  return {
+    query: typeof body.query === "string" ? body.query : "",
+    variables: isRecord(body.variables) ? body.variables : undefined,
+    operationName: typeof body.operationName === "string" ? body.operationName : undefined,
+  };
+}
+
+function createRoot(context: LinearGraphQLContext) {
+  const { store, c, baseUrl } = context;
+  const ls = () => getLinearStore(store);
+
+  return {
+    viewer: () => formatUser(context, requireCurrentUser(context)),
+    organization: () => formatOrganization(context),
+    users: (args: ConnectionArgs & { filter?: Record<string, unknown> }) =>
+      connectUsers(context, filterUsers(context, ls().users.all(), args.filter), args),
+    user: ({ id }: { id: string }) => {
+      const user = resolveUser(store, id);
+      return user ? formatUser(context, user) : null;
+    },
+    teams: (args: ConnectionArgs) => connectTeams(context, sortByCreated(ls().teams.all()), args),
+    team: ({ id }: { id: string }) => {
+      const team = resolveTeam(store, id);
+      return team ? formatTeam(context, team) : null;
+    },
+    workflowStates: (args: ConnectionArgs) => connectStates(context, sortByPosition(ls().workflowStates.all()), args),
+    workflowState: ({ id }: { id: string }) => {
+      const state = resolveState(store, id);
+      return state ? formatState(context, state) : null;
+    },
+    issues: (args: ConnectionArgs & { filter?: Record<string, unknown>; orderBy?: string }) =>
+      connectIssues(context, filteredIssues(context, args.filter, args.orderBy), args),
+    issue: ({ id }: { id: string }) => {
+      const issue = resolveIssue(store, id);
+      return issue ? formatIssue(context, issue) : null;
+    },
+    comments: (args: ConnectionArgs) => connectComments(context, sortByCreated(ls().comments.all()), args),
+    comment: ({ id }: { id: string }) => {
+      const comment = ls().comments.findOneBy("linear_id", id);
+      return comment ? formatComment(context, comment) : null;
+    },
+    issueLabels: (args: ConnectionArgs) => connectLabels(context, sortByCreated(ls().issueLabels.all()), args),
+    issueLabel: ({ id }: { id: string }) => {
+      const label = resolveLabel(store, id);
+      return label ? formatLabel(context, label) : null;
+    },
+    projects: (args: ConnectionArgs) => connectProjects(context, sortByCreated(ls().projects.all()), args),
+    project: ({ id }: { id: string }) => {
+      const project = resolveProject(store, id);
+      return project ? formatProject(context, project) : null;
+    },
+    cycles: (args: ConnectionArgs) => connectCycles(context, sortByCreated(ls().cycles.all()), args),
+    cycle: ({ id }: { id: string }) => {
+      const cycle = resolveCycle(store, id);
+      return cycle ? formatCycle(context, cycle) : null;
+    },
+    webhooks: (args: ConnectionArgs) => {
+      requireLinearScopes(store, c, ["admin"]);
+      return connectWebhooks(context, sortByCreated(ls().webhooks.all()), args);
+    },
+    webhook: ({ id }: { id: string }) => {
+      requireLinearScopes(store, c, ["admin"]);
+      const webhook = ls().webhooks.findOneBy("linear_id", id);
+      return webhook ? formatWebhook(context, webhook) : null;
+    },
+    agentSessions: (args: ConnectionArgs) =>
+      connectAgentSessions(context, sortByCreated(ls().agentSessions.all()), args),
+    agentSession: ({ id }: { id: string }) => {
+      const session = ls().agentSessions.findOneBy("linear_id", id);
+      return session ? formatAgentSession(context, session) : null;
+    },
+
+    issueCreate: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["issues:create"]);
+      const actor = requireCurrentUser(context);
+      const team = requireTeam(store, input.teamId);
+      const state =
+        resolveState(store, stringInput(input.stateId), team.linear_id) ??
+        resolveState(store, "Todo", team.linear_id) ??
+        ls().workflowStates.findBy("team_id", team.linear_id)[0];
+      if (!state) throw new Error("No workflow state exists for the selected team");
+      const number = nextIssueNumber(store, team.linear_id);
+      const labelIds = arrayInput(input.labelIds)
+        .map((labelId) => resolveLabel(store, labelId, team.linear_id)?.linear_id)
+        .filter((id): id is string => Boolean(id));
+      const issue = ls().issues.insert({
+        linear_id: linearId(),
+        identifier: `${team.key}-${number}`,
+        number,
+        team_id: team.linear_id,
+        title: requiredString(input.title, "title"),
+        description: nullableString(input.description),
+        priority: normalizePriority(input.priority),
+        state_id: state.linear_id,
+        assignee_id: resolveUser(store, stringInput(input.assigneeId))?.linear_id ?? null,
+        creator_id: actor.linear_id,
+        delegate_id: resolveUser(store, stringInput(input.delegateId))?.linear_id ?? null,
+        project_id: resolveProject(store, stringInput(input.projectId))?.linear_id ?? null,
+        cycle_id: resolveCycle(store, stringInput(input.cycleId), team.linear_id)?.linear_id ?? null,
+        label_ids: labelIds,
+        url: `${baseUrl}/issue/${team.key}-${number}`,
+        archived_at: null,
+        canceled_at: null,
+        completed_at: state.type === "completed" ? new Date().toISOString() : null,
+        started_at: state.type === "started" ? new Date().toISOString() : null,
+        due_date: nullableString(input.dueDate),
+        create_as_user: nullableString(input.createAsUser),
+        display_icon_url: nullableString(input.displayIconUrl),
+      });
+      await dispatchLinearWebhook(store, {
+        type: "Issue",
+        action: "create",
+        data: issueWebhookPayload(context, issue),
+        actor,
+        teamId: issue.team_id,
+        url: issue.url,
+      });
+      if (issue.delegate_id) {
+        await createAgentSessionForIssue(context, issue, issue.delegate_id, actor);
+      }
+      return { success: true, issue: formatIssue(context, issue) };
+    },
+
+    issueUpdate: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const actor = requireCurrentUser(context);
+      const issue = requireIssue(store, input.id);
+      const before = issueWebhookPayload(context, issue);
+      const patch: Partial<LinearIssue> = {};
+      if ("title" in input) patch.title = requiredString(input.title, "title");
+      if ("description" in input) patch.description = nullableString(input.description);
+      if ("priority" in input) patch.priority = normalizePriority(input.priority);
+      if ("stateId" in input) {
+        const state = resolveState(store, stringInput(input.stateId), issue.team_id);
+        if (!state) throw new Error("Workflow state not found");
+        patch.state_id = state.linear_id;
+        patch.started_at = state.type === "started" ? (issue.started_at ?? new Date().toISOString()) : issue.started_at;
+        patch.completed_at =
+          state.type === "completed"
+            ? (issue.completed_at ?? new Date().toISOString())
+            : state.type === "canceled"
+              ? null
+              : issue.completed_at;
+        patch.canceled_at =
+          state.type === "canceled" ? (issue.canceled_at ?? new Date().toISOString()) : issue.canceled_at;
+      }
+      if ("assigneeId" in input)
+        patch.assignee_id = resolveUser(store, stringInput(input.assigneeId))?.linear_id ?? null;
+      if ("delegateId" in input)
+        patch.delegate_id = resolveUser(store, stringInput(input.delegateId))?.linear_id ?? null;
+      if ("projectId" in input)
+        patch.project_id = resolveProject(store, stringInput(input.projectId))?.linear_id ?? null;
+      if ("cycleId" in input)
+        patch.cycle_id = resolveCycle(store, stringInput(input.cycleId), issue.team_id)?.linear_id ?? null;
+      if ("labelIds" in input) {
+        patch.label_ids = arrayInput(input.labelIds)
+          .map((labelId) => resolveLabel(store, labelId, issue.team_id)?.linear_id)
+          .filter((id): id is string => Boolean(id));
+      }
+      if ("archivedAt" in input) patch.archived_at = nullableString(input.archivedAt);
+      if ("dueDate" in input) patch.due_date = nullableString(input.dueDate);
+      const updated = ls().issues.update(issue.id, patch);
+      if (!updated) throw new Error("Issue not found");
+      await dispatchLinearWebhook(store, {
+        type: "Issue",
+        action: "update",
+        data: issueWebhookPayload(context, updated),
+        actor,
+        teamId: updated.team_id,
+        url: updated.url,
+        updatedFrom: before,
+      });
+      if (updated.delegate_id && updated.delegate_id !== issue.delegate_id) {
+        await createAgentSessionForIssue(context, updated, updated.delegate_id, actor);
+      }
+      return { success: true, issue: formatIssue(context, updated) };
+    },
+
+    issueDelete: async ({ id }: { id: string }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const issue = requireIssue(store, id);
+      const actor = requireCurrentUser(context);
+      ls().issues.delete(issue.id);
+      await dispatchLinearWebhook(store, {
+        type: "Issue",
+        action: "remove",
+        data: issueWebhookPayload(context, issue),
+        actor,
+        teamId: issue.team_id,
+        url: issue.url,
+      });
+      return { success: true };
+    },
+
+    issueArchive: async ({ id }: { id: string }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const issue = requireIssue(store, id);
+      const updated = ls().issues.update(issue.id, { archived_at: new Date().toISOString() })!;
+      await dispatchLinearWebhook(store, {
+        type: "Issue",
+        action: "archive",
+        data: issueWebhookPayload(context, updated),
+        actor: requireCurrentUser(context),
+        teamId: updated.team_id,
+        url: updated.url,
+      });
+      return { success: true, issue: formatIssue(context, updated) };
+    },
+
+    issueUnarchive: async ({ id }: { id: string }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const issue = requireIssue(store, id);
+      const updated = ls().issues.update(issue.id, { archived_at: null })!;
+      await dispatchLinearWebhook(store, {
+        type: "Issue",
+        action: "unarchive",
+        data: issueWebhookPayload(context, updated),
+        actor: requireCurrentUser(context),
+        teamId: updated.team_id,
+        url: updated.url,
+      });
+      return { success: true, issue: formatIssue(context, updated) };
+    },
+
+    commentCreate: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["comments:create"]);
+      const actor = requireCurrentUser(context);
+      const issue = requireIssue(store, input.issueId);
+      const comment = ls().comments.insert({
+        linear_id: linearId(),
+        issue_id: issue.linear_id,
+        user_id: actor.linear_id,
+        body: requiredString(input.body, "body"),
+        create_as_user: nullableString(input.createAsUser),
+        display_icon_url: nullableString(input.displayIconUrl),
+      });
+      await dispatchLinearWebhook(store, {
+        type: "Comment",
+        action: "create",
+        data: commentWebhookPayload(context, comment),
+        actor,
+        teamId: issue.team_id,
+        url: issue.url,
+      });
+      if (mentionsAppUser(context, comment.body)) {
+        const appUser = ls()
+          .users.all()
+          .find((user) => user.app && comment.body.includes(user.display_name));
+        if (appUser) await createAgentSessionForComment(context, comment, appUser.linear_id, actor);
+      }
+      return { success: true, comment: formatComment(context, comment) };
+    },
+
+    commentUpdate: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const comment = requireComment(store, input.id);
+      const before = commentWebhookPayload(context, comment);
+      const updated = ls().comments.update(comment.id, { body: requiredString(input.body, "body") })!;
+      const issue = requireIssue(store, updated.issue_id);
+      await dispatchLinearWebhook(store, {
+        type: "Comment",
+        action: "update",
+        data: commentWebhookPayload(context, updated),
+        actor: requireCurrentUser(context),
+        teamId: issue.team_id,
+        url: issue.url,
+        updatedFrom: before,
+      });
+      return { success: true, comment: formatComment(context, updated) };
+    },
+
+    commentDelete: async ({ id }: { id: string }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const comment = requireComment(store, id);
+      const issue = requireIssue(store, comment.issue_id);
+      ls().comments.delete(comment.id);
+      await dispatchLinearWebhook(store, {
+        type: "Comment",
+        action: "remove",
+        data: commentWebhookPayload(context, comment),
+        actor: requireCurrentUser(context),
+        teamId: issue.team_id,
+        url: issue.url,
+      });
+      return { success: true };
+    },
+
+    issueLabelCreate: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const team = resolveTeam(store, stringInput(input.teamId));
+      const label = ls().issueLabels.insert({
+        linear_id: linearId(),
+        team_id: team?.linear_id ?? null,
+        name: requiredString(input.name, "name"),
+        color: stringInput(input.color) ?? "#64748b",
+        description: nullableString(input.description),
+      });
+      await dispatchLinearWebhook(store, {
+        type: "IssueLabel",
+        action: "create",
+        data: labelWebhookPayload(context, label),
+        actor: requireCurrentUser(context),
+        teamId: label.team_id,
+      });
+      return { success: true, issueLabel: formatLabel(context, label) };
+    },
+
+    issueLabelUpdate: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const label = requireLabel(store, input.id);
+      const before = labelWebhookPayload(context, label);
+      const updated = ls().issueLabels.update(label.id, {
+        name: stringInput(input.name) ?? label.name,
+        color: stringInput(input.color) ?? label.color,
+        description: "description" in input ? nullableString(input.description) : label.description,
+      })!;
+      await dispatchLinearWebhook(store, {
+        type: "IssueLabel",
+        action: "update",
+        data: labelWebhookPayload(context, updated),
+        actor: requireCurrentUser(context),
+        teamId: updated.team_id,
+        updatedFrom: before,
+      });
+      return { success: true, issueLabel: formatLabel(context, updated) };
+    },
+
+    issueLabelDelete: async ({ id }: { id: string }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const label = requireLabel(store, id);
+      for (const issue of ls().issues.all()) {
+        if (issue.label_ids.includes(label.linear_id)) {
+          ls().issues.update(issue.id, { label_ids: issue.label_ids.filter((labelId) => labelId !== label.linear_id) });
+        }
+      }
+      ls().issueLabels.delete(label.id);
+      await dispatchLinearWebhook(store, {
+        type: "IssueLabel",
+        action: "remove",
+        data: labelWebhookPayload(context, label),
+        actor: requireCurrentUser(context),
+        teamId: label.team_id,
+      });
+      return { success: true };
+    },
+
+    issueAddLabel: async ({ id, labelId }: { id: string; labelId: string }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const issue = requireIssue(store, id);
+      const label = requireLabel(store, labelId);
+      const next = Array.from(new Set([...issue.label_ids, label.linear_id]));
+      const updated = ls().issues.update(issue.id, { label_ids: next })!;
+      return { success: true, issue: formatIssue(context, updated) };
+    },
+
+    issueRemoveLabel: async ({ id, labelId }: { id: string; labelId: string }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const issue = requireIssue(store, id);
+      const label = requireLabel(store, labelId);
+      const updated = ls().issues.update(issue.id, {
+        label_ids: issue.label_ids.filter((existing) => existing !== label.linear_id),
+      })!;
+      return { success: true, issue: formatIssue(context, updated) };
+    },
+
+    webhookCreate: ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["admin"]);
+      const team = resolveTeam(store, stringInput(input.teamId));
+      const webhook = ls().webhooks.insert({
+        linear_id: linearId(),
+        label: stringInput(input.label) ?? "Local webhook",
+        url: requiredString(input.url, "url"),
+        enabled: typeof input.enabled === "boolean" ? input.enabled : true,
+        resource_types: arrayInput(input.resourceTypes, ["Issue", "Comment"]),
+        team_id: team?.linear_id ?? null,
+        all_public_teams: typeof input.allPublicTeams === "boolean" ? input.allPublicTeams : !team,
+        secret: nullableString(input.secret),
+        creator_id: requireCurrentUser(context).linear_id,
+      });
+      return { success: true, webhook: formatWebhook(context, webhook) };
+    },
+
+    webhookDelete: ({ id }: { id: string }) => {
+      requireLinearScopes(store, c, ["admin"]);
+      const webhook = requireWebhook(store, id);
+      ls().webhooks.delete(webhook.id);
+      return { success: true };
+    },
+
+    agentSessionCreateOnIssue: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const issue = requireIssue(store, input.issueId);
+      const actor = requireCurrentUser(context);
+      const agentUser =
+        resolveUser(store, stringInput(input.agentUserId)) ??
+        ls()
+          .users.all()
+          .find((user) => user.app) ??
+        actor;
+      const session = await createAgentSessionForIssue(
+        context,
+        issue,
+        agentUser.linear_id,
+        actor,
+        nullableString(input.plan),
+        nullableString(input.externalUrl),
+      );
+      return { success: true, agentSession: formatAgentSession(context, session) };
+    },
+
+    agentSessionCreateOnComment: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const comment = requireComment(store, input.commentId);
+      const actor = requireCurrentUser(context);
+      const agentUser =
+        resolveUser(store, stringInput(input.agentUserId)) ??
+        ls()
+          .users.all()
+          .find((user) => user.app) ??
+        actor;
+      const session = await createAgentSessionForComment(
+        context,
+        comment,
+        agentUser.linear_id,
+        actor,
+        nullableString(input.plan),
+        nullableString(input.externalUrl),
+      );
+      return { success: true, agentSession: formatAgentSession(context, session) };
+    },
+
+    agentSessionUpdate: ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const session = requireAgentSession(store, input.id);
+      const updated = ls().agentSessions.update(session.id, {
+        state: normalizeSessionState(stringInput(input.state)) ?? session.state,
+        plan: "plan" in input ? nullableString(input.plan) : session.plan,
+        external_url: "externalUrl" in input ? nullableString(input.externalUrl) : session.external_url,
+      })!;
+      return { success: true, agentSession: formatAgentSession(context, updated) };
+    },
+
+    agentActivityCreate: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const session = requireAgentSession(store, input.sessionId);
+      const type = normalizeActivityType(requiredString(input.type, "type"));
+      const activity = ls().agentActivities.insert({
+        linear_id: linearId(),
+        session_id: session.linear_id,
+        user_id: requireCurrentUser(context).linear_id,
+        type,
+        body: requiredString(input.body, "body"),
+        ephemeral: typeof input.ephemeral === "boolean" ? input.ephemeral : type === "thought" || type === "action",
+      });
+      if (type === "prompt") {
+        await dispatchLinearWebhook(store, {
+          type: "AgentSessionEvent",
+          action: "prompted",
+          data: agentSessionWebhookPayload(context, session),
+          actor: requireCurrentUser(context),
+          teamId: session.issue_id ? requireIssue(store, session.issue_id).team_id : null,
+        });
+      }
+      return { success: true, agentActivity: formatAgentActivity(context, activity) };
+    },
+  };
+}
+
+function formatOrganization(context: LinearGraphQLContext) {
+  const org = getLinearStore(context.store).organizations.all()[0];
+  if (!org) throw new Error("Linear organization has not been seeded");
+  return {
+    id: org.linear_id,
+    name: org.name,
+    urlKey: org.url_key,
+    url: org.url,
+    createdAt: org.created_at,
+    updatedAt: org.updated_at,
+    users: (args: ConnectionArgs) =>
+      connectUsers(context, sortByCreated(getLinearStore(context.store).users.all()), args),
+    teams: (args: ConnectionArgs) =>
+      connectTeams(context, sortByCreated(getLinearStore(context.store).teams.all()), args),
+  };
+}
+
+function formatUser(context: LinearGraphQLContext, user: LinearUser) {
+  return {
+    id: user.linear_id,
+    name: user.name,
+    displayName: user.display_name,
+    email: user.email,
+    description: null,
+    avatarUrl: user.avatar_url,
+    createdIssueCount: getLinearStore(context.store).issues.count((issue) => issue.creator_id === user.linear_id),
+    avatarBackgroundColor: null,
+    statusUntilAt: null,
+    statusEmoji: null,
+    initials: initials(user.display_name || user.name),
+    lastSeen: user.active ? user.updated_at : null,
+    timezone: "UTC",
+    disableReason: null,
+    statusLabel: null,
+    archivedAt: null,
+    gitHubUserId: null,
+    title: null,
+    url: `https://linear.app/user/${encodeURIComponent(user.email)}`,
+    active: user.active,
+    isAssignable: user.active,
+    guest: false,
+    admin: user.admin,
+    owner: user.admin,
+    app: user.app,
+    isMentionable: user.active,
+    isMe: currentUser(context.store, context.c)?.linear_id === user.linear_id,
+    supportsAgentSessions: user.app,
+    canAccessAnyPublicTeam: true,
+    calendarHash: null,
+    inviteHash: null,
+    createdAt: user.created_at,
+    updatedAt: user.updated_at,
+    assignedIssues: (args: ConnectionArgs) =>
+      connectIssues(
+        context,
+        sortByCreated(getLinearStore(context.store).issues.findBy("assignee_id", user.linear_id)),
+        args,
+      ),
+    createdIssues: (args: ConnectionArgs) =>
+      connectIssues(
+        context,
+        sortByCreated(getLinearStore(context.store).issues.findBy("creator_id", user.linear_id)),
+        args,
+      ),
+  };
+}
+
+function formatTeam(context: LinearGraphQLContext, team: LinearTeam) {
+  const ls = getLinearStore(context.store);
+  return {
+    id: team.linear_id,
+    key: team.key,
+    name: team.name,
+    description: team.description,
+    private: team.private,
+    url: team.url,
+    createdAt: team.created_at,
+    updatedAt: team.updated_at,
+    states: (args: ConnectionArgs) =>
+      connectStates(context, sortByPosition(ls.workflowStates.findBy("team_id", team.linear_id)), args),
+    issues: (args: ConnectionArgs & { filter?: Record<string, unknown> }) =>
+      connectIssues(
+        context,
+        filteredIssues(context, args.filter).filter((issue) => issue.team_id === team.linear_id),
+        args,
+      ),
+    labels: (args: ConnectionArgs) =>
+      connectLabels(
+        context,
+        sortByCreated(
+          ls.issueLabels.all().filter((label) => label.team_id === team.linear_id || label.team_id === null),
+        ),
+        args,
+      ),
+    projects: (args: ConnectionArgs) =>
+      connectProjects(
+        context,
+        sortByCreated(
+          ls.projects.all().filter((project) => project.team_id === team.linear_id || project.team_id === null),
+        ),
+        args,
+      ),
+    cycles: (args: ConnectionArgs) =>
+      connectCycles(context, sortByCreated(ls.cycles.findBy("team_id", team.linear_id)), args),
+    webhooks: (args: ConnectionArgs) =>
+      connectWebhooks(
+        context,
+        sortByCreated(
+          ls.webhooks.all().filter((webhook) => webhook.team_id === team.linear_id || webhook.all_public_teams),
+        ),
+        args,
+      ),
+  };
+}
+
+function formatState(context: LinearGraphQLContext, state: LinearWorkflowState) {
+  return {
+    id: state.linear_id,
+    name: state.name,
+    type: state.type,
+    position: state.position,
+    createdAt: state.created_at,
+    updatedAt: state.updated_at,
+    team: () => formatTeam(context, requireTeam(context.store, state.team_id)),
+    issues: (args: ConnectionArgs) =>
+      connectIssues(
+        context,
+        sortByCreated(getLinearStore(context.store).issues.findBy("state_id", state.linear_id)),
+        args,
+      ),
+  };
+}
+
+function formatIssue(context: LinearGraphQLContext, issue: LinearIssue) {
+  const ls = getLinearStore(context.store);
+  return {
+    id: issue.linear_id,
+    identifier: issue.identifier,
+    number: issue.number,
+    title: issue.title,
+    description: issue.description,
+    priority: issue.priority,
+    url: issue.url,
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at,
+    archivedAt: issue.archived_at,
+    canceledAt: issue.canceled_at,
+    completedAt: issue.completed_at,
+    startedAt: issue.started_at,
+    dueDate: issue.due_date,
+    createAsUser: issue.create_as_user,
+    displayIconUrl: issue.display_icon_url,
+    team: () => formatTeam(context, requireTeam(context.store, issue.team_id)),
+    state: () => formatState(context, requireState(context.store, issue.state_id)),
+    assignee: () => (issue.assignee_id ? formatUser(context, requireUser(context.store, issue.assignee_id)) : null),
+    creator: () => (issue.creator_id ? formatUser(context, requireUser(context.store, issue.creator_id)) : null),
+    delegate: () => (issue.delegate_id ? formatUser(context, requireUser(context.store, issue.delegate_id)) : null),
+    labels: (args: ConnectionArgs) =>
+      connectLabels(
+        context,
+        issue.label_ids
+          .map((labelId) => ls.issueLabels.findOneBy("linear_id", labelId))
+          .filter((label): label is LinearIssueLabel => Boolean(label)),
+        args,
+      ),
+    comments: (args: ConnectionArgs) =>
+      connectComments(context, sortByCreated(ls.comments.findBy("issue_id", issue.linear_id)), args),
+    project: () => (issue.project_id ? formatProject(context, requireProject(context.store, issue.project_id)) : null),
+    cycle: () => (issue.cycle_id ? formatCycle(context, requireCycle(context.store, issue.cycle_id)) : null),
+  };
+}
+
+function formatComment(context: LinearGraphQLContext, comment: LinearComment) {
+  return {
+    id: comment.linear_id,
+    body: comment.body,
+    createdAt: comment.created_at,
+    updatedAt: comment.updated_at,
+    createAsUser: comment.create_as_user,
+    displayIconUrl: comment.display_icon_url,
+    issue: () => formatIssue(context, requireIssue(context.store, comment.issue_id)),
+    user: () => (comment.user_id ? formatUser(context, requireUser(context.store, comment.user_id)) : null),
+  };
+}
+
+function formatLabel(context: LinearGraphQLContext, label: LinearIssueLabel) {
+  return {
+    id: label.linear_id,
+    name: label.name,
+    color: label.color,
+    description: label.description,
+    createdAt: label.created_at,
+    updatedAt: label.updated_at,
+    team: () => (label.team_id ? formatTeam(context, requireTeam(context.store, label.team_id)) : null),
+    issues: (args: ConnectionArgs) =>
+      connectIssues(
+        context,
+        sortByCreated(
+          getLinearStore(context.store)
+            .issues.all()
+            .filter((issue) => issue.label_ids.includes(label.linear_id)),
+        ),
+        args,
+      ),
+  };
+}
+
+function formatProject(context: LinearGraphQLContext, project: LinearProject) {
+  return {
+    id: project.linear_id,
+    name: project.name,
+    description: project.description,
+    state: project.state,
+    createdAt: project.created_at,
+    updatedAt: project.updated_at,
+    team: () => (project.team_id ? formatTeam(context, requireTeam(context.store, project.team_id)) : null),
+    issues: (args: ConnectionArgs) =>
+      connectIssues(
+        context,
+        sortByCreated(getLinearStore(context.store).issues.findBy("project_id", project.linear_id)),
+        args,
+      ),
+  };
+}
+
+function formatCycle(context: LinearGraphQLContext, cycle: LinearCycle) {
+  return {
+    id: cycle.linear_id,
+    name: cycle.name,
+    number: cycle.number,
+    startsAt: cycle.starts_at,
+    endsAt: cycle.ends_at,
+    createdAt: cycle.created_at,
+    updatedAt: cycle.updated_at,
+    team: () => formatTeam(context, requireTeam(context.store, cycle.team_id)),
+    issues: (args: ConnectionArgs) =>
+      connectIssues(
+        context,
+        sortByCreated(getLinearStore(context.store).issues.findBy("cycle_id", cycle.linear_id)),
+        args,
+      ),
+  };
+}
+
+function formatWebhook(context: LinearGraphQLContext, webhook: LinearWebhook) {
+  return {
+    id: webhook.linear_id,
+    label: webhook.label,
+    url: webhook.url,
+    enabled: webhook.enabled,
+    resourceTypes: webhook.resource_types,
+    allPublicTeams: webhook.all_public_teams,
+    secret: webhook.secret,
+    createdAt: webhook.created_at,
+    updatedAt: webhook.updated_at,
+    team: () => (webhook.team_id ? formatTeam(context, requireTeam(context.store, webhook.team_id)) : null),
+  };
+}
+
+function formatAgentSession(context: LinearGraphQLContext, session: LinearAgentSession) {
+  return {
+    id: session.linear_id,
+    state: session.state,
+    plan: session.plan,
+    externalUrl: session.external_url,
+    createdAt: session.created_at,
+    updatedAt: session.updated_at,
+    issue: () => (session.issue_id ? formatIssue(context, requireIssue(context.store, session.issue_id)) : null),
+    comment: () =>
+      session.comment_id ? formatComment(context, requireComment(context.store, session.comment_id)) : null,
+    agentUser: () => formatUser(context, requireUser(context.store, session.agent_user_id)),
+    activities: (args: ConnectionArgs) =>
+      connectAgentActivities(
+        context,
+        sortByCreated(getLinearStore(context.store).agentActivities.findBy("session_id", session.linear_id)),
+        args,
+      ),
+  };
+}
+
+function formatAgentActivity(context: LinearGraphQLContext, activity: LinearAgentActivity) {
+  return {
+    id: activity.linear_id,
+    type: activity.type,
+    body: activity.body,
+    ephemeral: activity.ephemeral,
+    createdAt: activity.created_at,
+    updatedAt: activity.updated_at,
+    session: () => formatAgentSession(context, requireAgentSession(context.store, activity.session_id)),
+    user: () => (activity.user_id ? formatUser(context, requireUser(context.store, activity.user_id)) : null),
+  };
+}
+
+function connectUsers(context: LinearGraphQLContext, items: LinearUser[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatUser(context, item));
+}
+
+function connectTeams(context: LinearGraphQLContext, items: LinearTeam[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatTeam(context, item));
+}
+
+function connectStates(context: LinearGraphQLContext, items: LinearWorkflowState[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatState(context, item));
+}
+
+function connectIssues(context: LinearGraphQLContext, items: LinearIssue[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatIssue(context, item));
+}
+
+function connectComments(context: LinearGraphQLContext, items: LinearComment[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatComment(context, item));
+}
+
+function connectLabels(context: LinearGraphQLContext, items: LinearIssueLabel[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatLabel(context, item));
+}
+
+function connectProjects(context: LinearGraphQLContext, items: LinearProject[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatProject(context, item));
+}
+
+function connectCycles(context: LinearGraphQLContext, items: LinearCycle[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatCycle(context, item));
+}
+
+function connectWebhooks(context: LinearGraphQLContext, items: LinearWebhook[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatWebhook(context, item));
+}
+
+function connectAgentSessions(context: LinearGraphQLContext, items: LinearAgentSession[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatAgentSession(context, item));
+}
+
+function connectAgentActivities(context: LinearGraphQLContext, items: LinearAgentActivity[], args: ConnectionArgs) {
+  return mapConnection(items, args, (item) => formatAgentActivity(context, item));
+}
+
+function mapConnection<T, U>(items: T[], args: ConnectionArgs, mapper: (item: T) => U) {
+  const mapped = connectionFromArray(items, args);
+  return {
+    nodes: mapped.nodes.map(mapper),
+    edges: mapped.edges.map((edge) => ({ cursor: edge.cursor, node: mapper(edge.node) })),
+    pageInfo: mapped.pageInfo,
+  };
+}
+
+function filteredIssues(
+  context: LinearGraphQLContext,
+  filter?: Record<string, unknown>,
+  orderBy?: string,
+): LinearIssue[] {
+  let issues = sortByCreated(getLinearStore(context.store).issues.all());
+  if (orderBy === "updatedAt") {
+    issues = [...issues].sort((a, b) => a.updated_at.localeCompare(b.updated_at));
+  }
+  if (!filter) return issues;
+  return issues.filter((issue) => issueMatchesFilter(context, issue, filter));
+}
+
+function issueMatchesFilter(
+  context: LinearGraphQLContext,
+  issue: LinearIssue,
+  filter: Record<string, unknown>,
+): boolean {
+  const ls = getLinearStore(context.store);
+  const team = ls.teams.findOneBy("linear_id", issue.team_id);
+  const state = ls.workflowStates.findOneBy("linear_id", issue.state_id);
+  const assignee = issue.assignee_id ? ls.users.findOneBy("linear_id", issue.assignee_id) : undefined;
+  const creator = issue.creator_id ? ls.users.findOneBy("linear_id", issue.creator_id) : undefined;
+  const project = issue.project_id ? ls.projects.findOneBy("linear_id", issue.project_id) : undefined;
+  const cycle = issue.cycle_id ? ls.cycles.findOneBy("linear_id", issue.cycle_id) : undefined;
+  const labels = issue.label_ids
+    .map((labelId) => ls.issueLabels.findOneBy("linear_id", labelId))
+    .filter((label): label is LinearIssueLabel => Boolean(label));
+
+  const checks = [
+    comparatorMatches(issue.linear_id, filter.id),
+    comparatorMatches(issue.identifier, filter.identifier),
+    comparatorMatches(issue.title, filter.title),
+    comparatorMatches(team?.linear_id, filter.team) ||
+      comparatorMatches(team?.key, filter.team) ||
+      comparatorMatches(team?.name, filter.team),
+    comparatorMatches(state?.linear_id, filter.state) ||
+      comparatorMatches(state?.name, filter.state) ||
+      comparatorMatches(state?.type, filter.state),
+    comparatorMatches(assignee?.linear_id, filter.assignee) ||
+      comparatorMatches(assignee?.email, filter.assignee) ||
+      comparatorMatches(assignee?.name, filter.assignee),
+    comparatorMatches(creator?.linear_id, filter.creator) ||
+      comparatorMatches(creator?.email, filter.creator) ||
+      comparatorMatches(creator?.name, filter.creator),
+    comparatorMatches(project?.linear_id, filter.project) || comparatorMatches(project?.name, filter.project),
+    comparatorMatches(cycle?.linear_id, filter.cycle) || comparatorMatches(cycle?.name, filter.cycle),
+    filter.labels
+      ? labels.some(
+          (label) => comparatorMatches(label.linear_id, filter.labels) || comparatorMatches(label.name, filter.labels),
+        )
+      : true,
+  ];
+  const ownMatch = checks.every(Boolean);
+  const orFilters = Array.isArray(filter.or) ? filter.or.filter(isRecord) : [];
+  return ownMatch || orFilters.some((orFilter) => issueMatchesFilter(context, issue, orFilter));
+}
+
+function filterUsers(
+  context: LinearGraphQLContext,
+  users: LinearUser[],
+  filter?: Record<string, unknown>,
+): LinearUser[] {
+  if (!filter) return sortByCreated(users);
+  return sortByCreated(users).filter(
+    (user) =>
+      comparatorMatches(user.linear_id, filter.id) &&
+      comparatorMatches(user.email, filter.email) &&
+      comparatorMatches(user.name, filter.name) &&
+      (typeof filter.active !== "boolean" || user.active === filter.active) &&
+      (typeof filter.admin !== "boolean" || user.admin === filter.admin),
+  );
+}
+
+function comparatorMatches(value: string | undefined | null, input: unknown): boolean {
+  if (!input || !isRecord(input)) return true;
+  if ("null" in input && typeof input.null === "boolean") return input.null ? value == null : value != null;
+  if (value == null) return false;
+  const val = String(value);
+  if (typeof input.eq === "string" && val !== input.eq) return false;
+  if (typeof input.neq === "string" && val === input.neq) return false;
+  if (Array.isArray(input.in) && !input.in.includes(val)) return false;
+  if (Array.isArray(input.nin) && input.nin.includes(val)) return false;
+  if (typeof input.contains === "string" && !val.includes(input.contains)) return false;
+  if (typeof input.startsWith === "string" && !val.startsWith(input.startsWith)) return false;
+  if (typeof input.endsWith === "string" && !val.endsWith(input.endsWith)) return false;
+  if (typeof input.eqIgnoreCase === "string" && val.toLowerCase() !== input.eqIgnoreCase.toLowerCase()) return false;
+  if (typeof input.neqIgnoreCase === "string" && val.toLowerCase() === input.neqIgnoreCase.toLowerCase()) return false;
+  return true;
+}
+
+function sortByCreated<T extends { created_at: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.created_at.localeCompare(b.created_at));
+}
+
+function sortByPosition<T extends { position: number; created_at: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.position - b.position || a.created_at.localeCompare(b.created_at));
+}
+
+function requireCurrentUser(context: LinearGraphQLContext): LinearUser {
+  const user = currentUser(context.store, context.c);
+  if (!user) throw new Error("Linear user not found");
+  return user;
+}
+
+function requireUser(store: Store, id: string): LinearUser {
+  const user = resolveUser(store, id);
+  if (!user) throw new Error(`User not found: ${id}`);
+  return user;
+}
+
+function requireTeam(store: Store, id: unknown): LinearTeam {
+  const team = resolveTeam(store, requiredString(id, "teamId"));
+  if (!team) throw new Error(`Team not found: ${String(id)}`);
+  return team;
+}
+
+function requireState(store: Store, id: string): LinearWorkflowState {
+  const state = resolveState(store, id);
+  if (!state) throw new Error(`Workflow state not found: ${id}`);
+  return state;
+}
+
+function requireIssue(store: Store, id: unknown): LinearIssue {
+  const issue = resolveIssue(store, requiredString(id, "id"));
+  if (!issue) throw new Error(`Issue not found: ${String(id)}`);
+  return issue;
+}
+
+function requireComment(store: Store, id: unknown): LinearComment {
+  const ref = requiredString(id, "id");
+  const comment = getLinearStore(store).comments.findOneBy("linear_id", ref);
+  if (!comment) throw new Error(`Comment not found: ${ref}`);
+  return comment;
+}
+
+function requireLabel(store: Store, id: unknown): LinearIssueLabel {
+  const label = resolveLabel(store, requiredString(id, "id"));
+  if (!label) throw new Error(`Issue label not found: ${String(id)}`);
+  return label;
+}
+
+function requireProject(store: Store, id: string): LinearProject {
+  const project = resolveProject(store, id);
+  if (!project) throw new Error(`Project not found: ${id}`);
+  return project;
+}
+
+function requireCycle(store: Store, id: string): LinearCycle {
+  const cycle = resolveCycle(store, id);
+  if (!cycle) throw new Error(`Cycle not found: ${id}`);
+  return cycle;
+}
+
+function requireWebhook(store: Store, id: string): LinearWebhook {
+  const webhook = getLinearStore(store).webhooks.findOneBy("linear_id", id);
+  if (!webhook) throw new Error(`Webhook not found: ${id}`);
+  return webhook;
+}
+
+function requireAgentSession(store: Store, id: unknown): LinearAgentSession {
+  const ref = requiredString(id, "id");
+  const session = getLinearStore(store).agentSessions.findOneBy("linear_id", ref);
+  if (!session) throw new Error(`Agent session not found: ${ref}`);
+  return session;
+}
+
+async function createAgentSessionForIssue(
+  context: LinearGraphQLContext,
+  issue: LinearIssue,
+  agentUserId: string,
+  actor: LinearUser,
+  plan?: string | null,
+  externalUrl?: string | null,
+): Promise<LinearAgentSession> {
+  const ls = getLinearStore(context.store);
+  const existing = ls.agentSessions
+    .findBy("issue_id", issue.linear_id)
+    .find((session) => session.agent_user_id === agentUserId && session.state !== "completed");
+  if (existing) return existing;
+  const session = ls.agentSessions.insert({
+    linear_id: linearId(),
+    issue_id: issue.linear_id,
+    comment_id: null,
+    agent_user_id: agentUserId,
+    state: "pending",
+    plan: plan ?? null,
+    external_url: externalUrl ?? null,
+  });
+  await dispatchLinearWebhook(context.store, {
+    type: "AgentSessionEvent",
+    action: "created",
+    data: agentSessionWebhookPayload(context, session),
+    actor,
+    teamId: issue.team_id,
+    url: issue.url,
+  });
+  return session;
+}
+
+async function createAgentSessionForComment(
+  context: LinearGraphQLContext,
+  comment: LinearComment,
+  agentUserId: string,
+  actor: LinearUser,
+  plan?: string | null,
+  externalUrl?: string | null,
+): Promise<LinearAgentSession> {
+  const issue = requireIssue(context.store, comment.issue_id);
+  const session = getLinearStore(context.store).agentSessions.insert({
+    linear_id: linearId(),
+    issue_id: issue.linear_id,
+    comment_id: comment.linear_id,
+    agent_user_id: agentUserId,
+    state: "pending",
+    plan: plan ?? null,
+    external_url: externalUrl ?? null,
+  });
+  await dispatchLinearWebhook(context.store, {
+    type: "AgentSessionEvent",
+    action: "created",
+    data: agentSessionWebhookPayload(context, session),
+    actor,
+    teamId: issue.team_id,
+    url: issue.url,
+  });
+  return session;
+}
+
+function issueWebhookPayload(context: LinearGraphQLContext, issue: LinearIssue) {
+  return {
+    id: issue.linear_id,
+    identifier: issue.identifier,
+    title: issue.title,
+    description: issue.description,
+    priority: issue.priority,
+    teamId: issue.team_id,
+    stateId: issue.state_id,
+    assigneeId: issue.assignee_id,
+    delegateId: issue.delegate_id,
+    url: issue.url,
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at,
+    archivedAt: issue.archived_at,
+    labels: issue.label_ids
+      .map((labelId) => getLinearStore(context.store).issueLabels.findOneBy("linear_id", labelId))
+      .filter(Boolean)
+      .map((label) => ({ id: label!.linear_id, name: label!.name })),
+  };
+}
+
+function commentWebhookPayload(context: LinearGraphQLContext, comment: LinearComment) {
+  return {
+    id: comment.linear_id,
+    body: comment.body,
+    issueId: comment.issue_id,
+    userId: comment.user_id,
+    createdAt: comment.created_at,
+    updatedAt: comment.updated_at,
+  };
+}
+
+function labelWebhookPayload(_context: LinearGraphQLContext, label: LinearIssueLabel) {
+  return {
+    id: label.linear_id,
+    name: label.name,
+    color: label.color,
+    description: label.description,
+    teamId: label.team_id,
+    createdAt: label.created_at,
+    updatedAt: label.updated_at,
+  };
+}
+
+function agentSessionWebhookPayload(_context: LinearGraphQLContext, session: LinearAgentSession) {
+  return {
+    id: session.linear_id,
+    issueId: session.issue_id,
+    commentId: session.comment_id,
+    agentUserId: session.agent_user_id,
+    state: session.state,
+    plan: session.plan,
+    externalUrl: session.external_url,
+    createdAt: session.created_at,
+    updatedAt: session.updated_at,
+  };
+}
+
+function mentionsAppUser(context: LinearGraphQLContext, body: string): boolean {
+  return getLinearStore(context.store)
+    .users.all()
+    .some((user) => user.app && body.includes(user.display_name));
+}
+
+function normalizePriority(value: unknown): LinearIssuePriority {
+  if (typeof value !== "number") return 0;
+  if (value <= 0) return 0;
+  if (value >= 4) return 4;
+  return value as LinearIssuePriority;
+}
+
+function normalizeSessionState(value: string | undefined | null): LinearAgentSession["state"] | undefined {
+  if (
+    value === "pending" ||
+    value === "active" ||
+    value === "completed" ||
+    value === "failed" ||
+    value === "canceled"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+function normalizeActivityType(value: string): LinearAgentActivityType {
+  if (
+    value === "thought" ||
+    value === "elicitation" ||
+    value === "action" ||
+    value === "response" ||
+    value === "error" ||
+    value === "prompt"
+  ) {
+    return value;
+  }
+  throw new Error(`Unsupported agent activity type: ${value}`);
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`${field} is required`);
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function stringInput(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function arrayInput(value: unknown, fallback: string[] = []): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.length > 0)
+    : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function bodyStr(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v) && typeof v[0] === "string") return v[0];
+  return "";
+}
+
+function parseVariables(value: unknown): Record<string, unknown> | undefined {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function initials(value: string): string {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -1354,6 +1354,19 @@ function mapConnection<T, U>(items: T[], args: ConnectionArgs, mapper: (item: T)
   };
 }
 
+const ISSUE_FILTER_FIELDS = [
+  "id",
+  "identifier",
+  "title",
+  "team",
+  "state",
+  "assignee",
+  "creator",
+  "project",
+  "cycle",
+  "labels",
+] as const;
+
 function filteredIssues(
   context: LinearGraphQLContext,
   filter?: Record<string, unknown>,
@@ -1407,9 +1420,13 @@ function issueMatchesFilter(
         )
       : true,
   ];
-  const ownMatch = checks.every(Boolean);
   const orFilters = Array.isArray(filter.or) ? filter.or.filter(isRecord) : [];
+  const ownMatch = issueFilterHasOwnPredicates(filter) ? checks.every(Boolean) : orFilters.length === 0;
   return ownMatch || orFilters.some((orFilter) => issueMatchesFilter(context, issue, orFilter));
+}
+
+function issueFilterHasOwnPredicates(filter: Record<string, unknown>): boolean {
+  return ISSUE_FILTER_FIELDS.some((field) => filter[field] != null);
 }
 
 function filterUsers(

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -698,10 +698,11 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["issues:create"]);
       const actor = requireCurrentUser(context);
       const team = requireTeam(store, input.teamId);
-      const state =
-        resolveState(store, stringInput(input.stateId), team.linear_id) ??
-        resolveState(store, "Todo", team.linear_id) ??
-        ls().workflowStates.findBy("team_id", team.linear_id)[0];
+      const requestedStateId = stringInput(input.stateId);
+      const state = requestedStateId
+        ? resolveState(store, requestedStateId, team.linear_id)
+        : (resolveState(store, "Todo", team.linear_id) ?? ls().workflowStates.findBy("team_id", team.linear_id)[0]);
+      if (requestedStateId && !state) throw new Error(`Workflow state not found: ${requestedStateId}`);
       if (!state) throw new Error("No workflow state exists for the selected team");
       const number = nextIssueNumber(store, team.linear_id);
       const labelIds = arrayInput(input.labelIds)
@@ -982,7 +983,7 @@ function createRoot(context: LinearGraphQLContext) {
     issueAddLabel: async ({ id, labelId }: { id: string; labelId: string }) => {
       requireLinearScopes(store, c, ["write"]);
       const issue = requireIssue(store, id);
-      const label = requireLabel(store, labelId);
+      const label = requireTeamLabel(store, labelId, issue.team_id);
       const before = issueWebhookPayload(context, issue);
       const actor = requireCurrentUser(context);
       const next = Array.from(new Set([...issue.label_ids, label.linear_id]));
@@ -1002,7 +1003,7 @@ function createRoot(context: LinearGraphQLContext) {
     issueRemoveLabel: async ({ id, labelId }: { id: string; labelId: string }) => {
       requireLinearScopes(store, c, ["write"]);
       const issue = requireIssue(store, id);
-      const label = requireLabel(store, labelId);
+      const label = requireTeamLabel(store, labelId, issue.team_id);
       const before = issueWebhookPayload(context, issue);
       const actor = requireCurrentUser(context);
       const updated = ls().issues.update(issue.id, {
@@ -1776,6 +1777,13 @@ function requireComment(store: Store, id: unknown): LinearComment {
 function requireLabel(store: Store, id: unknown): LinearIssueLabel {
   const label = resolveLabel(store, requiredString(id, "id"));
   if (!label) throw new Error(`Issue label not found: ${String(id)}`);
+  return label;
+}
+
+function requireTeamLabel(store: Store, id: unknown, teamId: string): LinearIssueLabel {
+  const ref = requiredString(id, "labelId");
+  const label = resolveLabel(store, ref, teamId);
+  if (!label) throw new Error(`Issue label not found for team: ${ref}`);
   return label;
 }
 

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -623,6 +623,7 @@ function createRoot(context: LinearGraphQLContext) {
       const labelIds = arrayInput(input.labelIds)
         .map((labelId) => resolveLabel(store, labelId, team.linear_id)?.linear_id)
         .filter((id): id is string => Boolean(id));
+      const now = new Date().toISOString();
       const issue = ls().issues.insert({
         linear_id: linearId(),
         identifier: `${team.key}-${number}`,
@@ -640,9 +641,9 @@ function createRoot(context: LinearGraphQLContext) {
         label_ids: labelIds,
         url: `${baseUrl}/issue/${team.key}-${number}`,
         archived_at: null,
-        canceled_at: null,
-        completed_at: state.type === "completed" ? new Date().toISOString() : null,
-        started_at: state.type === "started" ? new Date().toISOString() : null,
+        canceled_at: state.type === "canceled" ? now : null,
+        completed_at: state.type === "completed" ? now : null,
+        started_at: state.type === "started" ? now : null,
         due_date: nullableString(input.dueDate),
         create_as_user: nullableString(input.createAsUser),
         display_icon_url: nullableString(input.displayIconUrl),
@@ -673,16 +674,12 @@ function createRoot(context: LinearGraphQLContext) {
       if ("stateId" in input) {
         const state = resolveState(store, stringInput(input.stateId), issue.team_id);
         if (!state) throw new Error("Workflow state not found");
+        const now = new Date().toISOString();
         patch.state_id = state.linear_id;
-        patch.started_at = state.type === "started" ? (issue.started_at ?? new Date().toISOString()) : issue.started_at;
-        patch.completed_at =
-          state.type === "completed"
-            ? (issue.completed_at ?? new Date().toISOString())
-            : state.type === "canceled"
-              ? null
-              : issue.completed_at;
-        patch.canceled_at =
-          state.type === "canceled" ? (issue.canceled_at ?? new Date().toISOString()) : issue.canceled_at;
+        patch.started_at =
+          state.type === "started" ? (issue.started_at ?? now) : state.type === "completed" ? issue.started_at : null;
+        patch.completed_at = state.type === "completed" ? (issue.completed_at ?? now) : null;
+        patch.canceled_at = state.type === "canceled" ? (issue.canceled_at ?? now) : null;
       }
       if ("assigneeId" in input)
         patch.assignee_id = resolveUser(store, stringInput(input.assigneeId))?.linear_id ?? null;
@@ -821,6 +818,12 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["write"]);
       const comment = requireComment(store, id);
       const issue = requireIssue(store, comment.issue_id);
+      const commentSessions = ls().agentSessions.findBy("comment_id", comment.linear_id);
+      const commentSessionIds = new Set(commentSessions.map((session) => session.linear_id));
+      for (const activity of ls().agentActivities.all()) {
+        if (commentSessionIds.has(activity.session_id)) ls().agentActivities.delete(activity.id);
+      }
+      for (const session of commentSessions) ls().agentSessions.delete(session.id);
       ls().comments.delete(comment.id);
       await dispatchLinearWebhook(store, {
         type: "Comment",
@@ -896,8 +899,19 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["write"]);
       const issue = requireIssue(store, id);
       const label = requireLabel(store, labelId);
+      const before = issueWebhookPayload(context, issue);
+      const actor = requireCurrentUser(context);
       const next = Array.from(new Set([...issue.label_ids, label.linear_id]));
       const updated = ls().issues.update(issue.id, { label_ids: next })!;
+      await dispatchLinearWebhook(store, {
+        type: "Issue",
+        action: "update",
+        data: issueWebhookPayload(context, updated),
+        actor,
+        teamId: updated.team_id,
+        url: updated.url,
+        updatedFrom: before,
+      });
       return { success: true, issue: formatIssue(context, updated) };
     },
 
@@ -905,9 +919,20 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["write"]);
       const issue = requireIssue(store, id);
       const label = requireLabel(store, labelId);
+      const before = issueWebhookPayload(context, issue);
+      const actor = requireCurrentUser(context);
       const updated = ls().issues.update(issue.id, {
         label_ids: issue.label_ids.filter((existing) => existing !== label.linear_id),
       })!;
+      await dispatchLinearWebhook(store, {
+        type: "Issue",
+        action: "update",
+        data: issueWebhookPayload(context, updated),
+        actor,
+        teamId: updated.team_id,
+        url: updated.url,
+        updatedFrom: before,
+      });
       return { success: true, issue: formatIssue(context, updated) };
     },
 

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -508,49 +508,86 @@ async function readGraphQLBody(c: Context): Promise<{
 function createRoot(context: LinearGraphQLContext) {
   const { store, c, baseUrl } = context;
   const ls = () => getLinearStore(store);
+  const requireRead = () => requireLinearScopes(store, c, ["read"]);
 
   return {
-    viewer: () => formatUser(context, requireCurrentUser(context)),
-    organization: () => formatOrganization(context),
-    users: (args: ConnectionArgs & { filter?: Record<string, unknown> }) =>
-      connectUsers(context, filterUsers(context, ls().users.all(), args.filter), args),
+    viewer: () => {
+      requireRead();
+      return formatUser(context, requireCurrentUser(context));
+    },
+    organization: () => {
+      requireRead();
+      return formatOrganization(context);
+    },
+    users: (args: ConnectionArgs & { filter?: Record<string, unknown> }) => {
+      requireRead();
+      return connectUsers(context, filterUsers(context, ls().users.all(), args.filter), args);
+    },
     user: ({ id }: { id: string }) => {
+      requireRead();
       const user = resolveUser(store, id);
       return user ? formatUser(context, user) : null;
     },
-    teams: (args: ConnectionArgs) => connectTeams(context, sortByCreated(ls().teams.all()), args),
+    teams: (args: ConnectionArgs) => {
+      requireRead();
+      return connectTeams(context, sortByCreated(ls().teams.all()), args);
+    },
     team: ({ id }: { id: string }) => {
+      requireRead();
       const team = resolveTeam(store, id);
       return team ? formatTeam(context, team) : null;
     },
-    workflowStates: (args: ConnectionArgs) => connectStates(context, sortByPosition(ls().workflowStates.all()), args),
+    workflowStates: (args: ConnectionArgs) => {
+      requireRead();
+      return connectStates(context, sortByPosition(ls().workflowStates.all()), args);
+    },
     workflowState: ({ id }: { id: string }) => {
+      requireRead();
       const state = resolveState(store, id);
       return state ? formatState(context, state) : null;
     },
-    issues: (args: ConnectionArgs & { filter?: Record<string, unknown>; orderBy?: string }) =>
-      connectIssues(context, filteredIssues(context, args.filter, args.orderBy), args),
+    issues: (args: ConnectionArgs & { filter?: Record<string, unknown>; orderBy?: string }) => {
+      requireRead();
+      return connectIssues(context, filteredIssues(context, args.filter, args.orderBy), args);
+    },
     issue: ({ id }: { id: string }) => {
+      requireRead();
       const issue = resolveIssue(store, id);
       return issue ? formatIssue(context, issue) : null;
     },
-    comments: (args: ConnectionArgs) => connectComments(context, sortByCreated(ls().comments.all()), args),
+    comments: (args: ConnectionArgs) => {
+      requireRead();
+      return connectComments(context, sortByCreated(ls().comments.all()), args);
+    },
     comment: ({ id }: { id: string }) => {
+      requireRead();
       const comment = ls().comments.findOneBy("linear_id", id);
       return comment ? formatComment(context, comment) : null;
     },
-    issueLabels: (args: ConnectionArgs) => connectLabels(context, sortByCreated(ls().issueLabels.all()), args),
+    issueLabels: (args: ConnectionArgs) => {
+      requireRead();
+      return connectLabels(context, sortByCreated(ls().issueLabels.all()), args);
+    },
     issueLabel: ({ id }: { id: string }) => {
+      requireRead();
       const label = resolveLabel(store, id);
       return label ? formatLabel(context, label) : null;
     },
-    projects: (args: ConnectionArgs) => connectProjects(context, sortByCreated(ls().projects.all()), args),
+    projects: (args: ConnectionArgs) => {
+      requireRead();
+      return connectProjects(context, sortByCreated(ls().projects.all()), args);
+    },
     project: ({ id }: { id: string }) => {
+      requireRead();
       const project = resolveProject(store, id);
       return project ? formatProject(context, project) : null;
     },
-    cycles: (args: ConnectionArgs) => connectCycles(context, sortByCreated(ls().cycles.all()), args),
+    cycles: (args: ConnectionArgs) => {
+      requireRead();
+      return connectCycles(context, sortByCreated(ls().cycles.all()), args);
+    },
     cycle: ({ id }: { id: string }) => {
+      requireRead();
       const cycle = resolveCycle(store, id);
       return cycle ? formatCycle(context, cycle) : null;
     },
@@ -563,9 +600,12 @@ function createRoot(context: LinearGraphQLContext) {
       const webhook = ls().webhooks.findOneBy("linear_id", id);
       return webhook ? formatWebhook(context, webhook) : null;
     },
-    agentSessions: (args: ConnectionArgs) =>
-      connectAgentSessions(context, sortByCreated(ls().agentSessions.all()), args),
+    agentSessions: (args: ConnectionArgs) => {
+      requireRead();
+      return connectAgentSessions(context, sortByCreated(ls().agentSessions.all()), args);
+    },
     agentSession: ({ id }: { id: string }) => {
+      requireRead();
       const session = ls().agentSessions.findOneBy("linear_id", id);
       return session ? formatAgentSession(context, session) : null;
     },
@@ -1070,14 +1110,16 @@ function formatTeam(context: LinearGraphQLContext, team: LinearTeam) {
       ),
     cycles: (args: ConnectionArgs) =>
       connectCycles(context, sortByCreated(ls.cycles.findBy("team_id", team.linear_id)), args),
-    webhooks: (args: ConnectionArgs) =>
-      connectWebhooks(
+    webhooks: (args: ConnectionArgs) => {
+      requireLinearScopes(context.store, context.c, ["admin"]);
+      return connectWebhooks(
         context,
         sortByCreated(
           ls.webhooks.all().filter((webhook) => webhook.team_id === team.linear_id || webhook.all_public_teams),
         ),
         args,
-      ),
+      );
+    },
   };
 }
 

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -720,6 +720,14 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["write"]);
       const issue = requireIssue(store, id);
       const actor = requireCurrentUser(context);
+      const issueComments = ls().comments.findBy("issue_id", issue.linear_id);
+      const issueSessions = ls().agentSessions.findBy("issue_id", issue.linear_id);
+      const issueSessionIds = new Set(issueSessions.map((session) => session.linear_id));
+      for (const activity of ls().agentActivities.all()) {
+        if (issueSessionIds.has(activity.session_id)) ls().agentActivities.delete(activity.id);
+      }
+      for (const comment of issueComments) ls().comments.delete(comment.id);
+      for (const session of issueSessions) ls().agentSessions.delete(session.id);
       ls().issues.delete(issue.id);
       await dispatchLinearWebhook(store, {
         type: "Issue",
@@ -1400,25 +1408,16 @@ function issueMatchesFilter(
     comparatorMatches(issue.linear_id, filter.id),
     comparatorMatches(issue.identifier, filter.identifier),
     comparatorMatches(issue.title, filter.title),
-    comparatorMatches(team?.linear_id, filter.team) ||
-      comparatorMatches(team?.key, filter.team) ||
-      comparatorMatches(team?.name, filter.team),
-    comparatorMatches(state?.linear_id, filter.state) ||
-      comparatorMatches(state?.name, filter.state) ||
-      comparatorMatches(state?.type, filter.state),
-    comparatorMatches(assignee?.linear_id, filter.assignee) ||
-      comparatorMatches(assignee?.email, filter.assignee) ||
-      comparatorMatches(assignee?.name, filter.assignee),
-    comparatorMatches(creator?.linear_id, filter.creator) ||
-      comparatorMatches(creator?.email, filter.creator) ||
-      comparatorMatches(creator?.name, filter.creator),
-    comparatorMatches(project?.linear_id, filter.project) || comparatorMatches(project?.name, filter.project),
-    comparatorMatches(cycle?.linear_id, filter.cycle) || comparatorMatches(cycle?.name, filter.cycle),
-    filter.labels
-      ? labels.some(
-          (label) => comparatorMatches(label.linear_id, filter.labels) || comparatorMatches(label.name, filter.labels),
-        )
-      : true,
+    aliasComparatorMatches([team?.linear_id, team?.key, team?.name], filter.team),
+    aliasComparatorMatches([state?.linear_id, state?.name, state?.type], filter.state),
+    aliasComparatorMatches([assignee?.linear_id, assignee?.email, assignee?.name], filter.assignee),
+    aliasComparatorMatches([creator?.linear_id, creator?.email, creator?.name], filter.creator),
+    aliasComparatorMatches([project?.linear_id, project?.name], filter.project),
+    aliasComparatorMatches([cycle?.linear_id, cycle?.name], filter.cycle),
+    aliasComparatorMatches(
+      labels.flatMap((label) => [label.linear_id, label.name]),
+      filter.labels,
+    ),
   ];
   const orFilters = Array.isArray(filter.or) ? filter.or.filter(isRecord) : [];
   const ownMatch = issueFilterHasOwnPredicates(filter) ? checks.every(Boolean) : orFilters.length === 0;
@@ -1459,6 +1458,48 @@ function comparatorMatches(value: string | undefined | null, input: unknown): bo
   if (typeof input.endsWith === "string" && !val.endsWith(input.endsWith)) return false;
   if (typeof input.eqIgnoreCase === "string" && val.toLowerCase() !== input.eqIgnoreCase.toLowerCase()) return false;
   if (typeof input.neqIgnoreCase === "string" && val.toLowerCase() === input.neqIgnoreCase.toLowerCase()) return false;
+  return true;
+}
+
+function aliasComparatorMatches(values: Array<string | undefined | null>, input: unknown): boolean {
+  if (!input || !isRecord(input)) return true;
+  const candidates = values.filter((value): value is string => value != null);
+  if ("null" in input && typeof input.null === "boolean") {
+    return input.null ? candidates.length === 0 : candidates.length > 0;
+  }
+  if (candidates.length === 0) return false;
+
+  const neq = typeof input.neq === "string" ? input.neq : undefined;
+  const nin = Array.isArray(input.nin) ? input.nin : undefined;
+  const neqIgnoreCase = typeof input.neqIgnoreCase === "string" ? input.neqIgnoreCase : undefined;
+  if (neq !== undefined && candidates.some((value) => value === neq)) return false;
+  if (nin && candidates.some((value) => nin.includes(value))) return false;
+  if (neqIgnoreCase !== undefined && candidates.some((value) => value.toLowerCase() === neqIgnoreCase.toLowerCase())) {
+    return false;
+  }
+
+  if (!hasPositiveComparator(input)) return true;
+  return candidates.some((value) => positiveComparatorMatches(value, input));
+}
+
+function hasPositiveComparator(input: Record<string, unknown>): boolean {
+  return (
+    typeof input.eq === "string" ||
+    Array.isArray(input.in) ||
+    typeof input.contains === "string" ||
+    typeof input.startsWith === "string" ||
+    typeof input.endsWith === "string" ||
+    typeof input.eqIgnoreCase === "string"
+  );
+}
+
+function positiveComparatorMatches(value: string, input: Record<string, unknown>): boolean {
+  if (typeof input.eq === "string" && value !== input.eq) return false;
+  if (Array.isArray(input.in) && !input.in.includes(value)) return false;
+  if (typeof input.contains === "string" && !value.includes(input.contains)) return false;
+  if (typeof input.startsWith === "string" && !value.startsWith(input.startsWith)) return false;
+  if (typeof input.endsWith === "string" && !value.endsWith(input.endsWith)) return false;
+  if (typeof input.eqIgnoreCase === "string" && value.toLowerCase() !== input.eqIgnoreCase.toLowerCase()) return false;
   return true;
 }
 

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -705,32 +705,42 @@ function createRoot(context: LinearGraphQLContext) {
         : (resolveState(store, "Todo", team.linear_id) ?? ls().workflowStates.findBy("team_id", team.linear_id)[0]);
       if (requestedStateId && !state) throw new Error(`Workflow state not found: ${requestedStateId}`);
       if (!state) throw new Error("No workflow state exists for the selected team");
-      const number = nextIssueNumber(store, team.linear_id);
       const labelIds = resolveIssueLabelIds(store, input.labelIds, team.linear_id);
+      const title = requiredString(input.title, "title");
+      const description = nullableString(input.description);
+      const priority = normalizePriority(input.priority);
+      const assigneeId = resolveNullableUserId(store, input.assigneeId, "assigneeId");
+      const delegateId = resolveNullableUserId(store, input.delegateId, "delegateId");
+      const projectId = resolveNullableProjectId(store, input.projectId, team.linear_id);
+      const cycleId = resolveNullableCycleId(store, input.cycleId, team.linear_id);
+      const dueDate = nullableString(input.dueDate);
+      const createAsUser = nullableString(input.createAsUser);
+      const displayIconUrl = nullableString(input.displayIconUrl);
+      const number = nextIssueNumber(store, team.linear_id);
       const now = new Date().toISOString();
       const issue = ls().issues.insert({
         linear_id: linearId(),
         identifier: `${team.key}-${number}`,
         number,
         team_id: team.linear_id,
-        title: requiredString(input.title, "title"),
-        description: nullableString(input.description),
-        priority: normalizePriority(input.priority),
+        title,
+        description,
+        priority,
         state_id: state.linear_id,
-        assignee_id: resolveNullableUserId(store, input.assigneeId, "assigneeId"),
+        assignee_id: assigneeId,
         creator_id: actor.linear_id,
-        delegate_id: resolveNullableUserId(store, input.delegateId, "delegateId"),
-        project_id: resolveNullableProjectId(store, input.projectId, team.linear_id),
-        cycle_id: resolveNullableCycleId(store, input.cycleId, team.linear_id),
+        delegate_id: delegateId,
+        project_id: projectId,
+        cycle_id: cycleId,
         label_ids: labelIds,
         url: `${baseUrl}/issue/${team.key}-${number}`,
         archived_at: null,
         canceled_at: state.type === "canceled" ? now : null,
         completed_at: state.type === "completed" ? now : null,
         started_at: state.type === "started" ? now : null,
-        due_date: nullableString(input.dueDate),
-        create_as_user: nullableString(input.createAsUser),
-        display_icon_url: nullableString(input.displayIconUrl),
+        due_date: dueDate,
+        create_as_user: createAsUser,
+        display_icon_url: displayIconUrl,
       });
       await dispatchLinearWebhook(store, {
         type: "Issue",
@@ -914,7 +924,9 @@ function createRoot(context: LinearGraphQLContext) {
 
     issueLabelCreate: async ({ input }: { input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
-      const team = resolveTeam(store, stringInput(input.teamId));
+      const teamRef = stringInput(input.teamId);
+      const team = teamRef ? resolveTeam(store, teamRef) : undefined;
+      if (teamRef && !team) throw new Error(`Team not found: ${teamRef}`);
       const label = ls().issueLabels.insert({
         linear_id: linearId(),
         team_id: team?.linear_id ?? null,
@@ -1014,7 +1026,9 @@ function createRoot(context: LinearGraphQLContext) {
 
     webhookCreate: ({ input }: { input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["admin"]);
-      const team = resolveTeam(store, stringInput(input.teamId));
+      const teamRef = stringInput(input.teamId);
+      const team = teamRef ? resolveTeam(store, teamRef) : undefined;
+      if (teamRef && !team) throw new Error(`Team not found: ${teamRef}`);
       const webhook = ls().webhooks.insert({
         linear_id: linearId(),
         label: stringInput(input.label) ?? "Local webhook",
@@ -1040,8 +1054,9 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["write"]);
       const issue = requireIssue(store, input.issueId);
       const actor = requireCurrentUser(context);
+      const agentUserRef = stringInput(input.agentUserId);
       const agentUser =
-        resolveUser(store, stringInput(input.agentUserId)) ??
+        (agentUserRef ? requireUser(store, agentUserRef) : undefined) ??
         ls()
           .users.all()
           .find((user) => user.app) ??
@@ -1061,8 +1076,9 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["write"]);
       const comment = requireComment(store, input.commentId);
       const actor = requireCurrentUser(context);
+      const agentUserRef = stringInput(input.agentUserId);
       const agentUser =
-        resolveUser(store, stringInput(input.agentUserId)) ??
+        (agentUserRef ? requireUser(store, agentUserRef) : undefined) ??
         ls()
           .users.all()
           .find((user) => user.app) ??

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -70,23 +70,23 @@ const schema = buildSchema(`
 
   type Mutation {
     issueCreate(input: IssueCreateInput!): IssuePayload!
-    issueUpdate(input: IssueUpdateInput!): IssuePayload!
-    issueDelete(id: String!): ArchivePayload!
-    issueArchive(id: String!): IssuePayload!
-    issueUnarchive(id: String!): IssuePayload!
+    issueUpdate(id: String, input: IssueUpdateInput!): IssuePayload!
+    issueDelete(id: String!, permanentlyDelete: Boolean): IssueArchivePayload!
+    issueArchive(id: String!, trash: Boolean): IssueArchivePayload!
+    issueUnarchive(id: String!): IssueArchivePayload!
     commentCreate(input: CommentCreateInput!): CommentPayload!
-    commentUpdate(input: CommentUpdateInput!): CommentPayload!
-    commentDelete(id: String!): ArchivePayload!
-    issueLabelCreate(input: IssueLabelCreateInput!): IssueLabelPayload!
-    issueLabelUpdate(input: IssueLabelUpdateInput!): IssueLabelPayload!
-    issueLabelDelete(id: String!): ArchivePayload!
+    commentUpdate(id: String, input: CommentUpdateInput!, skipEditedAt: Boolean): CommentPayload!
+    commentDelete(id: String!): DeletePayload!
+    issueLabelCreate(input: IssueLabelCreateInput!, replaceTeamLabels: Boolean): IssueLabelPayload!
+    issueLabelUpdate(id: String, input: IssueLabelUpdateInput!, replaceTeamLabels: Boolean): IssueLabelPayload!
+    issueLabelDelete(id: String!): DeletePayload!
     issueAddLabel(id: String!, labelId: String!): IssuePayload!
     issueRemoveLabel(id: String!, labelId: String!): IssuePayload!
     webhookCreate(input: WebhookCreateInput!): WebhookPayload!
-    webhookDelete(id: String!): ArchivePayload!
-    agentSessionCreateOnIssue(input: AgentSessionCreateOnIssueInput!): AgentSessionPayload!
-    agentSessionCreateOnComment(input: AgentSessionCreateOnCommentInput!): AgentSessionPayload!
-    agentSessionUpdate(input: AgentSessionUpdateInput!): AgentSessionPayload!
+    webhookDelete(id: String!): DeletePayload!
+    agentSessionCreateOnIssue(input: AgentSessionCreateOnIssue!): AgentSessionPayload!
+    agentSessionCreateOnComment(input: AgentSessionCreateOnComment!): AgentSessionPayload!
+    agentSessionUpdate(id: String, input: AgentSessionUpdateInput!): AgentSessionPayload!
     agentActivityCreate(input: AgentActivityCreateInput!): AgentActivityPayload!
   }
 
@@ -387,7 +387,8 @@ const schema = buildSchema(`
   type WebhookPayload { success: Boolean! lastSyncId: Float webhook: Webhook }
   type AgentSessionPayload { success: Boolean! lastSyncId: Float agentSession: AgentSession }
   type AgentActivityPayload { success: Boolean! lastSyncId: Float agentActivity: AgentActivity }
-  type ArchivePayload { success: Boolean! }
+  type IssueArchivePayload { success: Boolean! lastSyncId: Float entity: Issue }
+  type DeletePayload { success: Boolean! lastSyncId: Float entityId: String }
 
   input StringComparator {
     eq: String
@@ -441,7 +442,7 @@ const schema = buildSchema(`
   }
 
   input IssueUpdateInput {
-    id: String!
+    id: String
     title: String
     description: String
     priority: Int
@@ -463,7 +464,7 @@ const schema = buildSchema(`
   }
 
   input CommentUpdateInput {
-    id: String!
+    id: String
     body: String!
   }
 
@@ -475,7 +476,7 @@ const schema = buildSchema(`
   }
 
   input IssueLabelUpdateInput {
-    id: String!
+    id: String
     name: String
     color: String
     description: String
@@ -491,14 +492,14 @@ const schema = buildSchema(`
     enabled: Boolean
   }
 
-  input AgentSessionCreateOnIssueInput {
+  input AgentSessionCreateOnIssue {
     issueId: String!
     agentUserId: String
     plan: String
     externalUrl: String
   }
 
-  input AgentSessionCreateOnCommentInput {
+  input AgentSessionCreateOnComment {
     commentId: String!
     agentUserId: String
     plan: String
@@ -506,7 +507,7 @@ const schema = buildSchema(`
   }
 
   input AgentSessionUpdateInput {
-    id: String!
+    id: String
     state: String
     plan: String
     externalUrl: String
@@ -705,9 +706,7 @@ function createRoot(context: LinearGraphQLContext) {
       if (requestedStateId && !state) throw new Error(`Workflow state not found: ${requestedStateId}`);
       if (!state) throw new Error("No workflow state exists for the selected team");
       const number = nextIssueNumber(store, team.linear_id);
-      const labelIds = arrayInput(input.labelIds)
-        .map((labelId) => resolveLabel(store, labelId, team.linear_id)?.linear_id)
-        .filter((id): id is string => Boolean(id));
+      const labelIds = resolveIssueLabelIds(store, input.labelIds, team.linear_id);
       const now = new Date().toISOString();
       const issue = ls().issues.insert({
         linear_id: linearId(),
@@ -718,11 +717,11 @@ function createRoot(context: LinearGraphQLContext) {
         description: nullableString(input.description),
         priority: normalizePriority(input.priority),
         state_id: state.linear_id,
-        assignee_id: resolveUser(store, stringInput(input.assigneeId))?.linear_id ?? null,
+        assignee_id: resolveNullableUserId(store, input.assigneeId, "assigneeId"),
         creator_id: actor.linear_id,
-        delegate_id: resolveUser(store, stringInput(input.delegateId))?.linear_id ?? null,
-        project_id: resolveProject(store, stringInput(input.projectId))?.linear_id ?? null,
-        cycle_id: resolveCycle(store, stringInput(input.cycleId), team.linear_id)?.linear_id ?? null,
+        delegate_id: resolveNullableUserId(store, input.delegateId, "delegateId"),
+        project_id: resolveNullableProjectId(store, input.projectId, team.linear_id),
+        cycle_id: resolveNullableCycleId(store, input.cycleId, team.linear_id),
         label_ids: labelIds,
         url: `${baseUrl}/issue/${team.key}-${number}`,
         archived_at: null,
@@ -747,10 +746,10 @@ function createRoot(context: LinearGraphQLContext) {
       return mutationPayload({ success: true, issue: formatIssue(context, issue) });
     },
 
-    issueUpdate: async ({ input }: { input: Record<string, unknown> }) => {
+    issueUpdate: async ({ id, input }: { id?: string; input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
       const actor = requireCurrentUser(context);
-      const issue = requireIssue(store, input.id);
+      const issue = requireIssue(store, id ?? input.id);
       const before = issueWebhookPayload(context, issue);
       const patch: Partial<LinearIssue> = {};
       if ("title" in input) patch.title = requiredString(input.title, "title");
@@ -766,19 +765,11 @@ function createRoot(context: LinearGraphQLContext) {
         patch.completed_at = state.type === "completed" ? (issue.completed_at ?? now) : null;
         patch.canceled_at = state.type === "canceled" ? (issue.canceled_at ?? now) : null;
       }
-      if ("assigneeId" in input)
-        patch.assignee_id = resolveUser(store, stringInput(input.assigneeId))?.linear_id ?? null;
-      if ("delegateId" in input)
-        patch.delegate_id = resolveUser(store, stringInput(input.delegateId))?.linear_id ?? null;
-      if ("projectId" in input)
-        patch.project_id = resolveProject(store, stringInput(input.projectId))?.linear_id ?? null;
-      if ("cycleId" in input)
-        patch.cycle_id = resolveCycle(store, stringInput(input.cycleId), issue.team_id)?.linear_id ?? null;
-      if ("labelIds" in input) {
-        patch.label_ids = arrayInput(input.labelIds)
-          .map((labelId) => resolveLabel(store, labelId, issue.team_id)?.linear_id)
-          .filter((id): id is string => Boolean(id));
-      }
+      if ("assigneeId" in input) patch.assignee_id = resolveNullableUserId(store, input.assigneeId, "assigneeId");
+      if ("delegateId" in input) patch.delegate_id = resolveNullableUserId(store, input.delegateId, "delegateId");
+      if ("projectId" in input) patch.project_id = resolveNullableProjectId(store, input.projectId, issue.team_id);
+      if ("cycleId" in input) patch.cycle_id = resolveNullableCycleId(store, input.cycleId, issue.team_id);
+      if ("labelIds" in input) patch.label_ids = resolveIssueLabelIds(store, input.labelIds, issue.team_id);
       if ("archivedAt" in input) patch.archived_at = nullableString(input.archivedAt);
       if ("dueDate" in input) patch.due_date = nullableString(input.dueDate);
       const updated = ls().issues.update(issue.id, patch);
@@ -819,7 +810,7 @@ function createRoot(context: LinearGraphQLContext) {
         teamId: issue.team_id,
         url: issue.url,
       });
-      return { success: true };
+      return issueArchivePayload(context, issue);
     },
 
     issueArchive: async ({ id }: { id: string }) => {
@@ -834,7 +825,7 @@ function createRoot(context: LinearGraphQLContext) {
         teamId: updated.team_id,
         url: updated.url,
       });
-      return mutationPayload({ success: true, issue: formatIssue(context, updated) });
+      return issueArchivePayload(context, updated);
     },
 
     issueUnarchive: async ({ id }: { id: string }) => {
@@ -849,7 +840,7 @@ function createRoot(context: LinearGraphQLContext) {
         teamId: updated.team_id,
         url: updated.url,
       });
-      return mutationPayload({ success: true, issue: formatIssue(context, updated) });
+      return issueArchivePayload(context, updated);
     },
 
     commentCreate: async ({ input }: { input: Record<string, unknown> }) => {
@@ -881,9 +872,9 @@ function createRoot(context: LinearGraphQLContext) {
       return mutationPayload({ success: true, comment: formatComment(context, comment) });
     },
 
-    commentUpdate: async ({ input }: { input: Record<string, unknown> }) => {
+    commentUpdate: async ({ id, input }: { id?: string; input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
-      const comment = requireComment(store, input.id);
+      const comment = requireComment(store, id ?? input.id);
       const before = commentWebhookPayload(context, comment);
       const updated = ls().comments.update(comment.id, { body: requiredString(input.body, "body") })!;
       const issue = requireIssue(store, updated.issue_id);
@@ -918,7 +909,7 @@ function createRoot(context: LinearGraphQLContext) {
         teamId: issue.team_id,
         url: issue.url,
       });
-      return { success: true };
+      return deletePayload(comment.linear_id);
     },
 
     issueLabelCreate: async ({ input }: { input: Record<string, unknown> }) => {
@@ -941,9 +932,9 @@ function createRoot(context: LinearGraphQLContext) {
       return mutationPayload({ success: true, issueLabel: formatLabel(context, label) });
     },
 
-    issueLabelUpdate: async ({ input }: { input: Record<string, unknown> }) => {
+    issueLabelUpdate: async ({ id, input }: { id?: string; input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
-      const label = requireLabel(store, input.id);
+      const label = requireLabel(store, id ?? input.id);
       const before = labelWebhookPayload(context, label);
       const updated = ls().issueLabels.update(label.id, {
         name: stringInput(input.name) ?? label.name,
@@ -977,7 +968,7 @@ function createRoot(context: LinearGraphQLContext) {
         actor: requireCurrentUser(context),
         teamId: label.team_id,
       });
-      return { success: true };
+      return deletePayload(label.linear_id);
     },
 
     issueAddLabel: async ({ id, labelId }: { id: string; labelId: string }) => {
@@ -1042,7 +1033,7 @@ function createRoot(context: LinearGraphQLContext) {
       requireLinearScopes(store, c, ["admin"]);
       const webhook = requireWebhook(store, id);
       ls().webhooks.delete(webhook.id);
-      return { success: true };
+      return deletePayload(webhook.linear_id);
     },
 
     agentSessionCreateOnIssue: async ({ input }: { input: Record<string, unknown> }) => {
@@ -1087,9 +1078,9 @@ function createRoot(context: LinearGraphQLContext) {
       return mutationPayload({ success: true, agentSession: formatAgentSession(context, session) });
     },
 
-    agentSessionUpdate: ({ input }: { input: Record<string, unknown> }) => {
+    agentSessionUpdate: ({ id, input }: { id?: string; input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
-      const session = requireAgentSession(store, input.id);
+      const session = requireAgentSession(store, id ?? input.id);
       const updated = ls().agentSessions.update(session.id, {
         state: normalizeSessionState(stringInput(input.state)) ?? session.state,
         plan: "plan" in input ? nullableString(input.plan) : session.plan,
@@ -1126,6 +1117,14 @@ function createRoot(context: LinearGraphQLContext) {
 
 function mutationPayload<T extends Record<string, unknown>>(payload: T): T & { lastSyncId: number } {
   return { lastSyncId: Date.now(), ...payload };
+}
+
+function deletePayload(entityId: string) {
+  return mutationPayload({ success: true, entityId });
+}
+
+function issueArchivePayload(context: LinearGraphQLContext, issue: LinearIssue) {
+  return mutationPayload({ success: true, entity: formatIssue(context, issue) });
 }
 
 function formatOrganization(context: LinearGraphQLContext) {
@@ -1810,6 +1809,40 @@ function requireAgentSession(store: Store, id: unknown): LinearAgentSession {
   const session = getLinearStore(store).agentSessions.findOneBy("linear_id", ref);
   if (!session) throw new Error(`Agent session not found: ${ref}`);
   return session;
+}
+
+function resolveNullableUserId(store: Store, value: unknown, field: string): string | null {
+  const ref = stringInput(value);
+  if (!ref) return null;
+  const user = resolveUser(store, ref);
+  if (!user) throw new Error(`User not found for ${field}: ${ref}`);
+  return user.linear_id;
+}
+
+function resolveNullableProjectId(store: Store, value: unknown, teamId: string): string | null {
+  const ref = stringInput(value);
+  if (!ref) return null;
+  const project = resolveProject(store, ref);
+  if (!project || (project.team_id !== null && project.team_id !== teamId)) {
+    throw new Error(`Project not found for team: ${ref}`);
+  }
+  return project.linear_id;
+}
+
+function resolveNullableCycleId(store: Store, value: unknown, teamId: string): string | null {
+  const ref = stringInput(value);
+  if (!ref) return null;
+  const cycle = resolveCycle(store, ref, teamId);
+  if (!cycle) throw new Error(`Cycle not found for team: ${ref}`);
+  return cycle.linear_id;
+}
+
+function resolveIssueLabelIds(store: Store, value: unknown, teamId: string): string[] {
+  return arrayInput(value).map((labelId) => {
+    const label = resolveLabel(store, labelId, teamId);
+    if (!label) throw new Error(`Issue label not found for team: ${labelId}`);
+    return label.linear_id;
+  });
 }
 
 async function createAgentSessionForIssue(

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -32,12 +32,23 @@ import type {
 import { dispatchLinearWebhook } from "../webhooks.js";
 
 const schema = buildSchema(`
+  scalar TeamFilter
+  scalar PaginationOrderBy
+
   type Query {
     viewer: User!
     organization: Organization!
     users(first: Int, after: String, last: Int, before: String, filter: UserFilter): UserConnection!
     user(id: String!): User
-    teams(first: Int, after: String, last: Int, before: String): TeamConnection!
+    teams(
+      first: Int
+      after: String
+      last: Int
+      before: String
+      filter: TeamFilter
+      includeArchived: Boolean
+      orderBy: PaginationOrderBy
+    ): TeamConnection!
     team(id: String!): Team
     workflowStates(first: Int, after: String, last: Int, before: String): WorkflowStateConnection!
     workflowState(id: String!): WorkflowState
@@ -87,7 +98,15 @@ const schema = buildSchema(`
     createdAt: String!
     updatedAt: String!
     users(first: Int, after: String, last: Int, before: String): UserConnection!
-    teams(first: Int, after: String, last: Int, before: String): TeamConnection!
+    teams(
+      first: Int
+      after: String
+      last: Int
+      before: String
+      filter: TeamFilter
+      includeArchived: Boolean
+      orderBy: PaginationOrderBy
+    ): TeamConnection!
   }
 
   type User {
@@ -137,6 +156,67 @@ const schema = buildSchema(`
     url: String!
     createdAt: String!
     updatedAt: String!
+    cycleIssueAutoAssignCompleted: Boolean
+    cycleLockToActive: Boolean
+    cycleIssueAutoAssignStarted: Boolean
+    cycleCalenderUrl: String
+    upcomingCycleCount: Int
+    autoArchivePeriod: Int
+    autoClosePeriod: Int
+    securitySettings: String
+    integrationsSettings: NodeRef
+    activeCycle: Cycle
+    triageResponsibility: NodeRef
+    scimGroupName: String
+    autoCloseStateId: String
+    cycleCooldownTime: Int
+    cycleStartDay: Int
+    defaultTemplateForMembers: NodeRef
+    defaultTemplateForNonMembers: NodeRef
+    defaultProjectTemplate: NodeRef
+    defaultIssueState: WorkflowState
+    cycleDuration: Int
+    icon: String
+    defaultTemplateForMembersId: String
+    defaultTemplateForNonMembersId: String
+    issueEstimationType: String
+    displayName: String
+    color: String
+    parent: Team
+    archivedAt: String
+    retiredAt: String
+    timezone: String
+    issueCount: Int
+    visibility: String
+    mergeWorkflowState: WorkflowState
+    draftWorkflowState: WorkflowState
+    startWorkflowState: WorkflowState
+    mergeableWorkflowState: WorkflowState
+    reviewWorkflowState: WorkflowState
+    markedAsDuplicateWorkflowState: WorkflowState
+    triageIssueState: WorkflowState
+    defaultIssueEstimate: Int
+    setIssueSortOrderOnStateChange: Boolean
+    allMembersCanJoin: Boolean
+    requirePriorityToLeaveTriage: Boolean
+    autoCloseChildIssues: Boolean
+    autoCloseParentIssues: Boolean
+    scimManaged: Boolean
+    inheritIssueEstimation: Boolean
+    inheritWorkflowStatuses: Boolean
+    cyclesEnabled: Boolean
+    issueEstimationExtended: Boolean
+    issueEstimationAllowZero: Boolean
+    aiDiscussionSummariesEnabled: Boolean
+    aiThreadSummariesEnabled: Boolean
+    groupIssueHistory: Boolean
+    slackIssueComments: Boolean
+    slackNewIssue: Boolean
+    slackIssueStatuses: Boolean
+    triageEnabled: Boolean
+    inviteHash: String
+    issueOrderingNoPriorityFirst: Boolean
+    issueSortOrderDefaultToBottom: Boolean
     states(first: Int, after: String, last: Int, before: String): WorkflowStateConnection!
     issues(first: Int, after: String, last: Int, before: String, filter: IssueFilter): IssueConnection!
     labels(first: Int, after: String, last: Int, before: String): IssueLabelConnection!
@@ -266,6 +346,10 @@ const schema = buildSchema(`
     user: User
   }
 
+  type NodeRef {
+    id: String!
+  }
+
   type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
@@ -297,12 +381,12 @@ const schema = buildSchema(`
   type AgentSessionConnection { nodes: [AgentSession!]! edges: [AgentSessionEdge!]! pageInfo: PageInfo! }
   type AgentActivityConnection { nodes: [AgentActivity!]! edges: [AgentActivityEdge!]! pageInfo: PageInfo! }
 
-  type IssuePayload { success: Boolean! issue: Issue }
-  type CommentPayload { success: Boolean! comment: Comment }
-  type IssueLabelPayload { success: Boolean! issueLabel: IssueLabel }
-  type WebhookPayload { success: Boolean! webhook: Webhook }
-  type AgentSessionPayload { success: Boolean! agentSession: AgentSession }
-  type AgentActivityPayload { success: Boolean! agentActivity: AgentActivity }
+  type IssuePayload { success: Boolean! lastSyncId: Float issue: Issue }
+  type CommentPayload { success: Boolean! lastSyncId: Float comment: Comment }
+  type IssueLabelPayload { success: Boolean! lastSyncId: Float issueLabel: IssueLabel }
+  type WebhookPayload { success: Boolean! lastSyncId: Float webhook: Webhook }
+  type AgentSessionPayload { success: Boolean! lastSyncId: Float agentSession: AgentSession }
+  type AgentActivityPayload { success: Boolean! lastSyncId: Float agentActivity: AgentActivity }
   type ArchivePayload { success: Boolean! }
 
   input StringComparator {
@@ -528,9 +612,9 @@ function createRoot(context: LinearGraphQLContext) {
       const user = resolveUser(store, id);
       return user ? formatUser(context, user) : null;
     },
-    teams: (args: ConnectionArgs) => {
+    teams: (args: ConnectionArgs & { filter?: unknown; includeArchived?: boolean; orderBy?: unknown }) => {
       requireRead();
-      return connectTeams(context, sortByCreated(ls().teams.all()), args);
+      return connectTeams(context, filteredTeams(context, args.filter, args.includeArchived, args.orderBy), args);
     },
     team: ({ id }: { id: string }) => {
       requireRead();
@@ -659,7 +743,7 @@ function createRoot(context: LinearGraphQLContext) {
       if (issue.delegate_id) {
         await createAgentSessionForIssue(context, issue, issue.delegate_id, actor);
       }
-      return { success: true, issue: formatIssue(context, issue) };
+      return mutationPayload({ success: true, issue: formatIssue(context, issue) });
     },
 
     issueUpdate: async ({ input }: { input: Record<string, unknown> }) => {
@@ -710,7 +794,7 @@ function createRoot(context: LinearGraphQLContext) {
       if (updated.delegate_id && updated.delegate_id !== issue.delegate_id) {
         await createAgentSessionForIssue(context, updated, updated.delegate_id, actor);
       }
-      return { success: true, issue: formatIssue(context, updated) };
+      return mutationPayload({ success: true, issue: formatIssue(context, updated) });
     },
 
     issueDelete: async ({ id }: { id: string }) => {
@@ -749,7 +833,7 @@ function createRoot(context: LinearGraphQLContext) {
         teamId: updated.team_id,
         url: updated.url,
       });
-      return { success: true, issue: formatIssue(context, updated) };
+      return mutationPayload({ success: true, issue: formatIssue(context, updated) });
     },
 
     issueUnarchive: async ({ id }: { id: string }) => {
@@ -764,7 +848,7 @@ function createRoot(context: LinearGraphQLContext) {
         teamId: updated.team_id,
         url: updated.url,
       });
-      return { success: true, issue: formatIssue(context, updated) };
+      return mutationPayload({ success: true, issue: formatIssue(context, updated) });
     },
 
     commentCreate: async ({ input }: { input: Record<string, unknown> }) => {
@@ -793,7 +877,7 @@ function createRoot(context: LinearGraphQLContext) {
           .find((user) => user.app && comment.body.includes(user.display_name));
         if (appUser) await createAgentSessionForComment(context, comment, appUser.linear_id, actor);
       }
-      return { success: true, comment: formatComment(context, comment) };
+      return mutationPayload({ success: true, comment: formatComment(context, comment) });
     },
 
     commentUpdate: async ({ input }: { input: Record<string, unknown> }) => {
@@ -811,7 +895,7 @@ function createRoot(context: LinearGraphQLContext) {
         url: issue.url,
         updatedFrom: before,
       });
-      return { success: true, comment: formatComment(context, updated) };
+      return mutationPayload({ success: true, comment: formatComment(context, updated) });
     },
 
     commentDelete: async ({ id }: { id: string }) => {
@@ -853,7 +937,7 @@ function createRoot(context: LinearGraphQLContext) {
         actor: requireCurrentUser(context),
         teamId: label.team_id,
       });
-      return { success: true, issueLabel: formatLabel(context, label) };
+      return mutationPayload({ success: true, issueLabel: formatLabel(context, label) });
     },
 
     issueLabelUpdate: async ({ input }: { input: Record<string, unknown> }) => {
@@ -873,7 +957,7 @@ function createRoot(context: LinearGraphQLContext) {
         teamId: updated.team_id,
         updatedFrom: before,
       });
-      return { success: true, issueLabel: formatLabel(context, updated) };
+      return mutationPayload({ success: true, issueLabel: formatLabel(context, updated) });
     },
 
     issueLabelDelete: async ({ id }: { id: string }) => {
@@ -912,7 +996,7 @@ function createRoot(context: LinearGraphQLContext) {
         url: updated.url,
         updatedFrom: before,
       });
-      return { success: true, issue: formatIssue(context, updated) };
+      return mutationPayload({ success: true, issue: formatIssue(context, updated) });
     },
 
     issueRemoveLabel: async ({ id, labelId }: { id: string; labelId: string }) => {
@@ -933,7 +1017,7 @@ function createRoot(context: LinearGraphQLContext) {
         url: updated.url,
         updatedFrom: before,
       });
-      return { success: true, issue: formatIssue(context, updated) };
+      return mutationPayload({ success: true, issue: formatIssue(context, updated) });
     },
 
     webhookCreate: ({ input }: { input: Record<string, unknown> }) => {
@@ -950,7 +1034,7 @@ function createRoot(context: LinearGraphQLContext) {
         secret: nullableString(input.secret),
         creator_id: requireCurrentUser(context).linear_id,
       });
-      return { success: true, webhook: formatWebhook(context, webhook) };
+      return mutationPayload({ success: true, webhook: formatWebhook(context, webhook) });
     },
 
     webhookDelete: ({ id }: { id: string }) => {
@@ -978,7 +1062,7 @@ function createRoot(context: LinearGraphQLContext) {
         nullableString(input.plan),
         nullableString(input.externalUrl),
       );
-      return { success: true, agentSession: formatAgentSession(context, session) };
+      return mutationPayload({ success: true, agentSession: formatAgentSession(context, session) });
     },
 
     agentSessionCreateOnComment: async ({ input }: { input: Record<string, unknown> }) => {
@@ -999,7 +1083,7 @@ function createRoot(context: LinearGraphQLContext) {
         nullableString(input.plan),
         nullableString(input.externalUrl),
       );
-      return { success: true, agentSession: formatAgentSession(context, session) };
+      return mutationPayload({ success: true, agentSession: formatAgentSession(context, session) });
     },
 
     agentSessionUpdate: ({ input }: { input: Record<string, unknown> }) => {
@@ -1010,7 +1094,7 @@ function createRoot(context: LinearGraphQLContext) {
         plan: "plan" in input ? nullableString(input.plan) : session.plan,
         external_url: "externalUrl" in input ? nullableString(input.externalUrl) : session.external_url,
       })!;
-      return { success: true, agentSession: formatAgentSession(context, updated) };
+      return mutationPayload({ success: true, agentSession: formatAgentSession(context, updated) });
     },
 
     agentActivityCreate: async ({ input }: { input: Record<string, unknown> }) => {
@@ -1034,9 +1118,13 @@ function createRoot(context: LinearGraphQLContext) {
           teamId: session.issue_id ? requireIssue(store, session.issue_id).team_id : null,
         });
       }
-      return { success: true, agentActivity: formatAgentActivity(context, activity) };
+      return mutationPayload({ success: true, agentActivity: formatAgentActivity(context, activity) });
     },
   };
+}
+
+function mutationPayload<T extends Record<string, unknown>>(payload: T): T & { lastSyncId: number } {
+  return { lastSyncId: Date.now(), ...payload };
 }
 
 function formatOrganization(context: LinearGraphQLContext) {
@@ -1051,8 +1139,8 @@ function formatOrganization(context: LinearGraphQLContext) {
     updatedAt: org.updated_at,
     users: (args: ConnectionArgs) =>
       connectUsers(context, sortByCreated(getLinearStore(context.store).users.all()), args),
-    teams: (args: ConnectionArgs) =>
-      connectTeams(context, sortByCreated(getLinearStore(context.store).teams.all()), args),
+    teams: (args: ConnectionArgs & { filter?: unknown; includeArchived?: boolean; orderBy?: unknown }) =>
+      connectTeams(context, filteredTeams(context, args.filter, args.includeArchived, args.orderBy), args),
   };
 }
 
@@ -1108,6 +1196,9 @@ function formatUser(context: LinearGraphQLContext, user: LinearUser) {
 
 function formatTeam(context: LinearGraphQLContext, team: LinearTeam) {
   const ls = getLinearStore(context.store);
+  const teamStates = () => ls.workflowStates.findBy("team_id", team.linear_id);
+  const stateByType = (type: LinearWorkflowState["type"]) => teamStates().find((state) => state.type === type);
+  const formatOptionalState = (state: LinearWorkflowState | undefined) => (state ? formatState(context, state) : null);
   return {
     id: team.linear_id,
     key: team.key,
@@ -1117,6 +1208,70 @@ function formatTeam(context: LinearGraphQLContext, team: LinearTeam) {
     url: team.url,
     createdAt: team.created_at,
     updatedAt: team.updated_at,
+    cycleIssueAutoAssignCompleted: false,
+    cycleLockToActive: false,
+    cycleIssueAutoAssignStarted: false,
+    cycleCalenderUrl: null,
+    upcomingCycleCount: 0,
+    autoArchivePeriod: null,
+    autoClosePeriod: null,
+    securitySettings: null,
+    integrationsSettings: null,
+    activeCycle: () => {
+      const activeCycle = ls.cycles.findBy("team_id", team.linear_id)[0];
+      return activeCycle ? formatCycle(context, activeCycle) : null;
+    },
+    triageResponsibility: null,
+    scimGroupName: null,
+    autoCloseStateId: null,
+    cycleCooldownTime: 0,
+    cycleStartDay: 1,
+    defaultTemplateForMembers: null,
+    defaultTemplateForNonMembers: null,
+    defaultProjectTemplate: null,
+    defaultIssueState: () => formatOptionalState(stateByType("unstarted") ?? teamStates()[0]),
+    cycleDuration: 2,
+    icon: null,
+    defaultTemplateForMembersId: null,
+    defaultTemplateForNonMembersId: null,
+    issueEstimationType: "notUsed",
+    displayName: team.name,
+    color: "#5e6ad2",
+    parent: null,
+    archivedAt: null,
+    retiredAt: null,
+    timezone: "UTC",
+    issueCount: () => ls.issues.count((issue) => issue.team_id === team.linear_id),
+    visibility: team.private ? "private" : "public",
+    mergeWorkflowState: () => formatOptionalState(stateByType("completed")),
+    draftWorkflowState: () => formatOptionalState(stateByType("backlog")),
+    startWorkflowState: () => formatOptionalState(stateByType("started")),
+    mergeableWorkflowState: () => formatOptionalState(stateByType("started")),
+    reviewWorkflowState: () => formatOptionalState(stateByType("started")),
+    markedAsDuplicateWorkflowState: () => formatOptionalState(stateByType("canceled")),
+    triageIssueState: () => formatOptionalState(stateByType("unstarted") ?? teamStates()[0]),
+    defaultIssueEstimate: null,
+    setIssueSortOrderOnStateChange: false,
+    allMembersCanJoin: !team.private,
+    requirePriorityToLeaveTriage: false,
+    autoCloseChildIssues: false,
+    autoCloseParentIssues: false,
+    scimManaged: false,
+    inheritIssueEstimation: false,
+    inheritWorkflowStatuses: false,
+    cyclesEnabled: true,
+    issueEstimationExtended: false,
+    issueEstimationAllowZero: true,
+    aiDiscussionSummariesEnabled: false,
+    aiThreadSummariesEnabled: false,
+    groupIssueHistory: false,
+    slackIssueComments: false,
+    slackNewIssue: false,
+    slackIssueStatuses: false,
+    triageEnabled: false,
+    inviteHash: null,
+    issueOrderingNoPriorityFirst: false,
+    issueSortOrderDefaultToBottom: false,
     states: (args: ConnectionArgs) =>
       connectStates(context, sortByPosition(ls.workflowStates.findBy("team_id", team.linear_id)), args),
     issues: (args: ConnectionArgs & { filter?: Record<string, unknown> }) =>
@@ -1411,6 +1566,51 @@ function filteredIssues(
   }
   if (!filter) return issues;
   return issues.filter((issue) => issueMatchesFilter(context, issue, filter));
+}
+
+function filteredTeams(
+  context: LinearGraphQLContext,
+  filter?: unknown,
+  _includeArchived?: boolean,
+  orderBy?: unknown,
+): LinearTeam[] {
+  let teams = sortByCreated(getLinearStore(context.store).teams.all());
+  if (isRecord(orderBy)) {
+    const field = typeof orderBy.field === "string" ? orderBy.field : Object.keys(orderBy)[0];
+    const direction =
+      typeof orderBy.direction === "string"
+        ? orderBy.direction
+        : field && typeof orderBy[field] === "string"
+          ? orderBy[field]
+          : undefined;
+    const multiplier = direction?.toLowerCase().startsWith("desc") ? -1 : 1;
+    if (field === "key" || field === "name" || field === "createdAt" || field === "updatedAt") {
+      teams = [...teams].sort((a, b) => teamOrderValue(a, field).localeCompare(teamOrderValue(b, field)) * multiplier);
+    }
+  }
+  if (!isRecord(filter)) return teams;
+  return teams.filter((team) => teamMatchesFilter(team, filter));
+}
+
+function teamOrderValue(team: LinearTeam, field: string): string {
+  if (field === "key") return team.key;
+  if (field === "name") return team.name;
+  if (field === "updatedAt") return team.updated_at;
+  return team.created_at;
+}
+
+function teamMatchesFilter(team: LinearTeam, filter: Record<string, unknown>): boolean {
+  const checks = [
+    aliasComparatorMatches([team.linear_id, team.key, team.name], filter.id),
+    comparatorMatches(team.key, filter.key),
+    comparatorMatches(team.name, filter.name),
+    comparatorMatches(team.name, filter.displayName),
+    typeof filter.private !== "boolean" || team.private === filter.private,
+  ];
+  const orFilters = Array.isArray(filter.or) ? filter.or.filter(isRecord) : [];
+  const hasOwnPredicate = ["id", "key", "name", "displayName", "private"].some((field) => filter[field] != null);
+  const ownMatch = hasOwnPredicate ? checks.every(Boolean) : orFilters.length === 0;
+  return ownMatch || orFilters.some((orFilter) => teamMatchesFilter(team, orFilter));
 }
 
 function issueMatchesFilter(

--- a/packages/@emulators/linear/src/routes/inspector.ts
+++ b/packages/@emulators/linear/src/routes/inspector.ts
@@ -1,0 +1,251 @@
+import type { InspectorTab, RouteContext } from "@emulators/core";
+import { escapeAttr, escapeHtml, renderInspectorPage } from "@emulators/core";
+import { getLinearStore } from "../store.js";
+import type { LinearUser } from "../entities.js";
+
+const SERVICE_LABEL = "Linear";
+
+const TABS: InspectorTab[] = [
+  { id: "issues", label: "Issues", href: "/?tab=issues" },
+  { id: "teams", label: "Teams", href: "/?tab=teams" },
+  { id: "users", label: "Users", href: "/?tab=users" },
+  { id: "projects", label: "Projects", href: "/?tab=projects" },
+  { id: "agents", label: "Agents", href: "/?tab=agents" },
+  { id: "auth", label: "Auth", href: "/?tab=auth" },
+  { id: "webhooks", label: "Webhooks", href: "/?tab=webhooks" },
+];
+
+type TabId = (typeof TABS)[number]["id"];
+
+export function inspectorRoutes({ app, store }: RouteContext): void {
+  const ls = () => getLinearStore(store);
+
+  app.get("/", (c) => {
+    const requested = c.req.query("tab") ?? "issues";
+    const active = TABS.some((tab) => tab.id === requested) ? (requested as TabId) : "issues";
+    const body =
+      active === "teams"
+        ? teamsView()
+        : active === "users"
+          ? usersView()
+          : active === "projects"
+            ? projectsView()
+            : active === "agents"
+              ? agentsView()
+              : active === "auth"
+                ? authView()
+                : active === "webhooks"
+                  ? webhooksView()
+                  : issuesView();
+    return c.html(renderInspectorPage("Linear Inspector", TABS, active, body, SERVICE_LABEL));
+  });
+
+  function issuesView(): string {
+    const rows = ls()
+      .issues.all()
+      .sort((a, b) => a.identifier.localeCompare(b.identifier))
+      .map((issue) => {
+        const team = ls().teams.findOneBy("linear_id", issue.team_id);
+        const state = ls().workflowStates.findOneBy("linear_id", issue.state_id);
+        const assignee = issue.assignee_id ? ls().users.findOneBy("linear_id", issue.assignee_id) : undefined;
+        const delegate = issue.delegate_id ? ls().users.findOneBy("linear_id", issue.delegate_id) : undefined;
+        const labels = issue.label_ids
+          .map((labelId) => ls().issueLabels.findOneBy("linear_id", labelId)?.name)
+          .filter((name): name is string => Boolean(name))
+          .join(", ");
+        return [
+          linkCell(`/?tab=issues&issue=${encodeURIComponent(issue.linear_id)}`, issue.identifier),
+          escapeHtml(issue.title),
+          escapeHtml(team?.key ?? issue.team_id),
+          escapeHtml(state?.name ?? issue.state_id),
+          escapeHtml(userLabel(assignee)),
+          escapeHtml(userLabel(delegate)),
+          escapeHtml(labels),
+          escapeHtml(issue.updated_at),
+        ];
+      });
+    return section(
+      "Issues",
+      table(["ID", "Title", "Team", "State", "Assignee", "Delegate", "Labels", "Updated"], rows, "No issues."),
+    );
+  }
+
+  function teamsView(): string {
+    const rows = ls()
+      .teams.all()
+      .sort((a, b) => a.key.localeCompare(b.key))
+      .map((team) => {
+        const stateNames = ls()
+          .workflowStates.findBy("team_id", team.linear_id)
+          .sort((a, b) => a.position - b.position)
+          .map((state) => state.name)
+          .join(", ");
+        const issueCount = ls().issues.count((issue) => issue.team_id === team.linear_id);
+        return [
+          escapeHtml(team.key),
+          escapeHtml(team.name),
+          escapeHtml(String(issueCount)),
+          escapeHtml(stateNames),
+          escapeHtml(team.private ? "private" : "public"),
+        ];
+      });
+    return section("Teams", table(["Key", "Name", "Issues", "States", "Access"], rows, "No teams."));
+  }
+
+  function usersView(): string {
+    const rows = ls()
+      .users.all()
+      .sort((a, b) => a.email.localeCompare(b.email))
+      .map((user) => [
+        escapeHtml(user.display_name),
+        escapeHtml(user.email),
+        escapeHtml(user.app ? "app" : "user"),
+        escapeHtml(user.admin ? "admin" : "member"),
+        escapeHtml(user.active ? "active" : "inactive"),
+        escapeHtml(String(ls().issues.count((issue) => issue.assignee_id === user.linear_id))),
+      ]);
+    return section("Users", table(["Name", "Email", "Kind", "Role", "Status", "Assigned"], rows, "No users."));
+  }
+
+  function projectsView(): string {
+    const projectRows = ls()
+      .projects.all()
+      .map((project) => [
+        escapeHtml(project.name),
+        escapeHtml(project.state),
+        escapeHtml(
+          project.team_id ? (ls().teams.findOneBy("linear_id", project.team_id)?.key ?? project.team_id) : "workspace",
+        ),
+        escapeHtml(String(ls().issues.count((issue) => issue.project_id === project.linear_id))),
+      ]);
+    const cycleRows = ls()
+      .cycles.all()
+      .map((cycle) => [
+        escapeHtml(cycle.name),
+        escapeHtml(String(cycle.number)),
+        escapeHtml(ls().teams.findOneBy("linear_id", cycle.team_id)?.key ?? cycle.team_id),
+        escapeHtml(String(ls().issues.count((issue) => issue.cycle_id === cycle.linear_id))),
+      ]);
+    return (
+      section("Projects", table(["Name", "State", "Team", "Issues"], projectRows, "No projects.")) +
+      section("Cycles", table(["Name", "Number", "Team", "Issues"], cycleRows, "No cycles."))
+    );
+  }
+
+  function agentsView(): string {
+    const rows = ls()
+      .agentSessions.all()
+      .map((session) => {
+        const issue = session.issue_id ? ls().issues.findOneBy("linear_id", session.issue_id) : undefined;
+        const agent = ls().users.findOneBy("linear_id", session.agent_user_id);
+        return [
+          escapeHtml(session.linear_id),
+          escapeHtml(session.state),
+          escapeHtml(issue?.identifier ?? ""),
+          escapeHtml(userLabel(agent)),
+          escapeHtml(String(ls().agentActivities.count((activity) => activity.session_id === session.linear_id))),
+          escapeHtml(session.updated_at),
+        ];
+      });
+    return section(
+      "Agent Sessions",
+      table(["ID", "State", "Issue", "Agent", "Activities", "Updated"], rows, "No agent sessions."),
+    );
+  }
+
+  function authView(): string {
+    const appRows = ls()
+      .oauthApps.all()
+      .map((oauthApp) => [
+        escapeHtml(oauthApp.name),
+        escapeHtml(oauthApp.client_id),
+        escapeHtml(oauthApp.actor),
+        escapeHtml(oauthApp.scopes.join(", ")),
+        escapeHtml(oauthApp.app_user_id ? userLabel(ls().users.findOneBy("linear_id", oauthApp.app_user_id)) : ""),
+      ]);
+    const tokenRows = ls()
+      .tokens.all()
+      .map((token) => [
+        escapeHtml(maskToken(token.token)),
+        escapeHtml(token.type),
+        escapeHtml(token.actor_type),
+        escapeHtml(token.user_id ? userLabel(ls().users.findOneBy("linear_id", token.user_id)) : (token.app_id ?? "")),
+        escapeHtml(token.scopes.join(", ")),
+        escapeHtml(token.revoked ? "revoked" : (token.expires_at ?? "active")),
+      ]);
+    return (
+      section("OAuth Apps", table(["Name", "Client ID", "Actor", "Scopes", "App User"], appRows, "No OAuth apps.")) +
+      section("Tokens", table(["Token", "Type", "Actor", "Subject", "Scopes", "Status"], tokenRows, "No tokens."))
+    );
+  }
+
+  function webhooksView(): string {
+    const webhookRows = ls()
+      .webhooks.all()
+      .map((webhook) => [
+        escapeHtml(webhook.label),
+        escapeHtml(webhook.url),
+        escapeHtml(webhook.enabled ? "enabled" : "disabled"),
+        escapeHtml(webhook.resource_types.join(", ")),
+        escapeHtml(
+          webhook.team_id
+            ? (ls().teams.findOneBy("linear_id", webhook.team_id)?.key ?? webhook.team_id)
+            : "all public teams",
+        ),
+      ]);
+    const deliveryRows = ls()
+      .webhookDeliveries.all()
+      .slice(-30)
+      .reverse()
+      .map((delivery) => [
+        escapeHtml(delivery.event),
+        escapeHtml(delivery.action),
+        escapeHtml(String(delivery.status ?? "")),
+        escapeHtml(delivery.error ?? ""),
+        escapeHtml(delivery.url),
+        escapeHtml(delivery.created_at),
+      ]);
+    return (
+      section(
+        "Webhook Subscriptions",
+        table(["Label", "URL", "Status", "Resources", "Scope"], webhookRows, "No webhooks."),
+      ) +
+      section(
+        "Webhook Deliveries",
+        table(["Event", "Action", "Status", "Error", "URL", "Created"], deliveryRows, "No deliveries."),
+      )
+    );
+  }
+}
+
+function section(title: string, body: string): string {
+  return `<section class="inspector-section">
+  <h2>${escapeHtml(title)}</h2>
+  ${body}
+</section>`;
+}
+
+function table(headers: string[], rows: string[][], empty: string): string {
+  if (rows.length === 0) return `<p class="inspector-empty">${escapeHtml(empty)}</p>`;
+  const headerHtml = headers.map((header) => `<th>${escapeHtml(header)}</th>`).join("");
+  const rowHtml = rows.map((row) => `<tr>${row.map((cell) => `<td>${cell}</td>`).join("")}</tr>`).join("\n");
+  return `<table class="inspector-table">
+  <thead><tr>${headerHtml}</tr></thead>
+  <tbody>
+${rowHtml}
+  </tbody>
+</table>`;
+}
+
+function linkCell(href: string, label: string): string {
+  return `<a href="${escapeAttr(href)}">${escapeHtml(label)}</a>`;
+}
+
+function userLabel(user: LinearUser | undefined): string {
+  return user?.display_name ?? user?.email ?? "";
+}
+
+function maskToken(value: string): string {
+  if (value.length <= 12) return value;
+  return `${value.slice(0, 8)}...${value.slice(-4)}`;
+}

--- a/packages/@emulators/linear/src/routes/oauth.ts
+++ b/packages/@emulators/linear/src/routes/oauth.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+import type { RouteContext, Store } from "@emulators/core";
+import {
+  bodyStr,
+  constantTimeSecretEqual,
+  escapeHtml,
+  matchesRedirectUri,
+  renderCardPage,
+  renderErrorPage,
+  renderUserButton,
+} from "@emulators/core";
+import { getLinearStore } from "../store.js";
+import { token } from "../ids.js";
+import { normalizeScopes } from "../index.js";
+import type { LinearOAuthApp, LinearTokenActorType } from "../entities.js";
+
+const SERVICE_LABEL = "Linear";
+const CODE_TTL_MS = 10 * 60 * 1000;
+const ACCESS_TOKEN_TTL_SECONDS = 3600;
+
+interface PendingCode {
+  appId: string | null;
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  userId: string | null;
+  actor: LinearTokenActorType;
+  codeChallenge: string | null;
+  codeChallengeMethod: string | null;
+  createdAt: number;
+}
+
+function pendingCodes(store: Store): Map<string, PendingCode> {
+  let map = store.getData<Map<string, PendingCode>>("linear.oauth.pending_codes");
+  if (!map) {
+    map = new Map();
+    store.setData("linear.oauth.pending_codes", map);
+  }
+  return map;
+}
+
+export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
+  const ls = () => getLinearStore(store);
+
+  app.get("/oauth/authorize", (c) => {
+    const clientId = c.req.query("client_id") ?? "";
+    const redirectUri = c.req.query("redirect_uri") ?? "";
+    const responseType = c.req.query("response_type") ?? "code";
+    const state = c.req.query("state") ?? "";
+    const scope = c.req.query("scope") ?? "read";
+    const actor = normalizeActor(c.req.query("actor")) ?? "user";
+    const codeChallenge = c.req.query("code_challenge") ?? "";
+    const codeChallengeMethod = c.req.query("code_challenge_method") ?? "";
+
+    if (responseType !== "code") {
+      return c.html(
+        renderErrorPage("Unsupported response_type", "Only response_type=code is supported.", SERVICE_LABEL),
+        400,
+      );
+    }
+    if (!redirectUri) {
+      return c.html(
+        renderErrorPage("Missing redirect URI", "The redirect_uri parameter is required.", SERVICE_LABEL),
+        400,
+      );
+    }
+
+    const oauthApp = resolveOAuthApp(clientId);
+    if (ls().oauthApps.all().length > 0) {
+      if (!oauthApp) {
+        return c.html(
+          renderErrorPage("Application not found", `The client_id '${clientId}' is not registered.`, SERVICE_LABEL),
+          400,
+        );
+      }
+      if (!matchesRedirectUri(redirectUri, oauthApp.redirect_uris)) {
+        return c.html(
+          renderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this app.", SERVICE_LABEL),
+          400,
+        );
+      }
+    }
+
+    const requestedScopes = normalizeScopes(scope, oauthApp?.scopes ?? ["read"]);
+    const title = actor === "app" ? "Install Linear App" : "Authorize Linear App";
+    const appName = oauthApp?.name ?? "Linear App";
+
+    const buttons =
+      actor === "app"
+        ? renderUserButton({
+            letter: "L",
+            login: appName,
+            name: `Install ${appName}`,
+            email: requestedScopes.join(", "),
+            formAction: "/oauth/authorize/callback",
+            hiddenFields: {
+              user_ref: oauthApp?.app_user_id ?? "",
+              actor,
+              redirect_uri: redirectUri,
+              scope: requestedScopes.join(" "),
+              state,
+              client_id: clientId,
+              code_challenge: codeChallenge,
+              code_challenge_method: codeChallengeMethod,
+            },
+          })
+        : ls()
+            .users.all()
+            .filter((user) => !user.app && user.active)
+            .map((user) =>
+              renderUserButton({
+                letter: (user.display_name[0] ?? "U").toUpperCase(),
+                login: user.email,
+                name: user.display_name,
+                email: user.email,
+                formAction: "/oauth/authorize/callback",
+                hiddenFields: {
+                  user_ref: user.linear_id,
+                  actor,
+                  redirect_uri: redirectUri,
+                  scope: requestedScopes.join(" "),
+                  state,
+                  client_id: clientId,
+                  code_challenge: codeChallenge,
+                  code_challenge_method: codeChallengeMethod,
+                },
+              }),
+            )
+            .join("\n");
+
+    return c.html(
+      renderCardPage(
+        title,
+        `Continue to <strong>${escapeHtml(appName)}</strong> with scopes <strong>${escapeHtml(requestedScopes.join(", "))}</strong>.`,
+        buttons || '<p class="empty">No users in the Linear emulator store.</p>',
+        SERVICE_LABEL,
+      ),
+    );
+  });
+
+  app.post("/oauth/authorize/callback", async (c) => {
+    const body = await c.req.parseBody();
+    const clientId = bodyStr(body.client_id);
+    const redirectUri = bodyStr(body.redirect_uri);
+    const state = bodyStr(body.state);
+    const scopes = normalizeScopes(bodyStr(body.scope), ["read"]);
+    const actor = normalizeActor(bodyStr(body.actor)) ?? "user";
+    const userRef = bodyStr(body.user_ref);
+    const codeChallenge = bodyStr(body.code_challenge);
+    const codeChallengeMethod = bodyStr(body.code_challenge_method);
+
+    const oauthApp = resolveOAuthApp(clientId);
+    if (ls().oauthApps.all().length > 0) {
+      if (!oauthApp) {
+        return c.html(renderErrorPage("Application not found", "The OAuth app is not registered.", SERVICE_LABEL), 400);
+      }
+      if (!matchesRedirectUri(redirectUri, oauthApp.redirect_uris)) {
+        return c.html(
+          renderErrorPage("Redirect URI mismatch", "The redirect_uri is not registered for this app.", SERVICE_LABEL),
+          400,
+        );
+      }
+    }
+
+    const user =
+      userRef && actor === "app"
+        ? ls().users.findOneBy("linear_id", userRef)
+        : (ls().users.findOneBy("linear_id", userRef) ??
+          ls()
+            .users.all()
+            .find((u) => !u.app));
+    const appUser =
+      actor === "app" ? (oauthApp?.app_user_id ? ls().users.findOneBy("linear_id", oauthApp.app_user_id) : user) : user;
+    if (!appUser) {
+      return c.html(
+        renderErrorPage("No Linear actor", "No matching user or app actor is available.", SERVICE_LABEL),
+        400,
+      );
+    }
+
+    const code = token("lin_code");
+    pendingCodes(store).set(code, {
+      appId: oauthApp?.linear_id ?? null,
+      clientId,
+      redirectUri,
+      scopes,
+      userId: appUser.linear_id,
+      actor,
+      codeChallenge: codeChallenge || null,
+      codeChallengeMethod: codeChallengeMethod || null,
+      createdAt: Date.now(),
+    });
+
+    const url = new URL(redirectUri);
+    url.searchParams.set("code", code);
+    if (state) url.searchParams.set("state", state);
+    return c.redirect(url.toString());
+  });
+
+  app.post("/oauth/token", async (c) => {
+    const body = await c.req.parseBody();
+    const grantType = bodyStr(body.grant_type);
+    const clientAuth = clientCredentials(c.req.header("Authorization"), body);
+    const oauthApp = resolveOAuthApp(clientAuth.clientId);
+
+    if (ls().oauthApps.all().length > 0) {
+      if (!oauthApp) return oauthError("invalid_client", "The OAuth app is not registered.");
+      if (!constantTimeSecretEqual(clientAuth.clientSecret, oauthApp.client_secret)) {
+        return oauthError("invalid_client", "Invalid client credentials.");
+      }
+    }
+
+    if (grantType === "authorization_code") {
+      const code = bodyStr(body.code);
+      const pending = pendingCodes(store).get(code);
+      if (!pending) return oauthError("invalid_grant", "Authorization code is invalid.");
+      if (Date.now() - pending.createdAt > CODE_TTL_MS) {
+        pendingCodes(store).delete(code);
+        return oauthError("invalid_grant", "Authorization code has expired.");
+      }
+      if (pending.redirectUri !== bodyStr(body.redirect_uri)) {
+        return oauthError("invalid_grant", "redirect_uri does not match the authorization request.");
+      }
+      if (pending.clientId !== clientAuth.clientId) {
+        return oauthError("invalid_grant", "client_id does not match the authorization request.");
+      }
+      if (!verifyPkce(pending, bodyStr(body.code_verifier))) {
+        return oauthError("invalid_grant", "PKCE verification failed.");
+      }
+      pendingCodes(store).delete(code);
+      return c.json(issueTokens(pending.userId, pending.appId, pending.actor, pending.scopes));
+    }
+
+    if (grantType === "refresh_token") {
+      const refreshToken = bodyStr(body.refresh_token);
+      const existing = ls().tokens.findOneBy("token", refreshToken);
+      if (!existing || existing.type !== "oauth_refresh" || existing.revoked) {
+        return oauthError("invalid_grant", "Refresh token is invalid.");
+      }
+      ls().tokens.update(existing.id, { revoked: true });
+      return c.json(issueTokens(existing.user_id, existing.app_id, existing.actor_type, existing.scopes));
+    }
+
+    if (grantType === "client_credentials") {
+      const scopes = normalizeScopes(bodyStr(body.scope), oauthApp?.scopes ?? ["read"]);
+      const appUserId =
+        oauthApp?.app_user_id ??
+        ls()
+          .users.all()
+          .find((user) => user.app)?.linear_id ??
+        null;
+      return c.json(issueTokens(appUserId, oauthApp?.linear_id ?? null, "app", scopes, false));
+    }
+
+    return oauthError(
+      "unsupported_grant_type",
+      "Only authorization_code, refresh_token, and client_credentials are supported.",
+    );
+  });
+
+  app.post("/oauth/revoke", async (c) => {
+    const body = await c.req.parseBody();
+    const value = bodyStr(body.token) || bodyStr(body.access_token) || bodyStr(body.refresh_token);
+    if (value) {
+      const record = ls().tokens.findOneBy("token", value);
+      if (record) {
+        ls().tokens.update(record.id, { revoked: true });
+        tokenMap?.delete(value);
+      }
+    }
+    return c.body(null, 200);
+  });
+
+  function issueTokens(
+    userId: string | null,
+    appId: string | null,
+    actor: LinearTokenActorType,
+    scopes: string[],
+    includeRefresh = true,
+  ) {
+    const accessToken = token("lin");
+    const refreshToken = includeRefresh ? token("lin_refresh") : null;
+    const expiresAt = new Date(Date.now() + ACCESS_TOKEN_TTL_SECONDS * 1000).toISOString();
+    const access = ls().tokens.insert({
+      token: accessToken,
+      type: actor === "app" && !includeRefresh ? "client_credentials" : "oauth_access",
+      actor_type: actor,
+      user_id: userId,
+      app_id: appId,
+      scopes,
+      expires_at: expiresAt,
+      revoked: false,
+      refresh_token: refreshToken,
+    });
+    tokenMap?.set(accessToken, {
+      login: userId ? (ls().users.findOneBy("linear_id", userId)?.email ?? userId) : (appId ?? "linear-app"),
+      id: access.id,
+      scopes,
+    });
+    if (refreshToken) {
+      ls().tokens.insert({
+        token: refreshToken,
+        type: "oauth_refresh",
+        actor_type: actor,
+        user_id: userId,
+        app_id: appId,
+        scopes,
+        expires_at: null,
+        revoked: false,
+        refresh_token: null,
+      });
+    }
+    return {
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: ACCESS_TOKEN_TTL_SECONDS,
+      scope: scopes.join(" "),
+      ...(refreshToken ? { refresh_token: refreshToken } : {}),
+    };
+  }
+
+  function resolveOAuthApp(clientId: string): LinearOAuthApp | undefined {
+    return ls().oauthApps.findOneBy("client_id", clientId);
+  }
+}
+
+function oauthError(error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status: 400,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function clientCredentials(
+  authHeader: string | undefined,
+  body: Record<string, unknown>,
+): { clientId: string; clientSecret: string } {
+  if (authHeader?.startsWith("Basic ")) {
+    try {
+      const decoded = Buffer.from(authHeader.slice("Basic ".length), "base64").toString("utf-8");
+      const [clientId, clientSecret] = decoded.split(":");
+      return { clientId: decodeURIComponent(clientId ?? ""), clientSecret: decodeURIComponent(clientSecret ?? "") };
+    } catch {
+      return { clientId: "", clientSecret: "" };
+    }
+  }
+  return {
+    clientId: bodyStr(body.client_id),
+    clientSecret: bodyStr(body.client_secret),
+  };
+}
+
+function normalizeActor(value: string | undefined): LinearTokenActorType | undefined {
+  if (value === "app" || value === "user") return value;
+  return undefined;
+}
+
+function verifyPkce(code: PendingCode, verifier: string): boolean {
+  if (!code.codeChallenge) return true;
+  if (!verifier) return false;
+  if (code.codeChallengeMethod === "S256") {
+    const hashed = createHash("sha256").update(verifier).digest("base64url");
+    return hashed === code.codeChallenge;
+  }
+  return verifier === code.codeChallenge;
+}

--- a/packages/@emulators/linear/src/routes/oauth.ts
+++ b/packages/@emulators/linear/src/routes/oauth.ts
@@ -48,7 +48,7 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
     const responseType = c.req.query("response_type") ?? "code";
     const state = c.req.query("state") ?? "";
     const scope = c.req.query("scope") ?? "read";
-    const actor = normalizeActor(c.req.query("actor")) ?? "user";
+    const requestedActor = normalizeActor(c.req.query("actor"));
     const codeChallenge = c.req.query("code_challenge") ?? "";
     const codeChallengeMethod = c.req.query("code_challenge_method") ?? "";
 
@@ -79,6 +79,13 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
           400,
         );
       }
+    }
+    const actor = requestedActor ?? oauthApp?.actor ?? "user";
+    if (requestedActor && oauthApp && requestedActor !== oauthApp.actor) {
+      return c.html(
+        renderErrorPage("Invalid actor", `This app is configured for actor=${oauthApp.actor}.`, SERVICE_LABEL),
+        400,
+      );
     }
 
     const requestedScopes = normalizeScopes(scope, oauthApp?.scopes ?? ["read"]);
@@ -155,7 +162,7 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
     const redirectUri = bodyStr(body.redirect_uri);
     const state = bodyStr(body.state);
     const scopes = normalizeScopes(bodyStr(body.scope), ["read"]);
-    const actor = normalizeActor(bodyStr(body.actor)) ?? "user";
+    const requestedActor = normalizeActor(bodyStr(body.actor));
     const userRef = bodyStr(body.user_ref);
     const codeChallenge = bodyStr(body.code_challenge);
     const codeChallengeMethod = bodyStr(body.code_challenge_method);
@@ -171,6 +178,13 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
           400,
         );
       }
+    }
+    const actor = requestedActor ?? oauthApp?.actor ?? "user";
+    if (requestedActor && oauthApp && requestedActor !== oauthApp.actor) {
+      return c.html(
+        renderErrorPage("Invalid actor", `This app is configured for actor=${oauthApp.actor}.`, SERVICE_LABEL),
+        400,
+      );
     }
     const invalidScopes = scopesOutsideApp(scopes, oauthApp);
     if (invalidScopes.length > 0) {
@@ -271,6 +285,9 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
     }
 
     if (grantType === "client_credentials") {
+      if (oauthApp && oauthApp.actor !== "app") {
+        return oauthError("unauthorized_client", "The OAuth app is not configured for app actor tokens.");
+      }
       const scopes = normalizeScopes(bodyStr(body.scope), oauthApp?.scopes ?? ["read"]);
       const invalidScopes = scopesOutsideApp(scopes, oauthApp);
       if (invalidScopes.length > 0) {

--- a/packages/@emulators/linear/src/routes/oauth.ts
+++ b/packages/@emulators/linear/src/routes/oauth.ts
@@ -388,8 +388,12 @@ function clientCredentials(
   if (authHeader?.startsWith("Basic ")) {
     try {
       const decoded = Buffer.from(authHeader.slice("Basic ".length), "base64").toString("utf-8");
-      const [clientId, clientSecret] = decoded.split(":");
-      return { clientId: decodeURIComponent(clientId ?? ""), clientSecret: decodeURIComponent(clientSecret ?? "") };
+      const separator = decoded.indexOf(":");
+      if (separator < 0) return { clientId: "", clientSecret: "" };
+      return {
+        clientId: decodeURIComponent(decoded.slice(0, separator)),
+        clientSecret: decodeURIComponent(decoded.slice(separator + 1)),
+      };
     } catch {
       return { clientId: "", clientSecret: "" };
     }

--- a/packages/@emulators/linear/src/routes/oauth.ts
+++ b/packages/@emulators/linear/src/routes/oauth.ts
@@ -82,6 +82,17 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
     }
 
     const requestedScopes = normalizeScopes(scope, oauthApp?.scopes ?? ["read"]);
+    const invalidScopes = scopesOutsideApp(requestedScopes, oauthApp);
+    if (invalidScopes.length > 0) {
+      return c.html(
+        renderErrorPage(
+          "Invalid scope",
+          `The app is not registered for scopes: ${invalidScopes.join(", ")}.`,
+          SERVICE_LABEL,
+        ),
+        400,
+      );
+    }
     const title = actor === "app" ? "Install Linear App" : "Authorize Linear App";
     const appName = oauthApp?.name ?? "Linear App";
 
@@ -161,6 +172,17 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
         );
       }
     }
+    const invalidScopes = scopesOutsideApp(scopes, oauthApp);
+    if (invalidScopes.length > 0) {
+      return c.html(
+        renderErrorPage(
+          "Invalid scope",
+          `The app is not registered for scopes: ${invalidScopes.join(", ")}.`,
+          SERVICE_LABEL,
+        ),
+        400,
+      );
+    }
 
     const user =
       userRef && actor === "app"
@@ -224,6 +246,10 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
       if (pending.clientId !== clientAuth.clientId) {
         return oauthError("invalid_grant", "client_id does not match the authorization request.");
       }
+      const invalidScopes = scopesOutsideApp(pending.scopes, oauthApp);
+      if (invalidScopes.length > 0) {
+        return oauthError("invalid_scope", `The app is not registered for scopes: ${invalidScopes.join(", ")}.`);
+      }
       if (!verifyPkce(pending, bodyStr(body.code_verifier))) {
         return oauthError("invalid_grant", "PKCE verification failed.");
       }
@@ -237,12 +263,19 @@ export function oauthRoutes({ app, store, tokenMap }: RouteContext): void {
       if (!existing || existing.type !== "oauth_refresh" || existing.revoked) {
         return oauthError("invalid_grant", "Refresh token is invalid.");
       }
+      if (existing.app_id !== (oauthApp?.linear_id ?? null)) {
+        return oauthError("invalid_grant", "Refresh token was not issued to this OAuth app.");
+      }
       ls().tokens.update(existing.id, { revoked: true });
       return c.json(issueTokens(existing.user_id, existing.app_id, existing.actor_type, existing.scopes));
     }
 
     if (grantType === "client_credentials") {
       const scopes = normalizeScopes(bodyStr(body.scope), oauthApp?.scopes ?? ["read"]);
+      const invalidScopes = scopesOutsideApp(scopes, oauthApp);
+      if (invalidScopes.length > 0) {
+        return oauthError("invalid_scope", `The app is not registered for scopes: ${invalidScopes.join(", ")}.`);
+      }
       const appUserId =
         oauthApp?.app_user_id ??
         ls()
@@ -353,6 +386,12 @@ function clientCredentials(
 function normalizeActor(value: string | undefined): LinearTokenActorType | undefined {
   if (value === "app" || value === "user") return value;
   return undefined;
+}
+
+function scopesOutsideApp(scopes: string[], oauthApp: LinearOAuthApp | undefined): string[] {
+  if (!oauthApp) return [];
+  const allowed = new Set(oauthApp.scopes);
+  return scopes.filter((scope) => !allowed.has(scope));
 }
 
 function verifyPkce(code: PendingCode, verifier: string): boolean {

--- a/packages/@emulators/linear/src/store.ts
+++ b/packages/@emulators/linear/src/store.ts
@@ -1,0 +1,63 @@
+import { Store, type Collection } from "@emulators/core";
+import type {
+  LinearAgentActivity,
+  LinearAgentSession,
+  LinearComment,
+  LinearCycle,
+  LinearIssue,
+  LinearIssueLabel,
+  LinearOAuthApp,
+  LinearOrganization,
+  LinearProject,
+  LinearTeam,
+  LinearToken,
+  LinearUser,
+  LinearWebhook,
+  LinearWebhookDelivery,
+  LinearWorkflowState,
+} from "./entities.js";
+
+export interface LinearStore {
+  organizations: Collection<LinearOrganization>;
+  users: Collection<LinearUser>;
+  teams: Collection<LinearTeam>;
+  workflowStates: Collection<LinearWorkflowState>;
+  issueLabels: Collection<LinearIssueLabel>;
+  projects: Collection<LinearProject>;
+  cycles: Collection<LinearCycle>;
+  issues: Collection<LinearIssue>;
+  comments: Collection<LinearComment>;
+  oauthApps: Collection<LinearOAuthApp>;
+  tokens: Collection<LinearToken>;
+  webhooks: Collection<LinearWebhook>;
+  webhookDeliveries: Collection<LinearWebhookDelivery>;
+  agentSessions: Collection<LinearAgentSession>;
+  agentActivities: Collection<LinearAgentActivity>;
+}
+
+export function getLinearStore(store: Store): LinearStore {
+  return {
+    organizations: store.collection<LinearOrganization>("linear.organizations", ["linear_id", "url_key"]),
+    users: store.collection<LinearUser>("linear.users", ["linear_id", "email"]),
+    teams: store.collection<LinearTeam>("linear.teams", ["linear_id", "key"]),
+    workflowStates: store.collection<LinearWorkflowState>("linear.workflow_states", ["linear_id", "team_id", "name"]),
+    issueLabels: store.collection<LinearIssueLabel>("linear.issue_labels", ["linear_id", "team_id", "name"]),
+    projects: store.collection<LinearProject>("linear.projects", ["linear_id", "team_id", "name"]),
+    cycles: store.collection<LinearCycle>("linear.cycles", ["linear_id", "team_id"]),
+    issues: store.collection<LinearIssue>("linear.issues", ["linear_id", "identifier", "team_id", "state_id"]),
+    comments: store.collection<LinearComment>("linear.comments", ["linear_id", "issue_id"]),
+    oauthApps: store.collection<LinearOAuthApp>("linear.oauth_apps", ["linear_id", "client_id"]),
+    tokens: store.collection<LinearToken>("linear.tokens", ["token", "user_id", "app_id"]),
+    webhooks: store.collection<LinearWebhook>("linear.webhooks", ["linear_id", "team_id"]),
+    webhookDeliveries: store.collection<LinearWebhookDelivery>("linear.webhook_deliveries", [
+      "linear_id",
+      "webhook_id",
+    ]),
+    agentSessions: store.collection<LinearAgentSession>("linear.agent_sessions", [
+      "linear_id",
+      "issue_id",
+      "comment_id",
+    ]),
+    agentActivities: store.collection<LinearAgentActivity>("linear.agent_activities", ["linear_id", "session_id"]),
+  };
+}

--- a/packages/@emulators/linear/src/webhooks.ts
+++ b/packages/@emulators/linear/src/webhooks.ts
@@ -1,0 +1,85 @@
+import { createHmac } from "node:crypto";
+import type { Store } from "@emulators/core";
+import { getLinearStore } from "./store.js";
+import { linearId } from "./ids.js";
+import type { LinearUser } from "./entities.js";
+
+export interface LinearWebhookEvent {
+  type: string;
+  action: string;
+  data: unknown;
+  actor?: LinearUser | null;
+  teamId?: string | null;
+  url?: string | null;
+  updatedFrom?: Record<string, unknown>;
+}
+
+export async function dispatchLinearWebhook(store: Store, event: LinearWebhookEvent): Promise<void> {
+  const ls = getLinearStore(store);
+  const organization = ls.organizations.all()[0];
+  const webhooks = ls.webhooks.all().filter((webhook) => {
+    if (!webhook.enabled) return false;
+    if (!webhook.resource_types.includes(event.type) && !webhook.resource_types.includes("*")) return false;
+    if (webhook.all_public_teams) return true;
+    return webhook.team_id === event.teamId;
+  });
+
+  for (const webhook of webhooks) {
+    const payload = {
+      action: event.action,
+      type: event.type,
+      actor: event.actor
+        ? {
+            id: event.actor.linear_id,
+            name: event.actor.name,
+            displayName: event.actor.display_name,
+            email: event.actor.email,
+          }
+        : null,
+      data: event.data,
+      url: event.url ?? null,
+      createdAt: new Date().toISOString(),
+      organizationId: organization?.linear_id ?? null,
+      webhookTimestamp: Date.now(),
+      webhookId: webhook.linear_id,
+      ...(event.updatedFrom ? { updatedFrom: event.updatedFrom } : {}),
+    };
+    const body = JSON.stringify(payload);
+    const headers: Record<string, string> = {
+      "Accept-Charset": "utf-8",
+      "Content-Type": "application/json; charset=utf-8",
+      "Linear-Delivery": linearId(),
+      "Linear-Event": event.type,
+      "User-Agent": "Linear-Webhook",
+    };
+    if (webhook.secret) {
+      headers["Linear-Signature"] = createHmac("sha256", webhook.secret).update(body).digest("hex");
+    }
+
+    let status: number | null = null;
+    let error: string | null = null;
+    try {
+      const res = await fetch(webhook.url, {
+        method: "POST",
+        headers,
+        body,
+        signal: AbortSignal.timeout(10000),
+      });
+      status = res.status;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+
+    ls.webhookDeliveries.insert({
+      linear_id: linearId(),
+      webhook_id: webhook.linear_id,
+      event: event.type,
+      action: event.action,
+      url: webhook.url,
+      status,
+      error,
+      payload,
+      headers,
+    });
+  }
+}

--- a/packages/@emulators/linear/src/webhooks.ts
+++ b/packages/@emulators/linear/src/webhooks.ts
@@ -20,7 +20,10 @@ export async function dispatchLinearWebhook(store: Store, event: LinearWebhookEv
   const webhooks = ls.webhooks.all().filter((webhook) => {
     if (!webhook.enabled) return false;
     if (!webhook.resource_types.includes(event.type) && !webhook.resource_types.includes("*")) return false;
-    if (webhook.all_public_teams) return true;
+    if (webhook.all_public_teams) {
+      const team = event.teamId ? ls.teams.findOneBy("linear_id", event.teamId) : undefined;
+      return !team?.private;
+    }
     return webhook.team_id === event.teamId;
   });
 

--- a/packages/@emulators/linear/tsconfig.json
+++ b/packages/@emulators/linear/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/linear/tsup.config.ts
+++ b/packages/@emulators/linear/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -70,6 +70,7 @@
     "@emulators/resend": "workspace:*",
     "@emulators/stripe": "workspace:*",
     "@emulators/clerk": "workspace:*",
+    "@emulators/linear": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -27,6 +27,7 @@ const SERVICE_NAME_LIST = [
   "stripe",
   "mongoatlas",
   "clerk",
+  "linear",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -499,6 +500,72 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
             redirect_uris: ["http://localhost:3000/api/auth/callback/clerk"],
           },
         ],
+      },
+    },
+  },
+  linear: {
+    label: "Linear GraphQL API emulator",
+    endpoints:
+      "GraphQL, OAuth, issues, teams, users, workflow states, comments, labels, projects, cycles, webhooks, agents, inspector",
+    async load() {
+      const mod = await import("@emulators/linear");
+      return { plugin: mod.linearPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback(cfg) {
+      const firstEmail = (cfg?.users as Array<{ email?: string }> | undefined)?.[0]?.email ?? "admin@linear.local";
+      return { login: firstEmail, id: 1, scopes: ["read", "write", "issues:create", "comments:create", "admin"] };
+    },
+    initConfig: {
+      linear: {
+        organization: { name: "Acme", url_key: "acme" },
+        users: [
+          { email: "admin@example.com", name: "Admin User", admin: true },
+          { email: "dev@example.com", name: "Developer" },
+        ],
+        teams: [
+          {
+            key: "ENG",
+            name: "Engineering",
+            states: [
+              { name: "Backlog", type: "backlog" },
+              { name: "Todo", type: "unstarted" },
+              { name: "In Progress", type: "started" },
+              { name: "Done", type: "completed" },
+            ],
+          },
+        ],
+        labels: [
+          { name: "Bug", color: "#d92d20", team: "ENG" },
+          { name: "Feature", color: "#2563eb", team: "ENG" },
+        ],
+        issues: [
+          {
+            team: "ENG",
+            title: "Fix local checkout test",
+            description: "Reproduce and fix the checkout failure.",
+            state: "Todo",
+            assignee: "dev@example.com",
+            labels: ["Bug"],
+          },
+        ],
+        oauth_apps: [
+          {
+            client_id: "lin_example_client_id",
+            client_secret: "example_client_secret",
+            name: "My Linear App",
+            redirect_uris: ["http://localhost:3000/api/auth/callback/linear"],
+            scopes: ["read", "write", "issues:create", "comments:create"],
+            actor: "user",
+          },
+        ],
+        tokens: [
+          {
+            token: "lin_test_admin",
+            user: "admin@example.com",
+            scopes: ["read", "write", "issues:create", "comments:create", "admin"],
+          },
+        ],
+        strict_scopes: false,
       },
     },
   },

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -513,7 +513,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
     },
     defaultFallback(cfg) {
       const firstEmail = (cfg?.users as Array<{ email?: string }> | undefined)?.[0]?.email ?? "admin@linear.local";
-      return { login: firstEmail, id: 1, scopes: ["read", "write", "issues:create", "comments:create", "admin"] };
+      return { login: firstEmail, id: 1, scopes: [] };
     },
     initConfig: {
       linear: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,28 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/@emulators/linear:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+      graphql:
+        specifier: ^17.0.0
+        version: 17.0.0
+    devDependencies:
+      '@linear/sdk':
+        specifier: ^86.0.0
+        version: 86.0.0(graphql@17.0.0)
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+
   packages/@emulators/microsoft:
     dependencies:
       '@emulators/core':
@@ -713,6 +735,9 @@ importers:
       '@emulators/google':
         specifier: workspace:*
         version: link:../@emulators/google
+      '@emulators/linear':
+        specifier: workspace:*
+        version: link:../@emulators/linear
       '@emulators/microsoft':
         specifier: workspace:*
         version: link:../@emulators/microsoft
@@ -1270,6 +1295,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1475,6 +1505,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@linear/sdk@86.0.0':
+    resolution: {integrity: sha512-Lr47874CGGPCDiPQoKYjcZDWyyu18N8zzEGvss86uzjZaeZrhNsuwKTARswG27VAJ3fPVJAvl/5dPl8QwndSlg==}
+    engines: {node: '>=18.x'}
 
   '@mdx-js/loader@3.1.1':
     resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
@@ -4272,6 +4306,10 @@ packages:
   graceful-readlink@1.0.1:
     resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
 
+  graphql@17.0.0:
+    resolution: {integrity: sha512-RSEgqrRNqHVGa46w2pmL9uTFkYPJiJbD5kksOvOaPLrKvBIidX/ttQVlWsR3+Ee8l+mNroC6darpcPIZeElbNg==}
+    engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -5143,10 +5181,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -6893,6 +6927,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@17.0.0)':
+    dependencies:
+      graphql: 17.0.0
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -7045,6 +7083,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@linear/sdk@86.0.0(graphql@17.0.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.0)
+    transitivePeerDependencies:
+      - graphql
 
   '@mdx-js/loader@3.1.1':
     dependencies:
@@ -10011,9 +10055,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -10146,6 +10190,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graceful-readlink@1.0.1: {}
+
+  graphql@17.0.0: {}
 
   hachure-fill@0.5.2: {}
 
@@ -11363,8 +11409,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
@@ -12163,8 +12207,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
 
@@ -12459,7 +12503,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: emulate
-description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*)
+description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, and other developer APIs. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation.
+allowed-tools: Bash(npx emulate:*)
 ---
 
 # Service Emulation with emulate
@@ -24,7 +24,13 @@ All services start with sensible defaults:
 | Slack     | 4003        |
 | Apple     | 4004        |
 | Microsoft | 4005        |
-| AWS       | 4006        |
+| Okta      | 4006        |
+| AWS       | 4007        |
+| Resend    | 4008        |
+| Stripe    | 4009        |
+| MongoDB Atlas | 4010   |
+| Clerk     | 4011        |
+| Linear    | 4012        |
 
 ## CLI
 
@@ -90,7 +96,7 @@ await vercel.close()
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, or `'linear'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -212,6 +218,36 @@ slack:
       redirect_uris:
         - http://localhost:3000/api/auth/callback/slack
 
+linear:
+  organization:
+    name: Acme
+    url_key: acme
+  users:
+    - email: admin@example.com
+      name: Admin User
+      admin: true
+    - email: dev@example.com
+      name: Developer
+  teams:
+    - key: ENG
+      name: Engineering
+  issues:
+    - team: ENG
+      title: Fix local checkout test
+      state: Todo
+      assignee: dev@example.com
+  oauth_apps:
+    - client_id: lin_example_client_id
+      client_secret: example_client_secret
+      name: My Linear App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/linear
+      scopes: [read, write, issues:create, comments:create]
+  tokens:
+    - token: lin_test_admin
+      user: admin@example.com
+      scopes: [read, write, issues:create, comments:create, admin]
+
 apple:
   users:
     - email: testuser@icloud.com
@@ -307,7 +343,8 @@ GOOGLE_EMULATOR_URL=http://localhost:4002
 SLACK_EMULATOR_URL=http://localhost:4003
 APPLE_EMULATOR_URL=http://localhost:4004
 MICROSOFT_EMULATOR_URL=http://localhost:4005
-AWS_EMULATOR_URL=http://localhost:4006
+AWS_EMULATOR_URL=http://localhost:4007
+LINEAR_EMULATOR_URL=http://localhost:4012
 ```
 
 Then use these in your app to construct API and OAuth URLs. See each service's skill for SDK-specific override instructions.
@@ -354,6 +391,7 @@ packages/
     github/          # GitHub API service plugin
     google/          # Google OAuth 2.0 / OIDC plugin
     slack/           # Slack Web API, OAuth, incoming webhooks plugin
+    linear/          # Linear GraphQL API, OAuth, webhooks plugin
     apple/           # Sign in with Apple / OIDC plugin
     microsoft/       # Microsoft Entra ID OAuth 2.0 / OIDC plugin
     aws/             # AWS S3, SQS, IAM, STS plugin

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: linear
+description: Emulated Linear GraphQL API for local development and testing. Use when the user needs to test Linear integrations locally, emulate Linear issues, comments, teams, workflow states, OAuth apps, webhooks, agent sessions, or work with the Linear API without hitting the real Linear service. Triggers include "Linear API", "emulate Linear", "mock Linear", "test Linear OAuth", "Linear webhook", "Linear agent", "local Linear", or any task requiring a local Linear API.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# Linear API Emulator
+
+Stateful Linear GraphQL API emulation with organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and basic agent sessions.
+
+## Start
+
+```bash
+# Linear only
+npx emulate --service linear
+```
+
+Default URL: `http://localhost:4012` when all services are started, or `http://localhost:4000` when Linear is the only service.
+
+## URL Mapping
+
+| Real Linear URL | Emulator URL |
+|-----------------|--------------|
+| `https://api.linear.app/graphql` | `$LINEAR_EMULATOR_URL/graphql` |
+| `https://linear.app/oauth/authorize` | `$LINEAR_EMULATOR_URL/oauth/authorize` |
+| `https://api.linear.app/oauth/token` | `$LINEAR_EMULATOR_URL/oauth/token` |
+| `https://api.linear.app/oauth/revoke` | `$LINEAR_EMULATOR_URL/oauth/revoke` |
+
+## Auth
+
+GraphQL accepts a bearer token or bare personal API key:
+
+```bash
+curl "$LINEAR_EMULATOR_URL/graphql" \
+  -H "Authorization: Bearer lin_test_admin" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ viewer { id email } }"}'
+```
+
+Scope checks are relaxed by default. Set `linear.strict_scopes: true` in seed config to require supported operation scopes such as `read`, `write`, `issues:create`, `comments:create`, and `admin`.
+
+## Seed Config
+
+```yaml
+linear:
+  organization:
+    name: Acme
+    url_key: acme
+  users:
+    - email: admin@example.com
+      name: Admin User
+      admin: true
+    - email: dev@example.com
+      name: Developer
+  teams:
+    - key: ENG
+      name: Engineering
+  issues:
+    - team: ENG
+      title: Fix local checkout test
+      state: Todo
+      assignee: dev@example.com
+  oauth_apps:
+    - client_id: lin_example_client_id
+      client_secret: example_client_secret
+      name: My Linear App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/linear
+      scopes: [read, write, issues:create, comments:create]
+  tokens:
+    - token: lin_test_admin
+      user: admin@example.com
+      scopes: [read, write, issues:create, comments:create, admin]
+  strict_scopes: false
+```
+
+## GraphQL Surface
+
+Supported queries:
+
+- `viewer`
+- `organization`
+- `users`, `user`
+- `teams`, `team`
+- `workflowStates`, `workflowState`
+- `issues`, `issue`
+- `comments`, `comment`
+- `issueLabels`, `issueLabel`
+- `projects`, `project`
+- `cycles`, `cycle`
+- `webhooks`, `webhook`
+- `agentSessions`, `agentSession`
+
+Supported mutations:
+
+- `issueCreate`, `issueUpdate`, `issueDelete`, `issueArchive`, `issueUnarchive`
+- `commentCreate`, `commentUpdate`, `commentDelete`
+- `issueLabelCreate`, `issueLabelUpdate`, `issueLabelDelete`
+- `issueAddLabel`, `issueRemoveLabel`
+- `webhookCreate`, `webhookDelete`
+- `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`
+- `agentActivityCreate`
+
+Connections use Relay-style cursors with `nodes`, `edges`, and `pageInfo`.
+
+## OAuth
+
+- `GET /oauth/authorize` - authorization endpoint with local user picker
+- `POST /oauth/authorize/callback` - local user picker callback
+- `POST /oauth/token` - authorization code, refresh token, and client credentials grants
+- `POST /oauth/revoke` - revoke access or refresh tokens
+
+OAuth apps can use `actor: user` or `actor: app`. App actor support is sufficient for local agent and service-account tests, but it is not full production Linear agent behavior.
+
+## Webhooks
+
+Create local webhook subscriptions through `webhookCreate` or seed config. Supported writes dispatch Linear-shaped payloads with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers when a secret is configured.
+
+## Inspector
+
+Open `GET /` in the Linear emulator to inspect issues, teams, users, projects, agent sessions, OAuth apps, tokens, webhook subscriptions, and webhook deliveries.
+
+## Current Limits
+
+Full Linear schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and full production agent behavior are not implemented.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -110,7 +110,7 @@ Connections use Relay-style cursors with `nodes`, `edges`, and `pageInfo`.
 - `POST /oauth/token` - authorization code, refresh token, and client credentials grants
 - `POST /oauth/revoke` - revoke access or refresh tokens
 
-OAuth apps can use `actor: user` or `actor: app`. App actor support is sufficient for local agent and service-account tests, but it is not full production Linear agent behavior.
+OAuth apps can use `actor: user` or `actor: app`. The configured actor is authoritative. User actor apps use authorization code flows. App actor apps use the app install flow and can request client credentials tokens. App actor support is sufficient for local agent and service-account tests, but it is not full production Linear agent behavior.
 
 ## Webhooks
 


### PR DESCRIPTION
- Add a stateful Linear service with GraphQL, OAuth, webhooks, inspector, and seed support.
- Register Linear in the CLI package and default service config.
- Document the supported surface and cover it with Linear SDK conformance tests.