### PR TITLE
Prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
 <!-- release:start -->
+## 0.7.0
+
+### New Features
+
+- **Linear emulator** — stateful Linear GraphQL API emulation with seeded organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, agent sessions, and local inspector support (#180)
+
+### Improvements
+
+- **Linear docs and agent guidance** — added README, docs site, programmatic API, and skill coverage for Linear API, OAuth, and webhook testing (#180)
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
 ## 0.6.1
 
 ### New Features
@@ -14,8 +30,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.6.0
 

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-next",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/apple/package.json
+++ b/packages/@emulators/apple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/apple",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/aws",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/clerk/package.json
+++ b/packages/@emulators/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/clerk",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/core/package.json
+++ b/packages/@emulators/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/core",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/github/package.json
+++ b/packages/@emulators/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/github",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/google/package.json
+++ b/packages/@emulators/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/google",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/linear/package.json
+++ b/packages/@emulators/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/linear",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/microsoft/package.json
+++ b/packages/@emulators/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/microsoft",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/mongoatlas/package.json
+++ b/packages/@emulators/mongoatlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/mongoatlas",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/okta/package.json
+++ b/packages/@emulators/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/okta",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/resend/package.json
+++ b/packages/@emulators/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/resend",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/slack/package.json
+++ b/packages/@emulators/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/slack",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/stripe/package.json
+++ b/packages/@emulators/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/stripe",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/vercel/package.json
+++ b/packages/@emulators/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/vercel",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulate",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Local drop-in replacement services for CI and no-network sandboxes",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
- Bump emulate and @emulators packages to 0.7.0
- Add Linear-focused 0.7.0 changelog notes with release markers