### PR TITLE
[vercel] adding 2 new integration configuration endpoints to vercel emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,11 @@ vercel:
       name: "My Vercel App"
       redirect_uris:
         - "http://localhost:3000/api/auth/callback/vercel"
+  integration_configurations:
+    - id: "icfg_abc123"
+      integrationId: "oac_abc123"
+      ownerId: "team_xyz"
+      projectSelection: "all"
 ```
 
 ### GitHub OAuth Apps
@@ -584,6 +589,10 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `GET /v10/projects/:idOrName/env/:id` - get env var
 - `PATCH /v9/projects/:idOrName/env/:id` - update env var
 - `DELETE /v9/projects/:idOrName/env/:id` - delete env var
+
+### Integrations
+- `GET /v1/integrations/configuration/:id` - get integration configuration
+- `DELETE /v1/integrations/configuration/:id` - delete integration configuration
 
 ### Blob
 Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`).

--- a/apps/web/app/docs/vercel/page.mdx
+++ b/apps/web/app/docs/vercel/page.mdx
@@ -52,6 +52,11 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `PATCH /v9/projects/:idOrName/env/:id` - update env var
 - `DELETE /v9/projects/:idOrName/env/:id` - delete env var
 
+## Integrations
+
+- `GET /v1/integrations/configuration/:id` - get integration configuration
+- `DELETE /v1/integrations/configuration/:id` - delete integration configuration
+
 ## Blob
 
 Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`).

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -13,6 +13,7 @@ npm install @emulators/slack
 ## Endpoints
 
 ### Auth & Chat
+
 - `POST /api/auth.test` — test authentication
 - `POST /api/chat.postMessage` — post message with text or rich payload fields (supports threads via `thread_ts` and DM user IDs)
 - `POST /api/chat.postEphemeral` — post ephemeral message outside channel history
@@ -25,6 +26,7 @@ npm install @emulators/slack
 - `POST /api/chat.meMessage` — /me message
 
 ### Conversations
+
 - `POST /api/conversations.list` — list conversations (cursor pagination, `types`, `exclude_archived`)
 - `POST /api/conversations.info` — get channel info
 - `POST /api/conversations.create` — create channel
@@ -40,6 +42,7 @@ npm install @emulators/slack
 - `POST /api/conversations.members` — list members
 
 ### Users & Reactions
+
 - `POST /api/users.list` — list users (cursor pagination)
 - `POST /api/users.info` — get user info
 - `POST /api/users.lookupByEmail` — lookup by email
@@ -50,6 +53,7 @@ npm install @emulators/slack
 - `POST /api/reactions.add` / `reactions.remove` / `reactions.get` — manage reactions
 
 ### Files
+
 - `POST /api/files.getUploadURLExternal` — create a local external upload session
 - `POST /upload/v1/:fileId` — receive raw uploaded file bytes
 - `POST /api/files.completeUploadExternal` — complete uploads and optionally share file messages
@@ -59,6 +63,7 @@ npm install @emulators/slack
 - `POST /api/files.delete` — delete a completed file
 
 ### Pins & Bookmarks
+
 - `POST /api/pins.add` — pin a message to a channel
 - `GET /api/pins.list` / `POST /api/pins.list` — list pinned message items for a channel
 - `POST /api/pins.remove` — remove a message pin from a channel
@@ -68,6 +73,7 @@ npm install @emulators/slack
 - `POST /api/bookmarks.remove` — remove a bookmark from a channel
 
 ### Views
+
 - `POST /api/views.publish` — publish or update an App Home view for a user
 - `POST /api/views.open` — open a modal view
 - `POST /api/views.update` — update a view by `view_id` or `external_id`
@@ -77,16 +83,19 @@ npm install @emulators/slack
 Modal opens and pushes require values from `/api/views.generateTriggerId`. Pass the returned value as `trigger_id` or `interactivity_pointer`; generate push values with an existing `view_id` and use them within 3 seconds.
 
 ### Team, Bots & Webhooks
+
 - `POST /api/team.info` — workspace info
 - `POST /api/bots.info` — bot info
 - `POST /services/:teamId/:botId/:webhookId` — incoming webhook with text or rich payload fields
 
 ### OAuth
+
 - `GET /oauth/v2/authorize` — authorization (shows user picker)
 - `POST /oauth/v2/authorize/callback` — local user picker callback that creates the auth code
 - `POST /api/oauth.v2.access` — token exchange
 
 ### Inspector
+
 - `GET /` — tabbed local inspector for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries
 
 ## Auth

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -13,7 +13,6 @@ npm install @emulators/slack
 ## Endpoints
 
 ### Auth & Chat
-
 - `POST /api/auth.test` — test authentication
 - `POST /api/chat.postMessage` — post message with text or rich payload fields (supports threads via `thread_ts` and DM user IDs)
 - `POST /api/chat.postEphemeral` — post ephemeral message outside channel history
@@ -26,7 +25,6 @@ npm install @emulators/slack
 - `POST /api/chat.meMessage` — /me message
 
 ### Conversations
-
 - `POST /api/conversations.list` — list conversations (cursor pagination, `types`, `exclude_archived`)
 - `POST /api/conversations.info` — get channel info
 - `POST /api/conversations.create` — create channel
@@ -42,7 +40,6 @@ npm install @emulators/slack
 - `POST /api/conversations.members` — list members
 
 ### Users & Reactions
-
 - `POST /api/users.list` — list users (cursor pagination)
 - `POST /api/users.info` — get user info
 - `POST /api/users.lookupByEmail` — lookup by email
@@ -53,7 +50,6 @@ npm install @emulators/slack
 - `POST /api/reactions.add` / `reactions.remove` / `reactions.get` — manage reactions
 
 ### Files
-
 - `POST /api/files.getUploadURLExternal` — create a local external upload session
 - `POST /upload/v1/:fileId` — receive raw uploaded file bytes
 - `POST /api/files.completeUploadExternal` — complete uploads and optionally share file messages
@@ -63,7 +59,6 @@ npm install @emulators/slack
 - `POST /api/files.delete` — delete a completed file
 
 ### Pins & Bookmarks
-
 - `POST /api/pins.add` — pin a message to a channel
 - `GET /api/pins.list` / `POST /api/pins.list` — list pinned message items for a channel
 - `POST /api/pins.remove` — remove a message pin from a channel
@@ -73,7 +68,6 @@ npm install @emulators/slack
 - `POST /api/bookmarks.remove` — remove a bookmark from a channel
 
 ### Views
-
 - `POST /api/views.publish` — publish or update an App Home view for a user
 - `POST /api/views.open` — open a modal view
 - `POST /api/views.update` — update a view by `view_id` or `external_id`
@@ -83,19 +77,16 @@ npm install @emulators/slack
 Modal opens and pushes require values from `/api/views.generateTriggerId`. Pass the returned value as `trigger_id` or `interactivity_pointer`; generate push values with an existing `view_id` and use them within 3 seconds.
 
 ### Team, Bots & Webhooks
-
 - `POST /api/team.info` — workspace info
 - `POST /api/bots.info` — bot info
 - `POST /services/:teamId/:botId/:webhookId` — incoming webhook with text or rich payload fields
 
 ### OAuth
-
 - `GET /oauth/v2/authorize` — authorization (shows user picker)
 - `POST /oauth/v2/authorize/callback` — local user picker callback that creates the auth code
 - `POST /api/oauth.v2.access` — token exchange
 
 ### Inspector
-
 - `GET /` — tabbed local inspector for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries
 
 ## Auth

--- a/packages/@emulators/vercel/README.md
+++ b/packages/@emulators/vercel/README.md
@@ -13,6 +13,7 @@ npm install @emulators/vercel
 ## Endpoints
 
 ### User & Teams
+
 - `GET /v2/user` — authenticated user
 - `PATCH /v2/user` — update user
 - `GET /v2/teams` — list teams (cursor paginated)
@@ -23,6 +24,7 @@ npm install @emulators/vercel
 - `POST /v2/teams/:teamId/members` — add member
 
 ### Projects
+
 - `POST /v11/projects` — create project (with optional env vars and git integration)
 - `GET /v10/projects` — list projects (search, cursor pagination)
 - `GET /v9/projects/:idOrName` — get project (includes env vars)
@@ -32,6 +34,7 @@ npm install @emulators/vercel
 - `PATCH /v1/projects/:idOrName/protection-bypass` — manage bypass secrets
 
 ### Deployments
+
 - `POST /v13/deployments` — create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` — get deployment (by ID or URL)
 - `GET /v6/deployments` — list deployments (filter by project, target, state)
@@ -43,6 +46,7 @@ npm install @emulators/vercel
 - `POST /v2/files` — upload file (by SHA digest)
 
 ### Domains
+
 - `POST /v10/projects/:idOrName/domains` — add domain (with verification challenge)
 - `GET /v9/projects/:idOrName/domains` — list domains
 - `GET /v9/projects/:idOrName/domains/:domain` — get domain
@@ -51,6 +55,7 @@ npm install @emulators/vercel
 - `POST /v9/projects/:idOrName/domains/:domain/verify` — verify domain
 
 ### Environment Variables
+
 - `GET /v10/projects/:idOrName/env` — list env vars (with decrypt option)
 - `POST /v10/projects/:idOrName/env` — create env vars (single, batch, upsert)
 - `GET /v10/projects/:idOrName/env/:id` — get env var
@@ -58,6 +63,7 @@ npm install @emulators/vercel
 - `DELETE /v9/projects/:idOrName/env/:id` — delete env var
 
 ### Integrations
+
 - `GET /v1/integrations/configuration/:id` — get integration configuration
 - `DELETE /v1/integrations/configuration/:id` — delete integration configuration
 

--- a/packages/@emulators/vercel/README.md
+++ b/packages/@emulators/vercel/README.md
@@ -57,6 +57,10 @@ npm install @emulators/vercel
 - `PATCH /v9/projects/:idOrName/env/:id` — update env var
 - `DELETE /v9/projects/:idOrName/env/:id` — delete env var
 
+### Integrations
+- `GET /v1/integrations/configuration/:id` — get integration configuration
+- `DELETE /v1/integrations/configuration/:id` — delete integration configuration
+
 ## Auth
 
 All endpoints accept `teamId` or `slug` query params for team scoping. Pagination uses cursor-based `limit`/`since`/`until` with `pagination` response objects.
@@ -82,6 +86,11 @@ vercel:
       name: "My Vercel App"
       redirect_uris:
         - "http://localhost:3000/api/auth/callback/vercel"
+  integration_configurations:
+    - id: "icfg_abc123"
+      integrationId: "oac_abc123"
+      ownerId: "team_xyz"
+      projectSelection: "all"
 ```
 
 ## Links

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Hono } from "@emulators/core";
 import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
 import { vercelPlugin, seedFromConfig } from "../index.js";
+import { getVercelStore } from "../store.js";
 
 const base = "http://localhost:4000";
 
@@ -24,6 +25,12 @@ function createTestApp() {
 
 function authHeaders(): Record<string, string> {
   return { Authorization: "Bearer test-token" };
+}
+
+function getTestUserOwnerId(store: Store): string {
+  const user = getVercelStore(store).users.findOneBy("username", "testuser");
+  if (!user) throw new Error("Expected testuser to be seeded");
+  return user.uid;
 }
 
 describe("Vercel plugin integration", () => {
@@ -78,15 +85,16 @@ describe("Vercel plugin integration", () => {
     expect(res.status).toBe(404);
   });
 
-  it("GET /v1/integrations/configuration/:id returns seeded configuration", async () => {
+  it("GET /v1/integrations/configuration/:id returns user-owned seeded configuration", async () => {
     const { app: testApp, store } = createTestApp();
+    const ownerId = getTestUserOwnerId(store);
     seedFromConfig(store, base, {
       integrations: [{ client_id: "test-app", client_secret: "secret", name: "test-integration", redirect_uris: [] }],
       integration_configurations: [
         {
           id: "icfg_test123",
           integrationId: "test-app",
-          ownerId: "team_abc",
+          ownerId,
           projectSelection: "all",
           canConfigureOpenTelemetry: true,
         },
@@ -105,8 +113,9 @@ describe("Vercel plugin integration", () => {
 
   it("DELETE /v1/integrations/configuration/:id removes configuration", async () => {
     const { app: testApp, store } = createTestApp();
+    const ownerId = getTestUserOwnerId(store);
     seedFromConfig(store, base, {
-      integration_configurations: [{ id: "icfg_delete_me", integrationId: "test-app", ownerId: "team_abc" }],
+      integration_configurations: [{ id: "icfg_delete_me", integrationId: "test-app", ownerId }],
     });
 
     const deleteRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me`, {
@@ -121,18 +130,17 @@ describe("Vercel plugin integration", () => {
     expect(getRes.status).toBe(404);
   });
 
-  it("GET /v1/integrations/configuration/:id returns 403 when slug does not match ownerId", async () => {
+  it("GET /v1/integrations/configuration/:id returns 400 when slug scope cannot be resolved", async () => {
     const { app: testApp, store } = createTestApp();
     seedFromConfig(store, base, {
-      teams: [{ slug: "other-team", name: "Other Team" }],
       integration_configurations: [{ id: "icfg_forbidden", integrationId: "test-app", ownerId: "team_abc" }],
     });
 
-    const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_forbidden?slug=other-team`, {
+    const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_forbidden?slug=missing-team`, {
       headers: authHeaders(),
     });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: { code: string } };
-    expect(body.error.code).toBe("forbidden");
+    expect(body.error.code).toBe("bad_request");
   });
 });

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -27,10 +27,13 @@ function authHeaders(): Record<string, string> {
   return { Authorization: "Bearer test-token" };
 }
 
-function getTestUserOwnerId(store: Store): string {
-  const user = getVercelStore(store).users.findOneBy("username", "testuser");
-  if (!user) throw new Error("Expected testuser to be seeded");
-  return user.uid;
+function seedTestTeam(store: Store, slug = "test-team"): string {
+  seedFromConfig(store, base, {
+    teams: [{ slug, name: "Test Team" }],
+  });
+  const team = getVercelStore(store).teams.findOneBy("slug", slug);
+  if (!team) throw new Error("Expected test team to be seeded");
+  return team.uid;
 }
 
 describe("Vercel plugin integration", () => {
@@ -79,15 +82,18 @@ describe("Vercel plugin integration", () => {
   });
 
   it("GET /v1/integrations/configuration/:id returns 404 for unknown config", async () => {
-    const res = await app.request(`${base}/v1/integrations/configuration/icfg_unknown`, {
+    const { app: testApp, store } = createTestApp();
+    const ownerId = seedTestTeam(store);
+
+    const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_unknown?teamId=${ownerId}`, {
       headers: authHeaders(),
     });
     expect(res.status).toBe(404);
   });
 
-  it("GET /v1/integrations/configuration/:id returns user-owned seeded configuration", async () => {
+  it("GET /v1/integrations/configuration/:id returns team-owned seeded configuration", async () => {
     const { app: testApp, store } = createTestApp();
-    const ownerId = getTestUserOwnerId(store);
+    const ownerId = seedTestTeam(store);
     seedFromConfig(store, base, {
       integrations: [{ client_id: "test-app", client_secret: "secret", name: "test-integration", redirect_uris: [] }],
       integration_configurations: [
@@ -101,7 +107,7 @@ describe("Vercel plugin integration", () => {
       ],
     });
 
-    const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_test123`, {
+    const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_test123?teamId=${ownerId}`, {
       headers: authHeaders(),
     });
     expect(res.status).toBe(200);
@@ -113,24 +119,24 @@ describe("Vercel plugin integration", () => {
 
   it("DELETE /v1/integrations/configuration/:id removes configuration", async () => {
     const { app: testApp, store } = createTestApp();
-    const ownerId = getTestUserOwnerId(store);
+    const ownerId = seedTestTeam(store);
     seedFromConfig(store, base, {
       integration_configurations: [{ id: "icfg_delete_me", integrationId: "test-app", ownerId }],
     });
 
-    const deleteRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me`, {
+    const deleteRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me?teamId=${ownerId}`, {
       method: "DELETE",
       headers: authHeaders(),
     });
     expect(deleteRes.status).toBe(204);
 
-    const getRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me`, {
+    const getRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me?teamId=${ownerId}`, {
       headers: authHeaders(),
     });
     expect(getRes.status).toBe(404);
   });
 
-  it("GET /v1/integrations/configuration/:id returns 400 when slug scope cannot be resolved", async () => {
+  it("GET /v1/integrations/configuration/:id returns 403 when slug scope cannot be resolved", async () => {
     const { app: testApp, store } = createTestApp();
     seedFromConfig(store, base, {
       integration_configurations: [{ id: "icfg_forbidden", integrationId: "test-app", ownerId: "team_abc" }],
@@ -139,8 +145,8 @@ describe("Vercel plugin integration", () => {
     const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_forbidden?slug=missing-team`, {
       headers: authHeaders(),
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(403);
     const body = (await res.json()) as { error: { code: string } };
-    expect(body.error.code).toBe("bad_request");
+    expect(body.error.code).toBe("forbidden");
   });
 });

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -122,4 +122,21 @@ describe("Vercel plugin integration", () => {
     });
     expect(getRes.status).toBe(404);
   });
+
+  it("GET /v1/integrations/configuration/:id returns 403 when slug does not match ownerId", async () => {
+    const { app: testApp, store } = createTestApp();
+    seedFromConfig(store, base, {
+      teams: [{ slug: "other-team", name: "Other Team" }],
+      integration_configurations: [
+        { id: "icfg_forbidden", integrationId: "test-app", ownerId: "team_abc" },
+      ],
+    });
+
+    const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_forbidden?slug=other-team`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("forbidden");
+  });
 });

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -70,4 +70,56 @@ describe("Vercel plugin integration", () => {
     expect(Array.isArray(body.deployments)).toBe(true);
     expect(body.pagination).toBeDefined();
   });
+
+  it("GET /v1/integrations/configuration/:id returns 404 for unknown config", async () => {
+    const res = await app.request(`${base}/v1/integrations/configuration/icfg_unknown`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /v1/integrations/configuration/:id returns seeded configuration", async () => {
+    const { app: testApp, store } = createTestApp();
+    seedFromConfig(store, base, {
+      integrations: [{ client_id: "test-app", client_secret: "secret", name: "test-integration", redirect_uris: [] }],
+      integration_configurations: [
+        {
+          id: "icfg_test123",
+          integrationId: "test-app",
+          ownerId: "team_abc",
+          projectSelection: "all",
+          canConfigureOpenTelemetry: true,
+        },
+      ],
+    });
+
+    const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_test123`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; projectSelection: string; canConfigureOpenTelemetry: boolean };
+    expect(body.id).toBe("icfg_test123");
+    expect(body.projectSelection).toBe("all");
+    expect(body.canConfigureOpenTelemetry).toBe(true);
+  });
+
+  it("DELETE /v1/integrations/configuration/:id removes configuration", async () => {
+    const { app: testApp, store } = createTestApp();
+    seedFromConfig(store, base, {
+      integration_configurations: [
+        { id: "icfg_delete_me", integrationId: "test-app", ownerId: "team_abc" },
+      ],
+    });
+
+    const deleteRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleteRes.status).toBe(204);
+
+    const getRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me`, {
+      headers: authHeaders(),
+    });
+    expect(getRes.status).toBe(404);
+  });
 });

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -106,9 +106,7 @@ describe("Vercel plugin integration", () => {
   it("DELETE /v1/integrations/configuration/:id removes configuration", async () => {
     const { app: testApp, store } = createTestApp();
     seedFromConfig(store, base, {
-      integration_configurations: [
-        { id: "icfg_delete_me", integrationId: "test-app", ownerId: "team_abc" },
-      ],
+      integration_configurations: [{ id: "icfg_delete_me", integrationId: "test-app", ownerId: "team_abc" }],
     });
 
     const deleteRes = await testApp.request(`${base}/v1/integrations/configuration/icfg_delete_me`, {
@@ -127,9 +125,7 @@ describe("Vercel plugin integration", () => {
     const { app: testApp, store } = createTestApp();
     seedFromConfig(store, base, {
       teams: [{ slug: "other-team", name: "Other Team" }],
-      integration_configurations: [
-        { id: "icfg_forbidden", integrationId: "test-app", ownerId: "team_abc" },
-      ],
+      integration_configurations: [{ id: "icfg_forbidden", integrationId: "test-app", ownerId: "team_abc" }],
     });
 
     const res = await testApp.request(`${base}/v1/integrations/configuration/icfg_forbidden?slug=other-team`, {

--- a/packages/@emulators/vercel/src/entities.ts
+++ b/packages/@emulators/vercel/src/entities.ts
@@ -254,3 +254,27 @@ export interface VercelIntegration extends Entity {
   name: string;
   redirect_uris: string[];
 }
+
+export interface VercelIntegrationConfiguration extends Entity {
+  uid: string;
+  integrationId: string;
+  ownerId: string;
+  userId: string;
+  teamId: string | null;
+  projectSelection: "all" | "selected";
+  projects: string[];
+  scopes: string[];
+  slug: string;
+  type: "integration-configuration";
+  status: "error" | "onboarding" | "pending" | "ready" | "resumed" | "suspended" | "uninstalled";
+  source: "backoffice" | "cli" | "deploy-button" | "external" | "marketplace" | "oauth" | "resource-claims" | "v0" | null;
+  installationType: "external" | "marketplace" | null;
+  canConfigureOpenTelemetry: boolean;
+  externalId: string | null;
+  completedAt: number | null;
+  disabledAt: number | null;
+  disabledReason: string | null;
+  deletedAt: number | null;
+  deleteRequestedAt: number | null;
+  customerDeleteRequestedAt: number | null;
+}

--- a/packages/@emulators/vercel/src/entities.ts
+++ b/packages/@emulators/vercel/src/entities.ts
@@ -267,7 +267,16 @@ export interface VercelIntegrationConfiguration extends Entity {
   slug: string;
   type: "integration-configuration";
   status: "error" | "onboarding" | "pending" | "ready" | "resumed" | "suspended" | "uninstalled";
-  source: "backoffice" | "cli" | "deploy-button" | "external" | "marketplace" | "oauth" | "resource-claims" | "v0" | null;
+  source:
+    | "backoffice"
+    | "cli"
+    | "deploy-button"
+    | "external"
+    | "marketplace"
+    | "oauth"
+    | "resource-claims"
+    | "v0"
+    | null;
   installationType: "external" | "marketplace" | null;
   canConfigureOpenTelemetry: boolean;
   externalId: string | null;

--- a/packages/@emulators/vercel/src/index.ts
+++ b/packages/@emulators/vercel/src/index.ts
@@ -11,6 +11,7 @@ import { envRoutes } from "./routes/env.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { apiKeysRoutes } from "./routes/api-keys.js";
 import { blobRoutes } from "./routes/blob.js";
+import { integrationsRoutes } from "./routes/integrations.js";
 
 export { getVercelStore, type VercelStore } from "./store.js";
 export * from "./entities.js";
@@ -47,6 +48,19 @@ export interface VercelSeedConfig {
     client_secret: string;
     name: string;
     redirect_uris: string[];
+  }>;
+  integration_configurations?: Array<{
+    id: string;
+    integrationId: string;
+    ownerId: string;
+    userId?: string;
+    teamId?: string;
+    projectSelection?: "all" | "selected";
+    projects?: string[];
+    scopes?: string[];
+    slug?: string;
+    status?: "error" | "onboarding" | "pending" | "ready" | "resumed" | "suspended" | "uninstalled";
+    canConfigureOpenTelemetry?: boolean;
   }>;
 }
 
@@ -206,6 +220,40 @@ export function seedFromConfig(store: Store, baseUrl: string, config: VercelSeed
       });
     }
   }
+
+  if (config.integration_configurations) {
+    for (const ic of config.integration_configurations) {
+      const existing = vs.integrationConfigurations.findOneBy("uid", ic.id);
+      if (existing) continue;
+
+      const integration = vs.integrations.findOneBy("client_id", ic.integrationId);
+      const t = nowMs();
+
+      vs.integrationConfigurations.insert({
+        uid: ic.id,
+        integrationId: ic.integrationId,
+        ownerId: ic.ownerId,
+        userId: ic.userId ?? ic.ownerId,
+        teamId: ic.teamId ?? null,
+        projectSelection: ic.projectSelection ?? "all",
+        projects: ic.projects ?? [],
+        scopes: ic.scopes ?? [],
+        slug: ic.slug ?? integration?.name ?? "unknown",
+        type: "integration-configuration",
+        status: ic.status ?? "ready",
+        source: "external",
+        installationType: "external",
+        canConfigureOpenTelemetry: ic.canConfigureOpenTelemetry ?? false,
+        externalId: null,
+        completedAt: t,
+        disabledAt: null,
+        disabledReason: null,
+        deletedAt: null,
+        deleteRequestedAt: null,
+        customerDeleteRequestedAt: null,
+      });
+    }
+  }
 }
 
 export const vercelPlugin: ServicePlugin = {
@@ -220,6 +268,7 @@ export const vercelPlugin: ServicePlugin = {
     envRoutes(ctx);
     apiKeysRoutes(ctx);
     blobRoutes(ctx);
+    integrationsRoutes(ctx);
   },
   seed(store: Store, baseUrl: string): void {
     seedDefaults(store, baseUrl);

--- a/packages/@emulators/vercel/src/routes/integrations.ts
+++ b/packages/@emulators/vercel/src/routes/integrations.ts
@@ -1,0 +1,109 @@
+import type { Context } from "@emulators/core";
+import type { ContentfulStatusCode } from "@emulators/core";
+import type { RouteContext } from "@emulators/core";
+import { ApiError } from "@emulators/core";
+export { ApiError };
+import { getVercelStore } from "../store.js";
+import type { VercelIntegrationConfiguration, VercelTeam } from "../entities.js";
+
+function vercelErr(c: Context, status: ContentfulStatusCode, code: string, message: string) {
+  return c.json({ error: { code, message } }, status);
+}
+
+function formatConfiguration(config: VercelIntegrationConfiguration) {
+  return {
+    id: config.uid,
+    integrationId: config.integrationId,
+    ownerId: config.ownerId,
+    userId: config.userId,
+    teamId: config.teamId,
+    projectSelection: config.projectSelection,
+    projects: config.projects,
+    scopes: config.scopes,
+    slug: config.slug,
+    type: config.type,
+    status: config.status,
+    source: config.source,
+    installationType: config.installationType,
+    canConfigureOpenTelemetry: config.canConfigureOpenTelemetry,
+    externalId: config.externalId,
+    createdAt: new Date(config.created_at).getTime(),
+    updatedAt: new Date(config.updated_at).getTime(),
+    completedAt: config.completedAt,
+    disabledAt: config.disabledAt,
+    disabledReason: config.disabledReason,
+    deletedAt: config.deletedAt,
+    deleteRequestedAt: config.deleteRequestedAt,
+    customerDeleteRequestedAt: config.customerDeleteRequestedAt,
+  };
+}
+
+export function integrationsRoutes({ app, store }: RouteContext): void {
+  const vs = getVercelStore(store);
+
+  app.get("/v1/integrations/configuration/:id", (c) => {
+    const auth = c.get("authUser");
+    if (!auth) {
+      return vercelErr(c, 401, "not_authenticated", "Authentication required");
+    }
+
+    const configId = c.req.param("id");
+    const config = vs.integrationConfigurations.findOneBy("uid", configId as VercelIntegrationConfiguration["uid"]);
+
+    if (!config) {
+      return vercelErr(c, 404, "not_found", "The configuration was not found");
+    }
+
+    const teamId = c.req.query("teamId");
+    const slug = c.req.query("slug");
+
+    let scopeOwnerId: string | null = null;
+    if (teamId) {
+      const team = vs.teams.findOneBy("uid", teamId as VercelTeam["uid"]);
+      if (team) scopeOwnerId = team.uid;
+    } else if (slug) {
+      const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
+      if (team) scopeOwnerId = team.uid;
+    }
+
+    if (scopeOwnerId && config.ownerId !== scopeOwnerId) {
+      return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
+    }
+
+    return c.json(formatConfiguration(config));
+  });
+
+  app.delete("/v1/integrations/configuration/:id", (c) => {
+    const auth = c.get("authUser");
+    if (!auth) {
+      return vercelErr(c, 401, "not_authenticated", "Authentication required");
+    }
+
+    const configId = c.req.param("id");
+    const config = vs.integrationConfigurations.findOneBy("uid", configId as VercelIntegrationConfiguration["uid"]);
+
+    if (!config) {
+      return vercelErr(c, 404, "not_found", "The configuration was not found");
+    }
+
+    const teamId = c.req.query("teamId");
+    const slug = c.req.query("slug");
+
+    let scopeOwnerId: string | null = null;
+    if (teamId) {
+      const team = vs.teams.findOneBy("uid", teamId as VercelTeam["uid"]);
+      if (team) scopeOwnerId = team.uid;
+    } else if (slug) {
+      const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
+      if (team) scopeOwnerId = team.uid;
+    }
+
+    if (scopeOwnerId && config.ownerId !== scopeOwnerId) {
+      return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
+    }
+
+    vs.integrationConfigurations.delete(config.id);
+
+    return c.body(null, 204);
+  });
+}

--- a/packages/@emulators/vercel/src/routes/integrations.ts
+++ b/packages/@emulators/vercel/src/routes/integrations.ts
@@ -37,34 +37,37 @@ function formatConfiguration(config: VercelIntegrationConfiguration) {
   };
 }
 
-function authorizeOwnerId(c: Context, config: VercelIntegrationConfiguration, ownerId: string): Response | null {
-  if (config.ownerId === ownerId) return null;
-  return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
-}
-
-function authorizeConfigurationScope(
-  c: Context,
-  vs: VercelStore,
-  config: VercelIntegrationConfiguration,
-  auth: AuthUser,
-): Response | null {
+function resolveTeamOwnerId(c: Context, vs: VercelStore, auth: AuthUser): string | Response {
   const teamId = c.req.query("teamId");
   if (teamId) {
-    return authorizeOwnerId(c, config, teamId);
+    const team = vs.teams.findOneBy("uid", teamId as VercelTeam["uid"]);
+    if (!team) return vercelErr(c, 403, "forbidden", "Not authorized");
+    return team.uid;
   }
+
   const slug = c.req.query("slug");
   if (slug) {
     const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
-    if (!team) {
-      return vercelErr(c, 400, "bad_request", "Could not resolve team or account scope");
-    }
-    return authorizeOwnerId(c, config, team.uid);
+    if (!team) return vercelErr(c, 403, "forbidden", "Not authorized");
+    return team.uid;
   }
+
   const user = vs.users.findOneBy("username", auth.login as VercelUser["username"]);
   if (!user) {
-    return vercelErr(c, 403, "forbidden", "User not found");
+    return vercelErr(c, 403, "forbidden", "Not authorized");
   }
-  return authorizeOwnerId(c, config, user.uid);
+  if (!user.defaultTeamId) {
+    return vercelErr(
+      c,
+      401,
+      "missing_team_param",
+      "You must supply a `teamId` query parameter or set your default team with `PATCH /user { defaultTeamId: string }`.",
+    );
+  }
+
+  const team = vs.teams.findOneBy("uid", user.defaultTeamId as VercelTeam["uid"]);
+  if (!team) return vercelErr(c, 403, "forbidden", "Not authorized");
+  return team.uid;
 }
 
 export function integrationsRoutes({ app, store }: RouteContext): void {
@@ -76,15 +79,14 @@ export function integrationsRoutes({ app, store }: RouteContext): void {
       return vercelErr(c, 401, "not_authenticated", "Authentication required");
     }
 
+    const ownerId = resolveTeamOwnerId(c, vs, auth);
+    if (typeof ownerId !== "string") return ownerId;
+
     const configId = c.req.param("id");
     const config = vs.integrationConfigurations.findOneBy("uid", configId);
-
-    if (!config) {
+    if (!config || config.ownerId !== ownerId) {
       return vercelErr(c, 404, "not_found", "The configuration was not found");
     }
-
-    const authorizationError = authorizeConfigurationScope(c, vs, config, auth);
-    if (authorizationError) return authorizationError;
 
     return c.json(formatConfiguration(config));
   });
@@ -95,15 +97,14 @@ export function integrationsRoutes({ app, store }: RouteContext): void {
       return vercelErr(c, 401, "not_authenticated", "Authentication required");
     }
 
+    const ownerId = resolveTeamOwnerId(c, vs, auth);
+    if (typeof ownerId !== "string") return ownerId;
+
     const configId = c.req.param("id");
     const config = vs.integrationConfigurations.findOneBy("uid", configId);
-
-    if (!config) {
+    if (!config || config.ownerId !== ownerId) {
       return vercelErr(c, 404, "not_found", "The configuration was not found");
     }
-
-    const authorizationError = authorizeConfigurationScope(c, vs, config, auth);
-    if (authorizationError) return authorizationError;
 
     vs.integrationConfigurations.delete(config.id);
 

--- a/packages/@emulators/vercel/src/routes/integrations.ts
+++ b/packages/@emulators/vercel/src/routes/integrations.ts
@@ -1,8 +1,9 @@
 import type { Context } from "@emulators/core";
+import type { AuthUser } from "@emulators/core";
 import type { ContentfulStatusCode } from "@emulators/core";
 import type { RouteContext } from "@emulators/core";
 import { getVercelStore, type VercelStore } from "../store.js";
-import type { VercelIntegrationConfiguration, VercelTeam } from "../entities.js";
+import type { VercelIntegrationConfiguration, VercelTeam, VercelUser } from "../entities.js";
 
 function vercelErr(c: Context, status: ContentfulStatusCode, code: string, message: string) {
   return c.json({ error: { code, message } }, status);
@@ -36,17 +37,34 @@ function formatConfiguration(config: VercelIntegrationConfiguration) {
   };
 }
 
-function resolveScopeOwnerId(c: Context, vs: VercelStore): string | null {
+function authorizeOwnerId(c: Context, config: VercelIntegrationConfiguration, ownerId: string): Response | null {
+  if (config.ownerId === ownerId) return null;
+  return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
+}
+
+function authorizeConfigurationScope(
+  c: Context,
+  vs: VercelStore,
+  config: VercelIntegrationConfiguration,
+  auth: AuthUser,
+): Response | null {
   const teamId = c.req.query("teamId");
-  const slug = c.req.query("slug");
   if (teamId) {
-    const team = vs.teams.findOneBy("uid", teamId as VercelTeam["uid"]);
-    if (team) return team.uid;
-  } else if (slug) {
-    const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
-    if (team) return team.uid;
+    return authorizeOwnerId(c, config, teamId);
   }
-  return null;
+  const slug = c.req.query("slug");
+  if (slug) {
+    const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
+    if (!team) {
+      return vercelErr(c, 400, "bad_request", "Could not resolve team or account scope");
+    }
+    return authorizeOwnerId(c, config, team.uid);
+  }
+  const user = vs.users.findOneBy("username", auth.login as VercelUser["username"]);
+  if (!user) {
+    return vercelErr(c, 403, "forbidden", "User not found");
+  }
+  return authorizeOwnerId(c, config, user.uid);
 }
 
 export function integrationsRoutes({ app, store }: RouteContext): void {
@@ -65,10 +83,8 @@ export function integrationsRoutes({ app, store }: RouteContext): void {
       return vercelErr(c, 404, "not_found", "The configuration was not found");
     }
 
-    const scopeOwnerId = resolveScopeOwnerId(c, vs);
-    if (scopeOwnerId && config.ownerId !== scopeOwnerId) {
-      return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
-    }
+    const authorizationError = authorizeConfigurationScope(c, vs, config, auth);
+    if (authorizationError) return authorizationError;
 
     return c.json(formatConfiguration(config));
   });
@@ -86,10 +102,8 @@ export function integrationsRoutes({ app, store }: RouteContext): void {
       return vercelErr(c, 404, "not_found", "The configuration was not found");
     }
 
-    const scopeOwnerId = resolveScopeOwnerId(c, vs);
-    if (scopeOwnerId && config.ownerId !== scopeOwnerId) {
-      return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
-    }
+    const authorizationError = authorizeConfigurationScope(c, vs, config, auth);
+    if (authorizationError) return authorizationError;
 
     vs.integrationConfigurations.delete(config.id);
 

--- a/packages/@emulators/vercel/src/routes/integrations.ts
+++ b/packages/@emulators/vercel/src/routes/integrations.ts
@@ -1,9 +1,7 @@
 import type { Context } from "@emulators/core";
 import type { ContentfulStatusCode } from "@emulators/core";
 import type { RouteContext } from "@emulators/core";
-import { ApiError } from "@emulators/core";
-export { ApiError };
-import { getVercelStore } from "../store.js";
+import { getVercelStore, type VercelStore } from "../store.js";
 import type { VercelIntegrationConfiguration, VercelTeam } from "../entities.js";
 
 function vercelErr(c: Context, status: ContentfulStatusCode, code: string, message: string) {
@@ -38,6 +36,19 @@ function formatConfiguration(config: VercelIntegrationConfiguration) {
   };
 }
 
+function resolveScopeOwnerId(c: Context, vs: VercelStore): string | null {
+  const teamId = c.req.query("teamId");
+  const slug = c.req.query("slug");
+  if (teamId) {
+    const team = vs.teams.findOneBy("uid", teamId as VercelTeam["uid"]);
+    if (team) return team.uid;
+  } else if (slug) {
+    const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
+    if (team) return team.uid;
+  }
+  return null;
+}
+
 export function integrationsRoutes({ app, store }: RouteContext): void {
   const vs = getVercelStore(store);
 
@@ -48,24 +59,13 @@ export function integrationsRoutes({ app, store }: RouteContext): void {
     }
 
     const configId = c.req.param("id");
-    const config = vs.integrationConfigurations.findOneBy("uid", configId as VercelIntegrationConfiguration["uid"]);
+    const config = vs.integrationConfigurations.findOneBy("uid", configId);
 
     if (!config) {
       return vercelErr(c, 404, "not_found", "The configuration was not found");
     }
 
-    const teamId = c.req.query("teamId");
-    const slug = c.req.query("slug");
-
-    let scopeOwnerId: string | null = null;
-    if (teamId) {
-      const team = vs.teams.findOneBy("uid", teamId as VercelTeam["uid"]);
-      if (team) scopeOwnerId = team.uid;
-    } else if (slug) {
-      const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
-      if (team) scopeOwnerId = team.uid;
-    }
-
+    const scopeOwnerId = resolveScopeOwnerId(c, vs);
     if (scopeOwnerId && config.ownerId !== scopeOwnerId) {
       return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
     }
@@ -80,24 +80,13 @@ export function integrationsRoutes({ app, store }: RouteContext): void {
     }
 
     const configId = c.req.param("id");
-    const config = vs.integrationConfigurations.findOneBy("uid", configId as VercelIntegrationConfiguration["uid"]);
+    const config = vs.integrationConfigurations.findOneBy("uid", configId);
 
     if (!config) {
       return vercelErr(c, 404, "not_found", "The configuration was not found");
     }
 
-    const teamId = c.req.query("teamId");
-    const slug = c.req.query("slug");
-
-    let scopeOwnerId: string | null = null;
-    if (teamId) {
-      const team = vs.teams.findOneBy("uid", teamId as VercelTeam["uid"]);
-      if (team) scopeOwnerId = team.uid;
-    } else if (slug) {
-      const team = vs.teams.findOneBy("slug", slug as VercelTeam["slug"]);
-      if (team) scopeOwnerId = team.uid;
-    }
-
+    const scopeOwnerId = resolveScopeOwnerId(c, vs);
     if (scopeOwnerId && config.ownerId !== scopeOwnerId) {
       return vercelErr(c, 403, "forbidden", "You do not have permission to access this resource");
     }

--- a/packages/@emulators/vercel/src/store.ts
+++ b/packages/@emulators/vercel/src/store.ts
@@ -59,7 +59,11 @@ export function getVercelStore(store: Store): VercelStore {
     protectionBypasses: store.collection<VercelProtectionBypass>("vercel.protection_bypasses", ["projectId"]),
     apiKeys: store.collection<VercelApiKey>("vercel.api_keys", ["uid", "teamId", "userId"]),
     integrations: store.collection<VercelIntegration>("vercel.integrations", ["client_id"]),
-    integrationConfigurations: store.collection<VercelIntegrationConfiguration>("vercel.integration_configurations", ["uid", "ownerId", "integrationId"]),
+    integrationConfigurations: store.collection<VercelIntegrationConfiguration>("vercel.integration_configurations", [
+      "uid",
+      "ownerId",
+      "integrationId",
+    ]),
     blobs: store.collection<VercelBlob>("vercel.blobs", ["pathname", "storeId"]),
   };
 }

--- a/packages/@emulators/vercel/src/store.ts
+++ b/packages/@emulators/vercel/src/store.ts
@@ -14,6 +14,7 @@ import type {
   VercelEnvVar,
   VercelProtectionBypass,
   VercelIntegration,
+  VercelIntegrationConfiguration,
   VercelApiKey,
   VercelBlob,
 } from "./entities.js";
@@ -34,6 +35,7 @@ export interface VercelStore {
   protectionBypasses: Collection<VercelProtectionBypass>;
   apiKeys: Collection<VercelApiKey>;
   integrations: Collection<VercelIntegration>;
+  integrationConfigurations: Collection<VercelIntegrationConfiguration>;
   blobs: Collection<VercelBlob>;
 }
 
@@ -57,6 +59,7 @@ export function getVercelStore(store: Store): VercelStore {
     protectionBypasses: store.collection<VercelProtectionBypass>("vercel.protection_bypasses", ["projectId"]),
     apiKeys: store.collection<VercelApiKey>("vercel.api_keys", ["uid", "teamId", "userId"]),
     integrations: store.collection<VercelIntegration>("vercel.integrations", ["client_id"]),
+    integrationConfigurations: store.collection<VercelIntegrationConfiguration>("vercel.integration_configurations", ["uid", "ownerId", "integrationId"]),
     blobs: store.collection<VercelBlob>("vercel.blobs", ["pathname", "storeId"]),
   };
 }


### PR DESCRIPTION
Adding 2 new endpoints to `@emulators/vercel`: 
* `GET /v1/integrations/configuration/:id` - https://vercel.com/docs/rest-api/integrations/retrieve-an-integration-configuration
* `DELETE /v1/integrations/configuration/:id` - https://vercel.com/docs/rest-api/integrations/delete-an-integration-configuration