### PR TITLE
fix(github): resolve checks for created head SHAs

### DIFF
--- a/packages/@emulators/github/src/__tests__/checks.test.ts
+++ b/packages/@emulators/github/src/__tests__/checks.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "@emulators/core";
+import { Store } from "@emulators/core";
+import { WebhookDispatcher } from "@emulators/core";
+import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
+import { githubPlugin, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4000";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("test-token", { login: "octocat", id: 1, scopes: ["repo", "user", "admin:org"] });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap));
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ login: "octocat" }],
+    repos: [{ owner: "octocat", name: "hello-world" }],
+  });
+
+  return app;
+}
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: "Bearer test-token" };
+}
+
+describe("GitHub checks routes", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  it("lists a check run and suite by their created head SHA", async () => {
+    const headSha = "a".repeat(40);
+    const createRes = await app.request(`${base}/repos/octocat/hello-world/check-runs`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "test", head_sha: headSha }),
+    });
+
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as { id: number; head_sha: string };
+    expect(created.head_sha).toBe(headSha);
+
+    const runsRes = await app.request(`${base}/repos/octocat/hello-world/commits/${headSha}/check-runs`, {
+      headers: authHeaders(),
+    });
+
+    expect(runsRes.status).toBe(200);
+    const runs = (await runsRes.json()) as {
+      total_count: number;
+      check_runs: Array<{ id: number; head_sha: string }>;
+    };
+    expect(runs).toEqual({
+      total_count: 1,
+      check_runs: [expect.objectContaining({ id: created.id, head_sha: headSha })],
+    });
+
+    const suitesRes = await app.request(`${base}/repos/octocat/hello-world/commits/${headSha}/check-suites`, {
+      headers: authHeaders(),
+    });
+
+    expect(suitesRes.status).toBe(200);
+    const suites = (await suitesRes.json()) as {
+      total_count: number;
+      check_suites: Array<{ head_sha: string }>;
+    };
+    expect(suites).toEqual({
+      total_count: 1,
+      check_suites: [expect.objectContaining({ head_sha: headSha })],
+    });
+  });
+
+  it("returns 404 for a head SHA unknown to the repository and checks subsystem", async () => {
+    const headSha = "b".repeat(40);
+
+    const runsRes = await app.request(`${base}/repos/octocat/hello-world/commits/${headSha}/check-runs`, {
+      headers: authHeaders(),
+    });
+    expect(runsRes.status).toBe(404);
+
+    const suitesRes = await app.request(`${base}/repos/octocat/hello-world/commits/${headSha}/check-suites`, {
+      headers: authHeaders(),
+    });
+    expect(suitesRes.status).toBe(404);
+  });
+});

--- a/packages/@emulators/github/src/routes/checks.ts
+++ b/packages/@emulators/github/src/routes/checks.ts
@@ -37,6 +37,8 @@ function resolveRefToHeadSha(gh: GitHubStore, repo: GitHubRepo, refParam: string
   const fullRef = refParam.startsWith("refs/") ? refParam : `refs/heads/${refParam}`;
   const r = gh.refs.findBy("repo_id", repo.id).find((x) => x.ref === fullRef);
   if (r) return r.sha;
+  const checkSuite = gh.checkSuites.findBy("repo_id", repo.id).find((suite) => suite.head_sha === refParam);
+  if (checkSuite) return checkSuite.head_sha;
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

This fixes an inconsistency between creating GitHub Check Runs and listing them by commit reference.

The emulator accepts a non-empty `head_sha` when creating a Check Run and creates a Check Suite for that SHA. The list-by-reference routes previously resolved only stored commits, branches, and Git refs. A successfully created Check Run could therefore become unreachable through `GET /repos/:owner/:repo/commits/:ref/check-runs` and the corresponding Check Suites route.

The ref resolver now falls back to an exact SHA already known by the repository's Check Suites. Resolution of real commits, branches, and Git refs retains its existing precedence. A SHA unknown to both the repository and checks subsystem continues to return 404.

## User impact

Clients can create a Check Run for a valid external commit SHA and immediately reconcile or list that Check Run through the same SHA without also manufacturing an unrelated commit entity in emulator state.

## Root cause

Check Run creation and check lookup used different definitions of a known SHA. Creation registered the SHA in a Check Suite, while lookup considered only commits, branches, and refs.

## Validation

- Added route-level coverage for creating a Check Run and listing both its run and generated suite by the same SHA.
- Added coverage proving a never-seen SHA still returns 404 from both list routes.
- `pnpm exec turbo run build --filter=@emulators/github`
- `pnpm --filter @emulators/github test` with 19 tests passing.
- `pnpm --filter @emulators/github type-check`
- `pnpm --filter @emulators/github lint` with zero errors and only existing warnings.
- Prettier and `git diff --check`.
