### PR TITLE
Add Twilio emulator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All services start with sensible defaults. No config file needed:
 - **MongoDB Atlas** on `http://localhost:4010`
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
+- **Twilio** on `http://localhost:4013`
 
 ## CLI
 
@@ -147,7 +148,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, or `'linear'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -865,6 +866,49 @@ Linear scope checks are relaxed by default so local tests can use simple bearer 
 
 Current Linear limits: full schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and production agent behavior are not implemented. Agent support is a focused local-test subset.
 
+## Twilio API
+
+Stateful Twilio REST emulation with seeded accounts, Auth Tokens, API keys, incoming phone numbers, Programmable Messaging, Messaging Services, Verify, basic Voice calls, Conversations REST resources, signed webhooks, local simulator routes, and an inspector. No real SMS, MMS, WhatsApp, email, voice, carrier, compliance, billing, or SendGrid traffic is performed.
+
+Default local credentials:
+
+```text
+TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000
+TWILIO_AUTH_TOKEN=twilio_test_auth_token
+TWILIO_API_KEY=SK00000000000000000000000000000000
+TWILIO_API_SECRET=twilio_test_api_secret
+TWILIO_PHONE_NUMBER=+15551234567
+TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
+```
+
+### REST Routes
+
+- `GET /2010-04-01/Accounts/{AccountSid}.json` - fetch account
+- `GET /2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers.json` - list phone numbers
+- `POST /2010-04-01/Accounts/{AccountSid}/Messages.json` - create outbound message
+- `GET /2010-04-01/Accounts/{AccountSid}/Messages.json` - list messages
+- `POST /2010-04-01/Accounts/{AccountSid}/Calls.json` - create outbound call
+- `POST /messaging/v1/Services` - create Messaging Service
+- `POST /verify/v2/Services/{ServiceSid}/Verifications` - start verification
+- `POST /verify/v2/Services/{ServiceSid}/VerificationCheck` - check verification code
+- `POST /conversations/v1/Services` - create Conversation Service
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations` - create Conversation
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Participants` - add participant
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Messages` - add message
+
+Twilio uses multiple product hosts. For local SDK tests, rewrite Twilio SDK requests to the emulator and map `messaging.twilio.com` to `/messaging`, `verify.twilio.com` to `/verify`, and `conversations.twilio.com` to `/conversations`.
+
+### Simulator And Inspector
+
+- `POST /_twilio/simulate/inbound-message` - create an inbound message and invoke the configured SMS webhook
+- `POST /_twilio/simulate/message-status` - advance message status and send status callbacks
+- `POST /_twilio/simulate/inbound-call` - create an inbound call and invoke the configured voice webhook
+- `POST /_twilio/simulate/call-status` - advance call status
+- `POST /_twilio/simulate/verification-status` - force a verification state
+- `GET /` - tabbed inspector for messages, Verify, calls, Conversations, phone numbers, services, auth, and webhook deliveries
+
+Current Twilio limits: no carrier delivery, A2P 10DLC, toll-free verification, real phone number purchasing, exact rate limits, Studio, Flex, TaskRouter, Video, Sync, Segment, SendGrid, Conversations SDK websocket behavior, or complete TwiML interpreter.
+
 ## Apple Sign In
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
@@ -1049,6 +1093,7 @@ packages/
     google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, Drive
     slack/          # Slack Web API, OAuth v2, incoming webhooks
     linear/         # Linear GraphQL API, OAuth, webhooks
+    twilio/         # Twilio Messaging, Verify, Voice, webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
@@ -1071,6 +1116,8 @@ Tokens are configured in the seed config and map to users. Pass them as `Authori
 **Slack**: All Web API endpoints require `Authorization: Bearer <token>`. Seeded OAuth apps create local installation records, and OAuth v2 flow with user picker UI creates scoped bot tokens. Optional strict scope mode returns `missing_scope` when a token lacks a required method scope.
 
 **Linear**: GraphQL accepts `Authorization: Bearer <token>` or a bare personal API key value. Seeded Linear tokens map to users or app actors, OAuth apps support local authorization code and client credentials flows, and optional strict scope mode checks supported GraphQL operations.
+
+**Twilio**: HTTP Basic auth accepts the seeded Account SID/Auth Token pair or API Key/API Secret pair. Product-host APIs are exposed under local prefixes such as `/messaging/v1` and `/verify/v2`; the 2010 API lives at `/2010-04-01`.
 
 **Apple**: OIDC authorization code flow with RS256 ID tokens. On first auth per user/client pair, a `user` JSON blob is included.
 

--- a/README.md
+++ b/README.md
@@ -898,13 +898,27 @@ TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
 
 Twilio uses multiple product hosts. For local SDK tests, rewrite Twilio SDK requests to the emulator and map `messaging.twilio.com` to `/messaging`, `verify.twilio.com` to `/verify`, and `conversations.twilio.com` to `/conversations`.
 
+### SMS And OTP Testing
+
+For the common SMS verification loop, the seeded Verify Service uses code `123456`. Start a verification through the normal Verify API, then either submit `123456` in your app test or fetch the latest local code with the authenticated helper route:
+
+```sh
+curl -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" \
+  "http://localhost:4000/_twilio/simulate/verification-code?To=%2B15550002222&ServiceSid=$TWILIO_VERIFY_SERVICE_SID"
+```
+
+The helper returns the latest local verification for that phone number, including `verification_sid`, `status`, `attempts`, and `code`. It is local-only test support and is not part of Twilio's production API. The Verify inspector also shows each attempted code.
+
+To test inbound SMS webhooks, configure a seeded phone number `sms_url`, then call `POST /_twilio/simulate/inbound-message` with `To`, `From`, and `Body`. If the destination number is assigned to a Messaging Service with `inbound_request_url`, the simulator sends the inbound webhook there and includes `MessagingServiceSid`; otherwise it uses the phone number `sms_url`. To test outbound delivery transitions, create a message with `StatusCallback`, then call `POST /_twilio/simulate/message-status`.
+
 ### Simulator And Inspector
 
 - `POST /_twilio/simulate/inbound-message` - create an inbound message and invoke the configured SMS webhook
 - `POST /_twilio/simulate/message-status` - advance message status and send status callbacks
+- `GET /_twilio/simulate/verification-code` - fetch the latest local Verify code by `VerificationSid` or `To`
 - `POST /_twilio/simulate/inbound-call` - create an inbound call and invoke the configured voice webhook
 - `POST /_twilio/simulate/call-status` - advance call status
-- `POST /_twilio/simulate/verification-status` - force a verification state
+- `POST /_twilio/simulate/verification-status` - force a verification state by `VerificationSid` or `To`
 - `GET /` - tabbed inspector for messages, Verify, calls, Conversations, phone numbers, services, auth, and webhook deliveries
 
 Current Twilio limits: no carrier delivery, A2P 10DLC, toll-free verification, real phone number purchasing, exact rate limits, Studio, Flex, TaskRouter, Video, Sync, Segment, SendGrid, Conversations SDK websocket behavior, or complete TwiML interpreter.

--- a/apps/web/app/api/docs-chat/route.ts
+++ b/apps/web/app/api/docs-chat/route.ts
@@ -12,7 +12,7 @@ export const maxDuration = 60;
 
 const DEFAULT_MODEL = "anthropic/claude-haiku-4.5";
 
-const SYSTEM_PROMPT = `You are a helpful documentation assistant for emulate, a local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, and Linear APIs used in CI and no-network sandboxes.
+const SYSTEM_PROMPT = `You are a helpful documentation assistant for emulate, a local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, Linear, and Twilio APIs used in CI and no-network sandboxes.
 
 emulate provides fully stateful, production-fidelity API emulation, not mocks. The CLI is installed as the "emulate" npm package and run via "npx emulate". It also supports a programmatic API via createEmulator and a Next.js adapter (@emulators/adapter-next) for embedding emulators in your app.
 

--- a/apps/web/app/docs/twilio/layout.tsx
+++ b/apps/web/app/docs/twilio/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("twilio");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/twilio/page.mdx
+++ b/apps/web/app/docs/twilio/page.mdx
@@ -53,10 +53,24 @@ The official Node SDK builds absolute Twilio product URLs. In SDK tests, use a c
 - `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Participants`
 - `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Messages`
 
+## SMS And OTP Testing
+
+The seeded Verify Service uses code `123456`, so most local OTP tests can start a verification through the normal Verify API and submit that code. Tests that need to read the current local code can use the authenticated helper route:
+
+```bash
+curl -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" \
+  "http://localhost:4000/_twilio/simulate/verification-code?To=%2B15550002222&ServiceSid=$TWILIO_VERIFY_SERVICE_SID"
+```
+
+The helper returns the latest local verification for that phone number, including `verification_sid`, `status`, `attempts`, and `code`. It is local-only test support, not a production Twilio API. The Verify inspector also shows each attempted code.
+
+For inbound SMS, configure a phone number `sms_url`, then call `POST /_twilio/simulate/inbound-message` with `To`, `From`, and `Body`. If the destination number is assigned to a Messaging Service with `inbound_request_url`, the simulator sends the inbound webhook there and includes `MessagingServiceSid`; otherwise it uses the phone number `sms_url`. For outbound delivery transitions, create a message with `StatusCallback`, then call `POST /_twilio/simulate/message-status`.
+
 ## Simulator
 
 - `POST /_twilio/simulate/inbound-message`
 - `POST /_twilio/simulate/message-status`
+- `GET /_twilio/simulate/verification-code`
 - `POST /_twilio/simulate/inbound-call`
 - `POST /_twilio/simulate/call-status`
 - `POST /_twilio/simulate/verification-status`

--- a/apps/web/app/docs/twilio/page.mdx
+++ b/apps/web/app/docs/twilio/page.mdx
@@ -1,0 +1,99 @@
+# Twilio API
+
+Stateful Twilio REST emulation with seeded accounts, Auth Tokens, API keys, incoming phone numbers, Programmable Messaging, Messaging Services, Verify, basic Voice calls, Conversations REST resources, signed webhooks, local simulator routes, and an inspector.
+
+## Start
+
+```bash
+npx emulate --service twilio
+```
+
+When Twilio is the only enabled service, it starts on `http://localhost:4000`. When all services are started, it uses `http://localhost:4013`.
+
+## Defaults
+
+```text
+TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000
+TWILIO_AUTH_TOKEN=twilio_test_auth_token
+TWILIO_API_KEY=SK00000000000000000000000000000000
+TWILIO_API_SECRET=twilio_test_api_secret
+TWILIO_PHONE_NUMBER=+15551234567
+TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
+```
+
+## URL Mapping
+
+| Real Twilio URL | Emulator URL |
+|-----------------|--------------|
+| `https://api.twilio.com/2010-04-01/...` | `$TWILIO_EMULATOR_URL/2010-04-01/...` |
+| `https://messaging.twilio.com/v1/...` | `$TWILIO_EMULATOR_URL/messaging/v1/...` |
+| `https://verify.twilio.com/v2/...` | `$TWILIO_EMULATOR_URL/verify/v2/...` |
+| `https://conversations.twilio.com/v1/...` | `$TWILIO_EMULATOR_URL/conversations/v1/...` |
+
+The official Node SDK builds absolute Twilio product URLs. In SDK tests, use a custom request client that rewrites those hosts to the emulator prefixes above.
+
+## Supported Routes
+
+- `GET /2010-04-01/Accounts/{AccountSid}.json`
+- `GET /2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers.json`
+- `POST /2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers.json`
+- `POST /2010-04-01/Accounts/{AccountSid}/Messages.json`
+- `GET /2010-04-01/Accounts/{AccountSid}/Messages.json`
+- `GET /2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}.json`
+- `POST /2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}.json`
+- `DELETE /2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}.json`
+- `POST /2010-04-01/Accounts/{AccountSid}/Calls.json`
+- `GET /2010-04-01/Accounts/{AccountSid}/Calls.json`
+- `POST /messaging/v1/Services`
+- `GET /messaging/v1/Services`
+- `POST /verify/v2/Services/{ServiceSid}/Verifications`
+- `POST /verify/v2/Services/{ServiceSid}/VerificationCheck`
+- `POST /conversations/v1/Services`
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations`
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Participants`
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Messages`
+
+## Simulator
+
+- `POST /_twilio/simulate/inbound-message`
+- `POST /_twilio/simulate/message-status`
+- `POST /_twilio/simulate/inbound-call`
+- `POST /_twilio/simulate/call-status`
+- `POST /_twilio/simulate/verification-status`
+
+## Seed Config
+
+```yaml
+twilio:
+  account:
+    sid: AC00000000000000000000000000000000
+    auth_token: twilio_test_auth_token
+    friendly_name: Local Twilio Account
+  api_keys:
+    - sid: SK00000000000000000000000000000000
+      secret: twilio_test_api_secret
+      friendly_name: Local API Key
+  phone_numbers:
+    - phone_number: "+15551234567"
+      friendly_name: Local SMS and Voice Number
+      sms_url: http://localhost:3000/api/twilio/sms
+      voice_url: http://localhost:3000/api/twilio/voice
+  messaging_services:
+    - friendly_name: Local Messaging Service
+      phone_numbers: ["+15551234567"]
+  verify_services:
+    - friendly_name: Local Verify Service
+      code: "123456"
+      default_channel: sms
+  conversations:
+    services:
+      - friendly_name: Local Conversations
+```
+
+## Inspector
+
+Open `GET /` in the Twilio emulator to inspect messages, Verify attempts, calls, Conversations, phone numbers, services, credentials, and webhook deliveries.
+
+## Current Limits
+
+No real SMS, MMS, WhatsApp, email, voice, carrier, compliance, billing, SendGrid, Studio, Flex, TaskRouter, Video, Sync, Segment, Conversations SDK websocket behavior, or complete TwiML interpreter behavior is implemented.

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -13,6 +13,7 @@ export const allDocsPages: NavItem[] = [
   { name: "Google API", href: "/docs/google" },
   { name: "Slack API", href: "/docs/slack" },
   { name: "Linear API", href: "/docs/linear" },
+  { name: "Twilio API", href: "/docs/twilio" },
   { name: "Apple Sign In", href: "/docs/apple" },
   { name: "Microsoft Entra ID", href: "/docs/microsoft" },
   { name: "AWS", href: "/docs/aws" },

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -8,6 +8,7 @@ export const PAGE_TITLES: Record<string, string> = {
   google: "Google API",
   slack: "Slack API",
   linear: "Linear API",
+  twilio: "Twilio API",
   apple: "Apple Sign In",
   microsoft: "Microsoft Entra ID",
   aws: "AWS",

--- a/packages/@emulators/twilio/README.md
+++ b/packages/@emulators/twilio/README.md
@@ -1,0 +1,30 @@
+# @emulators/twilio
+
+Twilio API emulator for local development and CI. Part of [emulate](https://github.com/vercel-labs/emulate).
+
+```bash
+npm install @emulators/twilio
+```
+
+Run it through the CLI:
+
+```bash
+npx emulate --service twilio
+```
+
+The first supported surface includes seeded Account SID/Auth Token credentials, API key credentials, incoming phone numbers, Programmable Messaging, Messaging Services, Verify, basic Voice calls, Conversations REST resources, signed webhooks, simulator routes, and an inspector.
+
+Default local credentials:
+
+```text
+TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000
+TWILIO_AUTH_TOKEN=twilio_test_auth_token
+TWILIO_API_KEY=SK00000000000000000000000000000000
+TWILIO_API_SECRET=twilio_test_api_secret
+TWILIO_PHONE_NUMBER=+15551234567
+TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
+```
+
+Twilio uses multiple product hosts. When testing with the official Node SDK, use a custom request client that rewrites Twilio hosts to the local emulator. The emulator exposes product-prefixed local routes such as `/verify/v2` and `/messaging/v1`.
+
+No real SMS, voice, carrier, compliance, billing, or SendGrid traffic is performed.

--- a/packages/@emulators/twilio/README.md
+++ b/packages/@emulators/twilio/README.md
@@ -27,4 +27,6 @@ TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
 
 Twilio uses multiple product hosts. When testing with the official Node SDK, use a custom request client that rewrites Twilio hosts to the local emulator. The emulator exposes product-prefixed local routes such as `/verify/v2` and `/messaging/v1`.
 
+For SMS and OTP tests, the seeded Verify Service uses code `123456`. Test runners can also read the latest local code with `GET /_twilio/simulate/verification-code?To=...&ServiceSid=...` using Basic auth. Inbound SMS webhooks are simulated with `POST /_twilio/simulate/inbound-message`, using an assigned Messaging Service `inbound_request_url` before falling back to the phone number `sms_url`. Outbound delivery transitions are simulated with `POST /_twilio/simulate/message-status`.
+
 No real SMS, voice, carrier, compliance, billing, or SendGrid traffic is performed.

--- a/packages/@emulators/twilio/package.json
+++ b/packages/@emulators/twilio/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@emulators/twilio",
+  "version": "0.7.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/twilio"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "twilio": "^6.0.2",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/twilio/src/__tests__/helpers.ts
+++ b/packages/@emulators/twilio/src/__tests__/helpers.ts
@@ -1,0 +1,93 @@
+import { Hono, Store, WebhookDispatcher, type AppEnv } from "@emulators/core";
+import { twilioPlugin, DEFAULT_ACCOUNT_SID, DEFAULT_AUTH_TOKEN } from "../index.js";
+
+export const twilioTestBaseUrl = "http://localhost:4301";
+
+export interface TwilioTestApp {
+  app: Hono<AppEnv>;
+  store: Store;
+  webhooks: WebhookDispatcher;
+}
+
+export function createTwilioTestApp(): TwilioTestApp {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const app = new Hono<AppEnv>();
+  twilioPlugin.register(app, store, webhooks, twilioTestBaseUrl);
+  twilioPlugin.seed?.(store, twilioTestBaseUrl);
+  return { app, store, webhooks };
+}
+
+export function basicAuth(username = DEFAULT_ACCOUNT_SID, password = DEFAULT_AUTH_TOKEN): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+
+export function formBody(data: Record<string, string>): string {
+  return new URLSearchParams(data).toString();
+}
+
+export function formHeaders(username = DEFAULT_ACCOUNT_SID, password = DEFAULT_AUTH_TOKEN): Record<string, string> {
+  return {
+    Authorization: basicAuth(username, password),
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+}
+
+export class LocalTwilioRequestClient {
+  lastResponse?: { statusCode: number; body: unknown; headers: Record<string, string> };
+
+  constructor(private app: Hono<AppEnv>) {}
+
+  async request(opts: {
+    method: string;
+    uri: string;
+    username?: string;
+    password?: string;
+    headers?: Record<string, string>;
+    params?: Record<string, string | number>;
+    data?: Record<string, unknown>;
+  }) {
+    const url = new URL(opts.uri);
+    for (const [key, value] of Object.entries(opts.params ?? {})) {
+      url.searchParams.set(key, String(value));
+    }
+    const prefix =
+      url.hostname === "messaging.twilio.com"
+        ? "/messaging"
+        : url.hostname === "verify.twilio.com"
+          ? "/verify"
+          : url.hostname === "conversations.twilio.com"
+            ? "/conversations"
+            : "";
+    const localUrl = `${twilioTestBaseUrl}${prefix}${url.pathname}${url.search}`;
+    const headers = { ...(opts.headers ?? {}) };
+    if (opts.username && opts.password) {
+      headers.Authorization = basicAuth(opts.username, opts.password);
+    }
+    let body: string | undefined;
+    if (opts.data) {
+      body = new URLSearchParams(
+        Object.entries(opts.data).flatMap(([key, value]) => {
+          if (Array.isArray(value)) return value.map((item) => [key, String(item)] as [string, string]);
+          if (value === undefined || value === null) return [];
+          return [[key, String(value)] as [string, string]];
+        }),
+      ).toString();
+      headers["Content-Type"] = headers["Content-Type"] ?? "application/x-www-form-urlencoded";
+    }
+    const response = await this.app.request(localUrl, {
+      method: opts.method.toUpperCase(),
+      headers,
+      body,
+    });
+    const text = await response.text();
+    const parsed = text ? JSON.parse(text) : "";
+    const result = {
+      statusCode: response.status,
+      body: parsed,
+      headers: Object.fromEntries(response.headers.entries()),
+    };
+    this.lastResponse = result;
+    return result;
+  }
+}

--- a/packages/@emulators/twilio/src/__tests__/twilio-sdk.test.ts
+++ b/packages/@emulators/twilio/src/__tests__/twilio-sdk.test.ts
@@ -1,0 +1,57 @@
+import twilio from "twilio";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_ACCOUNT_SID, DEFAULT_AUTH_TOKEN, DEFAULT_PHONE_NUMBER, DEFAULT_VERIFY_SERVICE_SID } from "../index.js";
+import { createTwilioTestApp, LocalTwilioRequestClient } from "./helpers.js";
+
+describe("Twilio SDK compatibility", () => {
+  let setup: ReturnType<typeof createTwilioTestApp>;
+  let requestClient: LocalTwilioRequestClient;
+  let client: ReturnType<typeof twilio>;
+
+  beforeEach(() => {
+    setup = createTwilioTestApp();
+    requestClient = new LocalTwilioRequestClient(setup.app);
+    client = twilio(DEFAULT_ACCOUNT_SID, DEFAULT_AUTH_TOKEN, { httpClient: requestClient as any });
+  });
+
+  it("creates and lists messages through twilio-node", async () => {
+    const message = await client.messages.create({
+      to: "+15550004444",
+      from: DEFAULT_PHONE_NUMBER,
+      body: "Hello from SDK",
+    });
+    expect(message.sid).toMatch(/^SM/);
+    expect(message.status).toBe("queued");
+
+    const messages = await client.messages.list({ limit: 10 });
+    expect(messages.map((item) => item.sid)).toContain(message.sid);
+  });
+
+  it("starts and checks Verify flows through twilio-node", async () => {
+    const verification = await client.verify.v2.services(DEFAULT_VERIFY_SERVICE_SID).verifications.create({
+      to: "+15550005555",
+      channel: "sms",
+    });
+    expect(verification.status).toBe("pending");
+
+    const check = await client.verify.v2.services(DEFAULT_VERIFY_SERVICE_SID).verificationChecks.create({
+      to: "+15550005555",
+      code: "123456",
+    });
+    expect(check.status).toBe("approved");
+    expect(check.valid).toBe(true);
+  });
+
+  it("creates and updates calls through twilio-node", async () => {
+    const call = await client.calls.create({
+      to: "+15550006666",
+      from: DEFAULT_PHONE_NUMBER,
+      twiml: "<Response><Say>Hi</Say></Response>",
+    });
+    expect(call.sid).toMatch(/^CA/);
+    expect(call.status).toBe("ringing");
+
+    const updated = await client.calls(call.sid).update({ status: "completed" });
+    expect(updated.status).toBe("completed");
+  });
+});

--- a/packages/@emulators/twilio/src/__tests__/twilio-sdk.test.ts
+++ b/packages/@emulators/twilio/src/__tests__/twilio-sdk.test.ts
@@ -42,6 +42,14 @@ describe("Twilio SDK compatibility", () => {
     expect(check.valid).toBe(true);
   });
 
+  it("paginates product-host service lists through twilio-node", async () => {
+    const created = await client.messaging.v1.services.create({ friendlyName: "Paged Messaging Service" });
+    const services = await client.messaging.v1.services.list({ pageSize: 1, limit: 2 });
+
+    expect(services.map((service) => service.sid)).toContain(created.sid);
+    expect(requestClient.lastResponse?.statusCode).toBe(200);
+  });
+
   it("creates and updates calls through twilio-node", async () => {
     const call = await client.calls.create({
       to: "+15550006666",

--- a/packages/@emulators/twilio/src/__tests__/twilio.test.ts
+++ b/packages/@emulators/twilio/src/__tests__/twilio.test.ts
@@ -120,6 +120,59 @@ describe("Twilio emulator", () => {
     expect(del.status).toBe(204);
   });
 
+  it("validates MessagingServiceSid even when From is supplied", async () => {
+    const create = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages.json`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({
+          To: "+15550001111",
+          From: DEFAULT_PHONE_NUMBER,
+          MessagingServiceSid: "MG11111111111111111111111111111111",
+          Body: "Invalid service",
+        }),
+      },
+    );
+    expect(create.status).toBe(400);
+    const error = (await create.json()) as any;
+    expect(error.code).toBe(20404);
+    expect(getTwilioStore(setup.store).messages.all()).toHaveLength(0);
+  });
+
+  it("removes Messaging Service sender assignments when phone numbers are deleted", async () => {
+    const ts = getTwilioStore(setup.store);
+    const number = ts.phoneNumbers.findOneBy("phone_number", DEFAULT_PHONE_NUMBER)!;
+    expect(ts.messagingServicePhoneNumbers.findBy("phone_number_sid", number.sid)).toHaveLength(1);
+
+    const del = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/IncomingPhoneNumbers/${number.sid}.json`,
+      {
+        method: "DELETE",
+        headers: { Authorization: basicAuth() },
+      },
+    );
+    expect(del.status).toBe(204);
+    expect(ts.messagingServicePhoneNumbers.findBy("phone_number_sid", number.sid)).toHaveLength(0);
+
+    const create = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages.json`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({
+          To: "+15550001111",
+          MessagingServiceSid: DEFAULT_MESSAGING_SERVICE_SID,
+          Body: "No sender",
+        }),
+      },
+    );
+    expect(create.status).toBe(400);
+    const error = (await create.json()) as any;
+    expect(error.code).toBe(21712);
+    expect(ts.messages.all()).toHaveLength(0);
+  });
+
   it("dispatches signed message callbacks and captures deliveries", async () => {
     vi.stubGlobal(
       "fetch",
@@ -325,6 +378,41 @@ describe("Twilio emulator", () => {
     );
     const completed = (await complete.json()) as any;
     expect(completed.status).toBe("completed");
+  });
+
+  it("rejects invalid simulator status values without mutating resources", async () => {
+    const messageRes = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages.json`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ To: "+15550001111", From: DEFAULT_PHONE_NUMBER, Body: "Status check" }),
+      },
+    );
+    const message = (await messageRes.json()) as any;
+
+    const invalidMessageStatus = await setup.app.request("http://localhost/_twilio/simulate/message-status", {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ MessageSid: message.sid, Status: "totally-done" }),
+    });
+    expect(invalidMessageStatus.status).toBe(400);
+    expect(getTwilioStore(setup.store).messages.findOneBy("sid", message.sid)?.status).toBe("queued");
+
+    const callRes = await setup.app.request(`http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Calls.json`, {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ To: "+15550003333", From: DEFAULT_PHONE_NUMBER, Twiml: "<Response><Say>Hi</Say></Response>" }),
+    });
+    const call = (await callRes.json()) as any;
+
+    const invalidCallStatus = await setup.app.request("http://localhost/_twilio/simulate/call-status", {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ CallSid: call.sid, Status: "totally-done" }),
+    });
+    expect(invalidCallStatus.status).toBe(400);
+    expect(getTwilioStore(setup.store).calls.findOneBy("sid", call.sid)?.status).toBe("ringing");
   });
 
   it("creates Conversations resources", async () => {

--- a/packages/@emulators/twilio/src/__tests__/twilio.test.ts
+++ b/packages/@emulators/twilio/src/__tests__/twilio.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getTwilioStore,
+  seedFromConfig,
   DEFAULT_ACCOUNT_SID,
+  DEFAULT_API_KEY_SID,
   DEFAULT_MESSAGING_SERVICE_SID,
   DEFAULT_PHONE_NUMBER,
   DEFAULT_VERIFY_SERVICE_SID,
@@ -27,6 +29,54 @@ describe("Twilio emulator", () => {
     const body = (await res.json()) as any;
     expect(body.sid).toBe(DEFAULT_ACCOUNT_SID);
     expect(body.friendly_name).toBe("Local Twilio Account");
+  });
+
+  it("applies seed config to default resources without duplicating them", () => {
+    seedFromConfig(setup.store, "http://localhost:4301", {
+      account: {
+        sid: DEFAULT_ACCOUNT_SID,
+        auth_token: "custom_auth_token",
+        friendly_name: "Custom Twilio Account",
+      },
+      api_keys: [{ sid: DEFAULT_API_KEY_SID, secret: "custom_api_secret", friendly_name: "Custom API Key" }],
+      phone_numbers: [
+        {
+          phone_number: DEFAULT_PHONE_NUMBER,
+          friendly_name: "Custom SMS Number",
+          sms_url: "http://app.local/twilio/sms",
+          sms_method: "GET",
+          voice_url: "http://app.local/twilio/voice",
+        },
+      ],
+      messaging_services: [
+        {
+          friendly_name: "Local Messaging Service",
+          phone_numbers: [DEFAULT_PHONE_NUMBER],
+          inbound_request_url: "http://app.local/twilio/messaging-service-inbound",
+          status_callback: "http://app.local/twilio/status",
+        },
+      ],
+      verify_services: [{ friendly_name: "Local Verify Service", code: "654321", default_channel: "call" }],
+      conversations: { services: [{ friendly_name: "Local Conversations" }] },
+    });
+
+    const ts = getTwilioStore(setup.store);
+    expect(ts.accounts.findOneBy("sid", DEFAULT_ACCOUNT_SID)?.friendly_name).toBe("Custom Twilio Account");
+    expect(ts.apiKeys.all()).toHaveLength(1);
+    expect(ts.apiKeys.findOneBy("sid", DEFAULT_API_KEY_SID)?.secret).toBe("custom_api_secret");
+    expect(ts.phoneNumbers.all()).toHaveLength(1);
+    expect(ts.phoneNumbers.findOneBy("phone_number", DEFAULT_PHONE_NUMBER)?.sms_url).toBe(
+      "http://app.local/twilio/sms",
+    );
+    expect(ts.phoneNumbers.findOneBy("phone_number", DEFAULT_PHONE_NUMBER)?.sms_method).toBe("GET");
+    expect(ts.messagingServices.all()).toHaveLength(1);
+    expect(ts.messagingServices.findOneBy("sid", DEFAULT_MESSAGING_SERVICE_SID)?.inbound_request_url).toBe(
+      "http://app.local/twilio/messaging-service-inbound",
+    );
+    expect(ts.messagingServicePhoneNumbers.all()).toHaveLength(1);
+    expect(ts.verifyServices.all()).toHaveLength(1);
+    expect(ts.verifyServices.findOneBy("sid", DEFAULT_VERIFY_SERVICE_SID)?.code).toBe("654321");
+    expect(ts.conversationServices.all()).toHaveLength(1);
   });
 
   it("creates, reads, updates, and deletes messages", async () => {
@@ -119,6 +169,37 @@ describe("Twilio emulator", () => {
     expect(delivery.request_headers["X-Twilio-Signature"]).toBeTruthy();
     expect(delivery.request_body.Body).toBe("hello from user");
     expect(delivery.request_body.From).toBe("+15550009999");
+  });
+
+  it("sends inbound webhook params in the query string for GET callbacks", async () => {
+    let requestedUrl = "";
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      requestedUrl = String(url);
+      return new Response("ok", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const number = getTwilioStore(setup.store).phoneNumbers.findOneBy("phone_number", DEFAULT_PHONE_NUMBER)!;
+    getTwilioStore(setup.store).phoneNumbers.update(number.id, {
+      sms_url: "http://app.local/twilio/inbound",
+      sms_method: "GET",
+    });
+
+    const inbound = await setup.app.request("http://localhost/_twilio/simulate/inbound-message", {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ To: DEFAULT_PHONE_NUMBER, From: "+15550009999", Body: "hello over get" }),
+    });
+    expect(inbound.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const callbackUrl = new URL(requestedUrl);
+    expect(`${callbackUrl.origin}${callbackUrl.pathname}`).toBe("http://app.local/twilio/inbound");
+    expect(callbackUrl.searchParams.get("To")).toBe(DEFAULT_PHONE_NUMBER);
+    expect(callbackUrl.searchParams.get("From")).toBe("+15550009999");
+    expect(callbackUrl.searchParams.get("Body")).toBe("hello over get");
+
+    const delivery = getTwilioStore(setup.store).webhookDeliveries.all()[0];
+    expect(delivery.method).toBe("GET");
+    expect(new URL(delivery.url).searchParams.get("MessageSid")).toBe(delivery.request_body.MessageSid);
   });
 
   it("routes inbound SMS through assigned Messaging Service inbound URLs", async () => {

--- a/packages/@emulators/twilio/src/__tests__/twilio.test.ts
+++ b/packages/@emulators/twilio/src/__tests__/twilio.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getTwilioStore, DEFAULT_ACCOUNT_SID, DEFAULT_PHONE_NUMBER, DEFAULT_VERIFY_SERVICE_SID } from "../index.js";
+import { basicAuth, createTwilioTestApp, formBody, formHeaders } from "./helpers.js";
+
+describe("Twilio emulator", () => {
+  let setup: ReturnType<typeof createTwilioTestApp>;
+
+  beforeEach(() => {
+    setup = createTwilioTestApp();
+    vi.restoreAllMocks();
+  });
+
+  it("requires Basic auth and fetches the seeded account", async () => {
+    const missingAuth = await setup.app.request(`http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}.json`);
+    expect(missingAuth.status).toBe(401);
+
+    const res = await setup.app.request(`http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}.json`, {
+      headers: { Authorization: basicAuth() },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.sid).toBe(DEFAULT_ACCOUNT_SID);
+    expect(body.friendly_name).toBe("Local Twilio Account");
+  });
+
+  it("creates, reads, updates, and deletes messages", async () => {
+    const create = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages.json`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ To: "+15550001111", From: DEFAULT_PHONE_NUMBER, Body: "Ahoy" }),
+      },
+    );
+    expect(create.status).toBe(201);
+    const created = (await create.json()) as any;
+    expect(created.sid).toMatch(/^SM/);
+    expect(created.status).toBe("queued");
+
+    const list = await setup.app.request(`http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages.json`, {
+      headers: { Authorization: basicAuth() },
+    });
+    const listed = (await list.json()) as any;
+    expect(listed.messages).toHaveLength(1);
+
+    const update = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages/${created.sid}.json`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ Status: "delivered" }),
+      },
+    );
+    const updated = (await update.json()) as any;
+    expect(updated.status).toBe("delivered");
+
+    const del = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages/${created.sid}.json`,
+      {
+        method: "DELETE",
+        headers: { Authorization: basicAuth() },
+      },
+    );
+    expect(del.status).toBe(204);
+  });
+
+  it("dispatches signed message callbacks and captures deliveries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    );
+    const number = getTwilioStore(setup.store).phoneNumbers.findOneBy("phone_number", DEFAULT_PHONE_NUMBER)!;
+    getTwilioStore(setup.store).phoneNumbers.update(number.id, {
+      status_callback: "http://app.local/twilio/status",
+    });
+
+    await setup.app.request(`http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Messages.json`, {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ To: "+15550001111", From: DEFAULT_PHONE_NUMBER, Body: "Callback" }),
+    });
+
+    const delivery = getTwilioStore(setup.store).webhookDeliveries.all()[0];
+    expect(delivery.event).toBe("message.queued");
+    expect(delivery.request_headers["X-Twilio-Signature"]).toBeTruthy();
+    expect(delivery.request_body.MessageStatus).toBe("queued");
+  });
+
+  it("runs Verify start and check flows", async () => {
+    const start = await setup.app.request(
+      `http://localhost/verify/v2/Services/${DEFAULT_VERIFY_SERVICE_SID}/Verifications`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ To: "+15550002222", Channel: "sms" }),
+      },
+    );
+    expect(start.status).toBe(201);
+    const verification = (await start.json()) as any;
+    expect(verification.status).toBe("pending");
+
+    const check = await setup.app.request(
+      `http://localhost/verify/v2/Services/${DEFAULT_VERIFY_SERVICE_SID}/VerificationCheck`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ To: "+15550002222", Code: "123456" }),
+      },
+    );
+    const checked = (await check.json()) as any;
+    expect(checked.status).toBe("approved");
+    expect(checked.valid).toBe(true);
+  });
+
+  it("creates and completes calls", async () => {
+    const create = await setup.app.request(`http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Calls.json`, {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ To: "+15550003333", From: DEFAULT_PHONE_NUMBER, Twiml: "<Response><Say>Hi</Say></Response>" }),
+    });
+    expect(create.status).toBe(201);
+    const call = (await create.json()) as any;
+    expect(call.sid).toMatch(/^CA/);
+    expect(call.status).toBe("ringing");
+
+    const complete = await setup.app.request(
+      `http://localhost/2010-04-01/Accounts/${DEFAULT_ACCOUNT_SID}/Calls/${call.sid}.json`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ Status: "completed" }),
+      },
+    );
+    const completed = (await complete.json()) as any;
+    expect(completed.status).toBe("completed");
+  });
+
+  it("creates Conversations resources", async () => {
+    const serviceRes = await setup.app.request("http://localhost/conversations/v1/Services", {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ FriendlyName: "Support" }),
+    });
+    expect(serviceRes.status).toBe(201);
+    const service = (await serviceRes.json()) as any;
+    expect(service.sid).toMatch(/^IS/);
+
+    const conversationRes = await setup.app.request(
+      `http://localhost/conversations/v1/Services/${service.sid}/Conversations`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ FriendlyName: "Ticket 1", UniqueName: "ticket-1" }),
+      },
+    );
+    const conversation = (await conversationRes.json()) as any;
+    expect(conversation.sid).toMatch(/^CH/);
+
+    const participantRes = await setup.app.request(
+      `http://localhost/conversations/v1/Services/${service.sid}/Conversations/${conversation.sid}/Participants`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ Identity: "agent@example.com" }),
+      },
+    );
+    const participant = (await participantRes.json()) as any;
+    expect(participant.sid).toMatch(/^MB/);
+
+    const messageRes = await setup.app.request(
+      `http://localhost/conversations/v1/Services/${service.sid}/Conversations/${conversation.sid}/Messages`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ Author: "agent@example.com", Body: "Hello" }),
+      },
+    );
+    const message = (await messageRes.json()) as any;
+    expect(message.sid).toMatch(/^IM/);
+    expect(message.index).toBe(0);
+  });
+});

--- a/packages/@emulators/twilio/src/__tests__/twilio.test.ts
+++ b/packages/@emulators/twilio/src/__tests__/twilio.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getTwilioStore, DEFAULT_ACCOUNT_SID, DEFAULT_PHONE_NUMBER, DEFAULT_VERIFY_SERVICE_SID } from "../index.js";
+import {
+  getTwilioStore,
+  DEFAULT_ACCOUNT_SID,
+  DEFAULT_MESSAGING_SERVICE_SID,
+  DEFAULT_PHONE_NUMBER,
+  DEFAULT_VERIFY_SERVICE_SID,
+} from "../index.js";
 import { basicAuth, createTwilioTestApp, formBody, formHeaders } from "./helpers.js";
 
 describe("Twilio emulator", () => {
@@ -86,6 +92,61 @@ describe("Twilio emulator", () => {
     expect(delivery.request_body.MessageStatus).toBe("queued");
   });
 
+  it("simulates inbound SMS webhooks", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    );
+    const number = getTwilioStore(setup.store).phoneNumbers.findOneBy("phone_number", DEFAULT_PHONE_NUMBER)!;
+    getTwilioStore(setup.store).phoneNumbers.update(number.id, {
+      sms_url: "http://app.local/twilio/inbound",
+      sms_method: "POST",
+    });
+
+    const inbound = await setup.app.request("http://localhost/_twilio/simulate/inbound-message", {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ To: DEFAULT_PHONE_NUMBER, From: "+15550009999", Body: "hello from user" }),
+    });
+    expect(inbound.status).toBe(201);
+    const message = (await inbound.json()) as any;
+    expect(message.direction).toBe("inbound");
+    expect(message.status).toBe("received");
+
+    const delivery = getTwilioStore(setup.store).webhookDeliveries.all()[0];
+    expect(delivery.event).toBe("message.inbound");
+    expect(delivery.url).toBe("http://app.local/twilio/inbound");
+    expect(delivery.request_headers["X-Twilio-Signature"]).toBeTruthy();
+    expect(delivery.request_body.Body).toBe("hello from user");
+    expect(delivery.request_body.From).toBe("+15550009999");
+  });
+
+  it("routes inbound SMS through assigned Messaging Service inbound URLs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    );
+    const service = getTwilioStore(setup.store).messagingServices.findOneBy("sid", DEFAULT_MESSAGING_SERVICE_SID)!;
+    getTwilioStore(setup.store).messagingServices.update(service.id, {
+      inbound_request_url: "http://app.local/twilio/messaging-service-inbound",
+    });
+
+    const inbound = await setup.app.request("http://localhost/_twilio/simulate/inbound-message", {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ To: DEFAULT_PHONE_NUMBER, From: "+15550008888", Body: "service inbound" }),
+    });
+    expect(inbound.status).toBe(201);
+    const message = (await inbound.json()) as any;
+    expect(message.messaging_service_sid).toBe(DEFAULT_MESSAGING_SERVICE_SID);
+
+    const delivery = getTwilioStore(setup.store).webhookDeliveries.all()[0];
+    expect(delivery.event).toBe("message.inbound");
+    expect(delivery.url).toBe("http://app.local/twilio/messaging-service-inbound");
+    expect(delivery.request_body.MessagingServiceSid).toBe(DEFAULT_MESSAGING_SERVICE_SID);
+    expect(delivery.request_body.Body).toBe("service inbound");
+  });
+
   it("runs Verify start and check flows", async () => {
     const start = await setup.app.request(
       `http://localhost/verify/v2/Services/${DEFAULT_VERIFY_SERVICE_SID}/Verifications`,
@@ -99,6 +160,17 @@ describe("Twilio emulator", () => {
     const verification = (await start.json()) as any;
     expect(verification.status).toBe("pending");
 
+    const codeRes = await setup.app.request(
+      `http://localhost/_twilio/simulate/verification-code?To=${encodeURIComponent("+15550002222")}`,
+      {
+        headers: { Authorization: basicAuth() },
+      },
+    );
+    expect(codeRes.status).toBe(200);
+    const code = (await codeRes.json()) as any;
+    expect(code.code).toBe("123456");
+    expect(code.verification_sid).toBe(verification.sid);
+
     const check = await setup.app.request(
       `http://localhost/verify/v2/Services/${DEFAULT_VERIFY_SERVICE_SID}/VerificationCheck`,
       {
@@ -110,6 +182,45 @@ describe("Twilio emulator", () => {
     const checked = (await check.json()) as any;
     expect(checked.status).toBe("approved");
     expect(checked.valid).toBe(true);
+
+    const inspector = await setup.app.request("http://localhost/?tab=verify");
+    const html = await inspector.text();
+    expect(html).toContain("123456");
+    expect(html).toContain(verification.sid);
+  });
+
+  it("supports custom OTP codes and local verification status controls", async () => {
+    const start = await setup.app.request(
+      `http://localhost/verify/v2/Services/${DEFAULT_VERIFY_SERVICE_SID}/Verifications`,
+      {
+        method: "POST",
+        headers: formHeaders(),
+        body: formBody({ To: "+15550004444", Channel: "sms", CustomCode: "654321" }),
+      },
+    );
+    expect(start.status).toBe(201);
+    const verification = (await start.json()) as any;
+
+    const lookup = await setup.app.request(
+      `http://localhost/_twilio/simulate/verification-code?ServiceSid=${DEFAULT_VERIFY_SERVICE_SID}&To=${encodeURIComponent("+15550004444")}`,
+      {
+        headers: { Authorization: basicAuth() },
+      },
+    );
+    expect(lookup.status).toBe(200);
+    const localCode = (await lookup.json()) as any;
+    expect(localCode.code).toBe("654321");
+    expect(localCode.verification_sid).toBe(verification.sid);
+
+    const force = await setup.app.request("http://localhost/_twilio/simulate/verification-status", {
+      method: "POST",
+      headers: formHeaders(),
+      body: formBody({ To: "+15550004444", ServiceSid: DEFAULT_VERIFY_SERVICE_SID, Status: "approved" }),
+    });
+    expect(force.status).toBe(200);
+    const forced = (await force.json()) as any;
+    expect(forced.status).toBe("approved");
+    expect(forced.valid).toBe(true);
   });
 
   it("creates and completes calls", async () => {

--- a/packages/@emulators/twilio/src/entities.ts
+++ b/packages/@emulators/twilio/src/entities.ts
@@ -1,0 +1,223 @@
+import type { Entity } from "@emulators/core";
+
+export type TwilioAccountStatus = "active" | "suspended" | "closed";
+export type TwilioMessageDirection = "inbound" | "outbound-api" | "outbound-call" | "outbound-reply";
+export type TwilioMessageStatus =
+  | "accepted"
+  | "scheduled"
+  | "canceled"
+  | "queued"
+  | "sending"
+  | "sent"
+  | "failed"
+  | "delivered"
+  | "undelivered"
+  | "receiving"
+  | "received"
+  | "read";
+export type TwilioVerificationStatus =
+  | "pending"
+  | "approved"
+  | "canceled"
+  | "max_attempts_reached"
+  | "deleted"
+  | "failed"
+  | "expired";
+export type TwilioCallStatus =
+  | "queued"
+  | "ringing"
+  | "in-progress"
+  | "completed"
+  | "busy"
+  | "failed"
+  | "no-answer"
+  | "canceled";
+export type TwilioCallDirection = "inbound" | "outbound-api" | "outbound-dial" | "outbound-call";
+
+export interface TwilioAccount extends Entity {
+  sid: string;
+  friendly_name: string;
+  auth_token: string;
+  status: TwilioAccountStatus;
+  owner_account_sid: string | null;
+}
+
+export interface TwilioApiKey extends Entity {
+  sid: string;
+  account_sid: string;
+  secret: string;
+  friendly_name: string;
+  active: boolean;
+}
+
+export interface TwilioApplication extends Entity {
+  sid: string;
+  account_sid: string;
+  friendly_name: string;
+  sms_url: string | null;
+  sms_method: string;
+  voice_url: string | null;
+  voice_method: string;
+  status_callback: string | null;
+}
+
+export interface TwilioIncomingPhoneNumber extends Entity {
+  sid: string;
+  account_sid: string;
+  phone_number: string;
+  friendly_name: string;
+  capabilities: {
+    sms: boolean;
+    mms: boolean;
+    voice: boolean;
+  };
+  sms_url: string | null;
+  sms_method: string;
+  voice_url: string | null;
+  voice_method: string;
+  status_callback: string | null;
+  application_sid: string | null;
+}
+
+export interface TwilioMessagingService extends Entity {
+  sid: string;
+  account_sid: string;
+  friendly_name: string;
+  inbound_request_url: string | null;
+  status_callback: string | null;
+}
+
+export interface TwilioMessagingServicePhoneNumber extends Entity {
+  sid: string;
+  account_sid: string;
+  service_sid: string;
+  phone_number_sid: string;
+}
+
+export interface TwilioMessage extends Entity {
+  sid: string;
+  account_sid: string;
+  to: string;
+  from: string | null;
+  body: string | null;
+  direction: TwilioMessageDirection;
+  status: TwilioMessageStatus;
+  messaging_service_sid: string | null;
+  num_segments: string;
+  num_media: string;
+  media_urls: string[];
+  error_code: number | null;
+  error_message: string | null;
+  price: string | null;
+  price_unit: string;
+  api_version: string;
+  status_callback: string | null;
+  date_sent: string | null;
+}
+
+export interface TwilioMedia extends Entity {
+  sid: string;
+  account_sid: string;
+  message_sid: string;
+  content_type: string;
+  uri: string;
+}
+
+export interface TwilioVerifyService extends Entity {
+  sid: string;
+  account_sid: string;
+  friendly_name: string;
+  code: string;
+  default_channel: string;
+}
+
+export interface TwilioVerification extends Entity {
+  sid: string;
+  service_sid: string;
+  account_sid: string;
+  to: string;
+  channel: string;
+  status: TwilioVerificationStatus;
+  code: string;
+  attempts: number;
+  max_attempts: number;
+  lookup: Record<string, unknown>;
+  send_code_attempts: Array<Record<string, unknown>>;
+  tags: string | null;
+  valid: boolean;
+}
+
+export interface TwilioCall extends Entity {
+  sid: string;
+  account_sid: string;
+  to: string;
+  from: string;
+  status: TwilioCallStatus;
+  direction: TwilioCallDirection;
+  api_version: string;
+  price: string | null;
+  price_unit: string;
+  parent_call_sid: string | null;
+  phone_number_sid: string | null;
+  start_time: string | null;
+  end_time: string | null;
+  duration: string;
+  url: string | null;
+  method: string;
+  twiml: string | null;
+  twiml_steps: string[];
+  status_callback: string | null;
+  status_callback_event: string[];
+}
+
+export interface TwilioWebhookDelivery extends Entity {
+  twilio_id: string;
+  account_sid: string;
+  event: string;
+  url: string;
+  method: string;
+  request_body: Record<string, string>;
+  request_headers: Record<string, string>;
+  response_status: number | null;
+  response_body: string | null;
+  success: boolean;
+  error: string | null;
+}
+
+export interface TwilioConversationService extends Entity {
+  sid: string;
+  account_sid: string;
+  friendly_name: string;
+}
+
+export interface TwilioConversation extends Entity {
+  sid: string;
+  account_sid: string;
+  service_sid: string;
+  friendly_name: string | null;
+  unique_name: string | null;
+  state: "active" | "inactive" | "closed";
+  attributes: string;
+}
+
+export interface TwilioConversationParticipant extends Entity {
+  sid: string;
+  account_sid: string;
+  service_sid: string;
+  conversation_sid: string;
+  identity: string | null;
+  messaging_binding_address: string | null;
+  messaging_binding_proxy_address: string | null;
+  attributes: string;
+}
+
+export interface TwilioConversationMessage extends Entity {
+  sid: string;
+  account_sid: string;
+  service_sid: string;
+  conversation_sid: string;
+  author: string | null;
+  body: string | null;
+  index: number;
+  attributes: string;
+}

--- a/packages/@emulators/twilio/src/formatters.ts
+++ b/packages/@emulators/twilio/src/formatters.ts
@@ -1,0 +1,280 @@
+import type {
+  TwilioAccount,
+  TwilioCall,
+  TwilioConversation,
+  TwilioConversationMessage,
+  TwilioConversationParticipant,
+  TwilioConversationService,
+  TwilioIncomingPhoneNumber,
+  TwilioMedia,
+  TwilioMessage,
+  TwilioMessagingService,
+  TwilioMessagingServicePhoneNumber,
+  TwilioVerification,
+  TwilioVerifyService,
+} from "./entities.js";
+import { twilioDate } from "./helpers.js";
+
+const API_VERSION = "2010-04-01";
+
+export function formatAccount(account: TwilioAccount): Record<string, unknown> {
+  return {
+    sid: account.sid,
+    date_created: twilioDate(account.created_at),
+    date_updated: twilioDate(account.updated_at),
+    friendly_name: account.friendly_name,
+    owner_account_sid: account.owner_account_sid,
+    status: account.status,
+    type: account.owner_account_sid ? "SubAccount" : "Full",
+    uri: `/${API_VERSION}/Accounts/${account.sid}.json`,
+    subresource_uris: {
+      available_phone_numbers: `/${API_VERSION}/Accounts/${account.sid}/AvailablePhoneNumbers.json`,
+      calls: `/${API_VERSION}/Accounts/${account.sid}/Calls.json`,
+      incoming_phone_numbers: `/${API_VERSION}/Accounts/${account.sid}/IncomingPhoneNumbers.json`,
+      messages: `/${API_VERSION}/Accounts/${account.sid}/Messages.json`,
+      recordings: `/${API_VERSION}/Accounts/${account.sid}/Recordings.json`,
+    },
+  };
+}
+
+export function formatPhoneNumber(number: TwilioIncomingPhoneNumber): Record<string, unknown> {
+  return {
+    sid: number.sid,
+    account_sid: number.account_sid,
+    friendly_name: number.friendly_name,
+    phone_number: number.phone_number,
+    voice_url: number.voice_url,
+    voice_method: number.voice_method,
+    sms_url: number.sms_url,
+    sms_method: number.sms_method,
+    status_callback: number.status_callback,
+    capabilities: number.capabilities,
+    date_created: twilioDate(number.created_at),
+    date_updated: twilioDate(number.updated_at),
+    uri: `/${API_VERSION}/Accounts/${number.account_sid}/IncomingPhoneNumbers/${number.sid}.json`,
+  };
+}
+
+export function formatMessagingService(service: TwilioMessagingService): Record<string, unknown> {
+  return {
+    sid: service.sid,
+    account_sid: service.account_sid,
+    friendly_name: service.friendly_name,
+    inbound_request_url: service.inbound_request_url,
+    status_callback: service.status_callback,
+    date_created: service.created_at,
+    date_updated: service.updated_at,
+    url: `https://messaging.twilio.com/v1/Services/${service.sid}`,
+    links: {
+      phone_numbers: `https://messaging.twilio.com/v1/Services/${service.sid}/PhoneNumbers`,
+    },
+  };
+}
+
+export function formatMessagingServicePhoneNumber(
+  item: TwilioMessagingServicePhoneNumber,
+  phoneNumber: TwilioIncomingPhoneNumber | undefined,
+): Record<string, unknown> {
+  return {
+    sid: item.sid,
+    account_sid: item.account_sid,
+    service_sid: item.service_sid,
+    phone_number_sid: item.phone_number_sid,
+    phone_number: phoneNumber?.phone_number ?? null,
+    date_created: item.created_at,
+    date_updated: item.updated_at,
+    url: `https://messaging.twilio.com/v1/Services/${item.service_sid}/PhoneNumbers/${item.sid}`,
+  };
+}
+
+export function formatMessage(message: TwilioMessage): Record<string, unknown> {
+  return {
+    sid: message.sid,
+    date_created: twilioDate(message.created_at),
+    date_updated: twilioDate(message.updated_at),
+    date_sent: twilioDate(message.date_sent),
+    account_sid: message.account_sid,
+    to: message.to,
+    from: message.from,
+    messaging_service_sid: message.messaging_service_sid,
+    body: message.body,
+    status: message.status,
+    num_segments: message.num_segments,
+    num_media: message.num_media,
+    direction: message.direction,
+    api_version: message.api_version,
+    price: message.price,
+    price_unit: message.price_unit,
+    error_code: message.error_code,
+    error_message: message.error_message,
+    uri: `/${API_VERSION}/Accounts/${message.account_sid}/Messages/${message.sid}.json`,
+    subresource_uris: {
+      media: `/${API_VERSION}/Accounts/${message.account_sid}/Messages/${message.sid}/Media.json`,
+      feedback: `/${API_VERSION}/Accounts/${message.account_sid}/Messages/${message.sid}/Feedback.json`,
+    },
+  };
+}
+
+export function formatMedia(media: TwilioMedia): Record<string, unknown> {
+  return {
+    sid: media.sid,
+    account_sid: media.account_sid,
+    parent_sid: media.message_sid,
+    content_type: media.content_type,
+    date_created: twilioDate(media.created_at),
+    date_updated: twilioDate(media.updated_at),
+    uri: media.uri,
+  };
+}
+
+export function formatVerifyService(service: TwilioVerifyService): Record<string, unknown> {
+  return {
+    sid: service.sid,
+    account_sid: service.account_sid,
+    friendly_name: service.friendly_name,
+    code_length: service.code.length,
+    default_template_sid: null,
+    date_created: service.created_at,
+    date_updated: service.updated_at,
+    url: `https://verify.twilio.com/v2/Services/${service.sid}`,
+    links: {
+      verifications: `https://verify.twilio.com/v2/Services/${service.sid}/Verifications`,
+      verification_checks: `https://verify.twilio.com/v2/Services/${service.sid}/VerificationCheck`,
+    },
+  };
+}
+
+export function formatVerification(verification: TwilioVerification): Record<string, unknown> {
+  return {
+    sid: verification.sid,
+    service_sid: verification.service_sid,
+    account_sid: verification.account_sid,
+    to: verification.to,
+    channel: verification.channel,
+    status: verification.status,
+    valid: verification.valid,
+    lookup: verification.lookup,
+    amount: null,
+    payee: null,
+    send_code_attempts: verification.send_code_attempts,
+    date_created: verification.created_at,
+    date_updated: verification.updated_at,
+    url: `https://verify.twilio.com/v2/Services/${verification.service_sid}/Verifications/${verification.sid}`,
+  };
+}
+
+export function formatVerificationCheck(verification: TwilioVerification): Record<string, unknown> {
+  return {
+    sid: verification.sid,
+    service_sid: verification.service_sid,
+    account_sid: verification.account_sid,
+    to: verification.to,
+    channel: verification.channel,
+    status: verification.status,
+    valid: verification.valid,
+    date_created: verification.created_at,
+    date_updated: verification.updated_at,
+  };
+}
+
+export function formatCall(call: TwilioCall): Record<string, unknown> {
+  return {
+    sid: call.sid,
+    parent_call_sid: call.parent_call_sid,
+    date_created: twilioDate(call.created_at),
+    date_updated: twilioDate(call.updated_at),
+    account_sid: call.account_sid,
+    to: call.to,
+    from: call.from,
+    phone_number_sid: call.phone_number_sid,
+    status: call.status,
+    start_time: twilioDate(call.start_time),
+    end_time: twilioDate(call.end_time),
+    duration: call.duration,
+    price: call.price,
+    price_unit: call.price_unit,
+    direction: call.direction,
+    answered_by: null,
+    api_version: call.api_version,
+    annotation: null,
+    forwarded_from: null,
+    group_sid: null,
+    caller_name: null,
+    queue_time: "0",
+    trunk_sid: null,
+    uri: `/${API_VERSION}/Accounts/${call.account_sid}/Calls/${call.sid}.json`,
+    subresource_uris: {
+      notifications: `/${API_VERSION}/Accounts/${call.account_sid}/Calls/${call.sid}/Notifications.json`,
+      recordings: `/${API_VERSION}/Accounts/${call.account_sid}/Calls/${call.sid}/Recordings.json`,
+    },
+  };
+}
+
+export function formatConversationService(service: TwilioConversationService): Record<string, unknown> {
+  return {
+    sid: service.sid,
+    account_sid: service.account_sid,
+    friendly_name: service.friendly_name,
+    date_created: service.created_at,
+    date_updated: service.updated_at,
+    url: `https://conversations.twilio.com/v1/Services/${service.sid}`,
+    links: {
+      conversations: `https://conversations.twilio.com/v1/Services/${service.sid}/Conversations`,
+      users: `https://conversations.twilio.com/v1/Services/${service.sid}/Users`,
+    },
+  };
+}
+
+export function formatConversation(conversation: TwilioConversation): Record<string, unknown> {
+  return {
+    sid: conversation.sid,
+    account_sid: conversation.account_sid,
+    chat_service_sid: conversation.service_sid,
+    messaging_service_sid: null,
+    friendly_name: conversation.friendly_name,
+    unique_name: conversation.unique_name,
+    attributes: conversation.attributes,
+    state: conversation.state,
+    date_created: conversation.created_at,
+    date_updated: conversation.updated_at,
+    url: `https://conversations.twilio.com/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}`,
+    links: {
+      participants: `https://conversations.twilio.com/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Participants`,
+      messages: `https://conversations.twilio.com/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Messages`,
+    },
+  };
+}
+
+export function formatConversationParticipant(participant: TwilioConversationParticipant): Record<string, unknown> {
+  return {
+    sid: participant.sid,
+    account_sid: participant.account_sid,
+    chat_service_sid: participant.service_sid,
+    conversation_sid: participant.conversation_sid,
+    identity: participant.identity,
+    attributes: participant.attributes,
+    messaging_binding: {
+      address: participant.messaging_binding_address,
+      proxy_address: participant.messaging_binding_proxy_address,
+    },
+    date_created: participant.created_at,
+    date_updated: participant.updated_at,
+    url: `https://conversations.twilio.com/v1/Services/${participant.service_sid}/Conversations/${participant.conversation_sid}/Participants/${participant.sid}`,
+  };
+}
+
+export function formatConversationMessage(message: TwilioConversationMessage): Record<string, unknown> {
+  return {
+    sid: message.sid,
+    account_sid: message.account_sid,
+    chat_service_sid: message.service_sid,
+    conversation_sid: message.conversation_sid,
+    author: message.author,
+    body: message.body,
+    index: message.index,
+    attributes: message.attributes,
+    date_created: message.created_at,
+    date_updated: message.updated_at,
+    url: `https://conversations.twilio.com/v1/Services/${message.service_sid}/Conversations/${message.conversation_sid}/Messages/${message.sid}`,
+  };
+}

--- a/packages/@emulators/twilio/src/helpers.ts
+++ b/packages/@emulators/twilio/src/helpers.ts
@@ -192,17 +192,25 @@ export async function dispatchTwilioWebhook(
 ): Promise<void> {
   if (!url) return;
   const normalizedMethod = normalizeMethod(method);
-  const headers: Record<string, string> = {
-    "Content-Type": "application/x-www-form-urlencoded",
-    "X-Twilio-Signature": signTwilioRequest(url, params, account.auth_token),
-  };
+  let requestUrl = url;
+  let headers: Record<string, string> = {};
   let responseStatus: number | null = null;
   let responseBody: string | null = null;
   let success = false;
   let error: string | null = null;
 
   try {
-    const response = await fetch(url, {
+    if (normalizedMethod === "GET") {
+      const parsedUrl = new URL(url);
+      for (const [key, value] of Object.entries(params)) parsedUrl.searchParams.append(key, value);
+      requestUrl = parsedUrl.toString();
+    }
+    const signatureParams = normalizedMethod === "GET" ? {} : params;
+    headers = {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-Twilio-Signature": signTwilioRequest(requestUrl, signatureParams, account.auth_token),
+    };
+    const response = await fetch(requestUrl, {
       method: normalizedMethod,
       headers,
       body: normalizedMethod === "GET" ? undefined : new URLSearchParams(params).toString(),
@@ -219,7 +227,7 @@ export async function dispatchTwilioWebhook(
     twilio_id: `TW${String(Date.now())}${String(ts.webhookDeliveries.all().length + 1).padStart(6, "0")}`,
     account_sid: account.sid,
     event,
-    url,
+    url: requestUrl,
     method: normalizedMethod,
     request_body: params,
     request_headers: headers,

--- a/packages/@emulators/twilio/src/helpers.ts
+++ b/packages/@emulators/twilio/src/helpers.ts
@@ -1,0 +1,236 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { Context, ContentfulStatusCode } from "@emulators/core";
+import type { TwilioAccount } from "./entities.js";
+import type { TwilioStore } from "./store.js";
+import type { Entity } from "@emulators/core";
+
+export type TwilioBody = Record<string, string | string[]>;
+
+export async function parseTwilioBody(c: Context): Promise<TwilioBody> {
+  const contentType = c.req.header("Content-Type") ?? "";
+  const rawText = await c.req.text();
+  if (!rawText) return {};
+
+  if (contentType.includes("application/json")) {
+    const parsed = JSON.parse(rawText) as Record<string, unknown>;
+    const out: TwilioBody = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (Array.isArray(value)) out[key] = value.map(String);
+      else if (value !== undefined && value !== null) out[key] = String(value);
+    }
+    return out;
+  }
+
+  const params = new URLSearchParams(rawText);
+  const out: TwilioBody = {};
+  for (const [key, value] of params) {
+    const existing = out[key];
+    if (Array.isArray(existing)) existing.push(value);
+    else if (existing !== undefined) out[key] = [existing, value];
+    else out[key] = value;
+  }
+  return out;
+}
+
+export function bodyString(body: TwilioBody, key: string): string | undefined {
+  const direct = body[key];
+  if (Array.isArray(direct)) return direct[0];
+  if (direct !== undefined) return direct;
+
+  const lower = key.toLowerCase();
+  const found = Object.entries(body).find(([candidate]) => candidate.toLowerCase() === lower);
+  if (!found) return undefined;
+  return Array.isArray(found[1]) ? found[1][0] : found[1];
+}
+
+export function bodyStrings(body: TwilioBody, key: string): string[] {
+  const value = body[key] ?? body[`${key}[]`];
+  if (Array.isArray(value)) return value;
+  if (value !== undefined) return [value];
+  return [];
+}
+
+export function twilioError(c: Context, status: number, message: string, code?: number) {
+  return c.json(
+    {
+      code,
+      message,
+      more_info: code ? `https://www.twilio.com/docs/errors/${code}` : undefined,
+      status,
+    },
+    status as ContentfulStatusCode,
+  );
+}
+
+export function decodeBasicAuth(c: Context): { username: string; password: string } | null {
+  const header = c.req.header("Authorization") ?? "";
+  if (!header.toLowerCase().startsWith("basic ")) return null;
+  try {
+    const decoded = Buffer.from(header.slice(6), "base64").toString("utf8");
+    const idx = decoded.indexOf(":");
+    if (idx === -1) return null;
+    return { username: decoded.slice(0, idx), password: decoded.slice(idx + 1) };
+  } catch {
+    return null;
+  }
+}
+
+export function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export function requireTwilioAuth(c: Context, ts: TwilioStore): TwilioAccount | Response {
+  const auth = decodeBasicAuth(c);
+  if (!auth) return twilioError(c, 401, "Authenticate", 20003);
+
+  const account = ts.accounts.findOneBy("sid", auth.username);
+  if (account && constantTimeEqual(auth.password, account.auth_token)) return account;
+
+  const key = ts.apiKeys.findOneBy("sid", auth.username);
+  if (key && key.active && constantTimeEqual(auth.password, key.secret)) {
+    const keyAccount = ts.accounts.findOneBy("sid", key.account_sid);
+    if (keyAccount) return keyAccount;
+  }
+
+  return twilioError(c, 401, "Authenticate", 20003);
+}
+
+export function accountFromParam(c: Context, ts: TwilioStore, authenticated: TwilioAccount): TwilioAccount | Response {
+  const accountSid = c.req.param("accountSid");
+  const account = ts.accounts.findOneBy("sid", accountSid);
+  if (!account) return twilioError(c, 404, "The requested resource was not found", 20404);
+  if (account.sid !== authenticated.sid) return twilioError(c, 403, "Account access denied", 20003);
+  return account;
+}
+
+export function twilioDate(iso: string | null): string | null {
+  if (!iso) return null;
+  return new Date(iso).toUTCString().replace("GMT", "+0000");
+}
+
+export function isoDate(): string {
+  return new Date().toISOString();
+}
+
+export function normalizeMethod(method: string | undefined): string {
+  return (method ?? "POST").toUpperCase();
+}
+
+export function normalizePhoneNumber(value: string | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.startsWith("whatsapp:")) {
+    const number = normalizePhoneNumber(trimmed.slice("whatsapp:".length));
+    return number ? `whatsapp:${number}` : null;
+  }
+  if (/^\+[1-9]\d{6,14}$/.test(trimmed)) return trimmed;
+  return null;
+}
+
+export function messageSegments(body: string | null): string {
+  if (!body) return "0";
+  return String(Math.max(1, Math.ceil(body.length / 160)));
+}
+
+export function signTwilioRequest(url: string, params: Record<string, string>, authToken: string): string {
+  const sorted = Object.keys(params)
+    .sort()
+    .map((key) => `${key}${params[key]}`)
+    .join("");
+  return createHmac("sha1", authToken).update(`${url}${sorted}`).digest("base64");
+}
+
+export function pageSize(c: Context): number {
+  const requested = Number(c.req.query("PageSize") ?? c.req.query("pageSize") ?? 50);
+  if (!Number.isFinite(requested)) return 50;
+  return Math.min(Math.max(1, requested), 1000);
+}
+
+export function pageNumber(c: Context): number {
+  const requested = Number(c.req.query("Page") ?? c.req.query("page") ?? 0);
+  if (!Number.isFinite(requested)) return 0;
+  return Math.max(0, requested);
+}
+
+export function twilioList<T extends Entity>(
+  c: Context,
+  key: string,
+  items: T[],
+  uri: string,
+  formatter: (item: T) => Record<string, unknown>,
+) {
+  const size = pageSize(c);
+  const page = pageNumber(c);
+  const start = page * size;
+  const records = items.slice(start, start + size);
+  const firstPageUri = `${uri}?PageSize=${size}&Page=0`;
+  const previousPageUri = page > 0 ? `${uri}?PageSize=${size}&Page=${page - 1}` : null;
+  const nextPageUri = start + size < items.length ? `${uri}?PageSize=${size}&Page=${page + 1}` : null;
+  return c.json({
+    [key]: records.map(formatter),
+    end: start + records.length,
+    first_page_uri: firstPageUri,
+    next_page_uri: nextPageUri,
+    page,
+    page_size: size,
+    previous_page_uri: previousPageUri,
+    start,
+    uri,
+  });
+}
+
+export async function dispatchTwilioWebhook(
+  ts: TwilioStore,
+  account: TwilioAccount,
+  event: string,
+  url: string | null,
+  method: string,
+  params: Record<string, string>,
+): Promise<void> {
+  if (!url) return;
+  const normalizedMethod = normalizeMethod(method);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "X-Twilio-Signature": signTwilioRequest(url, params, account.auth_token),
+  };
+  let responseStatus: number | null = null;
+  let responseBody: string | null = null;
+  let success = false;
+  let error: string | null = null;
+
+  try {
+    const response = await fetch(url, {
+      method: normalizedMethod,
+      headers,
+      body: normalizedMethod === "GET" ? undefined : new URLSearchParams(params).toString(),
+      signal: AbortSignal.timeout(10_000),
+    });
+    responseStatus = response.status;
+    responseBody = await response.text();
+    success = response.ok;
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  ts.webhookDeliveries.insert({
+    twilio_id: `TW${String(Date.now())}${String(ts.webhookDeliveries.all().length + 1).padStart(6, "0")}`,
+    account_sid: account.sid,
+    event,
+    url,
+    method: normalizedMethod,
+    request_body: params,
+    request_headers: headers,
+    response_status: responseStatus,
+    response_body: responseBody,
+    success,
+    error,
+  });
+}
+
+export function maskSecret(value: string): string {
+  if (value.length <= 8) return "****";
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}

--- a/packages/@emulators/twilio/src/ids.ts
+++ b/packages/@emulators/twilio/src/ids.ts
@@ -1,0 +1,9 @@
+import { randomBytes } from "node:crypto";
+
+export function twilioSid(prefix: string): string {
+  return `${prefix}${randomBytes(16).toString("hex")}`;
+}
+
+export function fixedSid(prefix: string): string {
+  return `${prefix}${"0".repeat(32)}`;
+}

--- a/packages/@emulators/twilio/src/index.ts
+++ b/packages/@emulators/twilio/src/index.ts
@@ -1,0 +1,224 @@
+import type { Hono } from "@emulators/core";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { fixedSid, twilioSid } from "./ids.js";
+import { getTwilioStore } from "./store.js";
+import { accountRoutes } from "./routes/accounts.js";
+import { phoneNumberRoutes } from "./routes/phone-numbers.js";
+import { messagingServiceRoutes } from "./routes/messaging-services.js";
+import { messageRoutes } from "./routes/messages.js";
+import { verifyRoutes } from "./routes/verify.js";
+import { callRoutes } from "./routes/calls.js";
+import { conversationRoutes } from "./routes/conversations.js";
+import { simulatorRoutes } from "./routes/simulator.js";
+import { inspectorRoutes } from "./routes/inspector.js";
+
+export { getTwilioStore, type TwilioStore } from "./store.js";
+export * from "./entities.js";
+
+export interface TwilioSeedConfig {
+  port?: number;
+  account?: {
+    sid?: string;
+    auth_token?: string;
+    friendly_name?: string;
+    status?: "active" | "suspended" | "closed";
+  };
+  api_keys?: Array<{
+    sid?: string;
+    secret: string;
+    friendly_name?: string;
+  }>;
+  phone_numbers?: Array<{
+    sid?: string;
+    phone_number: string;
+    friendly_name?: string;
+    sms_url?: string;
+    sms_method?: string;
+    voice_url?: string;
+    voice_method?: string;
+    status_callback?: string;
+  }>;
+  messaging_services?: Array<{
+    sid?: string;
+    friendly_name: string;
+    phone_numbers?: string[];
+    status_callback?: string;
+    inbound_request_url?: string;
+  }>;
+  verify_services?: Array<{
+    sid?: string;
+    friendly_name: string;
+    code?: string;
+    default_channel?: string;
+  }>;
+  conversations?: {
+    services?: Array<{
+      sid?: string;
+      friendly_name: string;
+    }>;
+  };
+}
+
+export const DEFAULT_ACCOUNT_SID = fixedSid("AC");
+export const DEFAULT_API_KEY_SID = fixedSid("SK");
+export const DEFAULT_PHONE_NUMBER_SID = fixedSid("PN");
+export const DEFAULT_MESSAGING_SERVICE_SID = fixedSid("MG");
+export const DEFAULT_VERIFY_SERVICE_SID = fixedSid("VA");
+export const DEFAULT_AUTH_TOKEN = "twilio_test_auth_token";
+export const DEFAULT_API_KEY_SECRET = "twilio_test_api_secret";
+export const DEFAULT_PHONE_NUMBER = "+15551234567";
+
+function seedDefaults(store: Store): void {
+  seedFromConfig(store, "", {
+    account: {
+      sid: DEFAULT_ACCOUNT_SID,
+      auth_token: DEFAULT_AUTH_TOKEN,
+      friendly_name: "Local Twilio Account",
+      status: "active",
+    },
+    api_keys: [{ sid: DEFAULT_API_KEY_SID, secret: DEFAULT_API_KEY_SECRET, friendly_name: "Local API Key" }],
+    phone_numbers: [
+      {
+        sid: DEFAULT_PHONE_NUMBER_SID,
+        phone_number: DEFAULT_PHONE_NUMBER,
+        friendly_name: "Local SMS and Voice Number",
+      },
+    ],
+    messaging_services: [
+      {
+        sid: DEFAULT_MESSAGING_SERVICE_SID,
+        friendly_name: "Local Messaging Service",
+        phone_numbers: [DEFAULT_PHONE_NUMBER],
+      },
+    ],
+    verify_services: [
+      {
+        sid: DEFAULT_VERIFY_SERVICE_SID,
+        friendly_name: "Local Verify Service",
+        code: "123456",
+        default_channel: "sms",
+      },
+    ],
+    conversations: {
+      services: [{ friendly_name: "Local Conversations" }],
+    },
+  });
+}
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSeedConfig): void {
+  const ts = getTwilioStore(store);
+  const accountSid = config.account?.sid ?? DEFAULT_ACCOUNT_SID;
+  let account = ts.accounts.findOneBy("sid", accountSid);
+  if (!account) {
+    account = ts.accounts.insert({
+      sid: accountSid,
+      friendly_name: config.account?.friendly_name ?? "Local Twilio Account",
+      auth_token: config.account?.auth_token ?? DEFAULT_AUTH_TOKEN,
+      status: config.account?.status ?? "active",
+      owner_account_sid: null,
+    });
+  } else {
+    account = ts.accounts.update(account.id, {
+      friendly_name: config.account?.friendly_name ?? account.friendly_name,
+      auth_token: config.account?.auth_token ?? account.auth_token,
+      status: config.account?.status ?? account.status,
+    })!;
+  }
+
+  for (const key of config.api_keys ?? []) {
+    if (key.sid && ts.apiKeys.findOneBy("sid", key.sid)) continue;
+    ts.apiKeys.insert({
+      sid: key.sid ?? twilioSid("SK"),
+      account_sid: account.sid,
+      secret: key.secret,
+      friendly_name: key.friendly_name ?? "Local API Key",
+      active: true,
+    });
+  }
+
+  for (const number of config.phone_numbers ?? []) {
+    if (ts.phoneNumbers.findOneBy("phone_number", number.phone_number)) continue;
+    ts.phoneNumbers.insert({
+      sid: number.sid ?? twilioSid("PN"),
+      account_sid: account.sid,
+      phone_number: number.phone_number,
+      friendly_name: number.friendly_name ?? number.phone_number,
+      capabilities: { sms: true, mms: true, voice: true },
+      sms_url: number.sms_url ?? null,
+      sms_method: (number.sms_method ?? "POST").toUpperCase(),
+      voice_url: number.voice_url ?? null,
+      voice_method: (number.voice_method ?? "POST").toUpperCase(),
+      status_callback: number.status_callback ?? null,
+      application_sid: null,
+    });
+  }
+
+  for (const serviceCfg of config.messaging_services ?? []) {
+    let service = serviceCfg.sid ? ts.messagingServices.findOneBy("sid", serviceCfg.sid) : undefined;
+    if (!service) {
+      service = ts.messagingServices.insert({
+        sid: serviceCfg.sid ?? twilioSid("MG"),
+        account_sid: account.sid,
+        friendly_name: serviceCfg.friendly_name,
+        inbound_request_url: serviceCfg.inbound_request_url ?? null,
+        status_callback: serviceCfg.status_callback ?? null,
+      });
+    }
+    for (const numberRef of serviceCfg.phone_numbers ?? []) {
+      const phoneNumber =
+        ts.phoneNumbers.findOneBy("phone_number", numberRef) ?? ts.phoneNumbers.findOneBy("sid", numberRef);
+      if (!phoneNumber) continue;
+      const alreadyAssigned = ts.messagingServicePhoneNumbers
+        .findBy("service_sid", service.sid)
+        .some((item) => item.phone_number_sid === phoneNumber.sid);
+      if (alreadyAssigned) continue;
+      ts.messagingServicePhoneNumbers.insert({
+        sid: twilioSid("PN"),
+        account_sid: account.sid,
+        service_sid: service.sid,
+        phone_number_sid: phoneNumber.sid,
+      });
+    }
+  }
+
+  for (const service of config.verify_services ?? []) {
+    if (service.sid && ts.verifyServices.findOneBy("sid", service.sid)) continue;
+    ts.verifyServices.insert({
+      sid: service.sid ?? twilioSid("VA"),
+      account_sid: account.sid,
+      friendly_name: service.friendly_name,
+      code: service.code ?? "123456",
+      default_channel: service.default_channel ?? "sms",
+    });
+  }
+
+  for (const service of config.conversations?.services ?? []) {
+    if (service.sid && ts.conversationServices.findOneBy("sid", service.sid)) continue;
+    ts.conversationServices.insert({
+      sid: service.sid ?? twilioSid("IS"),
+      account_sid: account.sid,
+      friendly_name: service.friendly_name,
+    });
+  }
+}
+
+export const twilioPlugin: ServicePlugin = {
+  name: "twilio",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    accountRoutes(ctx);
+    phoneNumberRoutes(ctx);
+    messagingServiceRoutes(ctx);
+    messageRoutes(ctx);
+    verifyRoutes(ctx);
+    callRoutes(ctx);
+    conversationRoutes(ctx);
+    simulatorRoutes(ctx);
+    inspectorRoutes(ctx);
+  },
+  seed(store: Store): void {
+    seedDefaults(store);
+  },
+};
+
+export default twilioPlugin;

--- a/packages/@emulators/twilio/src/index.ts
+++ b/packages/@emulators/twilio/src/index.ts
@@ -126,7 +126,16 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSee
   }
 
   for (const key of config.api_keys ?? []) {
-    if (key.sid && ts.apiKeys.findOneBy("sid", key.sid)) continue;
+    const existing = key.sid ? ts.apiKeys.findOneBy("sid", key.sid) : undefined;
+    if (existing) {
+      ts.apiKeys.update(existing.id, {
+        account_sid: account.sid,
+        secret: key.secret,
+        friendly_name: key.friendly_name ?? existing.friendly_name,
+        active: true,
+      });
+      continue;
+    }
     ts.apiKeys.insert({
       sid: key.sid ?? twilioSid("SK"),
       account_sid: account.sid,
@@ -137,7 +146,22 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSee
   }
 
   for (const number of config.phone_numbers ?? []) {
-    if (ts.phoneNumbers.findOneBy("phone_number", number.phone_number)) continue;
+    const existing =
+      (number.sid ? ts.phoneNumbers.findOneBy("sid", number.sid) : undefined) ??
+      ts.phoneNumbers.findOneBy("phone_number", number.phone_number);
+    if (existing) {
+      ts.phoneNumbers.update(existing.id, {
+        account_sid: account.sid,
+        phone_number: number.phone_number,
+        friendly_name: number.friendly_name ?? existing.friendly_name,
+        sms_url: number.sms_url ?? existing.sms_url,
+        sms_method: number.sms_method ? number.sms_method.toUpperCase() : existing.sms_method,
+        voice_url: number.voice_url ?? existing.voice_url,
+        voice_method: number.voice_method ? number.voice_method.toUpperCase() : existing.voice_method,
+        status_callback: number.status_callback ?? existing.status_callback,
+      });
+      continue;
+    }
     ts.phoneNumbers.insert({
       sid: number.sid ?? twilioSid("PN"),
       account_sid: account.sid,
@@ -154,7 +178,11 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSee
   }
 
   for (const serviceCfg of config.messaging_services ?? []) {
-    let service = serviceCfg.sid ? ts.messagingServices.findOneBy("sid", serviceCfg.sid) : undefined;
+    let service = serviceCfg.sid
+      ? ts.messagingServices.findOneBy("sid", serviceCfg.sid)
+      : ts.messagingServices
+          .findBy("account_sid", account.sid)
+          .find((candidate) => candidate.friendly_name === serviceCfg.friendly_name);
     if (!service) {
       service = ts.messagingServices.insert({
         sid: serviceCfg.sid ?? twilioSid("MG"),
@@ -163,6 +191,12 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSee
         inbound_request_url: serviceCfg.inbound_request_url ?? null,
         status_callback: serviceCfg.status_callback ?? null,
       });
+    } else {
+      service = ts.messagingServices.update(service.id, {
+        friendly_name: serviceCfg.friendly_name,
+        inbound_request_url: serviceCfg.inbound_request_url ?? service.inbound_request_url,
+        status_callback: serviceCfg.status_callback ?? service.status_callback,
+      })!;
     }
     for (const numberRef of serviceCfg.phone_numbers ?? []) {
       const phoneNumber =
@@ -182,7 +216,19 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSee
   }
 
   for (const service of config.verify_services ?? []) {
-    if (service.sid && ts.verifyServices.findOneBy("sid", service.sid)) continue;
+    const existing = service.sid
+      ? ts.verifyServices.findOneBy("sid", service.sid)
+      : ts.verifyServices
+          .findBy("account_sid", account.sid)
+          .find((candidate) => candidate.friendly_name === service.friendly_name);
+    if (existing) {
+      ts.verifyServices.update(existing.id, {
+        friendly_name: service.friendly_name,
+        code: service.code ?? existing.code,
+        default_channel: service.default_channel ?? existing.default_channel,
+      });
+      continue;
+    }
     ts.verifyServices.insert({
       sid: service.sid ?? twilioSid("VA"),
       account_sid: account.sid,
@@ -193,7 +239,15 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: TwilioSee
   }
 
   for (const service of config.conversations?.services ?? []) {
-    if (service.sid && ts.conversationServices.findOneBy("sid", service.sid)) continue;
+    const existing = service.sid
+      ? ts.conversationServices.findOneBy("sid", service.sid)
+      : ts.conversationServices
+          .findBy("account_sid", account.sid)
+          .find((candidate) => candidate.friendly_name === service.friendly_name);
+    if (existing) {
+      ts.conversationServices.update(existing.id, { friendly_name: service.friendly_name });
+      continue;
+    }
     ts.conversationServices.insert({
       sid: service.sid ?? twilioSid("IS"),
       account_sid: account.sid,

--- a/packages/@emulators/twilio/src/routes/accounts.ts
+++ b/packages/@emulators/twilio/src/routes/accounts.ts
@@ -1,0 +1,50 @@
+import type { RouteContext } from "@emulators/core";
+import { getTwilioStore } from "../store.js";
+import { formatAccount } from "../formatters.js";
+import {
+  accountFromParam,
+  bodyString,
+  parseTwilioBody,
+  requireTwilioAuth,
+  twilioError,
+  twilioList,
+} from "../helpers.js";
+
+export function accountRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.get("/2010-04-01/Accounts.json", (c) => {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    const accounts = ts.accounts
+      .all()
+      .filter((account) => account.sid === auth.sid || account.owner_account_sid === auth.sid);
+    return twilioList(c, "accounts", accounts, "/2010-04-01/Accounts.json", formatAccount);
+  });
+
+  app.get("/2010-04-01/Accounts/:accountSid.json", (c) => {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    const account = accountFromParam(c, ts, auth);
+    if (account instanceof Response) return account;
+    return c.json(formatAccount(account));
+  });
+
+  app.post("/2010-04-01/Accounts/:accountSid.json", async (c) => {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    const account = accountFromParam(c, ts, auth);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const friendlyName = bodyString(body, "FriendlyName");
+    const status = bodyString(body, "Status");
+    if (status && !["active", "suspended", "closed"].includes(status)) {
+      return twilioError(c, 400, "Status is invalid", 20001);
+    }
+    const updated = ts.accounts.update(account.id, {
+      friendly_name: friendlyName ?? account.friendly_name,
+      status: (status as typeof account.status | undefined) ?? account.status,
+    })!;
+    return c.json(formatAccount(updated));
+  });
+}

--- a/packages/@emulators/twilio/src/routes/calls.ts
+++ b/packages/@emulators/twilio/src/routes/calls.ts
@@ -1,0 +1,155 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { twilioSid } from "../ids.js";
+import { formatCall } from "../formatters.js";
+import { getTwilioStore } from "../store.js";
+import type { TwilioAccount, TwilioCall, TwilioCallStatus } from "../entities.js";
+import {
+  accountFromParam,
+  bodyString,
+  bodyStrings,
+  dispatchTwilioWebhook,
+  normalizeMethod,
+  normalizePhoneNumber,
+  parseTwilioBody,
+  requireTwilioAuth,
+  twilioError,
+  twilioList,
+} from "../helpers.js";
+
+export function callRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.get("/2010-04-01/Accounts/:accountSid/Calls.json", (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    let calls = ts.calls.findBy("account_sid", account.sid);
+    const to = c.req.query("To");
+    const from = c.req.query("From");
+    if (to) calls = calls.filter((call) => call.to === to);
+    if (from) calls = calls.filter((call) => call.from === from);
+    calls = calls.sort((a, b) => b.id - a.id);
+    return twilioList(c, "calls", calls, `/2010-04-01/Accounts/${account.sid}/Calls.json`, formatCall);
+  });
+
+  app.post("/2010-04-01/Accounts/:accountSid/Calls.json", async (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const to = normalizePhoneNumber(bodyString(body, "To"));
+    const from = normalizePhoneNumber(bodyString(body, "From"));
+    if (!to) return twilioError(c, 400, "To is required", 21201);
+    if (!from) return twilioError(c, 400, "From is required", 21201);
+    const ownedNumber = ts.phoneNumbers.findOneBy("phone_number", from);
+    if (!ownedNumber || ownedNumber.account_sid !== account.sid) {
+      return twilioError(c, 400, "From phone number is not owned by this account", 21210);
+    }
+    const now = new Date().toISOString();
+    const call = ts.calls.insert({
+      sid: twilioSid("CA"),
+      account_sid: account.sid,
+      to,
+      from,
+      status: "queued",
+      direction: "outbound-api",
+      api_version: "2010-04-01",
+      price: null,
+      price_unit: "USD",
+      parent_call_sid: null,
+      phone_number_sid: ownedNumber.sid,
+      start_time: null,
+      end_time: null,
+      duration: "0",
+      url: bodyString(body, "Url") ?? null,
+      method: normalizeMethod(bodyString(body, "Method")),
+      twiml: bodyString(body, "Twiml") ?? null,
+      twiml_steps: parseTwimlSteps(bodyString(body, "Twiml") ?? ""),
+      status_callback: bodyString(body, "StatusCallback") ?? null,
+      status_callback_event: bodyStrings(body, "StatusCallbackEvent"),
+    });
+    await dispatchCallCallback(account, "queued", call);
+    const updated = ts.calls.update(call.id, { status: "ringing", start_time: now })!;
+    await dispatchCallCallback(account, "ringing", updated);
+    return c.json(formatCall(updated), 201);
+  });
+
+  app.get("/2010-04-01/Accounts/:accountSid/Calls/:callSid.json", (c) => {
+    const call = authenticatedCall(c);
+    if (call instanceof Response) return call;
+    return c.json(formatCall(call));
+  });
+
+  app.post("/2010-04-01/Accounts/:accountSid/Calls/:callSid.json", async (c) => {
+    const call = authenticatedCall(c);
+    if (call instanceof Response) return call;
+    const body = await parseTwilioBody(c);
+    const status = bodyString(body, "Status") as TwilioCallStatus | undefined;
+    if (status && !["completed", "canceled", "busy", "failed", "no-answer", "in-progress"].includes(status)) {
+      return twilioError(c, 400, "Status is invalid", 20001);
+    }
+    const terminal = status && ["completed", "canceled", "busy", "failed", "no-answer"].includes(status);
+    const updated = ts.calls.update(call.id, {
+      status: status ?? call.status,
+      url: bodyString(body, "Url") ?? call.url,
+      method: bodyString(body, "Method") ? normalizeMethod(bodyString(body, "Method")) : call.method,
+      twiml: bodyString(body, "Twiml") ?? call.twiml,
+      twiml_steps: bodyString(body, "Twiml") ? parseTwimlSteps(bodyString(body, "Twiml") ?? "") : call.twiml_steps,
+      end_time: terminal ? new Date().toISOString() : call.end_time,
+      duration: terminal ? durationSeconds(call.start_time, new Date().toISOString()) : call.duration,
+    })!;
+    const account = ts.accounts.findOneBy("sid", updated.account_sid)!;
+    if (status) await dispatchCallCallback(account, status, updated);
+    return c.json(formatCall(updated));
+  });
+
+  app.delete("/2010-04-01/Accounts/:accountSid/Calls/:callSid.json", (c) => {
+    const call = authenticatedCall(c);
+    if (call instanceof Response) return call;
+    ts.calls.delete(call.id);
+    return c.body(null, 204);
+  });
+
+  function authenticatedAccount(c: Context) {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    return accountFromParam(c, ts, auth);
+  }
+
+  function authenticatedCall(c: Context) {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const call = ts.calls.findOneBy("sid", c.req.param("callSid"));
+    if (!call || call.account_sid !== account.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return call;
+  }
+
+  async function dispatchCallCallback(account: TwilioAccount, status: TwilioCallStatus, call: TwilioCall) {
+    if (call.status_callback_event.length > 0 && !call.status_callback_event.includes(status)) return;
+    await dispatchTwilioWebhook(ts, account, `call.${status}`, call.status_callback, "POST", {
+      AccountSid: account.sid,
+      CallSid: call.sid,
+      CallStatus: status,
+      To: call.to,
+      From: call.from,
+      Direction: call.direction,
+      ApiVersion: call.api_version,
+    });
+  }
+}
+
+export function parseTwimlSteps(twiml: string): string[] {
+  if (!twiml) return [];
+  const steps: string[] = [];
+  const regex = /<([A-Z][A-Za-z0-9]*)\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(twiml))) {
+    if (match[1] !== "Response") steps.push(match[1]);
+  }
+  return steps;
+}
+
+function durationSeconds(start: string | null, end: string): string {
+  if (!start) return "0";
+  return String(Math.max(0, Math.floor((new Date(end).getTime() - new Date(start).getTime()) / 1000)));
+}

--- a/packages/@emulators/twilio/src/routes/conversations.ts
+++ b/packages/@emulators/twilio/src/routes/conversations.ts
@@ -1,0 +1,208 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { twilioSid } from "../ids.js";
+import {
+  formatConversation,
+  formatConversationMessage,
+  formatConversationParticipant,
+  formatConversationService,
+} from "../formatters.js";
+import { getTwilioStore } from "../store.js";
+import { bodyString, parseTwilioBody, requireTwilioAuth, twilioError, twilioList } from "../helpers.js";
+
+export function conversationRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.get("/conversations/v1/Services", (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const services = ts.conversationServices.findBy("account_sid", account.sid);
+    return twilioList(c, "services", services, "/conversations/v1/Services", formatConversationService);
+  });
+
+  app.post("/conversations/v1/Services", async (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const friendlyName = bodyString(body, "FriendlyName");
+    if (!friendlyName) return twilioError(c, 400, "FriendlyName is required", 20001);
+    const service = ts.conversationServices.insert({
+      sid: twilioSid("IS"),
+      account_sid: account.sid,
+      friendly_name: friendlyName,
+    });
+    return c.json(formatConversationService(service), 201);
+  });
+
+  app.get("/conversations/v1/Services/:serviceSid", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    return c.json(formatConversationService(service));
+  });
+
+  app.post("/conversations/v1/Services/:serviceSid/Conversations", async (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const body = await parseTwilioBody(c);
+    const uniqueName = bodyString(body, "UniqueName") ?? null;
+    if (uniqueName) {
+      const existing = ts.conversations
+        .findBy("service_sid", service.sid)
+        .find((conversation) => conversation.unique_name === uniqueName);
+      if (existing) return twilioError(c, 409, "Conversation unique name already exists", 50353);
+    }
+    const conversation = ts.conversations.insert({
+      sid: twilioSid("CH"),
+      account_sid: service.account_sid,
+      service_sid: service.sid,
+      friendly_name: bodyString(body, "FriendlyName") ?? null,
+      unique_name: uniqueName,
+      state: "active",
+      attributes: bodyString(body, "Attributes") ?? "{}",
+    });
+    return c.json(formatConversation(conversation), 201);
+  });
+
+  app.get("/conversations/v1/Services/:serviceSid/Conversations", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const conversations = ts.conversations.findBy("service_sid", service.sid);
+    return twilioList(
+      c,
+      "conversations",
+      conversations,
+      `/conversations/v1/Services/${service.sid}/Conversations`,
+      formatConversation,
+    );
+  });
+
+  app.get("/conversations/v1/Services/:serviceSid/Conversations/:conversationSid", (c) => {
+    const conversation = authenticatedConversation(c);
+    if (conversation instanceof Response) return conversation;
+    return c.json(formatConversation(conversation));
+  });
+
+  app.post("/conversations/v1/Services/:serviceSid/Conversations/:conversationSid", async (c) => {
+    const conversation = authenticatedConversation(c);
+    if (conversation instanceof Response) return conversation;
+    const body = await parseTwilioBody(c);
+    const state = bodyString(body, "State");
+    if (state && !["active", "inactive", "closed"].includes(state))
+      return twilioError(c, 400, "State is invalid", 20001);
+    const updated = ts.conversations.update(conversation.id, {
+      friendly_name: bodyString(body, "FriendlyName") ?? conversation.friendly_name,
+      unique_name: bodyString(body, "UniqueName") ?? conversation.unique_name,
+      attributes: bodyString(body, "Attributes") ?? conversation.attributes,
+      state: (state as typeof conversation.state | undefined) ?? conversation.state,
+    })!;
+    return c.json(formatConversation(updated));
+  });
+
+  app.delete("/conversations/v1/Services/:serviceSid/Conversations/:conversationSid", (c) => {
+    const conversation = authenticatedConversation(c);
+    if (conversation instanceof Response) return conversation;
+    for (const participant of ts.conversationParticipants.findBy("conversation_sid", conversation.sid)) {
+      ts.conversationParticipants.delete(participant.id);
+    }
+    for (const message of ts.conversationMessages.findBy("conversation_sid", conversation.sid)) {
+      ts.conversationMessages.delete(message.id);
+    }
+    ts.conversations.delete(conversation.id);
+    return c.body(null, 204);
+  });
+
+  app.post("/conversations/v1/Services/:serviceSid/Conversations/:conversationSid/Participants", async (c) => {
+    const conversation = authenticatedConversation(c);
+    if (conversation instanceof Response) return conversation;
+    const body = await parseTwilioBody(c);
+    const identity = bodyString(body, "Identity") ?? null;
+    const address = bodyString(body, "MessagingBinding.Address") ?? bodyString(body, "MessagingBindingAddress") ?? null;
+    if (!identity && !address) return twilioError(c, 400, "Identity or MessagingBinding.Address is required", 20001);
+    const participant = ts.conversationParticipants.insert({
+      sid: twilioSid("MB"),
+      account_sid: conversation.account_sid,
+      service_sid: conversation.service_sid,
+      conversation_sid: conversation.sid,
+      identity,
+      messaging_binding_address: address,
+      messaging_binding_proxy_address:
+        bodyString(body, "MessagingBinding.ProxyAddress") ?? bodyString(body, "MessagingBindingProxyAddress") ?? null,
+      attributes: bodyString(body, "Attributes") ?? "{}",
+    });
+    return c.json(formatConversationParticipant(participant), 201);
+  });
+
+  app.get("/conversations/v1/Services/:serviceSid/Conversations/:conversationSid/Participants", (c) => {
+    const conversation = authenticatedConversation(c);
+    if (conversation instanceof Response) return conversation;
+    const participants = ts.conversationParticipants.findBy("conversation_sid", conversation.sid);
+    return twilioList(
+      c,
+      "participants",
+      participants,
+      `/conversations/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Participants`,
+      formatConversationParticipant,
+    );
+  });
+
+  app.post("/conversations/v1/Services/:serviceSid/Conversations/:conversationSid/Messages", async (c) => {
+    const conversation = authenticatedConversation(c);
+    if (conversation instanceof Response) return conversation;
+    const body = await parseTwilioBody(c);
+    const index = ts.conversationMessages.count((message) => message.conversation_sid === conversation.sid);
+    const message = ts.conversationMessages.insert({
+      sid: twilioSid("IM"),
+      account_sid: conversation.account_sid,
+      service_sid: conversation.service_sid,
+      conversation_sid: conversation.sid,
+      author: bodyString(body, "Author") ?? null,
+      body: bodyString(body, "Body") ?? null,
+      index,
+      attributes: bodyString(body, "Attributes") ?? "{}",
+    });
+    return c.json(formatConversationMessage(message), 201);
+  });
+
+  app.get("/conversations/v1/Services/:serviceSid/Conversations/:conversationSid/Messages", (c) => {
+    const conversation = authenticatedConversation(c);
+    if (conversation instanceof Response) return conversation;
+    const messages = ts.conversationMessages
+      .findBy("conversation_sid", conversation.sid)
+      .sort((a, b) => a.index - b.index);
+    return twilioList(
+      c,
+      "messages",
+      messages,
+      `/conversations/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Messages`,
+      formatConversationMessage,
+    );
+  });
+
+  function authenticatedAccount(c: Context) {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    return auth;
+  }
+
+  function authenticatedService(c: Context) {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const service = ts.conversationServices.findOneBy("sid", c.req.param("serviceSid"));
+    if (!service || service.account_sid !== account.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return service;
+  }
+
+  function authenticatedConversation(c: Context) {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const conversationSid = c.req.param("conversationSid");
+    const conversation =
+      ts.conversations.findOneBy("sid", conversationSid) ??
+      ts.conversations.findBy("service_sid", service.sid).find((item) => item.unique_name === conversationSid);
+    if (!conversation || conversation.service_sid !== service.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return conversation;
+  }
+}

--- a/packages/@emulators/twilio/src/routes/conversations.ts
+++ b/packages/@emulators/twilio/src/routes/conversations.ts
@@ -16,7 +16,7 @@ export function conversationRoutes({ app, store }: RouteContext): void {
     const account = authenticatedAccount(c);
     if (account instanceof Response) return account;
     const services = ts.conversationServices.findBy("account_sid", account.sid);
-    return twilioList(c, "services", services, "/conversations/v1/Services", formatConversationService);
+    return twilioList(c, "services", services, "/v1/Services", formatConversationService);
   });
 
   app.post("/conversations/v1/Services", async (c) => {
@@ -70,7 +70,7 @@ export function conversationRoutes({ app, store }: RouteContext): void {
       c,
       "conversations",
       conversations,
-      `/conversations/v1/Services/${service.sid}/Conversations`,
+      `/v1/Services/${service.sid}/Conversations`,
       formatConversation,
     );
   });
@@ -139,7 +139,7 @@ export function conversationRoutes({ app, store }: RouteContext): void {
       c,
       "participants",
       participants,
-      `/conversations/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Participants`,
+      `/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Participants`,
       formatConversationParticipant,
     );
   });
@@ -172,7 +172,7 @@ export function conversationRoutes({ app, store }: RouteContext): void {
       c,
       "messages",
       messages,
-      `/conversations/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Messages`,
+      `/v1/Services/${conversation.service_sid}/Conversations/${conversation.sid}/Messages`,
       formatConversationMessage,
     );
   });

--- a/packages/@emulators/twilio/src/routes/inspector.ts
+++ b/packages/@emulators/twilio/src/routes/inspector.ts
@@ -73,13 +73,14 @@ export function inspectorRoutes({ app, store }: RouteContext): void {
         escapeHtml(verification.to),
         escapeHtml(verification.channel),
         escapeHtml(verification.status),
+        escapeHtml(verification.code),
         escapeHtml(String(verification.attempts)),
       ]);
     return (
       section("Verify Services", table(["SID", "Name", "Code"], serviceRows, "No Verify services.")) +
       section(
         "Verifications",
-        table(["SID", "To", "Channel", "Status", "Attempts"], verificationRows, "No verifications."),
+        table(["SID", "To", "Channel", "Status", "Code", "Attempts"], verificationRows, "No verifications."),
       )
     );
   }

--- a/packages/@emulators/twilio/src/routes/inspector.ts
+++ b/packages/@emulators/twilio/src/routes/inspector.ts
@@ -1,0 +1,229 @@
+import type { InspectorTab, RouteContext } from "@emulators/core";
+import { escapeHtml, renderInspectorPage } from "@emulators/core";
+import { getTwilioStore } from "../store.js";
+import { maskSecret } from "../helpers.js";
+
+const SERVICE_LABEL = "Twilio";
+const TABS: InspectorTab[] = [
+  { id: "messages", label: "Messages", href: "/?tab=messages" },
+  { id: "verify", label: "Verify", href: "/?tab=verify" },
+  { id: "calls", label: "Calls", href: "/?tab=calls" },
+  { id: "conversations", label: "Conversations", href: "/?tab=conversations" },
+  { id: "numbers", label: "Numbers", href: "/?tab=numbers" },
+  { id: "services", label: "Services", href: "/?tab=services" },
+  { id: "auth", label: "Auth", href: "/?tab=auth" },
+  { id: "webhooks", label: "Webhooks", href: "/?tab=webhooks" },
+];
+
+type TabId = (typeof TABS)[number]["id"];
+
+export function inspectorRoutes({ app, store }: RouteContext): void {
+  const ts = () => getTwilioStore(store);
+
+  app.get("/", (c) => {
+    const requested = c.req.query("tab") ?? "messages";
+    const active = TABS.some((tab) => tab.id === requested) ? (requested as TabId) : "messages";
+    const body =
+      active === "verify"
+        ? verifyView()
+        : active === "calls"
+          ? callsView()
+          : active === "conversations"
+            ? conversationsView()
+            : active === "numbers"
+              ? numbersView()
+              : active === "services"
+                ? servicesView()
+                : active === "auth"
+                  ? authView()
+                  : active === "webhooks"
+                    ? webhooksView()
+                    : messagesView();
+    return c.html(renderInspectorPage("Twilio Inspector", TABS, active, body, SERVICE_LABEL));
+  });
+
+  function messagesView(): string {
+    const rows = ts()
+      .messages.all()
+      .sort((a, b) => b.id - a.id)
+      .map((message) => [
+        escapeHtml(message.sid),
+        escapeHtml(message.direction),
+        escapeHtml(message.status),
+        escapeHtml(message.from ?? ""),
+        escapeHtml(message.to),
+        escapeHtml(message.body ?? ""),
+        escapeHtml(message.created_at),
+      ]);
+    return section(
+      "Messages",
+      table(["SID", "Direction", "Status", "From", "To", "Body", "Created"], rows, "No messages."),
+    );
+  }
+
+  function verifyView(): string {
+    const serviceRows = ts()
+      .verifyServices.all()
+      .map((service) => [escapeHtml(service.sid), escapeHtml(service.friendly_name), escapeHtml(service.code)]);
+    const verificationRows = ts()
+      .verifications.all()
+      .sort((a, b) => b.id - a.id)
+      .map((verification) => [
+        escapeHtml(verification.sid),
+        escapeHtml(verification.to),
+        escapeHtml(verification.channel),
+        escapeHtml(verification.status),
+        escapeHtml(String(verification.attempts)),
+      ]);
+    return (
+      section("Verify Services", table(["SID", "Name", "Code"], serviceRows, "No Verify services.")) +
+      section(
+        "Verifications",
+        table(["SID", "To", "Channel", "Status", "Attempts"], verificationRows, "No verifications."),
+      )
+    );
+  }
+
+  function callsView(): string {
+    const rows = ts()
+      .calls.all()
+      .sort((a, b) => b.id - a.id)
+      .map((call) => [
+        escapeHtml(call.sid),
+        escapeHtml(call.direction),
+        escapeHtml(call.status),
+        escapeHtml(call.from),
+        escapeHtml(call.to),
+        escapeHtml(call.twiml_steps.join(", ")),
+        escapeHtml(call.created_at),
+      ]);
+    return section("Calls", table(["SID", "Direction", "Status", "From", "To", "TwiML", "Created"], rows, "No calls."));
+  }
+
+  function numbersView(): string {
+    const rows = ts()
+      .phoneNumbers.all()
+      .map((number) => [
+        escapeHtml(number.sid),
+        escapeHtml(number.phone_number),
+        escapeHtml(number.friendly_name),
+        escapeHtml(number.sms_url ?? ""),
+        escapeHtml(number.voice_url ?? ""),
+      ]);
+    return section(
+      "Phone Numbers",
+      table(["SID", "Number", "Name", "SMS URL", "Voice URL"], rows, "No phone numbers."),
+    );
+  }
+
+  function conversationsView(): string {
+    const serviceRows = ts()
+      .conversationServices.all()
+      .map((service) => [
+        escapeHtml(service.sid),
+        escapeHtml(service.friendly_name),
+        escapeHtml(String(ts().conversations.count((item) => item.service_sid === service.sid))),
+      ]);
+    const conversationRows = ts()
+      .conversations.all()
+      .map((conversation) => [
+        escapeHtml(conversation.sid),
+        escapeHtml(conversation.friendly_name ?? ""),
+        escapeHtml(conversation.unique_name ?? ""),
+        escapeHtml(conversation.state),
+        escapeHtml(String(ts().conversationParticipants.count((item) => item.conversation_sid === conversation.sid))),
+        escapeHtml(String(ts().conversationMessages.count((item) => item.conversation_sid === conversation.sid))),
+      ]);
+    return (
+      section(
+        "Conversation Services",
+        table(["SID", "Name", "Conversations"], serviceRows, "No Conversation Services."),
+      ) +
+      section(
+        "Conversations",
+        table(
+          ["SID", "Name", "Unique Name", "State", "Participants", "Messages"],
+          conversationRows,
+          "No conversations.",
+        ),
+      )
+    );
+  }
+
+  function servicesView(): string {
+    const messagingRows = ts()
+      .messagingServices.all()
+      .map((service) => [
+        escapeHtml(service.sid),
+        escapeHtml(service.friendly_name),
+        escapeHtml(String(ts().messagingServicePhoneNumbers.count((item) => item.service_sid === service.sid))),
+        escapeHtml(service.status_callback ?? ""),
+      ]);
+    return section(
+      "Messaging Services",
+      table(["SID", "Name", "Senders", "Status Callback"], messagingRows, "No Messaging Services."),
+    );
+  }
+
+  function authView(): string {
+    const accountRows = ts()
+      .accounts.all()
+      .map((account) => [
+        escapeHtml(account.sid),
+        escapeHtml(account.friendly_name),
+        escapeHtml(account.status),
+        escapeHtml(maskSecret(account.auth_token)),
+      ]);
+    const keyRows = ts()
+      .apiKeys.all()
+      .map((key) => [
+        escapeHtml(key.sid),
+        escapeHtml(key.friendly_name),
+        escapeHtml(key.account_sid),
+        escapeHtml(key.active ? "active" : "inactive"),
+        escapeHtml(maskSecret(key.secret)),
+      ]);
+    return (
+      section("Accounts", table(["SID", "Name", "Status", "Auth Token"], accountRows, "No accounts.")) +
+      section("API Keys", table(["SID", "Name", "Account", "Status", "Secret"], keyRows, "No API keys."))
+    );
+  }
+
+  function webhooksView(): string {
+    const rows = ts()
+      .webhookDeliveries.all()
+      .slice(-50)
+      .reverse()
+      .map((delivery) => [
+        escapeHtml(delivery.event),
+        escapeHtml(delivery.url),
+        escapeHtml(String(delivery.response_status ?? "")),
+        escapeHtml(delivery.success ? "ok" : "failed"),
+        escapeHtml(delivery.error ?? ""),
+        escapeHtml(delivery.created_at),
+      ]);
+    return section(
+      "Webhook Deliveries",
+      table(["Event", "URL", "Status", "Result", "Error", "Created"], rows, "No webhook deliveries."),
+    );
+  }
+}
+
+function section(title: string, body: string): string {
+  return `<section class="inspector-section">
+  <h2>${escapeHtml(title)}</h2>
+  ${body}
+</section>`;
+}
+
+function table(headers: string[], rows: string[][], empty: string): string {
+  if (rows.length === 0) return `<p class="inspector-empty">${escapeHtml(empty)}</p>`;
+  const headerHtml = headers.map((header) => `<th>${escapeHtml(header)}</th>`).join("");
+  const rowHtml = rows.map((row) => `<tr>${row.map((cell) => `<td>${cell}</td>`).join("")}</tr>`).join("\n");
+  return `<table class="inspector-table">
+  <thead><tr>${headerHtml}</tr></thead>
+  <tbody>
+${rowHtml}
+  </tbody>
+</table>`;
+}

--- a/packages/@emulators/twilio/src/routes/messages.ts
+++ b/packages/@emulators/twilio/src/routes/messages.ts
@@ -1,0 +1,187 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { twilioSid } from "../ids.js";
+import { formatMedia, formatMessage } from "../formatters.js";
+import { getTwilioStore } from "../store.js";
+import type { TwilioAccount, TwilioMessage, TwilioMessageStatus } from "../entities.js";
+import {
+  accountFromParam,
+  bodyString,
+  bodyStrings,
+  dispatchTwilioWebhook,
+  messageSegments,
+  normalizePhoneNumber,
+  parseTwilioBody,
+  requireTwilioAuth,
+  twilioError,
+  twilioList,
+} from "../helpers.js";
+
+export function messageRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.get("/2010-04-01/Accounts/:accountSid/Messages.json", (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    let messages = ts.messages.findBy("account_sid", account.sid);
+    const to = c.req.query("To");
+    const from = c.req.query("From");
+    if (to) messages = messages.filter((message) => message.to === to);
+    if (from) messages = messages.filter((message) => message.from === from);
+    messages = messages.sort((a, b) => b.id - a.id);
+    return twilioList(c, "messages", messages, `/2010-04-01/Accounts/${account.sid}/Messages.json`, formatMessage);
+  });
+
+  app.post("/2010-04-01/Accounts/:accountSid/Messages.json", async (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const to = normalizePhoneNumber(bodyString(body, "To"));
+    if (!to) return twilioError(c, 400, "A 'To' phone number is required.", 21201);
+    const bodyText = bodyString(body, "Body") ?? null;
+    const mediaUrls = bodyStrings(body, "MediaUrl");
+    const serviceSid = bodyString(body, "MessagingServiceSid") ?? null;
+    const explicitFrom = normalizePhoneNumber(bodyString(body, "From") ?? undefined);
+    const sender = resolveSender(c, account, explicitFrom, serviceSid);
+    if (sender instanceof Response) return sender;
+    const statusCallback = bodyString(body, "StatusCallback") ?? sender.statusCallback;
+    const message = ts.messages.insert({
+      sid: twilioSid(mediaUrls.length > 0 ? "MM" : "SM"),
+      account_sid: account.sid,
+      to,
+      from: sender.from,
+      body: bodyText,
+      direction: "outbound-api",
+      status: bodyString(body, "ScheduleType") ? "scheduled" : "queued",
+      messaging_service_sid: serviceSid,
+      num_segments: messageSegments(bodyText),
+      num_media: String(mediaUrls.length),
+      media_urls: mediaUrls,
+      error_code: null,
+      error_message: null,
+      price: null,
+      price_unit: "USD",
+      api_version: "2010-04-01",
+      status_callback: statusCallback,
+      date_sent: null,
+    });
+    for (const mediaUrl of mediaUrls) {
+      ts.media.insert({
+        sid: twilioSid("ME"),
+        account_sid: account.sid,
+        message_sid: message.sid,
+        content_type: "application/octet-stream",
+        uri: mediaUrl,
+      });
+    }
+    await dispatchMessageCallback(account, message.status, message);
+    return c.json(formatMessage(message), 201);
+  });
+
+  app.get("/2010-04-01/Accounts/:accountSid/Messages/:messageSid.json", (c) => {
+    const message = authenticatedMessage(c);
+    if (message instanceof Response) return message;
+    return c.json(formatMessage(message));
+  });
+
+  app.post("/2010-04-01/Accounts/:accountSid/Messages/:messageSid.json", async (c) => {
+    const message = authenticatedMessage(c);
+    if (message instanceof Response) return message;
+    const body = await parseTwilioBody(c);
+    const requestedStatus = bodyString(body, "Status") as TwilioMessageStatus | undefined;
+    const bodyText = bodyString(body, "Body");
+    if (requestedStatus && !["canceled", "failed", "delivered", "sent", "undelivered"].includes(requestedStatus)) {
+      return twilioError(c, 400, "Status is invalid", 20001);
+    }
+    const updated = ts.messages.update(message.id, {
+      body: bodyText ?? message.body,
+      num_segments: bodyText !== undefined ? messageSegments(bodyText) : message.num_segments,
+      status: requestedStatus ?? message.status,
+      date_sent:
+        requestedStatus === "sent" || requestedStatus === "delivered" ? new Date().toISOString() : message.date_sent,
+    })!;
+    const account = ts.accounts.findOneBy("sid", updated.account_sid)!;
+    if (requestedStatus) await dispatchMessageCallback(account, requestedStatus, updated);
+    return c.json(formatMessage(updated));
+  });
+
+  app.delete("/2010-04-01/Accounts/:accountSid/Messages/:messageSid.json", (c) => {
+    const message = authenticatedMessage(c);
+    if (message instanceof Response) return message;
+    for (const media of ts.media.findBy("message_sid", message.sid)) ts.media.delete(media.id);
+    ts.messages.delete(message.id);
+    return c.body(null, 204);
+  });
+
+  app.get("/2010-04-01/Accounts/:accountSid/Messages/:messageSid/Media.json", (c) => {
+    const message = authenticatedMessage(c);
+    if (message instanceof Response) return message;
+    const media = ts.media.findBy("message_sid", message.sid);
+    return twilioList(
+      c,
+      "media_list",
+      media,
+      `/2010-04-01/Accounts/${message.account_sid}/Messages/${message.sid}/Media.json`,
+      formatMedia,
+    );
+  });
+
+  app.get("/2010-04-01/Accounts/:accountSid/Messages/:messageSid/Media/:mediaSid.json", (c) => {
+    const message = authenticatedMessage(c);
+    if (message instanceof Response) return message;
+    const media = ts.media.findOneBy("sid", c.req.param("mediaSid"));
+    if (!media || media.message_sid !== message.sid)
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    return c.json(formatMedia(media));
+  });
+
+  async function dispatchMessageCallback(account: TwilioAccount, status: TwilioMessageStatus, message: TwilioMessage) {
+    await dispatchTwilioWebhook(ts, account, `message.${status}`, message.status_callback, "POST", {
+      AccountSid: account.sid,
+      MessageSid: message.sid,
+      SmsSid: message.sid,
+      SmsStatus: status,
+      MessageStatus: status,
+      To: message.to,
+      From: message.from ?? "",
+      Body: message.body ?? "",
+      NumMedia: message.num_media,
+      NumSegments: message.num_segments,
+      ApiVersion: message.api_version,
+    });
+  }
+
+  function authenticatedAccount(c: Context) {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    return accountFromParam(c, ts, auth);
+  }
+
+  function authenticatedMessage(c: Context) {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const message = ts.messages.findOneBy("sid", c.req.param("messageSid"));
+    if (!message || message.account_sid !== account.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return message;
+  }
+
+  function resolveSender(c: Context, account: TwilioAccount, explicitFrom: string | null, serviceSid: string | null) {
+    if (explicitFrom) {
+      const number = ts.phoneNumbers.findOneBy("phone_number", explicitFrom);
+      if (!number || number.account_sid !== account.sid)
+        return twilioError(c, 400, "From phone number is not owned by this account", 21606);
+      return { from: explicitFrom, statusCallback: number.status_callback };
+    }
+    if (serviceSid) {
+      const service = ts.messagingServices.findOneBy("sid", serviceSid);
+      if (!service || service.account_sid !== account.sid)
+        return twilioError(c, 400, "Messaging Service was not found", 20404);
+      const assignment = ts.messagingServicePhoneNumbers.findBy("service_sid", serviceSid)[0];
+      if (!assignment) return twilioError(c, 400, "Messaging Service has no senders", 21712);
+      const number = ts.phoneNumbers.findOneBy("sid", assignment.phone_number_sid);
+      return { from: number?.phone_number ?? null, statusCallback: service.status_callback };
+    }
+    return twilioError(c, 400, "A 'From' phone number or MessagingServiceSid is required.", 21603);
+  }
+}

--- a/packages/@emulators/twilio/src/routes/messages.ts
+++ b/packages/@emulators/twilio/src/routes/messages.ts
@@ -167,20 +167,26 @@ export function messageRoutes({ app, store }: RouteContext): void {
   }
 
   function resolveSender(c: Context, account: TwilioAccount, explicitFrom: string | null, serviceSid: string | null) {
+    const service = serviceSid ? ts.messagingServices.findOneBy("sid", serviceSid) : null;
+    if (serviceSid && (!service || service.account_sid !== account.sid)) {
+      return twilioError(c, 400, "Messaging Service was not found", 20404);
+    }
+
     if (explicitFrom) {
       const number = ts.phoneNumbers.findOneBy("phone_number", explicitFrom);
       if (!number || number.account_sid !== account.sid)
         return twilioError(c, 400, "From phone number is not owned by this account", 21606);
-      return { from: explicitFrom, statusCallback: number.status_callback };
+      return { from: explicitFrom, statusCallback: number.status_callback ?? service?.status_callback ?? null };
     }
-    if (serviceSid) {
-      const service = ts.messagingServices.findOneBy("sid", serviceSid);
-      if (!service || service.account_sid !== account.sid)
-        return twilioError(c, 400, "Messaging Service was not found", 20404);
-      const assignment = ts.messagingServicePhoneNumbers.findBy("service_sid", serviceSid)[0];
-      if (!assignment) return twilioError(c, 400, "Messaging Service has no senders", 21712);
-      const number = ts.phoneNumbers.findOneBy("sid", assignment.phone_number_sid);
-      return { from: number?.phone_number ?? null, statusCallback: service.status_callback };
+
+    if (service && serviceSid) {
+      for (const assignment of ts.messagingServicePhoneNumbers.findBy("service_sid", serviceSid)) {
+        const number = ts.phoneNumbers.findOneBy("sid", assignment.phone_number_sid);
+        if (number && number.account_sid === account.sid) {
+          return { from: number.phone_number, statusCallback: service.status_callback };
+        }
+      }
+      return twilioError(c, 400, "Messaging Service has no senders", 21712);
     }
     return twilioError(c, 400, "A 'From' phone number or MessagingServiceSid is required.", 21603);
   }

--- a/packages/@emulators/twilio/src/routes/messaging-services.ts
+++ b/packages/@emulators/twilio/src/routes/messaging-services.ts
@@ -18,7 +18,7 @@ export function messagingServiceRoutes({ app, store }: RouteContext): void {
     const account = authenticatedAccount(c);
     if (account instanceof Response) return account;
     const services = ts.messagingServices.findBy("account_sid", account.sid);
-    return twilioList(c, "services", services, "/messaging/v1/Services", formatMessagingService);
+    return twilioList(c, "services", services, "/v1/Services", formatMessagingService);
   });
 
   app.post("/messaging/v1/Services", async (c) => {
@@ -69,13 +69,8 @@ export function messagingServiceRoutes({ app, store }: RouteContext): void {
     const service = authenticatedService(c);
     if (service instanceof Response) return service;
     const assignments = ts.messagingServicePhoneNumbers.findBy("service_sid", service.sid);
-    return twilioList(
-      c,
-      "phone_numbers",
-      assignments,
-      `/messaging/v1/Services/${service.sid}/PhoneNumbers`,
-      (assignment) =>
-        formatMessagingServicePhoneNumber(assignment, ts.phoneNumbers.findOneBy("sid", assignment.phone_number_sid)),
+    return twilioList(c, "phone_numbers", assignments, `/v1/Services/${service.sid}/PhoneNumbers`, (assignment) =>
+      formatMessagingServicePhoneNumber(assignment, ts.phoneNumbers.findOneBy("sid", assignment.phone_number_sid)),
     );
   });
 

--- a/packages/@emulators/twilio/src/routes/messaging-services.ts
+++ b/packages/@emulators/twilio/src/routes/messaging-services.ts
@@ -1,0 +1,135 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { twilioSid } from "../ids.js";
+import { formatMessagingService, formatMessagingServicePhoneNumber } from "../formatters.js";
+import { getTwilioStore } from "../store.js";
+import {
+  bodyString,
+  normalizePhoneNumber,
+  parseTwilioBody,
+  requireTwilioAuth,
+  twilioError,
+  twilioList,
+} from "../helpers.js";
+
+export function messagingServiceRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.get("/messaging/v1/Services", (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const services = ts.messagingServices.findBy("account_sid", account.sid);
+    return twilioList(c, "services", services, "/messaging/v1/Services", formatMessagingService);
+  });
+
+  app.post("/messaging/v1/Services", async (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const friendlyName = bodyString(body, "FriendlyName");
+    if (!friendlyName) return twilioError(c, 400, "FriendlyName is required", 20001);
+    const service = ts.messagingServices.insert({
+      sid: twilioSid("MG"),
+      account_sid: account.sid,
+      friendly_name: friendlyName,
+      inbound_request_url: bodyString(body, "InboundRequestUrl") ?? null,
+      status_callback: bodyString(body, "StatusCallback") ?? null,
+    });
+    return c.json(formatMessagingService(service), 201);
+  });
+
+  app.get("/messaging/v1/Services/:serviceSid", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    return c.json(formatMessagingService(service));
+  });
+
+  app.post("/messaging/v1/Services/:serviceSid", async (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const body = await parseTwilioBody(c);
+    const updated = ts.messagingServices.update(service.id, {
+      friendly_name: bodyString(body, "FriendlyName") ?? service.friendly_name,
+      inbound_request_url: bodyString(body, "InboundRequestUrl") ?? service.inbound_request_url,
+      status_callback: bodyString(body, "StatusCallback") ?? service.status_callback,
+    })!;
+    return c.json(formatMessagingService(updated));
+  });
+
+  app.delete("/messaging/v1/Services/:serviceSid", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    for (const assignment of ts.messagingServicePhoneNumbers.findBy("service_sid", service.sid)) {
+      ts.messagingServicePhoneNumbers.delete(assignment.id);
+    }
+    ts.messagingServices.delete(service.id);
+    return c.body(null, 204);
+  });
+
+  app.get("/messaging/v1/Services/:serviceSid/PhoneNumbers", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const assignments = ts.messagingServicePhoneNumbers.findBy("service_sid", service.sid);
+    return twilioList(
+      c,
+      "phone_numbers",
+      assignments,
+      `/messaging/v1/Services/${service.sid}/PhoneNumbers`,
+      (assignment) =>
+        formatMessagingServicePhoneNumber(assignment, ts.phoneNumbers.findOneBy("sid", assignment.phone_number_sid)),
+    );
+  });
+
+  app.post("/messaging/v1/Services/:serviceSid/PhoneNumbers", async (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const body = await parseTwilioBody(c);
+    const phoneNumberSid = bodyString(body, "PhoneNumberSid");
+    const phoneNumberValue = normalizePhoneNumber(bodyString(body, "PhoneNumber"));
+    const phoneNumber = phoneNumberSid
+      ? ts.phoneNumbers.findOneBy("sid", phoneNumberSid)
+      : phoneNumberValue
+        ? ts.phoneNumbers.findOneBy("phone_number", phoneNumberValue)
+        : undefined;
+    if (!phoneNumber || phoneNumber.account_sid !== service.account_sid) {
+      return twilioError(c, 404, "Phone number was not found", 20404);
+    }
+    const existing = ts.messagingServicePhoneNumbers
+      .findBy("service_sid", service.sid)
+      .find((assignment) => assignment.phone_number_sid === phoneNumber.sid);
+    if (existing) return c.json(formatMessagingServicePhoneNumber(existing, phoneNumber), 200);
+    const assignment = ts.messagingServicePhoneNumbers.insert({
+      sid: twilioSid("PN"),
+      account_sid: service.account_sid,
+      service_sid: service.sid,
+      phone_number_sid: phoneNumber.sid,
+    });
+    return c.json(formatMessagingServicePhoneNumber(assignment, phoneNumber), 201);
+  });
+
+  app.delete("/messaging/v1/Services/:serviceSid/PhoneNumbers/:sid", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const assignment = ts.messagingServicePhoneNumbers.findOneBy("sid", c.req.param("sid"));
+    if (!assignment || assignment.service_sid !== service.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    ts.messagingServicePhoneNumbers.delete(assignment.id);
+    return c.body(null, 204);
+  });
+
+  function authenticatedAccount(c: Context) {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    return auth;
+  }
+
+  function authenticatedService(c: Context) {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const service = ts.messagingServices.findOneBy("sid", c.req.param("serviceSid"));
+    if (!service || service.account_sid !== account.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return service;
+  }
+}

--- a/packages/@emulators/twilio/src/routes/phone-numbers.ts
+++ b/packages/@emulators/twilio/src/routes/phone-numbers.ts
@@ -1,0 +1,106 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { twilioSid } from "../ids.js";
+import { formatPhoneNumber } from "../formatters.js";
+import { getTwilioStore } from "../store.js";
+import {
+  accountFromParam,
+  bodyString,
+  normalizeMethod,
+  normalizePhoneNumber,
+  parseTwilioBody,
+  requireTwilioAuth,
+  twilioError,
+  twilioList,
+} from "../helpers.js";
+
+export function phoneNumberRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.get("/2010-04-01/Accounts/:accountSid/IncomingPhoneNumbers.json", (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    let numbers = ts.phoneNumbers.findBy("account_sid", account.sid);
+    const phoneNumber = c.req.query("PhoneNumber");
+    const friendlyName = c.req.query("FriendlyName");
+    if (phoneNumber) numbers = numbers.filter((number) => number.phone_number === phoneNumber);
+    if (friendlyName) numbers = numbers.filter((number) => number.friendly_name === friendlyName);
+    return twilioList(
+      c,
+      "incoming_phone_numbers",
+      numbers,
+      `/2010-04-01/Accounts/${account.sid}/IncomingPhoneNumbers.json`,
+      formatPhoneNumber,
+    );
+  });
+
+  app.post("/2010-04-01/Accounts/:accountSid/IncomingPhoneNumbers.json", async (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const phoneNumber = normalizePhoneNumber(bodyString(body, "PhoneNumber"));
+    if (!phoneNumber) return twilioError(c, 400, "PhoneNumber is invalid", 21421);
+    const existing = ts.phoneNumbers.findOneBy("phone_number", phoneNumber);
+    if (existing) return twilioError(c, 400, "Phone number is already owned by this account", 21452);
+    const inserted = ts.phoneNumbers.insert({
+      sid: twilioSid("PN"),
+      account_sid: account.sid,
+      phone_number: phoneNumber,
+      friendly_name: bodyString(body, "FriendlyName") ?? phoneNumber,
+      capabilities: { sms: true, mms: true, voice: true },
+      sms_url: bodyString(body, "SmsUrl") ?? null,
+      sms_method: normalizeMethod(bodyString(body, "SmsMethod")),
+      voice_url: bodyString(body, "VoiceUrl") ?? null,
+      voice_method: normalizeMethod(bodyString(body, "VoiceMethod")),
+      status_callback: bodyString(body, "StatusCallback") ?? null,
+      application_sid: bodyString(body, "ApplicationSid") ?? null,
+    });
+    return c.json(formatPhoneNumber(inserted), 201);
+  });
+
+  app.get("/2010-04-01/Accounts/:accountSid/IncomingPhoneNumbers/:sid.json", (c) => {
+    const number = authenticatedPhoneNumber(c);
+    if (number instanceof Response) return number;
+    return c.json(formatPhoneNumber(number));
+  });
+
+  app.post("/2010-04-01/Accounts/:accountSid/IncomingPhoneNumbers/:sid.json", async (c) => {
+    const number = authenticatedPhoneNumber(c);
+    if (number instanceof Response) return number;
+    const body = await parseTwilioBody(c);
+    const friendlyName = bodyString(body, "FriendlyName");
+    const updated = ts.phoneNumbers.update(number.id, {
+      friendly_name: friendlyName ?? number.friendly_name,
+      sms_url: bodyString(body, "SmsUrl") ?? number.sms_url,
+      sms_method: bodyString(body, "SmsMethod") ? normalizeMethod(bodyString(body, "SmsMethod")) : number.sms_method,
+      voice_url: bodyString(body, "VoiceUrl") ?? number.voice_url,
+      voice_method: bodyString(body, "VoiceMethod")
+        ? normalizeMethod(bodyString(body, "VoiceMethod"))
+        : number.voice_method,
+      status_callback: bodyString(body, "StatusCallback") ?? number.status_callback,
+      application_sid: bodyString(body, "ApplicationSid") ?? number.application_sid,
+    })!;
+    return c.json(formatPhoneNumber(updated));
+  });
+
+  app.delete("/2010-04-01/Accounts/:accountSid/IncomingPhoneNumbers/:sid.json", (c) => {
+    const number = authenticatedPhoneNumber(c);
+    if (number instanceof Response) return number;
+    ts.phoneNumbers.delete(number.id);
+    return c.body(null, 204);
+  });
+
+  function authenticatedAccount(c: Context) {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    return accountFromParam(c, ts, auth);
+  }
+
+  function authenticatedPhoneNumber(c: Context) {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const number = ts.phoneNumbers.findOneBy("sid", c.req.param("sid"));
+    if (!number || number.account_sid !== account.sid)
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    return number;
+  }
+}

--- a/packages/@emulators/twilio/src/routes/phone-numbers.ts
+++ b/packages/@emulators/twilio/src/routes/phone-numbers.ts
@@ -85,6 +85,9 @@ export function phoneNumberRoutes({ app, store }: RouteContext): void {
   app.delete("/2010-04-01/Accounts/:accountSid/IncomingPhoneNumbers/:sid.json", (c) => {
     const number = authenticatedPhoneNumber(c);
     if (number instanceof Response) return number;
+    for (const assignment of ts.messagingServicePhoneNumbers.findBy("phone_number_sid", number.sid)) {
+      ts.messagingServicePhoneNumbers.delete(assignment.id);
+    }
     ts.phoneNumbers.delete(number.id);
     return c.body(null, 204);
   });

--- a/packages/@emulators/twilio/src/routes/simulator.ts
+++ b/packages/@emulators/twilio/src/routes/simulator.ts
@@ -2,6 +2,7 @@ import type { RouteContext } from "@emulators/core";
 import { twilioSid } from "../ids.js";
 import { formatCall, formatMessage, formatVerification } from "../formatters.js";
 import { getTwilioStore } from "../store.js";
+import type { TwilioVerification, TwilioVerificationStatus } from "../entities.js";
 import {
   bodyString,
   dispatchTwilioWebhook,
@@ -12,6 +13,16 @@ import {
   twilioError,
 } from "../helpers.js";
 import { parseTwimlSteps } from "./calls.js";
+
+const VERIFICATION_STATUSES: TwilioVerificationStatus[] = [
+  "pending",
+  "approved",
+  "canceled",
+  "max_attempts_reached",
+  "deleted",
+  "failed",
+  "expired",
+];
 
 export function simulatorRoutes({ app, store }: RouteContext): void {
   const ts = getTwilioStore(store);
@@ -25,6 +36,10 @@ export function simulatorRoutes({ app, store }: RouteContext): void {
     if (!to || !from) return twilioError(c, 400, "To and From are required", 20001);
     const number = ts.phoneNumbers.findOneBy("phone_number", to);
     if (!number || number.account_sid !== account.sid) return twilioError(c, 404, "Phone number was not found", 20404);
+    const messagingServiceAssignment = ts.messagingServicePhoneNumbers.findOneBy("phone_number_sid", number.sid);
+    const messagingService = messagingServiceAssignment
+      ? ts.messagingServices.findOneBy("sid", messagingServiceAssignment.service_sid)
+      : undefined;
     const messageBody = bodyString(body, "Body") ?? "";
     const message = ts.messages.insert({
       sid: twilioSid("SM"),
@@ -34,7 +49,7 @@ export function simulatorRoutes({ app, store }: RouteContext): void {
       body: messageBody,
       direction: "inbound",
       status: "received",
-      messaging_service_sid: null,
+      messaging_service_sid: messagingService?.sid ?? null,
       num_segments: messageSegments(messageBody),
       num_media: "0",
       media_urls: [],
@@ -46,11 +61,14 @@ export function simulatorRoutes({ app, store }: RouteContext): void {
       status_callback: null,
       date_sent: new Date().toISOString(),
     });
-    await dispatchTwilioWebhook(ts, account, "message.inbound", number.sms_url, number.sms_method, {
+    const inboundUrl = messagingService?.inbound_request_url ?? number.sms_url;
+    const inboundMethod = messagingService?.inbound_request_url ? "POST" : number.sms_method;
+    await dispatchTwilioWebhook(ts, account, "message.inbound", inboundUrl, inboundMethod, {
       AccountSid: account.sid,
       MessageSid: message.sid,
       SmsSid: message.sid,
       SmsStatus: "received",
+      MessagingServiceSid: messagingService?.sid ?? "",
       To: message.to,
       From: message.from ?? "",
       Body: message.body ?? "",
@@ -169,16 +187,68 @@ export function simulatorRoutes({ app, store }: RouteContext): void {
     if (account instanceof Response) return account;
     const body = await parseTwilioBody(c);
     const sid = bodyString(body, "VerificationSid");
+    const to = normalizePhoneNumber(bodyString(body, "To"));
+    const serviceSid = bodyString(body, "ServiceSid");
     const status = bodyString(body, "Status");
-    if (!sid || !status) return twilioError(c, 400, "VerificationSid and Status are required", 20001);
-    const verification = ts.verifications.findOneBy("sid", sid);
-    if (!verification || verification.account_sid !== account.sid) {
+    if (!status) return twilioError(c, 400, "Status is required", 20001);
+    if (!sid && !to) return twilioError(c, 400, "VerificationSid or To is required", 20001);
+    if (!VERIFICATION_STATUSES.includes(status as TwilioVerificationStatus)) {
+      return twilioError(c, 400, "Status is invalid", 20001);
+    }
+    const verification = findVerification(account.sid, sid, to, serviceSid);
+    if (!verification) {
       return twilioError(c, 404, "The requested resource was not found", 20404);
     }
     const updated = ts.verifications.update(verification.id, {
-      status: status as typeof verification.status,
+      status: status as TwilioVerificationStatus,
       valid: status === "approved",
     })!;
     return c.json(formatVerification(updated));
   });
+
+  app.get("/_twilio/simulate/verification-code", (c) => {
+    const account = requireTwilioAuth(c, ts);
+    if (account instanceof Response) return account;
+    const sid = c.req.query("VerificationSid");
+    const to = normalizePhoneNumber(c.req.query("To"));
+    const serviceSid = c.req.query("ServiceSid");
+    if (!sid && !to) return twilioError(c, 400, "VerificationSid or To is required", 20001);
+    const verification = findVerification(account.sid, sid, to, serviceSid);
+    if (!verification) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return c.json({
+      account_sid: verification.account_sid,
+      service_sid: verification.service_sid,
+      verification_sid: verification.sid,
+      to: verification.to,
+      channel: verification.channel,
+      status: verification.status,
+      code: verification.code,
+      attempts: verification.attempts,
+      valid: verification.valid,
+      date_created: verification.created_at,
+      date_updated: verification.updated_at,
+    });
+  });
+
+  function findVerification(
+    accountSid: string,
+    verificationSid: string | undefined,
+    to: string | null,
+    serviceSid: string | undefined,
+  ): TwilioVerification | null {
+    const candidates = verificationSid
+      ? [ts.verifications.findOneBy("sid", verificationSid)].filter((item): item is TwilioVerification => Boolean(item))
+      : ts.verifications
+          .all()
+          .filter((verification) => verification.to === to)
+          .sort((a, b) => b.id - a.id);
+    return (
+      candidates.find(
+        (verification) =>
+          verification.account_sid === accountSid && (!serviceSid || verification.service_sid === serviceSid),
+      ) ?? null
+    );
+  }
 }

--- a/packages/@emulators/twilio/src/routes/simulator.ts
+++ b/packages/@emulators/twilio/src/routes/simulator.ts
@@ -1,0 +1,184 @@
+import type { RouteContext } from "@emulators/core";
+import { twilioSid } from "../ids.js";
+import { formatCall, formatMessage, formatVerification } from "../formatters.js";
+import { getTwilioStore } from "../store.js";
+import {
+  bodyString,
+  dispatchTwilioWebhook,
+  messageSegments,
+  normalizePhoneNumber,
+  parseTwilioBody,
+  requireTwilioAuth,
+  twilioError,
+} from "../helpers.js";
+import { parseTwimlSteps } from "./calls.js";
+
+export function simulatorRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.post("/_twilio/simulate/inbound-message", async (c) => {
+    const account = requireTwilioAuth(c, ts);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const to = normalizePhoneNumber(bodyString(body, "To"));
+    const from = normalizePhoneNumber(bodyString(body, "From"));
+    if (!to || !from) return twilioError(c, 400, "To and From are required", 20001);
+    const number = ts.phoneNumbers.findOneBy("phone_number", to);
+    if (!number || number.account_sid !== account.sid) return twilioError(c, 404, "Phone number was not found", 20404);
+    const messageBody = bodyString(body, "Body") ?? "";
+    const message = ts.messages.insert({
+      sid: twilioSid("SM"),
+      account_sid: account.sid,
+      to,
+      from,
+      body: messageBody,
+      direction: "inbound",
+      status: "received",
+      messaging_service_sid: null,
+      num_segments: messageSegments(messageBody),
+      num_media: "0",
+      media_urls: [],
+      error_code: null,
+      error_message: null,
+      price: null,
+      price_unit: "USD",
+      api_version: "2010-04-01",
+      status_callback: null,
+      date_sent: new Date().toISOString(),
+    });
+    await dispatchTwilioWebhook(ts, account, "message.inbound", number.sms_url, number.sms_method, {
+      AccountSid: account.sid,
+      MessageSid: message.sid,
+      SmsSid: message.sid,
+      SmsStatus: "received",
+      To: message.to,
+      From: message.from ?? "",
+      Body: message.body ?? "",
+      NumMedia: "0",
+      NumSegments: message.num_segments,
+      ApiVersion: message.api_version,
+    });
+    return c.json(formatMessage(message), 201);
+  });
+
+  app.post("/_twilio/simulate/message-status", async (c) => {
+    const account = requireTwilioAuth(c, ts);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const sid = bodyString(body, "MessageSid");
+    const status = bodyString(body, "Status");
+    if (!sid || !status) return twilioError(c, 400, "MessageSid and Status are required", 20001);
+    const message = ts.messages.findOneBy("sid", sid);
+    if (!message || message.account_sid !== account.sid)
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    const updated = ts.messages.update(message.id, {
+      status: status as typeof message.status,
+      date_sent: ["sent", "delivered"].includes(status) ? new Date().toISOString() : message.date_sent,
+    })!;
+    await dispatchTwilioWebhook(ts, account, `message.${status}`, updated.status_callback, "POST", {
+      AccountSid: account.sid,
+      MessageSid: updated.sid,
+      SmsSid: updated.sid,
+      SmsStatus: updated.status,
+      MessageStatus: updated.status,
+      To: updated.to,
+      From: updated.from ?? "",
+      Body: updated.body ?? "",
+      NumMedia: updated.num_media,
+      NumSegments: updated.num_segments,
+      ApiVersion: updated.api_version,
+    });
+    return c.json(formatMessage(updated));
+  });
+
+  app.post("/_twilio/simulate/inbound-call", async (c) => {
+    const account = requireTwilioAuth(c, ts);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const to = normalizePhoneNumber(bodyString(body, "To"));
+    const from = normalizePhoneNumber(bodyString(body, "From"));
+    if (!to || !from) return twilioError(c, 400, "To and From are required", 20001);
+    const number = ts.phoneNumbers.findOneBy("phone_number", to);
+    if (!number || number.account_sid !== account.sid) return twilioError(c, 404, "Phone number was not found", 20404);
+    const call = ts.calls.insert({
+      sid: twilioSid("CA"),
+      account_sid: account.sid,
+      to,
+      from,
+      status: "in-progress",
+      direction: "inbound",
+      api_version: "2010-04-01",
+      price: null,
+      price_unit: "USD",
+      parent_call_sid: null,
+      phone_number_sid: number.sid,
+      start_time: new Date().toISOString(),
+      end_time: null,
+      duration: "0",
+      url: number.voice_url,
+      method: number.voice_method,
+      twiml: null,
+      twiml_steps: [],
+      status_callback: number.status_callback,
+      status_callback_event: [],
+    });
+    await dispatchTwilioWebhook(ts, account, "call.inbound", number.voice_url, number.voice_method, {
+      AccountSid: account.sid,
+      CallSid: call.sid,
+      CallStatus: call.status,
+      To: call.to,
+      From: call.from,
+      Direction: call.direction,
+      ApiVersion: call.api_version,
+    });
+    return c.json(formatCall(call), 201);
+  });
+
+  app.post("/_twilio/simulate/call-status", async (c) => {
+    const account = requireTwilioAuth(c, ts);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const sid = bodyString(body, "CallSid");
+    const status = bodyString(body, "Status");
+    const twiml = bodyString(body, "Twiml");
+    if (!sid || !status) return twilioError(c, 400, "CallSid and Status are required", 20001);
+    const call = ts.calls.findOneBy("sid", sid);
+    if (!call || call.account_sid !== account.sid)
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    const terminal = ["completed", "busy", "failed", "no-answer", "canceled"].includes(status);
+    const updated = ts.calls.update(call.id, {
+      status: status as typeof call.status,
+      twiml: twiml ?? call.twiml,
+      twiml_steps: twiml ? parseTwimlSteps(twiml) : call.twiml_steps,
+      end_time: terminal ? new Date().toISOString() : call.end_time,
+    })!;
+    await dispatchTwilioWebhook(ts, account, `call.${status}`, updated.status_callback, "POST", {
+      AccountSid: account.sid,
+      CallSid: updated.sid,
+      CallStatus: updated.status,
+      To: updated.to,
+      From: updated.from,
+      Direction: updated.direction,
+      ApiVersion: updated.api_version,
+    });
+    return c.json(formatCall(updated));
+  });
+
+  app.post("/_twilio/simulate/verification-status", async (c) => {
+    const account = requireTwilioAuth(c, ts);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const sid = bodyString(body, "VerificationSid");
+    const status = bodyString(body, "Status");
+    if (!sid || !status) return twilioError(c, 400, "VerificationSid and Status are required", 20001);
+    const verification = ts.verifications.findOneBy("sid", sid);
+    if (!verification || verification.account_sid !== account.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    const updated = ts.verifications.update(verification.id, {
+      status: status as typeof verification.status,
+      valid: status === "approved",
+    })!;
+    return c.json(formatVerification(updated));
+  });
+}

--- a/packages/@emulators/twilio/src/routes/simulator.ts
+++ b/packages/@emulators/twilio/src/routes/simulator.ts
@@ -2,7 +2,12 @@ import type { RouteContext } from "@emulators/core";
 import { twilioSid } from "../ids.js";
 import { formatCall, formatMessage, formatVerification } from "../formatters.js";
 import { getTwilioStore } from "../store.js";
-import type { TwilioVerification, TwilioVerificationStatus } from "../entities.js";
+import type {
+  TwilioCallStatus,
+  TwilioMessageStatus,
+  TwilioVerification,
+  TwilioVerificationStatus,
+} from "../entities.js";
 import {
   bodyString,
   dispatchTwilioWebhook,
@@ -23,6 +28,31 @@ const VERIFICATION_STATUSES: TwilioVerificationStatus[] = [
   "failed",
   "expired",
 ];
+const MESSAGE_STATUSES: TwilioMessageStatus[] = [
+  "accepted",
+  "scheduled",
+  "canceled",
+  "queued",
+  "sending",
+  "sent",
+  "failed",
+  "delivered",
+  "undelivered",
+  "receiving",
+  "received",
+  "read",
+];
+const CALL_STATUSES: TwilioCallStatus[] = [
+  "queued",
+  "ringing",
+  "in-progress",
+  "completed",
+  "busy",
+  "failed",
+  "no-answer",
+  "canceled",
+];
+const TERMINAL_CALL_STATUSES: TwilioCallStatus[] = ["completed", "busy", "failed", "no-answer", "canceled"];
 
 export function simulatorRoutes({ app, store }: RouteContext): void {
   const ts = getTwilioStore(store);
@@ -86,11 +116,14 @@ export function simulatorRoutes({ app, store }: RouteContext): void {
     const sid = bodyString(body, "MessageSid");
     const status = bodyString(body, "Status");
     if (!sid || !status) return twilioError(c, 400, "MessageSid and Status are required", 20001);
+    if (!MESSAGE_STATUSES.includes(status as TwilioMessageStatus)) {
+      return twilioError(c, 400, "Status is invalid", 20001);
+    }
     const message = ts.messages.findOneBy("sid", sid);
     if (!message || message.account_sid !== account.sid)
       return twilioError(c, 404, "The requested resource was not found", 20404);
     const updated = ts.messages.update(message.id, {
-      status: status as typeof message.status,
+      status: status as TwilioMessageStatus,
       date_sent: ["sent", "delivered"].includes(status) ? new Date().toISOString() : message.date_sent,
     })!;
     await dispatchTwilioWebhook(ts, account, `message.${status}`, updated.status_callback, "POST", {
@@ -160,12 +193,15 @@ export function simulatorRoutes({ app, store }: RouteContext): void {
     const status = bodyString(body, "Status");
     const twiml = bodyString(body, "Twiml");
     if (!sid || !status) return twilioError(c, 400, "CallSid and Status are required", 20001);
+    if (!CALL_STATUSES.includes(status as TwilioCallStatus)) {
+      return twilioError(c, 400, "Status is invalid", 20001);
+    }
     const call = ts.calls.findOneBy("sid", sid);
     if (!call || call.account_sid !== account.sid)
       return twilioError(c, 404, "The requested resource was not found", 20404);
-    const terminal = ["completed", "busy", "failed", "no-answer", "canceled"].includes(status);
+    const terminal = TERMINAL_CALL_STATUSES.includes(status as TwilioCallStatus);
     const updated = ts.calls.update(call.id, {
-      status: status as typeof call.status,
+      status: status as TwilioCallStatus,
       twiml: twiml ?? call.twiml,
       twiml_steps: twiml ? parseTwimlSteps(twiml) : call.twiml_steps,
       end_time: terminal ? new Date().toISOString() : call.end_time,

--- a/packages/@emulators/twilio/src/routes/verify.ts
+++ b/packages/@emulators/twilio/src/routes/verify.ts
@@ -11,7 +11,7 @@ export function verifyRoutes({ app, store }: RouteContext): void {
     const account = authenticatedAccount(c);
     if (account instanceof Response) return account;
     const services = ts.verifyServices.findBy("account_sid", account.sid);
-    return twilioList(c, "services", services, "/verify/v2/Services", formatVerifyService);
+    return twilioList(c, "services", services, "/v2/Services", formatVerifyService);
   });
 
   app.post("/verify/v2/Services", async (c) => {

--- a/packages/@emulators/twilio/src/routes/verify.ts
+++ b/packages/@emulators/twilio/src/routes/verify.ts
@@ -1,0 +1,169 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { twilioSid } from "../ids.js";
+import { formatVerification, formatVerificationCheck, formatVerifyService } from "../formatters.js";
+import { getTwilioStore } from "../store.js";
+import { bodyString, parseTwilioBody, requireTwilioAuth, twilioError, twilioList } from "../helpers.js";
+
+export function verifyRoutes({ app, store }: RouteContext): void {
+  const ts = getTwilioStore(store);
+
+  app.get("/verify/v2/Services", (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const services = ts.verifyServices.findBy("account_sid", account.sid);
+    return twilioList(c, "services", services, "/verify/v2/Services", formatVerifyService);
+  });
+
+  app.post("/verify/v2/Services", async (c) => {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const body = await parseTwilioBody(c);
+    const friendlyName = bodyString(body, "FriendlyName");
+    if (!friendlyName) return twilioError(c, 400, "FriendlyName is required", 20001);
+    const service = ts.verifyServices.insert({
+      sid: twilioSid("VA"),
+      account_sid: account.sid,
+      friendly_name: friendlyName,
+      code: bodyString(body, "Code") ?? "123456",
+      default_channel: bodyString(body, "DefaultChannel") ?? "sms",
+    });
+    return c.json(formatVerifyService(service), 201);
+  });
+
+  app.get("/verify/v2/Services/:serviceSid", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    return c.json(formatVerifyService(service));
+  });
+
+  app.post("/verify/v2/Services/:serviceSid", async (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const body = await parseTwilioBody(c);
+    const updated = ts.verifyServices.update(service.id, {
+      friendly_name: bodyString(body, "FriendlyName") ?? service.friendly_name,
+      code: bodyString(body, "Code") ?? service.code,
+      default_channel: bodyString(body, "DefaultChannel") ?? service.default_channel,
+    })!;
+    return c.json(formatVerifyService(updated));
+  });
+
+  app.delete("/verify/v2/Services/:serviceSid", (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    ts.verifyServices.delete(service.id);
+    return c.body(null, 204);
+  });
+
+  app.post("/verify/v2/Services/:serviceSid/Verifications", async (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const body = await parseTwilioBody(c);
+    const to = bodyString(body, "To");
+    const channel = bodyString(body, "Channel") ?? service.default_channel;
+    if (!to) return twilioError(c, 400, "To is required", 60200);
+    if (!["sms", "call", "email", "whatsapp", "sna", "auto"].includes(channel)) {
+      return twilioError(c, 400, "Channel is invalid", 60200);
+    }
+    const existingPending = ts.verifications
+      .findBy("service_sid", service.sid)
+      .find((verification) => verification.to === to && verification.status === "pending");
+    if (existingPending) return c.json(formatVerification(existingPending), 201);
+    const code = bodyString(body, "CustomCode") ?? service.code;
+    const verification = ts.verifications.insert({
+      sid: twilioSid("VE"),
+      service_sid: service.sid,
+      account_sid: service.account_sid,
+      to,
+      channel,
+      status: "pending",
+      code,
+      attempts: 0,
+      max_attempts: 3,
+      lookup: {},
+      send_code_attempts: [
+        {
+          time: new Date().toISOString(),
+          channel,
+          attempt_sid: twilioSid("VL"),
+        },
+      ],
+      tags: bodyString(body, "Tags") ?? null,
+      valid: false,
+    });
+    return c.json(formatVerification(verification), 201);
+  });
+
+  app.get("/verify/v2/Services/:serviceSid/Verifications/:verificationSid", (c) => {
+    const verification = authenticatedVerification(c);
+    if (verification instanceof Response) return verification;
+    return c.json(formatVerification(verification));
+  });
+
+  app.post("/verify/v2/Services/:serviceSid/Verifications/:verificationSid", async (c) => {
+    const verification = authenticatedVerification(c);
+    if (verification instanceof Response) return verification;
+    const body = await parseTwilioBody(c);
+    const status = bodyString(body, "Status");
+    if (status !== "canceled") return twilioError(c, 400, "Status is invalid", 60200);
+    const updated = ts.verifications.update(verification.id, { status: "canceled", valid: false })!;
+    return c.json(formatVerification(updated));
+  });
+
+  app.post("/verify/v2/Services/:serviceSid/VerificationCheck", async (c) => {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const body = await parseTwilioBody(c);
+    const to = bodyString(body, "To");
+    const sid = bodyString(body, "VerificationSid");
+    const code = bodyString(body, "Code");
+    if (!code) return twilioError(c, 400, "Code is required", 60200);
+    const verification = sid
+      ? ts.verifications.findOneBy("sid", sid)
+      : ts.verifications
+          .findBy("service_sid", service.sid)
+          .filter((candidate) => candidate.to === to)
+          .sort((a, b) => b.id - a.id)[0];
+    if (!verification || verification.service_sid !== service.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    if (!["pending", "failed"].includes(verification.status)) {
+      return c.json(formatVerificationCheck(verification));
+    }
+    const attempts = verification.attempts + 1;
+    const approved = code === verification.code;
+    const status = approved ? "approved" : attempts >= verification.max_attempts ? "max_attempts_reached" : "pending";
+    const updated = ts.verifications.update(verification.id, {
+      attempts,
+      status,
+      valid: approved,
+    })!;
+    return c.json(formatVerificationCheck(updated));
+  });
+
+  function authenticatedAccount(c: Context) {
+    const auth = requireTwilioAuth(c, ts);
+    if (auth instanceof Response) return auth;
+    return auth;
+  }
+
+  function authenticatedService(c: Context) {
+    const account = authenticatedAccount(c);
+    if (account instanceof Response) return account;
+    const service = ts.verifyServices.findOneBy("sid", c.req.param("serviceSid"));
+    if (!service || service.account_sid !== account.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return service;
+  }
+
+  function authenticatedVerification(c: Context) {
+    const service = authenticatedService(c);
+    if (service instanceof Response) return service;
+    const verification = ts.verifications.findOneBy("sid", c.req.param("verificationSid"));
+    if (!verification || verification.service_sid !== service.sid) {
+      return twilioError(c, 404, "The requested resource was not found", 20404);
+    }
+    return verification;
+  }
+}

--- a/packages/@emulators/twilio/src/store.ts
+++ b/packages/@emulators/twilio/src/store.ts
@@ -1,0 +1,102 @@
+import { Store, type Collection } from "@emulators/core";
+import type {
+  TwilioAccount,
+  TwilioApiKey,
+  TwilioApplication,
+  TwilioCall,
+  TwilioConversation,
+  TwilioConversationMessage,
+  TwilioConversationParticipant,
+  TwilioConversationService,
+  TwilioIncomingPhoneNumber,
+  TwilioMedia,
+  TwilioMessage,
+  TwilioMessagingService,
+  TwilioMessagingServicePhoneNumber,
+  TwilioVerification,
+  TwilioVerifyService,
+  TwilioWebhookDelivery,
+} from "./entities.js";
+
+export interface TwilioStore {
+  accounts: Collection<TwilioAccount>;
+  apiKeys: Collection<TwilioApiKey>;
+  applications: Collection<TwilioApplication>;
+  phoneNumbers: Collection<TwilioIncomingPhoneNumber>;
+  messagingServices: Collection<TwilioMessagingService>;
+  messagingServicePhoneNumbers: Collection<TwilioMessagingServicePhoneNumber>;
+  messages: Collection<TwilioMessage>;
+  media: Collection<TwilioMedia>;
+  verifyServices: Collection<TwilioVerifyService>;
+  verifications: Collection<TwilioVerification>;
+  calls: Collection<TwilioCall>;
+  webhookDeliveries: Collection<TwilioWebhookDelivery>;
+  conversationServices: Collection<TwilioConversationService>;
+  conversations: Collection<TwilioConversation>;
+  conversationParticipants: Collection<TwilioConversationParticipant>;
+  conversationMessages: Collection<TwilioConversationMessage>;
+}
+
+export function getTwilioStore(store: Store): TwilioStore {
+  return {
+    accounts: store.collection<TwilioAccount>("twilio.accounts", ["sid"]),
+    apiKeys: store.collection<TwilioApiKey>("twilio.api_keys", ["sid", "account_sid"]),
+    applications: store.collection<TwilioApplication>("twilio.applications", ["sid", "account_sid"]),
+    phoneNumbers: store.collection<TwilioIncomingPhoneNumber>("twilio.phone_numbers", [
+      "sid",
+      "account_sid",
+      "phone_number",
+    ]),
+    messagingServices: store.collection<TwilioMessagingService>("twilio.messaging_services", ["sid", "account_sid"]),
+    messagingServicePhoneNumbers: store.collection<TwilioMessagingServicePhoneNumber>(
+      "twilio.messaging_service_phone_numbers",
+      ["sid", "account_sid", "service_sid", "phone_number_sid"],
+    ),
+    messages: store.collection<TwilioMessage>("twilio.messages", [
+      "sid",
+      "account_sid",
+      "to",
+      "from",
+      "status",
+      "messaging_service_sid",
+    ]),
+    media: store.collection<TwilioMedia>("twilio.media", ["sid", "account_sid", "message_sid"]),
+    verifyServices: store.collection<TwilioVerifyService>("twilio.verify_services", ["sid", "account_sid"]),
+    verifications: store.collection<TwilioVerification>("twilio.verifications", [
+      "sid",
+      "service_sid",
+      "account_sid",
+      "to",
+      "status",
+    ]),
+    calls: store.collection<TwilioCall>("twilio.calls", ["sid", "account_sid", "to", "from", "status"]),
+    webhookDeliveries: store.collection<TwilioWebhookDelivery>("twilio.webhook_deliveries", [
+      "twilio_id",
+      "account_sid",
+      "event",
+    ]),
+    conversationServices: store.collection<TwilioConversationService>("twilio.conversation_services", [
+      "sid",
+      "account_sid",
+    ]),
+    conversations: store.collection<TwilioConversation>("twilio.conversations", [
+      "sid",
+      "account_sid",
+      "service_sid",
+      "unique_name",
+    ]),
+    conversationParticipants: store.collection<TwilioConversationParticipant>("twilio.conversation_participants", [
+      "sid",
+      "account_sid",
+      "service_sid",
+      "conversation_sid",
+      "identity",
+    ]),
+    conversationMessages: store.collection<TwilioConversationMessage>("twilio.conversation_messages", [
+      "sid",
+      "account_sid",
+      "service_sid",
+      "conversation_sid",
+    ]),
+  };
+}

--- a/packages/@emulators/twilio/tsconfig.json
+++ b/packages/@emulators/twilio/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@emulators/twilio/tsup.config.ts
+++ b/packages/@emulators/twilio/tsup.config.ts
@@ -1,0 +1,19 @@
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineConfig } from "tsup";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/@emulators/twilio/vitest.config.ts
+++ b/packages/@emulators/twilio/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -71,6 +71,7 @@
     "@emulators/stripe": "workspace:*",
     "@emulators/clerk": "workspace:*",
     "@emulators/linear": "workspace:*",
+    "@emulators/twilio": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -28,6 +28,7 @@ const SERVICE_NAME_LIST = [
   "mongoatlas",
   "clerk",
   "linear",
+  "twilio",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -566,6 +567,64 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
           },
         ],
         strict_scopes: false,
+      },
+    },
+  },
+
+  twilio: {
+    label: "Twilio API emulator",
+    endpoints:
+      "accounts, API keys, phone numbers, Programmable Messaging, Messaging Services, Verify, Voice, webhooks, simulator, inspector",
+    async load() {
+      const mod = await import("@emulators/twilio");
+      return { plugin: mod.twilioPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback(cfg) {
+      const account = cfg?.account as { sid?: string } | undefined;
+      return {
+        login: account?.sid ?? "AC00000000000000000000000000000000",
+        id: 1,
+        scopes: [],
+      };
+    },
+    initConfig: {
+      twilio: {
+        account: {
+          sid: "AC00000000000000000000000000000000",
+          auth_token: "twilio_test_auth_token",
+          friendly_name: "Local Twilio Account",
+        },
+        api_keys: [
+          {
+            sid: "SK00000000000000000000000000000000",
+            secret: "twilio_test_api_secret",
+            friendly_name: "Local API Key",
+          },
+        ],
+        phone_numbers: [
+          {
+            phone_number: "+15551234567",
+            friendly_name: "Local SMS and Voice Number",
+            sms_url: "http://localhost:3000/api/twilio/sms",
+            voice_url: "http://localhost:3000/api/twilio/voice",
+          },
+        ],
+        messaging_services: [
+          {
+            friendly_name: "Local Messaging Service",
+            phone_numbers: ["+15551234567"],
+          },
+        ],
+        verify_services: [
+          {
+            friendly_name: "Local Verify Service",
+            code: "123456",
+            default_channel: "sms",
+          },
+        ],
+        conversations: {
+          services: [{ friendly_name: "Local Conversations" }],
+        },
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,25 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/@emulators/twilio:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
+      twilio:
+        specifier: ^6.0.2
+        version: 6.0.2
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+
   packages/@emulators/vercel:
     dependencies:
       '@emulators/core':
@@ -756,6 +775,9 @@ importers:
       '@emulators/stripe':
         specifier: workspace:*
         version: link:../@emulators/stripe
+      '@emulators/twilio':
+        specifier: workspace:*
+        version: link:../@emulators/twilio
       '@emulators/vercel':
         specifier: workspace:*
         version: link:../@emulators/vercel
@@ -3502,6 +3524,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -3897,6 +3922,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
@@ -4620,6 +4648,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -4627,6 +4659,12 @@ packages:
   just-bash@2.14.0:
     resolution: {integrity: sha512-hiwsAa7OugRX5/fHhRijpyASioZ/UGjt/fjS15DQmrcFJmsBFabefZogdBJifw0WJUVqUiqATVRbhcwKScrD3w==}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   katex@0.16.40:
     resolution: {integrity: sha512-1DJcK/L05k1Y9Gf7wMcyuqFOL6BiY3vY0CFcAM/LPRN04NALxcl6u7lOWNsp3f/bCHWxigzQl6FbR95XJ4R84Q==}
@@ -4751,8 +4789,29 @@ packages:
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -5264,6 +5323,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -5488,6 +5551,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  scmp@2.1.0:
+    resolution: {integrity: sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==}
+    deprecated: Just use Node.js's crypto.timingSafeEqual()
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5817,6 +5884,10 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  twilio@6.0.2:
+    resolution: {integrity: sha512-RN3TZxUtxLz2HBZVt62+LdZxQbrMVgYKtuzLgwmO7nqKvR+gQS5mCackD9hf4Y7MmoK/bX7tCm7kaJC8kC8zFA==}
+    engines: {node: '>=20.0.0'}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6088,6 +6159,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xmlbuilder@13.0.2:
+    resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
+    engines: {node: '>=6.0'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -9186,6 +9261,8 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -9592,6 +9669,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.321: {}
 
@@ -10559,6 +10640,19 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -10588,6 +10682,17 @@ snapshots:
       node-liblzma: 2.2.0
     transitivePeerDependencies:
       - supports-color
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   katex@0.16.40:
     dependencies:
@@ -10683,7 +10788,21 @@ snapshots:
 
   lodash-es@4.17.23: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   longest-streak@3.1.0: {}
 
@@ -11488,6 +11607,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   quickjs-emscripten-core@0.32.0:
@@ -11855,8 +11978,7 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
-  safe-buffer@5.2.1:
-    optional: true
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -11872,6 +11994,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
+
+  scmp@2.1.0: {}
 
   semver@6.3.1: {}
 
@@ -12293,6 +12417,19 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  twilio@6.0.2:
+    dependencies:
+      axios: 1.16.1
+      dayjs: 1.11.20
+      https-proxy-agent: 5.0.1
+      jsonwebtoken: 9.0.3
+      qs: 6.15.2
+      scmp: 2.1.0
+      xmlbuilder: 13.0.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -12590,6 +12727,8 @@ snapshots:
 
   wrappy@1.0.2:
     optional: true
+
+  xmlbuilder@13.0.2: {}
 
   yallist@3.1.1: {}
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -31,6 +31,7 @@ All services start with sensible defaults:
 | MongoDB Atlas | 4010   |
 | Clerk     | 4011        |
 | Linear    | 4012        |
+| Twilio    | 4013        |
 
 ## CLI
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -96,7 +96,7 @@ await vercel.close()
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, or `'linear'` |
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -392,6 +392,7 @@ packages/
     google/          # Google OAuth 2.0 / OIDC plugin
     slack/           # Slack Web API, OAuth, incoming webhooks plugin
     linear/          # Linear GraphQL API, OAuth, webhooks plugin
+    twilio/          # Twilio Messaging, Verify, Voice, webhooks plugin
     apple/           # Sign in with Apple / OIDC plugin
     microsoft/       # Microsoft Entra ID OAuth 2.0 / OIDC plugin
     aws/             # AWS S3, SQS, IAM, STS plugin

--- a/skills/twilio/SKILL.md
+++ b/skills/twilio/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: twilio
+description: Emulated Twilio REST APIs for local development and testing. Use when the user needs to test Twilio Messaging, Verify, Voice, phone numbers, webhooks, status callbacks, inbound SMS simulation, or Twilio SDK integrations without hitting the real Twilio service.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# Twilio API Emulator
+
+Stateful Twilio REST emulation with seeded accounts, Auth Tokens, API keys, incoming phone numbers, Programmable Messaging, Messaging Services, Verify, basic Voice calls, Conversations REST resources, signed webhooks, local simulator routes, and an inspector.
+
+## Start
+
+```bash
+npx emulate --service twilio
+```
+
+Default URL: `http://localhost:4013` when all services are started, or `http://localhost:4000` when Twilio is the only service.
+
+## Defaults
+
+```text
+TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000
+TWILIO_AUTH_TOKEN=twilio_test_auth_token
+TWILIO_API_KEY=SK00000000000000000000000000000000
+TWILIO_API_SECRET=twilio_test_api_secret
+TWILIO_PHONE_NUMBER=+15551234567
+TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
+```
+
+## URL Mapping
+
+| Real Twilio URL | Emulator URL |
+|-----------------|--------------|
+| `https://api.twilio.com/2010-04-01/...` | `$TWILIO_EMULATOR_URL/2010-04-01/...` |
+| `https://messaging.twilio.com/v1/...` | `$TWILIO_EMULATOR_URL/messaging/v1/...` |
+| `https://verify.twilio.com/v2/...` | `$TWILIO_EMULATOR_URL/verify/v2/...` |
+
+The official Node SDK builds absolute Twilio product URLs. In SDK tests, use a custom request client that rewrites those hosts to the emulator prefixes above.
+
+## Auth
+
+HTTP Basic auth accepts either:
+
+- Account SID and Auth Token
+- API Key SID and API Key Secret
+
+## Core Routes
+
+- `POST /2010-04-01/Accounts/{AccountSid}/Messages.json` - create outbound message
+- `GET /2010-04-01/Accounts/{AccountSid}/Messages.json` - list messages
+- `POST /2010-04-01/Accounts/{AccountSid}/Calls.json` - create outbound call
+- `POST /verify/v2/Services/{ServiceSid}/Verifications` - start verification
+- `POST /verify/v2/Services/{ServiceSid}/VerificationCheck` - check verification code
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations` - create Conversation
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Participants` - add participant
+- `POST /conversations/v1/Services/{ServiceSid}/Conversations/{ConversationSid}/Messages` - add message
+- `POST /_twilio/simulate/inbound-message` - simulate inbound SMS
+- `POST /_twilio/simulate/message-status` - simulate message status callback
+- `POST /_twilio/simulate/inbound-call` - simulate inbound call
+
+## Current Limits
+
+No real SMS, MMS, WhatsApp, email, voice, carrier, compliance, billing, SendGrid, Studio, Flex, TaskRouter, Video, Sync, Segment, Conversations SDK websocket behavior, or complete TwiML interpreter behavior is implemented.

--- a/skills/twilio/SKILL.md
+++ b/skills/twilio/SKILL.md
@@ -58,6 +58,16 @@ HTTP Basic auth accepts either:
 - `POST /_twilio/simulate/message-status` - simulate message status callback
 - `POST /_twilio/simulate/inbound-call` - simulate inbound call
 
+## SMS And OTP Testing
+
+- The seeded Verify Service code is `123456`.
+- Use `CustomCode` when creating a Verification to force a per-verification code.
+- Use `GET /_twilio/simulate/verification-code?To=...&ServiceSid=...` with Basic auth to fetch the latest local code for an E2E test.
+- Use `POST /_twilio/simulate/verification-status` with `VerificationSid` or `To` to force local Verify state.
+- Use `POST /_twilio/simulate/inbound-message` to test inbound SMS webhooks.
+- Inbound SMS uses an assigned Messaging Service `inbound_request_url` before falling back to the phone number `sms_url`.
+- Use `POST /_twilio/simulate/message-status` to test outbound status callbacks.
+
 ## Current Limits
 
 No real SMS, MMS, WhatsApp, email, voice, carrier, compliance, billing, SendGrid, Studio, Flex, TaskRouter, Video, Sync, Segment, Conversations SDK websocket behavior, or complete TwiML interpreter behavior is implemented.


### PR DESCRIPTION
- Add Twilio REST emulator package with Messaging, Verify, Voice, Conversations, simulator, and inspector surfaces.
- Register Twilio in the service registry with seeded local account, key, number, messaging, and verify resources.
- Document Twilio usage across README, web docs, package docs, and skills with SDK conformance coverage.