### PR TITLE
Add Twilio SMS verification example

### DIFF
--- a/examples/twilio-sms-verification/.gitignore
+++ b/examples/twilio-sms-verification/.gitignore
@@ -1,0 +1,15 @@
+/node_modules
+/.next/
+/out/
+/build
+.DS_Store
+*.pem
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.env*
+.vercel
+*.tsbuildinfo
+next-env.d.ts
+.emulate/

--- a/examples/twilio-sms-verification/README.md
+++ b/examples/twilio-sms-verification/README.md
@@ -1,0 +1,91 @@
+# SMS Verification with Twilio
+
+A Next.js app demonstrating phone number verification (SMS OTP) using the [Twilio Verify](https://www.twilio.com/docs/verify) API, powered by the emulated Twilio service from `emulate`.
+
+No real SMS is sent. The emulator runs the Verify flow entirely in-memory, so you can complete the verification with the seeded code or inspect state through the inspector UI.
+
+## How it works
+
+1. User enters their phone number on the home page
+2. The server starts a verification via the official Twilio SDK: `verify.v2.services(SID).verifications.create({ to, channel: "sms" })`
+3. The user is redirected to a verification page
+4. The user enters the code and the server checks it: `verify.v2.services(SID).verificationChecks.create({ to, code })`
+5. On success, a session cookie is set and the user lands on the dashboard
+
+The seeded Verify Service accepts the code `123456` for every verification, so the demo can be completed without reading an SMS.
+
+## Pointing the SDK at the emulator
+
+The official Twilio SDK builds absolute URLs against product hosts like `api.twilio.com` and `verify.twilio.com`. `src/lib/twilio.ts` installs a custom request client that rewrites those hosts onto the embedded emulator, which mounts each product under a path prefix:
+
+| Real Twilio URL                          | Emulator URL                                        |
+| ---------------------------------------- | --------------------------------------------------- |
+| `https://api.twilio.com/2010-04-01/...`  | `http://localhost:3000/emulate/twilio/2010-04-01/...` |
+| `https://verify.twilio.com/v2/...`       | `http://localhost:3000/emulate/twilio/verify/v2/...`  |
+| `https://messaging.twilio.com/v1/...`    | `http://localhost:3000/emulate/twilio/messaging/v1/...` |
+
+The base URL is set via `TWILIO_BASE_URL` in `next.config.ts`.
+
+## Getting started
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter twilio-sms-verification dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Inspecting verifications
+
+### Inspector UI
+
+Visit [http://localhost:3000/emulate/twilio/?tab=verify](http://localhost:3000/emulate/twilio/?tab=verify) to browse Verify services and verifications (including the issued code) in a web interface.
+
+### Fetching the code programmatically
+
+This is useful in tests or agent workflows where you need to complete the flow without a human reading the SMS:
+
+```bash
+# Start a verification (sets the pending_verification cookie)
+curl -s -c cookies.txt -L -X POST http://localhost:3000 \
+  --data-urlencode "phone=+15555550123"
+
+# Fetch the latest local code for that number
+curl -s -G http://localhost:3000/emulate/twilio/_twilio/simulate/verification-code \
+  --data-urlencode "To=+15555550123" \
+  --data-urlencode "ServiceSid=VA00000000000000000000000000000000" \
+  -u "AC00000000000000000000000000000000:twilio_test_auth_token" | jq -r '.code'
+```
+
+## Seeded defaults
+
+The Twilio emulator boots with a ready-to-use account and Verify Service:
+
+```text
+TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000
+TWILIO_AUTH_TOKEN=twilio_test_auth_token
+TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
+Seeded Verify code=123456
+```
+
+## Project structure
+
+```
+src/
+  app/
+    page.tsx                    Phone entry form
+    phone-form.tsx              Client component for phone input
+    actions.ts                  Server actions (send code, check code, sign out)
+    verify/
+      page.tsx                  Verification page (enter code)
+      verify-form.tsx           Client component for code input
+    dashboard/
+      page.tsx                  Verified landing page
+    emulate/
+      [...path]/route.ts        Embedded emulator (Twilio)
+  lib/
+    twilio.ts                   Twilio SDK client + request client that targets the emulator
+    session.ts                  Cookie-based session helpers
+```

--- a/examples/twilio-sms-verification/README.md
+++ b/examples/twilio-sms-verification/README.md
@@ -48,8 +48,8 @@ Visit [http://localhost:3000/emulate/twilio/?tab=verify](http://localhost:3000/e
 This is useful in tests or agent workflows where you need to complete the flow without a human reading the SMS:
 
 ```bash
-# Start a verification (sets the pending_verification cookie)
-curl -s -c cookies.txt -L -X POST http://localhost:3000 \
+# Start a verification through the example API route (sets the pending_verification cookie)
+curl -s -c cookies.txt -X POST http://localhost:3000/api/verification/start \
   --data-urlencode "phone=+15555550123"
 
 # Fetch the latest local code for that number
@@ -83,9 +83,13 @@ src/
       verify-form.tsx           Client component for code input
     dashboard/
       page.tsx                  Verified landing page
+    api/
+      verification/start/
+        route.ts                Programmatic send-code route for tests and agents
     emulate/
       [...path]/route.ts        Embedded emulator (Twilio)
   lib/
     twilio.ts                   Twilio SDK client + request client that targets the emulator
     session.ts                  Cookie-based session helpers
+    verification.ts             Shared verification starter
 ```

--- a/examples/twilio-sms-verification/eslint.config.mjs
+++ b/examples/twilio-sms-verification/eslint.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
+]);
+
+export default eslintConfig;

--- a/examples/twilio-sms-verification/next.config.ts
+++ b/examples/twilio-sms-verification/next.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from "path";
+import type { NextConfig } from "next";
+import { withEmulate } from "@emulators/adapter-next";
+
+const port = process.env.PORT ?? "3000";
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    root: resolve(import.meta.dirname, "../.."),
+  },
+  env: {
+    // Point the official Twilio SDK at the embedded emulator. The custom request
+    // client in src/lib/twilio.ts rewrites Twilio product hosts to this base URL.
+    TWILIO_BASE_URL: `http://localhost:${port}/emulate/twilio`,
+  },
+};
+
+export default withEmulate(nextConfig);

--- a/examples/twilio-sms-verification/package.json
+++ b/examples/twilio-sms-verification/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "twilio-sms-verification",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.3.0",
+    "@emulators/adapter-next": "workspace:*",
+    "@emulators/twilio": "workspace:*",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.577.0",
+    "next": "16.2.0",
+    "twilio": "^6.0.2",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "tailwind-merge": "^3.5.0",
+    "tw-animate-css": "^1.4.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.2.0",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}

--- a/examples/twilio-sms-verification/postcss.config.mjs
+++ b/examples/twilio-sms-verification/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/examples/twilio-sms-verification/src/app/actions.ts
+++ b/examples/twilio-sms-verification/src/app/actions.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { twilioClient, VERIFY_SERVICE_SID } from "@/lib/twilio";
+import { encodePendingVerification, encodeSession, getPendingVerification } from "@/lib/session";
+
+export async function sendCodeAction(_prev: { error: string } | null, formData: FormData) {
+  const phone = (formData.get("phone") as string)?.trim();
+  if (!phone) return { error: "Phone number is required" };
+
+  try {
+    await twilioClient.verify.v2.services(VERIFY_SERVICE_SID).verifications.create({
+      to: phone,
+      channel: "sms",
+    });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to send verification code" };
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set(
+    "pending_verification",
+    encodePendingVerification({ phone, expiresAt: Date.now() + 10 * 60 * 1000 }),
+    {
+      httpOnly: true,
+      path: "/",
+      maxAge: 600,
+    },
+  );
+
+  redirect("/verify");
+}
+
+export async function verifyCodeAction(_prev: { error: string } | null, formData: FormData) {
+  const code = (formData.get("code") as string)?.trim();
+  if (!code) return { error: "Code is required" };
+
+  const pending = await getPendingVerification();
+  if (!pending) return { error: "No pending verification. Please start over." };
+
+  let approved = false;
+  try {
+    const check = await twilioClient.verify.v2.services(VERIFY_SERVICE_SID).verificationChecks.create({
+      to: pending.phone,
+      code,
+    });
+    approved = check.status === "approved";
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to verify code" };
+  }
+
+  if (!approved) return { error: "Invalid code. Please try again." };
+
+  const cookieStore = await cookies();
+  cookieStore.delete("pending_verification");
+  cookieStore.set("session", encodeSession({ phone: pending.phone, verifiedAt: new Date().toISOString() }), {
+    httpOnly: true,
+    path: "/",
+    maxAge: 86400,
+  });
+
+  redirect("/dashboard");
+}
+
+export async function signOutAction() {
+  const cookieStore = await cookies();
+  cookieStore.delete("session");
+  redirect("/");
+}

--- a/examples/twilio-sms-verification/src/app/actions.ts
+++ b/examples/twilio-sms-verification/src/app/actions.ts
@@ -3,31 +3,18 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { twilioClient, VERIFY_SERVICE_SID } from "@/lib/twilio";
-import { encodePendingVerification, encodeSession, getPendingVerification } from "@/lib/session";
+import { encodeSession, getPendingVerification } from "@/lib/session";
+import { startSmsVerification } from "@/lib/verification";
 
 export async function sendCodeAction(_prev: { error: string } | null, formData: FormData) {
   const phone = (formData.get("phone") as string)?.trim();
   if (!phone) return { error: "Phone number is required" };
 
   try {
-    await twilioClient.verify.v2.services(VERIFY_SERVICE_SID).verifications.create({
-      to: phone,
-      channel: "sms",
-    });
+    await startSmsVerification(phone);
   } catch (err) {
     return { error: err instanceof Error ? err.message : "Failed to send verification code" };
   }
-
-  const cookieStore = await cookies();
-  cookieStore.set(
-    "pending_verification",
-    encodePendingVerification({ phone, expiresAt: Date.now() + 10 * 60 * 1000 }),
-    {
-      httpOnly: true,
-      path: "/",
-      maxAge: 600,
-    },
-  );
 
   redirect("/verify");
 }

--- a/examples/twilio-sms-verification/src/app/api/verification/start/route.ts
+++ b/examples/twilio-sms-verification/src/app/api/verification/start/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { startSmsVerification } from "@/lib/verification";
+
+async function phoneFromRequest(request: Request): Promise<string | null> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const body = (await request.json()) as { phone?: unknown };
+    return typeof body.phone === "string" ? body.phone.trim() : null;
+  }
+
+  const formData = await request.formData();
+  const phone = formData.get("phone");
+  return typeof phone === "string" ? phone.trim() : null;
+}
+
+export async function POST(request: Request) {
+  const phone = await phoneFromRequest(request);
+  if (!phone) {
+    return NextResponse.json({ error: "Phone number is required" }, { status: 400 });
+  }
+
+  try {
+    await startSmsVerification(phone);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to send verification code" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, phone, next: "/verify" });
+}

--- a/examples/twilio-sms-verification/src/app/dashboard/page.tsx
+++ b/examples/twilio-sms-verification/src/app/dashboard/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import { signOutAction } from "../actions";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button-variants";
+import { cn } from "@/lib/utils";
+
+export default async function DashboardPage() {
+  const session = await getSession();
+  if (!session) redirect("/");
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Phone verified</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 items-center">
+          <p className="text-sm text-muted-foreground">
+            Verified as <strong className="text-foreground">{session.phone}</strong>
+          </p>
+          <form action={signOutAction}>
+            <button type="submit" className={cn(buttonVariants({ variant: "outline", size: "lg" }))}>
+              Sign out
+            </button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/examples/twilio-sms-verification/src/app/emulate/[...path]/route.ts
+++ b/examples/twilio-sms-verification/src/app/emulate/[...path]/route.ts
@@ -1,0 +1,10 @@
+import { createEmulateHandler } from "@emulators/adapter-next";
+import * as twilio from "@emulators/twilio";
+
+export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
+  services: {
+    twilio: {
+      emulator: twilio,
+    },
+  },
+});

--- a/examples/twilio-sms-verification/src/app/globals.css
+++ b/examples/twilio-sms-verification/src/app/globals.css
@@ -1,0 +1,65 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-geist-mono);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+}
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+  html {
+    @apply font-sans;
+  }
+}

--- a/examples/twilio-sms-verification/src/app/layout.tsx
+++ b/examples/twilio-sms-verification/src/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+import "./globals.css";
+
+const geistSans = Geist({
+  variable: "--font-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "SMS Verification with Twilio",
+  description: "Phone number verification using the emulated Twilio Verify API",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+      <body className="min-h-full flex flex-col bg-background text-foreground">{children}</body>
+    </html>
+  );
+}

--- a/examples/twilio-sms-verification/src/app/page.tsx
+++ b/examples/twilio-sms-verification/src/app/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PhoneForm } from "./phone-form";
+
+export default async function Home() {
+  const session = await getSession();
+  if (session) redirect("/dashboard");
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Verify your phone</CardTitle>
+          <CardDescription>Enter your phone number to receive a verification code by SMS</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <PhoneForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/examples/twilio-sms-verification/src/app/phone-form.tsx
+++ b/examples/twilio-sms-verification/src/app/phone-form.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useActionState } from "react";
+import { sendCodeAction } from "./actions";
+import { Button } from "@/components/ui/button";
+
+export function PhoneForm() {
+  const [state, formAction, pending] = useActionState(sendCodeAction, null);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-3">
+      <label htmlFor="phone" className="text-sm font-medium">
+        Phone number
+      </label>
+      <input
+        id="phone"
+        name="phone"
+        type="tel"
+        required
+        defaultValue="+15555550123"
+        placeholder="+15555550123"
+        className="flex h-9 w-full rounded-lg border border-input bg-background px-3 py-1 text-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+      {state?.error && <p className="text-sm text-destructive">{state.error}</p>}
+      <Button type="submit" size="lg" disabled={pending} className="w-full mt-1">
+        {pending ? "Sending..." : "Send verification code"}
+      </Button>
+    </form>
+  );
+}

--- a/examples/twilio-sms-verification/src/app/verify/page.tsx
+++ b/examples/twilio-sms-verification/src/app/verify/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getSession, getPendingVerification } from "@/lib/session";
+import { SEEDED_VERIFY_CODE } from "@/lib/twilio";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { VerifyForm } from "./verify-form";
+
+export default async function VerifyPage() {
+  const session = await getSession();
+  if (session) redirect("/dashboard");
+
+  const pending = await getPendingVerification();
+  if (!pending) redirect("/");
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Enter the code</CardTitle>
+          <CardDescription>
+            We sent a 6-digit code to <strong className="text-foreground">{pending.phone}</strong>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <VerifyForm />
+          <div className="rounded-lg border border-dashed border-border bg-muted/50 p-3 text-center">
+            <p className="text-xs text-muted-foreground mb-2">
+              No SMS is actually sent. The emulator&apos;s seeded Verify Service always accepts the code{" "}
+              <code className="font-mono font-medium text-foreground">{SEEDED_VERIFY_CODE}</code>.
+            </p>
+            <a
+              href="/emulate/twilio/?tab=verify"
+              target="_blank"
+              className="text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80"
+            >
+              Open Twilio Inspector
+            </a>
+          </div>
+          <Link href="/" className="text-sm text-center text-muted-foreground hover:text-foreground transition-colors">
+            Use a different number
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/examples/twilio-sms-verification/src/app/verify/verify-form.tsx
+++ b/examples/twilio-sms-verification/src/app/verify/verify-form.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useActionState } from "react";
+import { verifyCodeAction } from "../actions";
+import { Button } from "@/components/ui/button";
+
+export function VerifyForm() {
+  const [state, formAction, pending] = useActionState(verifyCodeAction, null);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-3">
+      <label htmlFor="code" className="text-sm font-medium">
+        Verification code
+      </label>
+      <input
+        id="code"
+        name="code"
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]{6}"
+        maxLength={6}
+        required
+        autoFocus
+        placeholder="000000"
+        className="flex h-12 w-full rounded-lg border border-input bg-background px-3 py-1 text-center text-2xl font-mono tracking-[0.3em] transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+      {state?.error && <p className="text-sm text-destructive text-center">{state.error}</p>}
+      <Button type="submit" size="lg" disabled={pending} className="w-full">
+        {pending ? "Verifying..." : "Verify"}
+      </Button>
+    </form>
+  );
+}

--- a/examples/twilio-sms-verification/src/components/ui/button-variants.ts
+++ b/examples/twilio-sms-verification/src/components/ui/button-variants.ts
@@ -1,0 +1,27 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-8 gap-1.5 px-2.5",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem]",
+        lg: "h-9 gap-1.5 px-3",
+        icon: "size-8",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);

--- a/examples/twilio-sms-verification/src/components/ui/button.tsx
+++ b/examples/twilio-sms-verification/src/components/ui/button.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import type { VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "./button-variants";
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return <ButtonPrimitive data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />;
+}
+
+export { Button, buttonVariants };

--- a/examples/twilio-sms-verification/src/components/ui/card.tsx
+++ b/examples/twilio-sms-verification/src/components/ui/card.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-header" className={cn("grid auto-rows-min gap-1 px-4", className)} {...props} />;
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-title" className={cn("text-base leading-snug font-medium", className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-description" className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-content" className={cn("px-4", className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center rounded-b-xl border-t bg-muted/50 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/examples/twilio-sms-verification/src/lib/session.ts
+++ b/examples/twilio-sms-verification/src/lib/session.ts
@@ -1,0 +1,46 @@
+import { cookies } from "next/headers";
+
+const SESSION_COOKIE = "session";
+const PENDING_COOKIE = "pending_verification";
+
+export type Session = {
+  phone: string;
+  verifiedAt: string;
+};
+
+interface PendingVerification {
+  phone: string;
+  expiresAt: number;
+}
+
+export async function getSession(): Promise<Session | null> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!raw) return null;
+  try {
+    return JSON.parse(Buffer.from(raw, "base64url").toString("utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+export function encodeSession(session: Session): string {
+  return Buffer.from(JSON.stringify(session)).toString("base64url");
+}
+
+export async function getPendingVerification(): Promise<PendingVerification | null> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(PENDING_COOKIE)?.value;
+  if (!raw) return null;
+  try {
+    const pending = JSON.parse(Buffer.from(raw, "base64url").toString("utf-8")) as PendingVerification;
+    if (Date.now() > pending.expiresAt) return null;
+    return pending;
+  } catch {
+    return null;
+  }
+}
+
+export function encodePendingVerification(pending: PendingVerification): string {
+  return Buffer.from(JSON.stringify(pending)).toString("base64url");
+}

--- a/examples/twilio-sms-verification/src/lib/twilio.ts
+++ b/examples/twilio-sms-verification/src/lib/twilio.ts
@@ -1,0 +1,78 @@
+import twilio from "twilio";
+
+// Seeded defaults from the Twilio emulator. The emulator boots with a single
+// account, Auth Token, and Verify Service so no setup is required.
+export const TWILIO_ACCOUNT_SID = "AC00000000000000000000000000000000";
+export const TWILIO_AUTH_TOKEN = "twilio_test_auth_token";
+export const VERIFY_SERVICE_SID = "VA00000000000000000000000000000000";
+
+// The seeded Verify Service issues this code for every verification unless a
+// CustomCode is supplied. Shown in the UI so the demo can be completed without
+// opening the inspector.
+export const SEEDED_VERIFY_CODE = "123456";
+
+const EMULATOR_BASE_URL = process.env.TWILIO_BASE_URL ?? "http://localhost:3000/emulate/twilio";
+
+// The official Twilio SDK builds absolute URLs against product hosts such as
+// api.twilio.com and verify.twilio.com. This request client rewrites those
+// hosts onto the embedded emulator, which mounts each product under a path
+// prefix (see the URL mapping in the emulator docs).
+const HOST_PREFIXES: Record<string, string> = {
+  "api.twilio.com": "",
+  "verify.twilio.com": "/verify",
+  "messaging.twilio.com": "/messaging",
+  "conversations.twilio.com": "/conversations",
+};
+
+interface TwilioRequestOptions {
+  method: string;
+  uri: string;
+  username?: string;
+  password?: string;
+  headers?: Record<string, string>;
+  params?: Record<string, string | number | boolean>;
+  data?: Record<string, unknown>;
+}
+
+class EmulatorRequestClient {
+  async request(opts: TwilioRequestOptions) {
+    const original = new URL(opts.uri);
+    const prefix = HOST_PREFIXES[original.hostname] ?? "";
+    const target = new URL(`${EMULATOR_BASE_URL}${prefix}${original.pathname}`);
+
+    for (const [key, value] of Object.entries(opts.params ?? {})) {
+      target.searchParams.set(key, String(value));
+    }
+
+    const headers: Record<string, string> = { ...(opts.headers ?? {}) };
+    if (opts.username && opts.password) {
+      headers.Authorization = `Basic ${Buffer.from(`${opts.username}:${opts.password}`).toString("base64")}`;
+    }
+
+    let body: string | undefined;
+    if (opts.data && Object.keys(opts.data).length > 0) {
+      body = new URLSearchParams(
+        Object.entries(opts.data).flatMap(([key, value]) => {
+          if (Array.isArray(value)) return value.map((item) => [key, String(item)] as [string, string]);
+          if (value === undefined || value === null) return [];
+          return [[key, String(value)] as [string, string]];
+        }),
+      ).toString();
+      headers["Content-Type"] = headers["Content-Type"] ?? "application/x-www-form-urlencoded";
+    }
+
+    const response = await fetch(target, { method: opts.method.toUpperCase(), headers, body });
+    const text = await response.text();
+
+    return {
+      statusCode: response.status,
+      body: text ? JSON.parse(text) : "",
+      headers: Object.fromEntries(response.headers.entries()),
+    };
+  }
+}
+
+export const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  httpClient: new EmulatorRequestClient() as any,
+});

--- a/examples/twilio-sms-verification/src/lib/twilio.ts
+++ b/examples/twilio-sms-verification/src/lib/twilio.ts
@@ -38,7 +38,7 @@ class EmulatorRequestClient {
   async request(opts: TwilioRequestOptions) {
     const original = new URL(opts.uri);
     const prefix = HOST_PREFIXES[original.hostname] ?? "";
-    const target = new URL(`${EMULATOR_BASE_URL}${prefix}${original.pathname}`);
+    const target = new URL(`${EMULATOR_BASE_URL}${prefix}${original.pathname}${original.search}`);
 
     for (const [key, value] of Object.entries(opts.params ?? {})) {
       target.searchParams.set(key, String(value));

--- a/examples/twilio-sms-verification/src/lib/utils.ts
+++ b/examples/twilio-sms-verification/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/examples/twilio-sms-verification/src/lib/verification.ts
+++ b/examples/twilio-sms-verification/src/lib/verification.ts
@@ -1,0 +1,21 @@
+import { cookies } from "next/headers";
+import { encodePendingVerification } from "@/lib/session";
+import { twilioClient, VERIFY_SERVICE_SID } from "@/lib/twilio";
+
+export async function startSmsVerification(phone: string) {
+  await twilioClient.verify.v2.services(VERIFY_SERVICE_SID).verifications.create({
+    to: phone,
+    channel: "sms",
+  });
+
+  const cookieStore = await cookies();
+  cookieStore.set(
+    "pending_verification",
+    encodePendingVerification({ phone, expiresAt: Date.now() + 10 * 60 * 1000 }),
+    {
+      httpOnly: true,
+      path: "/",
+      maxAge: 600,
+    },
+  );
+}

--- a/examples/twilio-sms-verification/tsconfig.json
+++ b/examples/twilio-sms-verification/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,70 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  examples/twilio-sms-verification:
+    dependencies:
+      '@base-ui/react':
+        specifier: ^1.3.0
+        version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@emulators/adapter-next':
+        specifier: workspace:*
+        version: link:../../packages/@emulators/adapter-next
+      '@emulators/twilio':
+        specifier: workspace:*
+        version: link:../../packages/@emulators/twilio
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.4)
+      next:
+        specifier: 16.2.0
+        version: 16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      twilio:
+        specifier: ^6.0.2
+        version: 6.0.2
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.2.2
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^9
+        version: 9.39.4(jiti@2.6.1)
+      eslint-config-next:
+        specifier: 16.2.0
+        version: 16.2.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4
+        version: 4.2.2
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   examples/vercel-blob-sharing:
     dependencies:
       '@base-ui/react':


### PR DESCRIPTION
- Next.js OTP flow (enter phone -> verify code -> dashboard) using the official Twilio SDK against the embedded Twilio Verify emulator
- Custom SDK request client rewrites Twilio product hosts (api/verify/messaging) onto the emulator's path prefixes via TWILIO_BASE_URL
- No real SMS sent; uses seeded account/Verify Service defaults (code 123456) with a link to the Twilio inspector