### PR TITLE
Release 0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  EMULATOR_PACKAGES: adapter-next apple aws clerk core github google microsoft mongoatlas okta resend slack stripe vercel
+  EMULATOR_PACKAGES: adapter-next adapter-nuxt apple aws clerk core github google linear microsoft mongoatlas okta resend slack stripe twilio vercel
 
 jobs:
   check-release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 <!-- release:start -->
+## 0.9.0
+
+### New Features
+
+- **Nuxt emulator adapter** — new `@emulators/adapter-nuxt` package for embedding emulators in Nuxt apps, with Nuxt server route handling, persistence, response rewriting, and Nitro tracing support (#188)
+- **Nuxt embedded example** — added `examples/nuxt-embedded` demonstrating same-origin OAuth flows (GitHub + Google), a catch-all emulate server route, and cookie-based sessions (#188)
+
+### Improvements
+
+- **Nuxt docs and agent guidance** — documented Nuxt setup across the README, docs site, and agent skills (#188)
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
 ## 0.8.0
 
 ### New Features
@@ -15,8 +32,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.7.0
 

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-next",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/adapter-nuxt/package.json
+++ b/packages/@emulators/adapter-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-nuxt",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/apple/package.json
+++ b/packages/@emulators/apple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/apple",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/aws",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/clerk/package.json
+++ b/packages/@emulators/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/clerk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/core/package.json
+++ b/packages/@emulators/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/github/package.json
+++ b/packages/@emulators/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/github",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/google/package.json
+++ b/packages/@emulators/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/google",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/linear/package.json
+++ b/packages/@emulators/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/linear",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/microsoft/package.json
+++ b/packages/@emulators/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/microsoft",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/mongoatlas/package.json
+++ b/packages/@emulators/mongoatlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/mongoatlas",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/okta/package.json
+++ b/packages/@emulators/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/okta",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/resend/package.json
+++ b/packages/@emulators/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/resend",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/slack/package.json
+++ b/packages/@emulators/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/slack",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/stripe/package.json
+++ b/packages/@emulators/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/stripe",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/twilio/package.json
+++ b/packages/@emulators/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/twilio",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/vercel/package.json
+++ b/packages/@emulators/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/vercel",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulate",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Local drop-in replacement services for CI and no-network sandboxes",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Prepares the 0.9.0 release.

- **Bumped all `@emulators/*` packages and `emulate` to 0.9.0**
- **Added `adapter-nuxt`, `linear`, and `twilio` to the release workflow's publish list** (`EMULATOR_PACKAGES` in `release.yml`) so they get published alongside the other packages
- **Added a 0.9.0 changelog entry** covering:
  - New `@emulators/adapter-nuxt` package for embedding emulators in Nuxt apps (server route handling, persistence, response rewriting, Nitro tracing) (#188)
  - New `examples/nuxt-embedded` example demonstrating same-origin OAuth flows and cookie-based sessions (#188)
  - Nuxt documentation across the README, docs site, and agent skills (#188)