### PR TITLE
Add GitHub contents and commit APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 
 ### Repositories
 - `GET /repos/:owner/:repo` - get repo
+- `GET /repositories/:id` - get repo by numeric ID
 - `POST /user/repos` - create user repo
 - `POST /orgs/:org/repos` - create org repo
 - `PATCH /repos/:owner/:repo` - update repo
@@ -633,6 +634,14 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /repos/:owner/:repo/collaborators/:username/permission`
 - `POST /repos/:owner/:repo/transfer` - transfer repo
 - `GET /repos/:owner/:repo/tags` - list tags
+
+### Contents & Commit History
+- `GET /repos/:owner/:repo/readme` - get the repository README
+- `GET /repos/:owner/:repo/contents/:path` - get a file or list a directory at a ref
+- `PUT/DELETE /repos/:owner/:repo/contents/:path` - create, update, or delete a file and commit the change
+- `GET /repos/:owner/:repo/commits` - list commits with ref, path, author, and date filters
+- `GET /repos/:owner/:repo/commits/:ref` - get a commit with file diffs and stats
+- `GET /repos/:owner/:repo/compare/:base...:head` - compare two refs
 
 ### Issues
 - `GET /repos/:owner/:repo/issues` - list (filter by state, labels, assignee, milestone, creator, since)

--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 ### Contents & Commit History
 - `GET /repos/:owner/:repo/readme` - get the repository README
 - `GET /repos/:owner/:repo/contents/:path` - get a file or list a directory at a ref
+- `GET /:owner/:repo/raw/:ref/:path` - download file content from advertised raw URLs
 - `PUT/DELETE /repos/:owner/:repo/contents/:path` - create, update, or delete a file and commit the change
 - `GET /repos/:owner/:repo/commits` - list commits with ref, path, author, and date filters
 - `GET /repos/:owner/:repo/commits/:ref` - get a commit with file diffs and stats

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -35,6 +35,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 
 - `GET /repos/:owner/:repo/readme` - get the repository README
 - `GET /repos/:owner/:repo/contents/:path` - get a file or list a directory at a ref
+- `GET /:owner/:repo/raw/:ref/:path` - download file content from advertised raw URLs
 - `PUT/DELETE /repos/:owner/:repo/contents/:path` - create, update, or delete a file and commit the change
 - `GET /repos/:owner/:repo/commits` - list commits with ref, path, author, and date filters
 - `GET /repos/:owner/:repo/commits/:ref` - get a commit with file diffs and stats

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -16,6 +16,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 ## Repositories
 
 - `GET /repos/:owner/:repo` - get repo
+- `GET /repositories/:id` - get repo by numeric ID
 - `POST /user/repos` - create user repo
 - `POST /orgs/:org/repos` - create org repo
 - `PATCH /repos/:owner/:repo` - update repo
@@ -29,6 +30,15 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /repos/:owner/:repo/collaborators/:username/permission`
 - `POST /repos/:owner/:repo/transfer` - transfer repo
 - `GET /repos/:owner/:repo/tags` - list tags
+
+## Contents & Commit History
+
+- `GET /repos/:owner/:repo/readme` - get the repository README
+- `GET /repos/:owner/:repo/contents/:path` - get a file or list a directory at a ref
+- `PUT/DELETE /repos/:owner/:repo/contents/:path` - create, update, or delete a file and commit the change
+- `GET /repos/:owner/:repo/commits` - list commits with ref, path, author, and date filters
+- `GET /repos/:owner/:repo/commits/:ref` - get a commit with file diffs and stats
+- `GET /repos/:owner/:repo/compare/:base...:head` - compare two refs
 
 ## Issues
 

--- a/packages/@emulators/core/src/__tests__/auth.test.ts
+++ b/packages/@emulators/core/src/__tests__/auth.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Hono } from "../http.js";
-import { authMiddleware, requireAuth, requireAppAuth, type TokenMap, type AppEnv } from "../middleware/auth.js";
+import {
+  authMiddleware,
+  requireAuth,
+  requireAppAuth,
+  restoreTokenMap,
+  serializeTokenMap,
+  type TokenMap,
+  type AppEnv,
+} from "../middleware/auth.js";
 
 describe("authMiddleware", () => {
   let tokenMap: TokenMap;
@@ -54,6 +62,27 @@ describe("authMiddleware", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { user: unknown };
     expect(body.user).toBeNull();
+  });
+
+  it("preserves installation credentials when token maps are serialized", () => {
+    tokenMap.set("installation-token", {
+      login: "acme",
+      id: 7,
+      scopes: ["contents:write"],
+      installation: {
+        installationId: 42,
+        appId: 9,
+        accountId: 7,
+        accountType: "Organization",
+        permissions: { contents: "write" },
+        repositoryIds: [12],
+        repositorySelection: "selected",
+      },
+    });
+
+    const restored: TokenMap = new Map();
+    restoreTokenMap(restored, serializeTokenMap(tokenMap));
+    expect(restored.get("installation-token")).toEqual(tokenMap.get("installation-token"));
   });
 });
 

--- a/packages/@emulators/core/src/middleware/auth.ts
+++ b/packages/@emulators/core/src/middleware/auth.ts
@@ -6,6 +6,7 @@ export interface AuthUser {
   login: string;
   id: number;
   scopes: string[];
+  installation?: AuthInstallation;
 }
 
 export interface AuthApp {
@@ -17,6 +18,8 @@ export interface AuthApp {
 export interface AuthInstallation {
   installationId: number;
   appId: number;
+  accountId: number;
+  accountType: "User" | "Organization";
   permissions: Record<string, string>;
   repositoryIds: number[];
   repositorySelection: "all" | "selected";
@@ -29,6 +32,7 @@ export interface TokenEntry {
   login: string;
   id: number;
   scopes: string[];
+  installation?: AuthInstallation;
 }
 
 export function serializeTokenMap(tokenMap: TokenMap): TokenEntry[] {
@@ -37,13 +41,19 @@ export function serializeTokenMap(tokenMap: TokenMap): TokenEntry[] {
     login: user.login,
     id: user.id,
     scopes: user.scopes,
+    ...(user.installation ? { installation: user.installation } : {}),
   }));
 }
 
 export function restoreTokenMap(tokenMap: TokenMap, tokens: TokenEntry[]): void {
   tokenMap.clear();
   for (const t of tokens) {
-    tokenMap.set(t.token, { login: t.login, id: t.id, scopes: t.scopes });
+    tokenMap.set(t.token, {
+      login: t.login,
+      id: t.id,
+      scopes: t.scopes,
+      ...(t.installation ? { installation: t.installation } : {}),
+    });
   }
 }
 

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -24,6 +24,7 @@ npm install @emulators/github
 
 ### Repositories
 - `GET /repos/:owner/:repo` — get repo
+- `GET /repositories/:id` — get repo by numeric ID
 - `POST /user/repos` — create user repo
 - `POST /orgs/:org/repos` — create org repo
 - `PATCH /repos/:owner/:repo` — update repo
@@ -37,6 +38,14 @@ npm install @emulators/github
 - `GET /repos/:owner/:repo/collaborators/:username/permission`
 - `POST /repos/:owner/:repo/transfer` — transfer repo
 - `GET /repos/:owner/:repo/tags` — list tags
+
+### Contents & Commit History
+- `GET /repos/:owner/:repo/readme` — get the repository README
+- `GET /repos/:owner/:repo/contents/:path` — get a file or list a directory at a ref
+- `PUT/DELETE /repos/:owner/:repo/contents/:path` — create, update, or delete a file and commit the change
+- `GET /repos/:owner/:repo/commits` — list commits with ref, path, author, and date filters
+- `GET /repos/:owner/:repo/commits/:ref` — get a commit with file diffs and stats
+- `GET /repos/:owner/:repo/compare/:base...:head` — compare two refs
 
 ### Issues
 - `GET /repos/:owner/:repo/issues` — list (filter by state, labels, assignee, milestone, creator, since)

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -42,6 +42,7 @@ npm install @emulators/github
 ### Contents & Commit History
 - `GET /repos/:owner/:repo/readme` — get the repository README
 - `GET /repos/:owner/:repo/contents/:path` — get a file or list a directory at a ref
+- `GET /:owner/:repo/raw/:ref/:path` — download file content from advertised raw URLs
 - `PUT/DELETE /repos/:owner/:repo/contents/:path` — create, update, or delete a file and commit the change
 - `GET /repos/:owner/:repo/commits` — list commits with ref, path, author, and date filters
 - `GET /repos/:owner/:repo/commits/:ref` — get a commit with file diffs and stats

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -73,11 +73,33 @@ function jsonHeaders(token = "test-token"): Record<string, string> {
   return { ...authHeaders(token), "Content-Type": "application/json" };
 }
 
-function gitObjectSha(type: "blob" | "tree", content: Buffer): string {
+function gitObjectSha(type: "blob" | "tree" | "commit", content: Buffer): string {
   return createHash("sha1")
     .update(Buffer.from(`${type} ${content.byteLength}\0`, "utf8"))
     .update(content)
     .digest("hex");
+}
+
+function gitIdentityDate(date: string): string {
+  const zone = date.match(/(Z|([+-])(\d{2}):?(\d{2}))$/i);
+  const offset = !zone || zone[1].toUpperCase() === "Z" ? "+0000" : `${zone[2]}${zone[3]}${zone[4]}`;
+  return `${Math.floor(Date.parse(date) / 1000)} ${offset}`;
+}
+
+function gitCommitSha(commit: {
+  message: string;
+  tree: { sha: string };
+  parents: Array<{ sha: string }>;
+  author: { name: string; email: string; date: string };
+  committer: { name: string; email: string; date: string };
+}): string {
+  const headers = [`tree ${commit.tree.sha}`, ...commit.parents.map((parent) => `parent ${parent.sha}`)];
+  headers.push(
+    `author ${commit.author.name} <${commit.author.email}> ${gitIdentityDate(commit.author.date)}`,
+    `committer ${commit.committer.name} <${commit.committer.email}> ${gitIdentityDate(commit.committer.date)}`,
+  );
+  const message = commit.message.endsWith("\n") ? commit.message : `${commit.message}\n`;
+  return gitObjectSha("commit", Buffer.from(`${headers.join("\n")}\n\n${message}`, "utf8"));
 }
 
 async function putFile(app: Hono, path: string, text: string, extra: Record<string, unknown> = {}) {
@@ -765,6 +787,58 @@ describe("GitHub contents routes", () => {
     expect((await putFile(app, "allowed.txt", "allowed\n")).status).toBe(201);
   });
 
+  it("allows protected ref updates after every required check succeeds on the target commit", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: head.commit.tree.sha,
+        tree: [{ path: "checked.txt", mode: "100644", type: "blob", content: "checked\n" }],
+      }),
+    });
+    const treeBody = (await tree.json()) as { sha: string };
+    const pending = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Checked update", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    const pendingBody = (await pending.json()) as { sha: string };
+
+    const protect = await app.request(`${base}/repos/octocat/hello-world/branches/main/protection`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        required_status_checks: { strict: false, contexts: ["ci"] },
+        enforce_admins: true,
+        required_pull_request_reviews: null,
+        restrictions: null,
+        required_linear_history: false,
+        allow_force_pushes: false,
+        allow_deletions: false,
+        required_signatures: false,
+      }),
+    });
+    expect(protect.status).toBe(200);
+
+    const update = () =>
+      app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+        method: "PATCH",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ sha: pendingBody.sha }),
+      });
+    expect((await update()).status).toBe(409);
+
+    const check = await app.request(`${base}/repos/octocat/hello-world/check-runs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ name: "ci", head_sha: pendingBody.sha, status: "completed", conclusion: "success" }),
+    });
+    expect(check.status).toBe(201);
+    expect((await update()).status).toBe(200);
+  });
+
   it("requires an existing branch for content writes", async () => {
     const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
     const [head] = (await commits.json()) as Array<{ sha: string }>;
@@ -961,6 +1035,87 @@ describe("GitHub commits routes", () => {
     expect(body).toHaveLength(3);
     expect(body[0].commit.message).toBe("Update b.txt");
     expect(body[2].commit.message).toBe("Initial commit");
+  });
+
+  it("keeps the branch head before newer-dated parents", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+    const oldIdentity = { name: "Old Commit", email: "old@example.com", date: "2000-01-02T03:04:05Z" };
+    const created = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        message: "Old-dated child",
+        tree: head.commit.tree.sha,
+        parents: [head.sha],
+        author: oldIdentity,
+        committer: oldIdentity,
+      }),
+    });
+    const createdBody = (await created.json()) as { sha: string };
+    const updated = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: createdBody.sha }),
+    });
+    expect(updated.status).toBe(200);
+
+    const firstPage = await app.request(`${base}/repos/octocat/hello-world/commits?per_page=1`, {
+      headers: authHeaders(),
+    });
+    expect(((await firstPage.json()) as Array<{ sha: string }>)[0].sha).toBe(createdBody.sha);
+  });
+
+  it("uses canonical Git identities for Git Data and Contents commits", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+    const identity = { name: "Fixture User", email: "fixture@example.com", date: "2024-01-02T03:04:05Z" };
+    const requestBody = {
+      message: "Deterministic commit",
+      tree: head.commit.tree.sha,
+      parents: [head.sha],
+      author: identity,
+      committer: identity,
+    };
+    const createGitCommit = () =>
+      app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify(requestBody),
+      });
+
+    const first = await createGitCommit();
+    const firstBody = (await first.json()) as {
+      sha: string;
+      message: string;
+      tree: { sha: string };
+      parents: Array<{ sha: string }>;
+      author: typeof identity;
+      committer: typeof identity;
+    };
+    const second = await createGitCommit();
+    const secondBody = (await second.json()) as { sha: string };
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(firstBody.sha).toBe(gitCommitSha(firstBody));
+    expect(secondBody.sha).toBe(firstBody.sha);
+
+    const contents = await putFile(app, "canonical.txt", "canonical\n", {
+      author: identity,
+      committer: identity,
+    });
+    const contentsBody = (await contents.json()) as {
+      commit: {
+        sha: string;
+        message: string;
+        tree: { sha: string };
+        parents: Array<{ sha: string }>;
+        author: typeof identity;
+        committer: typeof identity;
+      };
+    };
+    expect(contents.status).toBe(201);
+    expect(contentsBody.commit.sha).toBe(gitCommitSha(contentsBody.commit));
   });
 
   it("filters commits by path", async () => {
@@ -1179,6 +1334,68 @@ describe("GitHub commits routes", () => {
     const comparisonBody = (await comparison.json()) as { files: Array<Record<string, unknown>> };
     expect(comparisonBody.files).toEqual([
       expect.objectContaining({ filename: "README.md", status: "modified", additions: 0, deletions: 0, changes: 0 }),
+    ]);
+  });
+
+  it("reports exact blob moves as renames", async () => {
+    const original = await putFile(app, "old-name.txt", "unchanged\n");
+    const originalBody = (await original.json()) as { content: { sha: string } };
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: head.commit.tree.sha,
+        tree: [
+          { path: "old-name.txt", mode: "100644", type: "blob", sha: null },
+          { path: "new-name.txt", mode: "100644", type: "blob", sha: originalBody.content.sha },
+        ],
+      }),
+    });
+    const treeBody = (await tree.json()) as { sha: string };
+    const created = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Rename file", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    const createdBody = (await created.json()) as { sha: string };
+    const updated = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: createdBody.sha }),
+    });
+    expect(updated.status).toBe(200);
+
+    const detail = await app.request(`${base}/repos/octocat/hello-world/commits/${createdBody.sha}`, {
+      headers: authHeaders(),
+    });
+    const detailBody = (await detail.json()) as {
+      stats: { additions: number; deletions: number; total: number };
+      files: Array<Record<string, unknown>>;
+    };
+    expect(detailBody.stats).toEqual({ additions: 0, deletions: 0, total: 0 });
+    expect(detailBody.files).toEqual([
+      expect.objectContaining({
+        filename: "new-name.txt",
+        previous_filename: "old-name.txt",
+        status: "renamed",
+        additions: 0,
+        deletions: 0,
+        changes: 0,
+      }),
+    ]);
+
+    const comparison = await app.request(`${base}/repos/octocat/hello-world/compare/${head.sha}...${createdBody.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(((await comparison.json()) as { files: Array<Record<string, unknown>> }).files).toEqual([
+      expect.objectContaining({
+        filename: "new-name.txt",
+        previous_filename: "old-name.txt",
+        status: "renamed",
+      }),
     ]);
   });
 

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "@emulators/core";
 import { Store } from "@emulators/core";
 import { WebhookDispatcher } from "@emulators/core";
 import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
-import { githubPlugin, seedFromConfig } from "../index.js";
+import { getGitHubStore, githubPlugin, seedFromConfig } from "../index.js";
 
 const base = "http://localhost:4000";
 
@@ -12,6 +12,8 @@ function createTestApp() {
   const webhooks = new WebhookDispatcher();
   const tokenMap: TokenMap = new Map();
   tokenMap.set("test-token", { login: "octocat", id: 1, scopes: ["repo", "user", "admin:org"] });
+  tokenMap.set("outsider-token", { login: "outsider", id: 2, scopes: ["repo"] });
+  tokenMap.set("org-member-token", { login: "org-member", id: 3, scopes: ["repo"] });
 
   const app = new Hono();
   app.onError(createApiErrorHandler());
@@ -20,22 +22,24 @@ function createTestApp() {
   githubPlugin.register(app as any, store, webhooks, base, tokenMap);
   githubPlugin.seed?.(store, base);
   seedFromConfig(store, base, {
-    users: [{ login: "octocat" }],
+    users: [{ login: "octocat" }, { login: "outsider" }, { login: "org-member" }],
+    orgs: [{ login: "acme" }],
     repos: [
       { owner: "octocat", name: "hello-world" },
       { owner: "octocat", name: "empty-repo", auto_init: false },
+      { owner: "acme", name: "project" },
     ],
   });
 
   return { app, store, webhooks, tokenMap };
 }
 
-function authHeaders(): Record<string, string> {
-  return { Authorization: "Bearer test-token" };
+function authHeaders(token = "test-token"): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
 }
 
-function jsonHeaders(): Record<string, string> {
-  return { ...authHeaders(), "Content-Type": "application/json" };
+function jsonHeaders(token = "test-token"): Record<string, string> {
+  return { ...authHeaders(token), "Content-Type": "application/json" };
 }
 
 async function putFile(app: Hono, path: string, text: string, extra: Record<string, unknown> = {}) {
@@ -168,6 +172,18 @@ describe("GitHub contents routes", () => {
     expect(await download.text()).toBe("hello\n");
   });
 
+  it("addresses literal percent signs without decoding route parameters twice", async () => {
+    const created = await putFile(app, "100%25.md", "percent\n");
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { content: { path: string; url: string } };
+    expect(createdBody.content.path).toBe("100%.md");
+    expect(createdBody.content.url).toContain("100%25.md");
+
+    const read = await app.request(createdBody.content.url, { headers: authHeaders() });
+    expect(read.status).toBe(200);
+    expect(((await read.json()) as { path: string }).path).toBe("100%.md");
+  });
+
   it("404s on a missing path", async () => {
     const res = await app.request(`${base}/repos/octocat/hello-world/contents/nope.txt`, {
       headers: authHeaders(),
@@ -208,6 +224,99 @@ describe("GitHub contents routes", () => {
 
     const gone = await app.request(`${base}/repos/octocat/hello-world/contents/notes.txt`, { headers: authHeaders() });
     expect(gone.status).toBe(404);
+  });
+
+  it("requires repository contents write permission for PUT and DELETE", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const repo = gh.repos.findOneBy("full_name", "octocat/hello-world")!;
+    const outsider = gh.users.findOneBy("login", "outsider")!;
+    const body = JSON.stringify({
+      message: "Create guarded.txt",
+      content: Buffer.from("guarded\n", "utf8").toString("base64"),
+    });
+
+    const deniedCreate = await app.request(`${base}/repos/octocat/hello-world/contents/guarded.txt`, {
+      method: "PUT",
+      headers: jsonHeaders("outsider-token"),
+      body,
+    });
+    expect(deniedCreate.status).toBe(403);
+
+    const readme = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    const readmeBody = (await readme.json()) as { sha: string };
+    const deniedDelete = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      method: "DELETE",
+      headers: jsonHeaders("outsider-token"),
+      body: JSON.stringify({ message: "Delete README", sha: readmeBody.sha }),
+    });
+    expect(deniedDelete.status).toBe(403);
+
+    const collaborator = gh.collaborators.insert({ repo_id: repo.id, user_id: outsider.id, permission: "pull" });
+    const deniedReader = await app.request(`${base}/repos/octocat/hello-world/contents/guarded.txt`, {
+      method: "PUT",
+      headers: jsonHeaders("outsider-token"),
+      body,
+    });
+    expect(deniedReader.status).toBe(403);
+
+    gh.collaborators.update(collaborator.id, { permission: "push" });
+    const allowedCreate = await app.request(`${base}/repos/octocat/hello-world/contents/guarded.txt`, {
+      method: "PUT",
+      headers: jsonHeaders("outsider-token"),
+      body,
+    });
+    expect(allowedCreate.status).toBe(201);
+    const allowedBody = (await allowedCreate.json()) as { content: { sha: string } };
+
+    const allowedDelete = await app.request(`${base}/repos/octocat/hello-world/contents/guarded.txt`, {
+      method: "DELETE",
+      headers: jsonHeaders("outsider-token"),
+      body: JSON.stringify({ message: "Delete guarded.txt", sha: allowedBody.content.sha }),
+    });
+    expect(allowedDelete.status).toBe(200);
+  });
+
+  it("honors organization default and team repository write permissions", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const org = gh.orgs.findOneBy("login", "acme")!;
+    const repo = gh.repos.findOneBy("full_name", "acme/project")!;
+    const member = gh.users.findOneBy("login", "org-member")!;
+    const team = gh.teams.insert({
+      node_id: "team-node",
+      name: "Developers",
+      slug: "developers",
+      description: null,
+      privacy: "closed",
+      permission: "pull",
+      org_id: org.id,
+      parent_id: null,
+      members_count: 1,
+      repos_count: 0,
+    });
+    gh.teamMembers.insert({ team_id: team.id, user_id: member.id, role: "member" });
+    const request = (path: string) =>
+      app.request(`${base}/repos/acme/project/contents/${path}`, {
+        method: "PUT",
+        headers: jsonHeaders("org-member-token"),
+        body: JSON.stringify({
+          message: `Create ${path}`,
+          content: Buffer.from(`${path}\n`, "utf8").toString("base64"),
+        }),
+      });
+
+    expect((await request("denied.txt")).status).toBe(403);
+
+    gh.orgs.update(org.id, { default_repository_permission: "write" });
+    expect((await request("org-default.txt")).status).toBe(201);
+
+    gh.orgs.update(org.id, { default_repository_permission: "read" });
+    gh.teams.update(team.id, { permission: "push" });
+    gh.teamRepos.insert({ team_id: team.id, repo_id: repo.id });
+    expect((await request("team-access.txt")).status).toBe(201);
   });
 
   it("rejects malformed Base64 and incomplete commit identities without creating commits", async () => {
@@ -488,6 +597,61 @@ describe("GitHub commits routes", () => {
     expect(commitBody.files[0].patch).toContain("No newline at end of file");
   });
 
+  it("reports mode-only changes in commit details and comparisons", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string }>;
+    const gitCommit = await app.request(`${base}/repos/octocat/hello-world/git/commits/${head.sha}`, {
+      headers: authHeaders(),
+    });
+    const gitCommitBody = (await gitCommit.json()) as { tree: { sha: string } };
+    const readme = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    const readmeBody = (await readme.json()) as { sha: string };
+
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: gitCommitBody.tree.sha,
+        tree: [{ path: "README.md", mode: "100755", type: "blob", sha: readmeBody.sha }],
+      }),
+    });
+    expect(tree.status).toBe(201);
+    const treeBody = (await tree.json()) as { sha: string };
+    const created = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Make README executable", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { sha: string };
+
+    const commit = await app.request(`${base}/repos/octocat/hello-world/commits/${createdBody.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(commit.status).toBe(200);
+    const commitBody = (await commit.json()) as {
+      stats: { additions: number; deletions: number; total: number };
+      files: Array<Record<string, unknown>>;
+    };
+    expect(commitBody.stats).toEqual({ additions: 0, deletions: 0, total: 0 });
+    expect(commitBody.files).toHaveLength(1);
+    expect(commitBody.files[0]).toEqual(
+      expect.objectContaining({ filename: "README.md", status: "modified", additions: 0, deletions: 0, changes: 0 }),
+    );
+    expect(commitBody.files[0]).not.toHaveProperty("patch");
+
+    const comparison = await app.request(`${base}/repos/octocat/hello-world/compare/${head.sha}...${createdBody.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(comparison.status).toBe(200);
+    const comparisonBody = (await comparison.json()) as { files: Array<Record<string, unknown>> };
+    expect(comparisonBody.files).toEqual([
+      expect.objectContaining({ filename: "README.md", status: "modified", additions: 0, deletions: 0, changes: 0 }),
+    ]);
+  });
+
   it("keeps Git Data and REST commit response shapes distinct", async () => {
     const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
     const [head] = (await list.json()) as Array<{ sha: string }>;
@@ -549,6 +713,35 @@ describe("GitHub commits routes", () => {
     );
     expect(byPrefix.status).toBe(200);
     expect(((await byPrefix.json()) as { sha: string }).sha).toBe(createdBody.commit.sha);
+  });
+
+  it("resolves percent signs in branch and comparison route parameters", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string }>;
+    const branch = await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ref: "refs/heads/release%", sha: head.sha }),
+    });
+    expect(branch.status).toBe(201);
+
+    const commit = await app.request(`${base}/repos/octocat/hello-world/commits/release%25`, {
+      headers: authHeaders(),
+    });
+    expect(commit.status).toBe(200);
+    expect(((await commit.json()) as { sha: string }).sha).toBe(head.sha);
+
+    const comparison = await app.request(`${base}/repos/octocat/hello-world/compare/main...release%25`, {
+      headers: authHeaders(),
+    });
+    expect(comparison.status).toBe(200);
+    expect(((await comparison.json()) as { status: string }).status).toBe("identical");
+
+    const branchDetails = await app.request(`${base}/repos/octocat/hello-world/branches/release%25`, {
+      headers: authHeaders(),
+    });
+    expect(branchDetails.status).toBe(200);
+    expect(((await branchDetails.json()) as { name: string }).name).toBe("release%");
   });
 
   it("compares base...head", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -90,15 +90,35 @@ describe("GitHub contents routes", () => {
 
     const root = await app.request(`${base}/repos/octocat/hello-world/contents`, { headers: authHeaders() });
     expect(root.status).toBe(200);
-    const rootBody = (await root.json()) as Array<{ name: string; type: string }>;
+    const rootBody = (await root.json()) as Array<{ name: string; type: string; sha: string; git_url: string | null }>;
     expect(rootBody.find((e) => e.name === "README.md")?.type).toBe("file");
-    expect(rootBody.find((e) => e.name === "src")?.type).toBe("dir");
+    const src = rootBody.find((e) => e.name === "src");
+    expect(src?.type).toBe("dir");
+    expect(src?.sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(src?.git_url).toBeTruthy();
+
+    const tree = await app.request(src!.git_url!, { headers: authHeaders() });
+    expect(tree.status).toBe(200);
+    const treeBody = (await tree.json()) as { tree: Array<{ path: string; type: string }> };
+    expect(treeBody.tree).toContainEqual(expect.objectContaining({ path: "index.ts", type: "blob" }));
 
     const dir = await app.request(`${base}/repos/octocat/hello-world/contents/src`, { headers: authHeaders() });
     expect(dir.status).toBe(200);
     const dirBody = (await dir.json()) as Array<{ path: string; type: string }>;
     expect(dirBody).toHaveLength(1);
     expect(dirBody[0].path).toBe("src/index.ts");
+  });
+
+  it("returns encoded content URLs that resolve for special path characters", async () => {
+    const created = await putFile(app, "docs/My%20File%20%231.md", "hello\n");
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { content: { path: string; url: string } };
+    expect(createdBody.content.path).toBe("docs/My File #1.md");
+    expect(createdBody.content.url).toContain("My%20File%20%231.md");
+
+    const read = await app.request(createdBody.content.url, { headers: authHeaders() });
+    expect(read.status).toBe(200);
+    expect(((await read.json()) as { path: string }).path).toBe("docs/My File #1.md");
   });
 
   it("404s on a missing path", async () => {
@@ -141,6 +161,60 @@ describe("GitHub contents routes", () => {
 
     const gone = await app.request(`${base}/repos/octocat/hello-world/contents/notes.txt`, { headers: authHeaders() });
     expect(gone.status).toBe(404);
+  });
+
+  it("rejects malformed Base64 and incomplete commit identities without creating commits", async () => {
+    const before = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const beforeCount = ((await before.json()) as unknown[]).length;
+
+    const invalidContent = await app.request(`${base}/repos/octocat/hello-world/contents/invalid.txt`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Invalid content", content: "not Base64!" }),
+    });
+    expect(invalidContent.status).toBe(422);
+
+    const invalidAuthor = await putFile(app, "invalid-author.txt", "hello\n", {
+      author: { name: "Missing Email" },
+    });
+    expect(invalidAuthor.status).toBe(422);
+
+    const after = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    expect((await after.json()) as unknown[]).toHaveLength(beforeCount);
+  });
+
+  it("uses an explicit committer as the default author", async () => {
+    const identity = { name: "Fixture User", email: "fixture@example.com", date: "2024-01-02T03:04:05Z" };
+    const created = await putFile(app, "identity.txt", "hello\n", { committer: identity });
+    expect(created.status).toBe(201);
+    const body = (await created.json()) as {
+      commit: { author: typeof identity; committer: typeof identity };
+    };
+    expect(body.commit.author).toEqual(identity);
+    expect(body.commit.committer).toEqual(identity);
+  });
+
+  it("updates only the selected branch", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [initial] = (await commits.json()) as Array<{ sha: string }>;
+    const branch = await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ref: "refs/heads/feature", sha: initial.sha }),
+    });
+    expect(branch.status).toBe(201);
+
+    const created = await putFile(app, "feature.txt", "feature\n", { branch: "feature" });
+    expect(created.status).toBe(201);
+
+    const onFeature = await app.request(`${base}/repos/octocat/hello-world/contents/feature.txt?ref=feature`, {
+      headers: authHeaders(),
+    });
+    expect(onFeature.status).toBe(200);
+    const onMain = await app.request(`${base}/repos/octocat/hello-world/contents/feature.txt?ref=main`, {
+      headers: authHeaders(),
+    });
+    expect(onMain.status).toBe(404);
   });
 
   it("reads a file at an older ref", async () => {
@@ -216,6 +290,35 @@ describe("GitHub commits routes", () => {
     expect(body.stats.additions).toBe(2);
   });
 
+  it("keeps Git Data and REST commit response shapes distinct", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string }>;
+
+    const gitData = await app.request(`${base}/repos/octocat/hello-world/git/commits/${head.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(gitData.status).toBe(200);
+    const gitDataBody = (await gitData.json()) as Record<string, unknown> & {
+      tree: { sha: string };
+      author: { name: string; email: string; date: string };
+    };
+    expect(gitDataBody.tree.sha).toBeTruthy();
+    expect(gitDataBody.author.email).toBeTruthy();
+    expect(gitDataBody).not.toHaveProperty("commit");
+    expect(gitDataBody).not.toHaveProperty("stats");
+    expect(gitDataBody).not.toHaveProperty("files");
+
+    const rest = await app.request(`${base}/repos/octocat/hello-world/commits/${head.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(rest.status).toBe(200);
+    const restBody = (await rest.json()) as Record<string, unknown>;
+    expect(restBody).toHaveProperty("commit");
+    expect(restBody).toHaveProperty("stats");
+    expect(restBody).toHaveProperty("files");
+    expect(restBody).not.toHaveProperty("tree");
+  });
+
   it("resolves a commit by branch name and by sha prefix", async () => {
     const created = await putFile(app, "notes.txt", "one\n");
     const createdBody = (await created.json()) as { commit: { sha: string } };
@@ -271,6 +374,35 @@ describe("GitHub commits routes", () => {
     expect(body.status).toBe("identical");
     expect(body.ahead_by).toBe(0);
     expect(body.files).toHaveLength(0);
+  });
+
+  it("paginates comparison commits and only returns files on the first page", async () => {
+    const initialList = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [initial] = (await initialList.json()) as Array<{ sha: string }>;
+    await putFile(app, "a.txt", "a\n");
+    await putFile(app, "b.txt", "b\n");
+    await putFile(app, "c.txt", "c\n");
+
+    const first = await app.request(
+      `${base}/repos/octocat/hello-world/compare/${initial.sha}...main?per_page=1&page=1`,
+      { headers: authHeaders() },
+    );
+    expect(first.status).toBe(200);
+    expect(first.headers.get("link")).toContain('rel="next"');
+    const firstBody = (await first.json()) as { total_commits: number; commits: unknown[]; files: unknown[] };
+    expect(firstBody.total_commits).toBe(3);
+    expect(firstBody.commits).toHaveLength(1);
+    expect(firstBody.files).toHaveLength(3);
+
+    const second = await app.request(
+      `${base}/repos/octocat/hello-world/compare/${initial.sha}...main?per_page=1&page=2`,
+      { headers: authHeaders() },
+    );
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as { total_commits: number; commits: unknown[]; files: unknown[] };
+    expect(secondBody.total_commits).toBe(3);
+    expect(secondBody.commits).toHaveLength(1);
+    expect(secondBody.files).toHaveLength(0);
   });
 
   it("does not shadow /commits/{sha}/comments", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -34,6 +34,7 @@ function createTestApp() {
       { owner: "octocat", name: "hello-world" },
       { owner: "octocat", name: "empty-repo", auto_init: false },
       { owner: "acme", name: "project" },
+      { owner: "acme", name: "other" },
     ],
     apps: [
       {
@@ -46,8 +47,7 @@ function createTestApp() {
           {
             installation_id: 41,
             account: "acme",
-            repository_selection: "selected",
-            repositories: ["acme/project"],
+            repository_selection: "all",
             permissions: { contents: "write" },
           },
           {
@@ -84,14 +84,18 @@ async function putFile(app: Hono, path: string, text: string, extra: Record<stri
   });
 }
 
-async function issueInstallationToken(app: Hono, installationId: number, permissions?: Record<string, string>) {
+async function issueInstallationToken(app: Hono, installationId: number, requestBody?: Record<string, unknown>) {
   const response = await app.request(`${base}/app/installations/${installationId}/access_tokens`, {
     method: "POST",
     headers: jsonHeaders("test-app-jwt"),
-    ...(permissions ? { body: JSON.stringify({ permissions }) } : {}),
+    ...(requestBody ? { body: JSON.stringify(requestBody) } : {}),
   });
-  const body = (await response.json()) as { token: string };
-  return { response, token: body.token };
+  const body = (await response.json()) as {
+    token: string;
+    repository_selection?: string;
+    repositories?: Array<{ name: string }>;
+  };
+  return { response, token: body.token, body };
 }
 
 describe("GitHub contents routes", () => {
@@ -387,11 +391,13 @@ describe("GitHub contents routes", () => {
 
   it("uses installation repository access and Contents permissions for writes", async () => {
     const { app } = createTestApp();
-    const orgInstallation = await issueInstallationToken(app, 41);
+    const orgInstallation = await issueInstallationToken(app, 41, { repositories: ["project"] });
     expect(orgInstallation.response.status).toBe(201);
+    expect(orgInstallation.body.repository_selection).toBe("selected");
+    expect(orgInstallation.body.repositories?.map((repo) => repo.name)).toEqual(["project"]);
     const userInstallation = await issueInstallationToken(app, 42);
     expect(userInstallation.response.status).toBe(201);
-    const escalated = await issueInstallationToken(app, 42, { contents: "write" });
+    const escalated = await issueInstallationToken(app, 42, { permissions: { contents: "write" } });
     expect(escalated.response.status).toBe(422);
 
     const orgWrite = await app.request(`${base}/repos/acme/project/contents/installed.txt`, {
@@ -404,7 +410,7 @@ describe("GitHub contents routes", () => {
     });
     expect(orgWrite.status).toBe(201);
 
-    const outsideSelection = await app.request(`${base}/repos/octocat/hello-world/contents/blocked.txt`, {
+    const outsideSelection = await app.request(`${base}/repos/acme/other/contents/blocked.txt`, {
       method: "PUT",
       headers: jsonHeaders(orgInstallation.token),
       body: JSON.stringify({
@@ -431,7 +437,7 @@ describe("GitHub contents routes", () => {
     const repo = gh.repos.findOneBy("full_name", "octocat/hello-world")!;
     gh.repos.update(repo.id, { private: true });
 
-    const noContents = await issueInstallationToken(app, 42, {});
+    const noContents = await issueInstallationToken(app, 42, { permissions: {} });
     expect(noContents.response.status).toBe(201);
     const readContents = await issueInstallationToken(app, 42);
     expect(readContents.response.status).toBe(201);
@@ -462,6 +468,20 @@ describe("GitHub contents routes", () => {
     for (const url of protectedUrls) {
       expect((await app.request(url, { headers: authHeaders(noContents.token) })).status, url).toBe(403);
       expect((await app.request(url, { headers: authHeaders(readContents.token) })).status, url).toBe(200);
+    }
+
+    const searches = [
+      `${base}/search/code?q=${encodeURIComponent("hello-world repo:octocat/hello-world")}`,
+      `${base}/search/commits?q=${encodeURIComponent("Initial commit repo:octocat/hello-world")}`,
+    ];
+    for (const url of searches) {
+      const denied = await app.request(url, { headers: authHeaders(noContents.token) });
+      expect(denied.status, url).toBe(200);
+      expect((await denied.json()) as { total_count: number }).toEqual(expect.objectContaining({ total_count: 0 }));
+
+      const allowed = await app.request(url, { headers: authHeaders(readContents.token) });
+      expect(allowed.status, url).toBe(200);
+      expect(((await allowed.json()) as { total_count: number }).total_count, url).toBeGreaterThan(0);
     }
   });
 
@@ -770,6 +790,18 @@ describe("GitHub contents routes", () => {
     expect((await subtree.json()) as { tree: unknown[] }).toEqual(
       expect.objectContaining({ tree: [expect.objectContaining({ path: "index.ts", type: "blob" })] }),
     );
+
+    const recursive = await app.request(`${base}/repos/octocat/hello-world/git/trees/${treeBody.sha}?recursive=1`, {
+      headers: authHeaders(),
+    });
+    expect(recursive.status).toBe(200);
+    const recursiveBody = (await recursive.json()) as { tree: Array<{ path: string; type: string }> };
+    expect(recursiveBody.tree).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "src", type: "tree" }),
+        expect.objectContaining({ path: "src/index.ts", type: "blob" }),
+      ]),
+    );
   });
 
   it("deletes base-tree entries whose SHA is null", async () => {
@@ -820,6 +852,31 @@ describe("GitHub contents routes", () => {
       headers: authHeaders(),
     });
     expect(removed.status).toBe(404);
+  });
+
+  it("keeps archived repositories read-only across Contents and Git Data", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const repo = gh.repos.findOneBy("full_name", "octocat/hello-world")!;
+    gh.repos.update(repo.id, { archived: true });
+
+    const read = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    expect(read.status).toBe(200);
+
+    const contentsWrite = await putFile(app, "archived.txt", "blocked\n");
+    expect(contentsWrite.status).toBe(403);
+    expect((await contentsWrite.json()) as { message: string }).toEqual(
+      expect.objectContaining({ message: "Repository was archived so is read-only." }),
+    );
+
+    const blobWrite = await app.request(`${base}/repos/octocat/hello-world/git/blobs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ content: "blocked", encoding: "utf-8" }),
+    });
+    expect(blobWrite.status).toBe(403);
   });
 });
 
@@ -966,6 +1023,31 @@ describe("GitHub commits routes", () => {
     expect(commitBody.stats).toEqual(expect.objectContaining({ additions: 1, deletions: 1 }));
     expect(commitBody.files[0]).toEqual(expect.objectContaining({ additions: 1, deletions: 1 }));
     expect(commitBody.files[0].patch).toContain("No newline at end of file");
+  });
+
+  it("reports sparse changes accurately in large files", async () => {
+    const original = Array.from({ length: 1_000 }, (_, index) => `line ${index + 1}\n`);
+    const created = await putFile(app, "large.txt", original.join(""));
+    const createdBody = (await created.json()) as { content: { sha: string } };
+
+    const changed = [...original];
+    changed[99] = "changed line 100\n";
+    changed[899] = "changed line 900\n";
+    const updated = await putFile(app, "large.txt", changed.join(""), { sha: createdBody.content.sha });
+    const updatedBody = (await updated.json()) as { commit: { sha: string } };
+
+    const commit = await app.request(`${base}/repos/octocat/hello-world/commits/${updatedBody.commit.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(commit.status).toBe(200);
+    const commitBody = (await commit.json()) as {
+      stats: { additions: number; deletions: number };
+      files: Array<{ additions: number; deletions: number; patch?: string }>;
+    };
+    expect(commitBody.stats).toEqual(expect.objectContaining({ additions: 2, deletions: 2 }));
+    expect(commitBody.files[0]).toEqual(expect.objectContaining({ additions: 2, deletions: 2 }));
+    expect(commitBody.files[0].patch).toContain("changed line 100");
+    expect(commitBody.files[0].patch).toContain("changed line 900");
   });
 
   it("reports mode-only changes in commit details and comparisons", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -43,19 +43,30 @@ function createTestApp() {
         slug: "contents-app",
         name: "Contents App",
         private_key: "test-key",
-        permissions: { contents: "write", issues: "read", pull_requests: "read" },
+        permissions: {
+          contents: "write",
+          workflows: "write",
+          actions: "write",
+          issues: "read",
+          pull_requests: "read",
+        },
         installations: [
           {
             installation_id: 41,
             account: "acme",
             repository_selection: "all",
-            permissions: { contents: "write" },
+            permissions: { contents: "write", workflows: "write", actions: "write" },
           },
           {
             installation_id: 42,
             account: "octocat",
             repository_selection: "all",
-            permissions: { contents: "read", issues: "read", pull_requests: "read" },
+            permissions: {
+              contents: "read",
+              issues: "read",
+              pull_requests: "read",
+              actions: "write",
+            },
           },
         ],
       },
@@ -481,6 +492,76 @@ describe("GitHub contents routes", () => {
     expect(readOnlyWrite.status).toBe(403);
   });
 
+  it("requires Workflows write permission for Contents mutations under .github/workflows", async () => {
+    const { app } = createTestApp();
+    const contentsOnly = await issueInstallationToken(app, 41, {
+      repositories: ["project"],
+      permissions: { contents: "write" },
+    });
+    const workflowWriter = await issueInstallationToken(app, 41, {
+      repositories: ["project"],
+      permissions: { contents: "write", workflows: "write" },
+    });
+    expect(contentsOnly.response.status).toBe(201);
+    expect(workflowWriter.response.status).toBe(201);
+
+    const createFile = (path: string, token: string) =>
+      app.request(`${base}/repos/acme/project/contents/${path}`, {
+        method: "PUT",
+        headers: jsonHeaders(token),
+        body: JSON.stringify({
+          message: `Create ${path}`,
+          content: Buffer.from("name: CI\n", "utf8").toString("base64"),
+        }),
+      });
+
+    expect((await createFile("ordinary.txt", contentsOnly.token)).status).toBe(201);
+    expect((await createFile(".github/workflows/ci.yml", contentsOnly.token)).status).toBe(403);
+
+    const created = await createFile(".github/workflows/ci.yml", workflowWriter.token);
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { content: { sha: string } };
+    const deleteWorkflow = (token: string) =>
+      app.request(`${base}/repos/acme/project/contents/.github/workflows/ci.yml`, {
+        method: "DELETE",
+        headers: jsonHeaders(token),
+        body: JSON.stringify({ message: "Delete workflow", sha: createdBody.content.sha }),
+      });
+
+    expect((await deleteWorkflow(contentsOnly.token)).status).toBe(403);
+    expect((await deleteWorkflow(workflowWriter.token)).status).toBe(200);
+  });
+
+  it("requires Actions write permission to dispatch a workflow", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const repo = gh.repos.findOneBy("full_name", "octocat/hello-world")!;
+    const workflow = gh.workflows.insert({
+      node_id: "workflow-node",
+      repo_id: repo.id,
+      name: "CI",
+      path: ".github/workflows/ci.yml",
+      state: "active",
+      badge_url: `${base}/repos/octocat/hello-world/actions/workflows/ci.yml/badge.svg`,
+    });
+    const reader = await issueInstallationToken(app, 42, { permissions: { actions: "read" } });
+    const writer = await issueInstallationToken(app, 42, { permissions: { actions: "write" } });
+    expect(reader.response.status).toBe(201);
+    expect(writer.response.status).toBe(201);
+
+    const dispatch = (token: string) =>
+      app.request(`${base}/repos/octocat/hello-world/actions/workflows/${workflow.id}/dispatches`, {
+        method: "POST",
+        headers: jsonHeaders(token),
+        body: JSON.stringify({ ref: "main" }),
+      });
+
+    expect((await dispatch(reader.token)).status).toBe(403);
+    expect(gh.workflowRuns.findBy("repo_id", repo.id)).toHaveLength(0);
+    expect((await dispatch(writer.token)).status).toBe(204);
+    expect(gh.workflowRuns.findBy("repo_id", repo.id)).toHaveLength(1);
+  });
+
   it("requires Contents permission for installation reads from private repositories", async () => {
     const { app, store } = createTestApp();
     const gh = getGitHubStore(store);
@@ -839,6 +920,52 @@ describe("GitHub contents routes", () => {
     expect((await update()).status).toBe(200);
   });
 
+  it("rejects merge commits anywhere in a protected linear-history update range", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [baseCommit] = (await commits.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+    const createCommit = async (message: string, parents: string[]) => {
+      const response = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ message, tree: baseCommit.commit.tree.sha, parents }),
+      });
+      expect(response.status).toBe(201);
+      return (await response.json()) as { sha: string };
+    };
+    const side = await createCommit("Side commit", [baseCommit.sha]);
+    const merge = await createCommit("Merge commit", [baseCommit.sha, side.sha]);
+    const tip = await createCommit("Tip commit", [merge.sha]);
+
+    const protection = await app.request(`${base}/repos/octocat/hello-world/branches/main/protection`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        required_status_checks: null,
+        enforce_admins: true,
+        required_pull_request_reviews: null,
+        restrictions: null,
+        required_linear_history: true,
+        allow_force_pushes: false,
+        allow_deletions: false,
+        required_signatures: false,
+      }),
+    });
+    expect(protection.status).toBe(200);
+
+    const update = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: tip.sha }),
+    });
+    expect(update.status).toBe(409);
+    const current = await app.request(`${base}/repos/octocat/hello-world/git/ref/heads/main`, {
+      headers: authHeaders(),
+    });
+    expect((await current.json()) as { object: { sha: string } }).toEqual(
+      expect.objectContaining({ object: expect.objectContaining({ sha: baseCommit.sha }) }),
+    );
+  });
+
   it("requires an existing branch for content writes", async () => {
     const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
     const [head] = (await commits.json()) as Array<{ sha: string }>;
@@ -1023,6 +1150,49 @@ describe("GitHub contents routes", () => {
       });
       expect(response.status, JSON.stringify(entry)).toBe(422);
     }
+  });
+
+  it("preserves submodules when Contents writes rebuild a neighboring tree", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+    const submoduleSha = "b".repeat(40);
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: head.commit.tree.sha,
+        tree: [{ path: "vendor/mod", mode: "160000", type: "commit", sha: submoduleSha }],
+      }),
+    });
+    expect(tree.status).toBe(201);
+    const treeBody = (await tree.json()) as { sha: string };
+    const commit = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Add submodule", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    expect(commit.status).toBe(201);
+    const commitBody = (await commit.json()) as { sha: string };
+    const update = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: commitBody.sha }),
+    });
+    expect(update.status).toBe(200);
+
+    expect((await putFile(app, "vendor/other.txt", "neighbor\n")).status).toBe(201);
+    const recursive = await app.request(`${base}/repos/octocat/hello-world/git/trees/main?recursive=1`, {
+      headers: authHeaders(),
+    });
+    expect(recursive.status).toBe(200);
+    expect((await recursive.json()) as { tree: unknown[] }).toEqual(
+      expect.objectContaining({
+        tree: expect.arrayContaining([
+          expect.objectContaining({ path: "vendor/mod", mode: "160000", type: "commit", sha: submoduleSha }),
+          expect.objectContaining({ path: "vendor/other.txt", mode: "100644", type: "blob" }),
+        ]),
+      }),
+    );
   });
 
   it("gets trees by branch and tag refs", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -19,6 +19,12 @@ function createTestApp() {
   app.onError(createApiErrorHandler());
   app.use("*", createErrorHandler());
   app.use("*", authMiddleware(tokenMap));
+  app.use("*", async (c, next) => {
+    if (c.req.header("Authorization") === "Bearer test-app-jwt") {
+      c.set("authApp", { appId: 9, slug: "contents-app", name: "Contents App" });
+    }
+    await next();
+  });
   githubPlugin.register(app as any, store, webhooks, base, tokenMap);
   githubPlugin.seed?.(store, base);
   seedFromConfig(store, base, {
@@ -28,6 +34,30 @@ function createTestApp() {
       { owner: "octocat", name: "hello-world" },
       { owner: "octocat", name: "empty-repo", auto_init: false },
       { owner: "acme", name: "project" },
+    ],
+    apps: [
+      {
+        app_id: 9,
+        slug: "contents-app",
+        name: "Contents App",
+        private_key: "test-key",
+        permissions: { contents: "write" },
+        installations: [
+          {
+            installation_id: 41,
+            account: "acme",
+            repository_selection: "selected",
+            repositories: ["acme/project"],
+            permissions: { contents: "write" },
+          },
+          {
+            installation_id: 42,
+            account: "octocat",
+            repository_selection: "all",
+            permissions: { contents: "read" },
+          },
+        ],
+      },
     ],
   });
 
@@ -207,7 +237,7 @@ describe("GitHub contents routes", () => {
 
     const updated = await putFile(app, "notes.txt", "two\n", { sha: createdBody.content.sha });
     expect(updated.status).toBe(200);
-    const updatedBody = (await updated.json()) as { content: { sha: string } };
+    const updatedBody = (await updated.json()) as { content: { sha: string }; commit: { sha: string } };
 
     const read = await app.request(`${base}/repos/octocat/hello-world/contents/notes.txt`, { headers: authHeaders() });
     const readBody = (await read.json()) as { content: string };
@@ -221,6 +251,39 @@ describe("GitHub contents routes", () => {
     expect(deleted.status).toBe(200);
     const deletedBody = (await deleted.json()) as { content: null; commit: { sha: string } };
     expect(deletedBody.content).toBeNull();
+
+    const deletionCommit = await app.request(`${base}/repos/octocat/hello-world/commits/${deletedBody.commit.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(deletionCommit.status).toBe(200);
+    const deletionCommitBody = (await deletionCommit.json()) as {
+      files: Array<{ status: string; raw_url: string; contents_url: string }>;
+    };
+    const removed = deletionCommitBody.files[0];
+    expect(removed.status).toBe("removed");
+    expect(removed.raw_url).toContain(updatedBody.commit.sha);
+    expect(removed.contents_url).toContain(`ref=${updatedBody.commit.sha}`);
+    const removedRaw = await app.request(removed.raw_url, { headers: authHeaders() });
+    expect(removedRaw.status).toBe(200);
+    expect(await removedRaw.text()).toBe("two\n");
+    const removedContents = await app.request(removed.contents_url, { headers: authHeaders() });
+    expect(removedContents.status).toBe(200);
+
+    const comparison = await app.request(
+      `${base}/repos/octocat/hello-world/compare/${updatedBody.commit.sha}...${deletedBody.commit.sha}`,
+      { headers: authHeaders() },
+    );
+    expect(comparison.status).toBe(200);
+    const comparisonBody = (await comparison.json()) as {
+      files: Array<{ status: string; raw_url: string; contents_url: string }>;
+    };
+    expect(comparisonBody.files[0]).toEqual(
+      expect.objectContaining({
+        status: "removed",
+        raw_url: expect.stringContaining(updatedBody.commit.sha),
+        contents_url: expect.stringContaining(`ref=${updatedBody.commit.sha}`),
+      }),
+    );
 
     const gone = await app.request(`${base}/repos/octocat/hello-world/contents/notes.txt`, { headers: authHeaders() });
     expect(gone.status).toBe(404);
@@ -277,6 +340,56 @@ describe("GitHub contents routes", () => {
       body: JSON.stringify({ message: "Delete guarded.txt", sha: allowedBody.content.sha }),
     });
     expect(allowedDelete.status).toBe(200);
+  });
+
+  it("uses installation repository access and Contents permissions for writes", async () => {
+    const { app } = createTestApp();
+    const issueToken = async (installationId: number, permissions?: Record<string, string>) => {
+      const response = await app.request(`${base}/app/installations/${installationId}/access_tokens`, {
+        method: "POST",
+        headers: jsonHeaders("test-app-jwt"),
+        ...(permissions ? { body: JSON.stringify({ permissions }) } : {}),
+      });
+      const body = (await response.json()) as { token: string };
+      return { response, token: body.token };
+    };
+
+    const orgInstallation = await issueToken(41);
+    expect(orgInstallation.response.status).toBe(201);
+    const userInstallation = await issueToken(42);
+    expect(userInstallation.response.status).toBe(201);
+    const escalated = await issueToken(42, { contents: "write" });
+    expect(escalated.response.status).toBe(422);
+
+    const orgWrite = await app.request(`${base}/repos/acme/project/contents/installed.txt`, {
+      method: "PUT",
+      headers: jsonHeaders(orgInstallation.token),
+      body: JSON.stringify({
+        message: "Write through installation",
+        content: Buffer.from("installed\n").toString("base64"),
+      }),
+    });
+    expect(orgWrite.status).toBe(201);
+
+    const outsideSelection = await app.request(`${base}/repos/octocat/hello-world/contents/blocked.txt`, {
+      method: "PUT",
+      headers: jsonHeaders(orgInstallation.token),
+      body: JSON.stringify({
+        message: "Write outside installation",
+        content: Buffer.from("blocked\n").toString("base64"),
+      }),
+    });
+    expect(outsideSelection.status).toBe(403);
+
+    const readOnlyWrite = await app.request(`${base}/repos/octocat/hello-world/contents/read-only.txt`, {
+      method: "PUT",
+      headers: jsonHeaders(userInstallation.token),
+      body: JSON.stringify({
+        message: "Write with read permission",
+        content: Buffer.from("blocked\n").toString("base64"),
+      }),
+    });
+    expect(readOnlyWrite.status).toBe(403);
   });
 
   it("honors organization default and team repository write permissions", async () => {
@@ -616,6 +729,19 @@ describe("GitHub commits routes", () => {
     const body = (await res.json()) as Array<{ commit: { message: string } }>;
     expect(body).toHaveLength(1);
     expect(body[0].commit.message).toBe("Update b.txt");
+  });
+
+  it("filters commits by directory path", async () => {
+    await putFile(app, "src/index.ts", "one\n");
+    await putFile(app, "src/nested/file.ts", "two\n");
+    await putFile(app, "outside.ts", "outside\n");
+
+    const res = await app.request(`${base}/repos/octocat/hello-world/commits?path=src`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ commit: { message: string } }>;
+    expect(body.map((item) => item.commit.message)).toEqual(["Update src/nested/file.ts", "Update src/index.ts"]);
   });
 
   it("409s on an empty repository", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -749,6 +749,19 @@ describe("GitHub commits routes", () => {
     expect(created.status).toBe(201);
     const createdBody = (await created.json()) as { sha: string };
 
+    const updateRef = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: createdBody.sha }),
+    });
+    expect(updateRef.status).toBe(200);
+
+    const pathHistory = await app.request(`${base}/repos/octocat/hello-world/commits?path=README.md`, {
+      headers: authHeaders(),
+    });
+    expect(pathHistory.status).toBe(200);
+    expect(((await pathHistory.json()) as Array<{ sha: string }>).map((item) => item.sha)).toContain(createdBody.sha);
+
     const commit = await app.request(`${base}/repos/octocat/hello-world/commits/${createdBody.sha}`, {
       headers: authHeaders(),
     });
@@ -772,6 +785,72 @@ describe("GitHub commits routes", () => {
     expect(comparisonBody.files).toEqual([
       expect.objectContaining({ filename: "README.md", status: "modified", additions: 0, deletions: 0, changes: 0 }),
     ]);
+  });
+
+  it("rejects default and disallowed protected branch deletion", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string }>;
+    const createBranch = await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ref: "refs/heads/protected", sha: head.sha }),
+    });
+    expect(createBranch.status).toBe(201);
+
+    const protectionBody = {
+      required_status_checks: null,
+      enforce_admins: true,
+      required_pull_request_reviews: null,
+      restrictions: null,
+      required_linear_history: false,
+      allow_force_pushes: false,
+      allow_deletions: false,
+      required_signatures: false,
+    };
+    const protect = await app.request(`${base}/repos/octocat/hello-world/branches/protected/protection`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify(protectionBody),
+    });
+    expect(protect.status).toBe(200);
+
+    const deleteDefault = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleteDefault.status).toBe(422);
+    const defaultStillExists = await app.request(`${base}/repos/octocat/hello-world/git/ref/heads/main`, {
+      headers: authHeaders(),
+    });
+    expect(defaultStillExists.status).toBe(200);
+
+    const deleteProtected = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/protected`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleteProtected.status).toBe(409);
+
+    const stillExists = await app.request(`${base}/repos/octocat/hello-world/git/ref/heads/protected`, {
+      headers: authHeaders(),
+    });
+    expect(stillExists.status).toBe(200);
+
+    const allowDeletion = await app.request(`${base}/repos/octocat/hello-world/branches/protected/protection`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ...protectionBody, allow_deletions: true }),
+    });
+    expect(allowDeletion.status).toBe(200);
+
+    const deleted = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/protected`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleted.status).toBe(204);
+    const noLongerExists = await app.request(`${base}/repos/octocat/hello-world/git/ref/heads/protected`, {
+      headers: authHeaders(),
+    });
+    expect(noLongerExists.status).toBe(404);
   });
 
   it("keeps Git Data and REST commit response shapes distinct", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { describe, it, expect, beforeEach } from "vitest";
 import { Hono } from "@emulators/core";
 import { Store } from "@emulators/core";
@@ -42,7 +43,7 @@ function createTestApp() {
         slug: "contents-app",
         name: "Contents App",
         private_key: "test-key",
-        permissions: { contents: "write" },
+        permissions: { contents: "write", issues: "read", pull_requests: "read" },
         installations: [
           {
             installation_id: 41,
@@ -54,7 +55,7 @@ function createTestApp() {
             installation_id: 42,
             account: "octocat",
             repository_selection: "all",
-            permissions: { contents: "read" },
+            permissions: { contents: "read", issues: "read", pull_requests: "read" },
           },
         ],
       },
@@ -70,6 +71,13 @@ function authHeaders(token = "test-token"): Record<string, string> {
 
 function jsonHeaders(token = "test-token"): Record<string, string> {
   return { ...authHeaders(token), "Content-Type": "application/json" };
+}
+
+function gitObjectSha(type: "blob" | "tree", content: Buffer): string {
+  return createHash("sha1")
+    .update(Buffer.from(`${type} ${content.byteLength}\0`, "utf8"))
+    .update(content)
+    .digest("hex");
 }
 
 async function putFile(app: Hono, path: string, text: string, extra: Record<string, unknown> = {}) {
@@ -121,7 +129,27 @@ describe("GitHub contents routes", () => {
     expect(body.type).toBe("file");
     expect(body.path).toBe("README.md");
     expect(Buffer.from(body.content, "base64").toString("utf8")).toBe("# hello-world\n");
-    expect(body.sha).toBeTruthy();
+    expect(body.sha).toBe(gitObjectSha("blob", Buffer.from("# hello-world\n", "utf8")));
+
+    const duplicateBlob = await app.request(`${base}/repos/octocat/hello-world/git/blobs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ content: "# hello-world\n", encoding: "utf-8" }),
+    });
+    expect(duplicateBlob.status).toBe(201);
+    expect(((await duplicateBlob.json()) as { sha: string }).sha).toBe(body.sha);
+
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ commit: { tree: { sha: string } } }>;
+    const duplicateTree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        tree: [{ path: "README.md", mode: "100644", type: "blob", sha: body.sha }],
+      }),
+    });
+    expect(duplicateTree.status).toBe(201);
+    expect(((await duplicateTree.json()) as { sha: string }).sha).toBe(head.commit.tree.sha);
 
     const download = await app.request(body.download_url, { headers: authHeaders() });
     expect(download.status).toBe(200);
@@ -483,6 +511,42 @@ describe("GitHub contents routes", () => {
       expect(allowed.status, url).toBe(200);
       expect(((await allowed.json()) as { total_count: number }).total_count, url).toBeGreaterThan(0);
     }
+  });
+
+  it("enforces endpoint-specific installation permissions on private repository reads", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const repo = gh.repos.findOneBy("full_name", "octocat/hello-world")!;
+    gh.repos.update(repo.id, { private: true });
+
+    const contents = await issueInstallationToken(app, 42, { permissions: { contents: "read" } });
+    const issues = await issueInstallationToken(app, 42, { permissions: { issues: "read" } });
+    const pulls = await issueInstallationToken(app, 42, { permissions: { pull_requests: "read" } });
+    expect(contents.response.status).toBe(201);
+    expect(issues.response.status).toBe(201);
+    expect(pulls.response.status).toBe(201);
+
+    const urls = {
+      contents: `${base}/repos/octocat/hello-world/branches`,
+      refs: `${base}/repos/octocat/hello-world/git/ref/heads/main`,
+      issues: `${base}/repos/octocat/hello-world/issues`,
+      pulls: `${base}/repos/octocat/hello-world/pulls`,
+    };
+
+    expect((await app.request(urls.contents, { headers: authHeaders(contents.token) })).status).toBe(200);
+    expect((await app.request(urls.refs, { headers: authHeaders(contents.token) })).status).toBe(200);
+    expect((await app.request(urls.issues, { headers: authHeaders(contents.token) })).status).toBe(403);
+    expect((await app.request(urls.pulls, { headers: authHeaders(contents.token) })).status).toBe(403);
+
+    expect((await app.request(urls.issues, { headers: authHeaders(issues.token) })).status).toBe(200);
+    expect((await app.request(urls.contents, { headers: authHeaders(issues.token) })).status).toBe(403);
+    expect((await app.request(urls.refs, { headers: authHeaders(issues.token) })).status).toBe(403);
+    expect((await app.request(urls.pulls, { headers: authHeaders(issues.token) })).status).toBe(403);
+
+    expect((await app.request(urls.pulls, { headers: authHeaders(pulls.token) })).status).toBe(200);
+    expect((await app.request(urls.contents, { headers: authHeaders(pulls.token) })).status).toBe(403);
+    expect((await app.request(urls.refs, { headers: authHeaders(pulls.token) })).status).toBe(403);
+    expect((await app.request(urls.issues, { headers: authHeaders(pulls.token) })).status).toBe(403);
   });
 
   it("honors organization default and team repository write permissions", async () => {
@@ -1247,6 +1311,61 @@ describe("GitHub commits routes", () => {
     expect(((await byPrefix.json()) as { sha: string }).sha).toBe(createdBody.commit.sha);
   });
 
+  it("does not resolve an annotated tag object until a tag ref points to it", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string }>;
+    const tag = await app.request(`${base}/repos/octocat/hello-world/git/tags`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        tag: "v1",
+        message: "Version 1",
+        object: head.sha,
+        type: "commit",
+        tagger: { name: "Octocat", email: "octocat@example.com", date: "2024-01-02T03:04:05Z" },
+      }),
+    });
+    expect(tag.status).toBe(201);
+    const tagBody = (await tag.json()) as { sha: string };
+
+    expect(
+      (
+        await app.request(`${base}/repos/octocat/hello-world/commits/v1`, {
+          headers: authHeaders(),
+        })
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await app.request(`${base}/repos/octocat/hello-world/contents/README.md?ref=v1`, {
+          headers: authHeaders(),
+        })
+      ).status,
+    ).toBe(404);
+
+    const ref = await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ref: "refs/tags/v1", sha: tagBody.sha }),
+    });
+    expect(ref.status).toBe(201);
+
+    expect(
+      (
+        await app.request(`${base}/repos/octocat/hello-world/commits/v1`, {
+          headers: authHeaders(),
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await app.request(`${base}/repos/octocat/hello-world/contents/README.md?ref=v1`, {
+          headers: authHeaders(),
+        })
+      ).status,
+    ).toBe(200);
+  });
+
   it("resolves percent signs in branch and comparison route parameters", async () => {
     const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
     const [head] = (await list.json()) as Array<{ sha: string }>;
@@ -1344,6 +1463,38 @@ describe("GitHub commits routes", () => {
     expect(secondBody.total_commits).toBe(3);
     expect(secondBody.commits).toHaveLength(1);
     expect(secondBody.files).toHaveLength(0);
+  });
+
+  it("reports stored commit comment counts in list, detail, and comparison responses", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string; commit: { comment_count: number } }>;
+    expect(head.commit.comment_count).toBe(0);
+
+    const comment = await app.request(`${base}/repos/octocat/hello-world/commits/${head.sha}/comments`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ body: "A commit comment" }),
+    });
+    expect(comment.status).toBe(201);
+
+    const updatedList = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [updatedHead] = (await updatedList.json()) as Array<{ commit: { comment_count: number } }>;
+    expect(updatedHead.commit.comment_count).toBe(1);
+
+    const detail = await app.request(`${base}/repos/octocat/hello-world/commits/${head.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(((await detail.json()) as { commit: { comment_count: number } }).commit.comment_count).toBe(1);
+
+    const comparison = await app.request(`${base}/repos/octocat/hello-world/compare/main...main`, {
+      headers: authHeaders(),
+    });
+    const comparisonBody = (await comparison.json()) as {
+      base_commit: { commit: { comment_count: number } };
+      merge_base_commit: { commit: { comment_count: number } };
+    };
+    expect(comparisonBody.base_commit.commit.comment_count).toBe(1);
+    expect(comparisonBody.merge_base_commit.commit.comment_count).toBe(1);
   });
 
   it("does not shadow /commits/{sha}/comments", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -84,6 +84,16 @@ async function putFile(app: Hono, path: string, text: string, extra: Record<stri
   });
 }
 
+async function issueInstallationToken(app: Hono, installationId: number, permissions?: Record<string, string>) {
+  const response = await app.request(`${base}/app/installations/${installationId}/access_tokens`, {
+    method: "POST",
+    headers: jsonHeaders("test-app-jwt"),
+    ...(permissions ? { body: JSON.stringify({ permissions }) } : {}),
+  });
+  const body = (await response.json()) as { token: string };
+  return { response, token: body.token };
+}
+
 describe("GitHub contents routes", () => {
   let app: Hono;
 
@@ -184,6 +194,39 @@ describe("GitHub contents routes", () => {
     const dirBody = (await dir.json()) as Array<{ path: string; type: string }>;
     expect(dirBody).toHaveLength(1);
     expect(dirBody[0].path).toBe("src/index.ts");
+  });
+
+  it("reuses blob and untouched subtree identities", async () => {
+    const createdA = await putFile(app, "a/x.txt", "one\n");
+    const createdABody = (await createdA.json()) as { content: { sha: string } };
+    expect(createdABody.content.sha).toBe("5626abf0f72e58d7a153368ba57db4c673c0e171");
+    await putFile(app, "b/y.txt", "two\n");
+
+    const rootBefore = await app.request(`${base}/repos/octocat/hello-world/contents`, { headers: authHeaders() });
+    const rootBeforeBody = (await rootBefore.json()) as Array<{ name: string; sha: string }>;
+    const bTreeSha = rootBeforeBody.find((entry) => entry.name === "b")!.sha;
+    const commitsBefore = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [headBefore] = (await commitsBefore.json()) as Array<{ commit: { tree: { sha: string } } }>;
+
+    const identical = await putFile(app, "a/x.txt", "one\n", { sha: createdABody.content.sha });
+    expect(identical.status).toBe(200);
+    const identicalBody = (await identical.json()) as {
+      content: { sha: string };
+      commit: { sha: string; tree: { sha: string } };
+    };
+    expect(identicalBody.content.sha).toBe(createdABody.content.sha);
+    expect(identicalBody.commit.tree.sha).toBe(headBefore.commit.tree.sha);
+
+    const identicalCommit = await app.request(`${base}/repos/octocat/hello-world/commits/${identicalBody.commit.sha}`, {
+      headers: authHeaders(),
+    });
+    expect((await identicalCommit.json()) as { files: unknown[] }).toEqual(expect.objectContaining({ files: [] }));
+
+    const changed = await putFile(app, "a/x.txt", "changed\n", { sha: createdABody.content.sha });
+    expect(changed.status).toBe(200);
+    const rootAfter = await app.request(`${base}/repos/octocat/hello-world/contents`, { headers: authHeaders() });
+    const rootAfterBody = (await rootAfter.json()) as Array<{ name: string; sha: string }>;
+    expect(rootAfterBody.find((entry) => entry.name === "b")!.sha).toBe(bTreeSha);
   });
 
   it("returns encoded content URLs that resolve for special path characters", async () => {
@@ -344,21 +387,11 @@ describe("GitHub contents routes", () => {
 
   it("uses installation repository access and Contents permissions for writes", async () => {
     const { app } = createTestApp();
-    const issueToken = async (installationId: number, permissions?: Record<string, string>) => {
-      const response = await app.request(`${base}/app/installations/${installationId}/access_tokens`, {
-        method: "POST",
-        headers: jsonHeaders("test-app-jwt"),
-        ...(permissions ? { body: JSON.stringify({ permissions }) } : {}),
-      });
-      const body = (await response.json()) as { token: string };
-      return { response, token: body.token };
-    };
-
-    const orgInstallation = await issueToken(41);
+    const orgInstallation = await issueInstallationToken(app, 41);
     expect(orgInstallation.response.status).toBe(201);
-    const userInstallation = await issueToken(42);
+    const userInstallation = await issueInstallationToken(app, 42);
     expect(userInstallation.response.status).toBe(201);
-    const escalated = await issueToken(42, { contents: "write" });
+    const escalated = await issueInstallationToken(app, 42, { contents: "write" });
     expect(escalated.response.status).toBe(422);
 
     const orgWrite = await app.request(`${base}/repos/acme/project/contents/installed.txt`, {
@@ -390,6 +423,46 @@ describe("GitHub contents routes", () => {
       }),
     });
     expect(readOnlyWrite.status).toBe(403);
+  });
+
+  it("requires Contents permission for installation reads from private repositories", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const repo = gh.repos.findOneBy("full_name", "octocat/hello-world")!;
+    gh.repos.update(repo.id, { private: true });
+
+    const noContents = await issueInstallationToken(app, 42, {});
+    expect(noContents.response.status).toBe(201);
+    const readContents = await issueInstallationToken(app, 42);
+    expect(readContents.response.status).toBe(201);
+
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string }>;
+    const gitCommit = await app.request(`${base}/repos/octocat/hello-world/git/commits/${head.sha}`, {
+      headers: authHeaders(),
+    });
+    const gitCommitBody = (await gitCommit.json()) as { tree: { sha: string } };
+    const readme = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    const readmeBody = (await readme.json()) as { sha: string };
+
+    const protectedUrls = [
+      `${base}/repos/octocat/hello-world/contents/README.md`,
+      `${base}/repos/octocat/hello-world/readme`,
+      `${base}/octocat/hello-world/raw/main/README.md`,
+      `${base}/repos/octocat/hello-world/commits`,
+      `${base}/repos/octocat/hello-world/commits/${head.sha}`,
+      `${base}/repos/octocat/hello-world/compare/${head.sha}...${head.sha}`,
+      `${base}/repos/octocat/hello-world/git/commits/${head.sha}`,
+      `${base}/repos/octocat/hello-world/git/trees/${gitCommitBody.tree.sha}`,
+      `${base}/repos/octocat/hello-world/git/blobs/${readmeBody.sha}`,
+    ];
+
+    for (const url of protectedUrls) {
+      expect((await app.request(url, { headers: authHeaders(noContents.token) })).status, url).toBe(403);
+      expect((await app.request(url, { headers: authHeaders(readContents.token) })).status, url).toBe(200);
+    }
   });
 
   it("honors organization default and team repository write permissions", async () => {
@@ -697,6 +770,56 @@ describe("GitHub contents routes", () => {
     expect((await subtree.json()) as { tree: unknown[] }).toEqual(
       expect.objectContaining({ tree: [expect.objectContaining({ path: "index.ts", type: "blob" })] }),
     );
+  });
+
+  it("deletes base-tree entries whose SHA is null", async () => {
+    const created = await putFile(app, "src/remove.txt", "remove me\n");
+    const createdBody = (await created.json()) as { commit: { sha: string; tree: { sha: string } } };
+
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: createdBody.commit.tree.sha,
+        tree: [{ path: "src/remove.txt", mode: "100644", type: "blob", sha: null }],
+      }),
+    });
+    expect(tree.status).toBe(201);
+    const treeBody = (await tree.json()) as { sha: string };
+
+    const nonexistent = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: createdBody.commit.tree.sha,
+        tree: [{ path: "src/missing.txt", mode: "100644", type: "blob", sha: null }],
+      }),
+    });
+    expect(nonexistent.status).toBe(422);
+
+    const commit = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        message: "Delete through Git Data",
+        tree: treeBody.sha,
+        parents: [createdBody.commit.sha],
+      }),
+    });
+    expect(commit.status).toBe(201);
+    const commitBody = (await commit.json()) as { sha: string };
+
+    const updateRef = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: commitBody.sha }),
+    });
+    expect(updateRef.status).toBe(200);
+
+    const removed = await app.request(`${base}/repos/octocat/hello-world/contents/src/remove.txt`, {
+      headers: authHeaders(),
+    });
+    expect(removed.status).toBe(404);
   });
 });
 

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -559,7 +559,45 @@ describe("GitHub contents routes", () => {
     expect((await dispatch(reader.token)).status).toBe(403);
     expect(gh.workflowRuns.findBy("repo_id", repo.id)).toHaveLength(0);
     expect((await dispatch(writer.token)).status).toBe(204);
-    expect(gh.workflowRuns.findBy("repo_id", repo.id)).toHaveLength(1);
+    const [run] = gh.workflowRuns.findBy("repo_id", repo.id);
+    expect(run).toBeDefined();
+    expect(gh.users.get(run.actor_id)?.login).toBe("contents-app[bot]");
+  });
+
+  it("keeps installation writes within selected public repositories", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const project = gh.repos.findOneBy("full_name", "acme/project")!;
+    const other = gh.repos.findOneBy("full_name", "acme/other")!;
+    const createWorkflow = (repoId: number, fullName: string) =>
+      gh.workflows.insert({
+        node_id: `workflow-${repoId}`,
+        repo_id: repoId,
+        name: "CI",
+        path: ".github/workflows/ci.yml",
+        state: "active",
+        badge_url: `${base}/repos/${fullName}/actions/workflows/ci.yml/badge.svg`,
+      });
+    const selectedWorkflow = createWorkflow(project.id, project.full_name);
+    const outsideWorkflow = createWorkflow(other.id, other.full_name);
+    const installation = await issueInstallationToken(app, 41, {
+      repositories: ["project"],
+      permissions: { actions: "write" },
+    });
+    expect(installation.response.status).toBe(201);
+
+    const dispatch = (repoName: string, workflowId: number) =>
+      app.request(`${base}/repos/acme/${repoName}/actions/workflows/${workflowId}/dispatches`, {
+        method: "POST",
+        headers: jsonHeaders(installation.token),
+        body: JSON.stringify({ ref: "main" }),
+      });
+
+    expect((await dispatch("project", selectedWorkflow.id)).status).toBe(204);
+    expect((await dispatch("other", outsideWorkflow.id)).status).toBe(403);
+    const [run] = gh.workflowRuns.findBy("repo_id", project.id);
+    expect(gh.users.get(run.actor_id)?.login).toBe("contents-app[bot]");
+    expect(gh.workflowRuns.findBy("repo_id", other.id)).toHaveLength(0);
   });
 
   it("requires Contents permission for installation reads from private repositories", async () => {
@@ -1152,6 +1190,93 @@ describe("GitHub contents routes", () => {
     }
   });
 
+  it("formats symlinks and submodules through the Contents API", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+    const submoduleSha = "c".repeat(40);
+    const gitmodules = [
+      '[submodule "vendor/mod"]',
+      "\tpath = vendor/mod",
+      "\turl = https://github.com/acme/dependency.git",
+      "",
+    ].join("\n");
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: head.commit.tree.sha,
+        tree: [
+          { path: ".gitmodules", mode: "100644", type: "blob", content: gitmodules },
+          { path: "target.txt", mode: "100644", type: "blob", content: "target\n" },
+          { path: "link.txt", mode: "120000", type: "blob", content: "target.txt" },
+          { path: "broken-link", mode: "120000", type: "blob", content: "missing.txt" },
+          { path: "vendor/mod", mode: "160000", type: "commit", sha: submoduleSha },
+        ],
+      }),
+    });
+    expect(tree.status).toBe(201);
+    const treeBody = (await tree.json()) as { sha: string };
+    const commit = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Add special entries", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    expect(commit.status).toBe(201);
+    const commitBody = (await commit.json()) as { sha: string };
+    const update = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: commitBody.sha }),
+    });
+    expect(update.status).toBe(200);
+
+    const link = await app.request(`${base}/repos/octocat/hello-world/contents/link.txt`, {
+      headers: authHeaders(),
+    });
+    expect(link.status).toBe(200);
+    const linkBody = (await link.json()) as { type: string; content: string };
+    expect(linkBody.type).toBe("file");
+    expect(Buffer.from(linkBody.content, "base64").toString("utf8")).toBe("target\n");
+    const rawLink = await app.request(`${base}/octocat/hello-world/raw/main/link.txt`, { headers: authHeaders() });
+    expect(rawLink.status).toBe(200);
+    expect(await rawLink.text()).toBe("target\n");
+
+    const broken = await app.request(`${base}/repos/octocat/hello-world/contents/broken-link`, {
+      headers: authHeaders(),
+    });
+    expect(broken.status).toBe(200);
+    expect(await broken.json()).toEqual(
+      expect.objectContaining({ type: "symlink", target: "missing.txt", size: "missing.txt".length }),
+    );
+
+    const submodule = await app.request(`${base}/repos/octocat/hello-world/contents/vendor/mod`, {
+      headers: authHeaders(),
+    });
+    expect(submodule.status).toBe(200);
+    expect(await submodule.json()).toEqual(
+      expect.objectContaining({
+        type: "submodule",
+        submodule_git_url: "https://github.com/acme/dependency.git",
+        sha: submoduleSha,
+        download_url: null,
+        git_url: `${base}/repos/acme/dependency/git/trees/${submoduleSha}`,
+        html_url: `${base}/acme/dependency/tree/${submoduleSha}`,
+      }),
+    );
+    const listing = await app.request(`${base}/repos/octocat/hello-world/contents/vendor`, {
+      headers: authHeaders(),
+    });
+    expect(listing.status).toBe(200);
+    expect(await listing.json()).toEqual([
+      expect.objectContaining({
+        type: "file",
+        name: "mod",
+        submodule_git_url: "https://github.com/acme/dependency.git",
+        download_url: null,
+      }),
+    ]);
+  });
+
   it("preserves submodules when Contents writes rebuild a neighboring tree", async () => {
     const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
     const [head] = (await commits.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
@@ -1262,6 +1387,48 @@ describe("GitHub contents routes", () => {
       headers: authHeaders(),
     });
     expect(removed.status).toBe(404);
+  });
+
+  it("initializes an empty repository even when loose Git objects exist", async () => {
+    const blob = await app.request(`${base}/repos/octocat/empty-repo/git/blobs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ content: "loose\n", encoding: "utf-8" }),
+    });
+    expect(blob.status).toBe(201);
+    const blobBody = (await blob.json()) as { sha: string };
+    const tree = await app.request(`${base}/repos/octocat/empty-repo/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        tree: [{ path: "loose.txt", mode: "100644", type: "blob", sha: blobBody.sha }],
+      }),
+    });
+    expect(tree.status).toBe(201);
+    const treeBody = (await tree.json()) as { sha: string };
+    const looseCommit = await app.request(`${base}/repos/octocat/empty-repo/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Loose commit", tree: treeBody.sha, parents: [] }),
+    });
+    expect(looseCommit.status).toBe(201);
+
+    const initialized = await app.request(`${base}/repos/octocat/empty-repo/contents/README.md`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        message: "Initialize repository",
+        content: Buffer.from("# Empty\n", "utf8").toString("base64"),
+      }),
+    });
+    expect(initialized.status).toBe(201);
+    const initializedBody = (await initialized.json()) as { commit: { parents: unknown[] } };
+    expect(initializedBody.commit.parents).toEqual([]);
+
+    const contents = await app.request(`${base}/repos/octocat/empty-repo/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    expect(contents.status).toBe(200);
   });
 
   it("keeps archived repositories read-only across Contents and Git Data", async () => {

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -942,6 +942,108 @@ describe("GitHub contents routes", () => {
     );
   });
 
+  it("applies nested tree updates independently of input order", async () => {
+    const subtree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        tree: [{ path: "base.txt", mode: "100644", type: "blob", content: "base\n" }],
+      }),
+    });
+    expect(subtree.status).toBe(201);
+    const subtreeBody = (await subtree.json()) as { sha: string };
+    const directory = { path: "dir", mode: "040000", type: "tree", sha: subtreeBody.sha };
+    const nested = { path: "dir/file.txt", mode: "100644", type: "blob", content: "nested\n" };
+
+    const create = (tree: Array<Record<string, unknown>>) =>
+      app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ tree }),
+      });
+    const nestedFirst = await create([nested, directory]);
+    const directoryFirst = await create([directory, nested]);
+    expect(nestedFirst.status).toBe(201);
+    expect(directoryFirst.status).toBe(201);
+    const nestedFirstBody = (await nestedFirst.json()) as { sha: string };
+    const directoryFirstBody = (await directoryFirst.json()) as { sha: string };
+    expect(nestedFirstBody.sha).toBe(directoryFirstBody.sha);
+
+    const recursive = await app.request(
+      `${base}/repos/octocat/hello-world/git/trees/${nestedFirstBody.sha}?recursive=1`,
+      { headers: authHeaders() },
+    );
+    expect(recursive.status).toBe(200);
+    const recursiveBody = (await recursive.json()) as { tree: Array<{ path: string }> };
+    expect(recursiveBody.tree.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining(["dir", "dir/base.txt", "dir/file.txt"]),
+    );
+  });
+
+  it("supports documented Git tree modes and rejects invalid mode and type pairs", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ commit: { tree: { sha: string } } }>;
+    const submoduleSha = "a".repeat(40);
+    const valid = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        tree: [
+          { path: "regular", mode: "100644", type: "blob", content: "regular\n" },
+          { path: "executable", mode: "100755", type: "blob", content: "executable\n" },
+          { path: "link", mode: "120000", type: "blob", content: "regular" },
+          { path: "directory", mode: "040000", type: "tree", sha: head.commit.tree.sha },
+          { path: "module", mode: "160000", type: "commit", sha: submoduleSha },
+        ],
+      }),
+    });
+    expect(valid.status).toBe(201);
+    expect((await valid.json()) as { tree: unknown[] }).toEqual(
+      expect.objectContaining({
+        tree: expect.arrayContaining([
+          expect.objectContaining({ path: "link", mode: "120000", type: "blob" }),
+          expect.objectContaining({ path: "module", mode: "160000", type: "commit", sha: submoduleSha }),
+        ]),
+      }),
+    );
+
+    const invalidEntries = [
+      { path: "bad", mode: "100600", type: "blob", content: "bad" },
+      { path: "bad", mode: "100644", type: "tree", sha: head.commit.tree.sha },
+      { path: "bad", mode: "040000", type: "blob", content: "bad" },
+      { path: "bad", mode: "160000", type: "blob", content: "bad" },
+      { path: "bad", mode: "120000", type: "commit", sha: submoduleSha },
+      { path: "bad", mode: "160000", type: "commit", sha: "not-a-sha" },
+    ];
+    for (const entry of invalidEntries) {
+      const response = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ tree: [entry] }),
+      });
+      expect(response.status, JSON.stringify(entry)).toBe(422);
+    }
+  });
+
+  it("gets trees by branch and tag refs", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string; commit: { tree: { sha: string } } }>;
+    const tag = await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ref: "refs/tags/tree-test", sha: head.sha }),
+    });
+    expect(tag.status).toBe(201);
+
+    for (const ref of ["main", "tree-test"]) {
+      const response = await app.request(`${base}/repos/octocat/hello-world/git/trees/${ref}`, {
+        headers: authHeaders(),
+      });
+      expect(response.status, ref).toBe(200);
+      expect(await response.json()).toEqual(expect.objectContaining({ sha: head.commit.tree.sha }));
+    }
+  });
+
   it("deletes base-tree entries whose SHA is null", async () => {
     const created = await putFile(app, "src/remove.txt", "remove me\n");
     const createdBody = (await created.json()) as { commit: { sha: string; tree: { sha: string } } };

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -350,6 +350,49 @@ describe("GitHub contents routes", () => {
     expect(body.commit.committer).toEqual(identity);
   });
 
+  it("associates and filters commit authors and committers independently", async () => {
+    const external = { name: "External", email: "external@example.com" };
+    const created = await putFile(app, "external.txt", "external\n", { author: external });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { commit: { sha: string } };
+
+    const commit = await app.request(`${base}/repos/octocat/hello-world/commits/${createdBody.commit.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(commit.status).toBe(200);
+    const commitBody = (await commit.json()) as {
+      commit: { author: { email: string }; committer: { email: string } };
+      author: { login: string } | null;
+      committer: { login: string } | null;
+    };
+    expect(commitBody.commit.author.email).toBe(external.email);
+    expect(commitBody.commit.committer.email).toBe("octocat@users.noreply.github.com");
+    expect(commitBody.author).toBeNull();
+    expect(commitBody.committer?.login).toBe("octocat");
+
+    const byExternalEmail = await app.request(
+      `${base}/repos/octocat/hello-world/commits?author=${encodeURIComponent(external.email)}`,
+      { headers: authHeaders() },
+    );
+    expect(((await byExternalEmail.json()) as Array<{ sha: string }>).map((item) => item.sha)).toContain(
+      createdBody.commit.sha,
+    );
+
+    const byActor = await app.request(`${base}/repos/octocat/hello-world/commits?author=octocat`, {
+      headers: authHeaders(),
+    });
+    expect(((await byActor.json()) as Array<{ sha: string }>).map((item) => item.sha)).not.toContain(
+      createdBody.commit.sha,
+    );
+
+    const byCommitter = await app.request(`${base}/repos/octocat/hello-world/commits?committer=octocat`, {
+      headers: authHeaders(),
+    });
+    expect(((await byCommitter.json()) as Array<{ sha: string }>).map((item) => item.sha)).toContain(
+      createdBody.commit.sha,
+    );
+  });
+
   it("updates only the selected branch", async () => {
     const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
     const [initial] = (await commits.json()) as Array<{ sha: string }>;
@@ -371,6 +414,85 @@ describe("GitHub contents routes", () => {
       headers: authHeaders(),
     });
     expect(onMain.status).toBe(404);
+  });
+
+  it("enforces protected-branch requirements for contents writes and ref updates", async () => {
+    const { app, store } = createTestApp();
+    const gh = getGitHubStore(store);
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string }>;
+    const gitCommit = await app.request(`${base}/repos/octocat/hello-world/git/commits/${head.sha}`, {
+      headers: authHeaders(),
+    });
+    const gitCommitBody = (await gitCommit.json()) as { tree: { sha: string } };
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: gitCommitBody.tree.sha,
+        tree: [{ path: "via-ref.txt", mode: "100644", type: "blob", content: "via ref\n" }],
+      }),
+    });
+    const treeBody = (await tree.json()) as { sha: string };
+    const pending = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Pending protected update", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    const pendingBody = (await pending.json()) as { sha: string };
+
+    const protectionBody = {
+      required_status_checks: null,
+      enforce_admins: true,
+      required_pull_request_reviews: { required_approving_review_count: 1 },
+      restrictions: null,
+      required_linear_history: false,
+      allow_force_pushes: false,
+      allow_deletions: false,
+      required_signatures: false,
+    };
+    const protect = await app.request(`${base}/repos/octocat/hello-world/branches/main/protection`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify(protectionBody),
+    });
+    expect(protect.status).toBe(200);
+
+    const blobCount = gh.blobs.findBy("repo_id", gh.repos.findOneBy("full_name", "octocat/hello-world")!.id).length;
+    expect((await putFile(app, "blocked.txt", "blocked\n")).status).toBe(409);
+    expect(gh.blobs.findBy("repo_id", gh.repos.findOneBy("full_name", "octocat/hello-world")!.id)).toHaveLength(
+      blobCount,
+    );
+
+    const readme = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    const readmeBody = (await readme.json()) as { sha: string };
+    const blockedDelete = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      method: "DELETE",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Blocked delete", sha: readmeBody.sha }),
+    });
+    expect(blockedDelete.status).toBe(409);
+
+    const blockedRef = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: pendingBody.sha }),
+    });
+    expect(blockedRef.status).toBe(409);
+    const unchangedRef = await app.request(`${base}/repos/octocat/hello-world/git/ref/heads/main`, {
+      headers: authHeaders(),
+    });
+    expect(((await unchangedRef.json()) as { object: { sha: string } }).object.sha).toBe(head.sha);
+
+    const allowAdminBypass = await app.request(`${base}/repos/octocat/hello-world/branches/main/protection`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ...protectionBody, enforce_admins: false }),
+    });
+    expect(allowAdminBypass.status).toBe(200);
+    expect((await putFile(app, "allowed.txt", "allowed\n")).status).toBe(201);
   });
 
   it("requires an existing branch for content writes", async () => {
@@ -860,5 +982,63 @@ describe("search result URLs resolve against the contents API", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { type: string };
     expect(body.type).toBe("file");
+  });
+
+  it("searches current default-branch paths and encodes result URLs", async () => {
+    const { app } = createTestApp();
+    expect((await putFile(app, "src/nested.txt", "nested-search-needle\n")).status).toBe(201);
+    expect((await putFile(app, "My%20File%20%231.txt", "special-search-needle\n")).status).toBe(201);
+
+    const deleted = await putFile(app, "deleted.txt", "deleted-search-needle\n");
+    const deletedBody = (await deleted.json()) as { content: { sha: string } };
+    expect(
+      (
+        await app.request(`${base}/repos/octocat/hello-world/contents/deleted.txt`, {
+          method: "DELETE",
+          headers: jsonHeaders(),
+          body: JSON.stringify({ message: "Delete searchable file", sha: deletedBody.content.sha }),
+        })
+      ).status,
+    ).toBe(200);
+
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string }>;
+    expect(
+      (
+        await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+          method: "POST",
+          headers: jsonHeaders(),
+          body: JSON.stringify({ ref: "refs/heads/search-feature", sha: head.sha }),
+        })
+      ).status,
+    ).toBe(201);
+    expect(
+      (await putFile(app, "feature-only.txt", "feature-search-needle\n", { branch: "search-feature" })).status,
+    ).toBe(201);
+
+    const search = async (term: string) => {
+      const query = encodeURIComponent(`${term} repo:octocat/hello-world`);
+      const response = await app.request(`${base}/search/code?q=${query}`, { headers: authHeaders() });
+      expect(response.status).toBe(200);
+      return (await response.json()) as {
+        total_count: number;
+        items: Array<{ path: string; url: string; html_url: string }>;
+      };
+    };
+
+    const nested = await search("nested-search-needle");
+    expect(nested.items).toHaveLength(1);
+    expect(nested.items[0].path).toBe("src/nested.txt");
+    expect((await app.request(nested.items[0].url, { headers: authHeaders() })).status).toBe(200);
+
+    const special = await search("special-search-needle");
+    expect(special.items).toHaveLength(1);
+    expect(special.items[0].path).toBe("My File #1.txt");
+    expect(special.items[0].url).toContain("My%20File%20%231.txt");
+    expect(special.items[0].html_url).toContain("My%20File%20%231.txt");
+    expect((await app.request(special.items[0].url, { headers: authHeaders() })).status).toBe(200);
+
+    expect((await search("deleted-search-needle")).total_count).toBe(0);
+    expect((await search("feature-search-needle")).total_count).toBe(0);
   });
 });

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -62,11 +62,22 @@ describe("GitHub contents routes", () => {
       headers: authHeaders(),
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { type: string; encoding: string; content: string; sha: string; path: string };
+    const body = (await res.json()) as {
+      type: string;
+      encoding: string;
+      content: string;
+      sha: string;
+      path: string;
+      download_url: string;
+    };
     expect(body.type).toBe("file");
     expect(body.path).toBe("README.md");
     expect(Buffer.from(body.content, "base64").toString("utf8")).toBe("# hello-world\n");
     expect(body.sha).toBeTruthy();
+
+    const download = await app.request(body.download_url, { headers: authHeaders() });
+    expect(download.status).toBe(200);
+    expect(await download.text()).toBe("# hello-world\n");
   });
 
   it("serves the URL shape that code search results advertise (?ref=HEAD)", async () => {
@@ -83,6 +94,38 @@ describe("GitHub contents routes", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { name: string; content: string };
     expect(body.name).toBe("README.md");
+  });
+
+  it("selects READMEs from .github, root, then docs", async () => {
+    const docs = await putFile(app, "docs/README.md", "docs\n");
+    const docsBody = (await docs.json()) as { content: { sha: string } };
+    const dotGitHub = await putFile(app, ".github/README.md", "github\n");
+    const dotGitHubBody = (await dotGitHub.json()) as { content: { sha: string } };
+
+    const preferred = await app.request(`${base}/repos/octocat/hello-world/readme`, { headers: authHeaders() });
+    expect(((await preferred.json()) as { path: string }).path).toBe(".github/README.md");
+
+    const deleteDotGitHub = await app.request(`${base}/repos/octocat/hello-world/contents/.github/README.md`, {
+      method: "DELETE",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Delete .github README", sha: dotGitHubBody.content.sha }),
+    });
+    expect(deleteDotGitHub.status).toBe(200);
+    const rootPreferred = await app.request(`${base}/repos/octocat/hello-world/readme`, { headers: authHeaders() });
+    expect(((await rootPreferred.json()) as { path: string }).path).toBe("README.md");
+
+    const root = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, { headers: authHeaders() });
+    const rootBody = (await root.json()) as { sha: string };
+    const deleteRoot = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      method: "DELETE",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Delete root README", sha: rootBody.sha }),
+    });
+    expect(deleteRoot.status).toBe(200);
+    const docsPreferred = await app.request(`${base}/repos/octocat/hello-world/readme`, { headers: authHeaders() });
+    const docsPreferredBody = (await docsPreferred.json()) as { path: string; sha: string };
+    expect(docsPreferredBody.path).toBe("docs/README.md");
+    expect(docsPreferredBody.sha).toBe(docsBody.content.sha);
   });
 
   it("lists the repo root and subdirectories", async () => {
@@ -112,13 +155,17 @@ describe("GitHub contents routes", () => {
   it("returns encoded content URLs that resolve for special path characters", async () => {
     const created = await putFile(app, "docs/My%20File%20%231.md", "hello\n");
     expect(created.status).toBe(201);
-    const createdBody = (await created.json()) as { content: { path: string; url: string } };
+    const createdBody = (await created.json()) as { content: { path: string; url: string; download_url: string } };
     expect(createdBody.content.path).toBe("docs/My File #1.md");
     expect(createdBody.content.url).toContain("My%20File%20%231.md");
 
     const read = await app.request(createdBody.content.url, { headers: authHeaders() });
     expect(read.status).toBe(200);
     expect(((await read.json()) as { path: string }).path).toBe("docs/My File #1.md");
+
+    const download = await app.request(createdBody.content.download_url, { headers: authHeaders() });
+    expect(download.status).toBe(200);
+    expect(await download.text()).toBe("hello\n");
   });
 
   it("404s on a missing path", async () => {
@@ -217,6 +264,36 @@ describe("GitHub contents routes", () => {
     expect(onMain.status).toBe(404);
   });
 
+  it("requires an existing branch for content writes", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string }>;
+    const tag = await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ref: "refs/tags/v1", sha: head.sha }),
+    });
+    expect(tag.status).toBe(201);
+
+    expect((await putFile(app, "from-tag.txt", "tag\n", { branch: "v1" })).status).toBe(404);
+    expect((await putFile(app, "from-sha.txt", "sha\n", { branch: head.sha })).status).toBe(404);
+
+    const readme = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    const readmeBody = (await readme.json()) as { sha: string };
+    const deleted = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      method: "DELETE",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Delete through tag", sha: readmeBody.sha, branch: "v1" }),
+    });
+    expect(deleted.status).toBe(404);
+
+    const inventedBranch = await app.request(`${base}/repos/octocat/hello-world/git/ref/heads/v1`, {
+      headers: authHeaders(),
+    });
+    expect(inventedBranch.status).toBe(404);
+  });
+
   it("reads a file at an older ref", async () => {
     const created = await putFile(app, "notes.txt", "one\n");
     const createdBody = (await created.json()) as { content: { sha: string }; commit: { sha: string } };
@@ -229,6 +306,53 @@ describe("GitHub contents routes", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { content: string };
     expect(Buffer.from(body.content, "base64").toString("utf8")).toBe("one\n");
+  });
+
+  it("creates traversable subtrees from nested Git Data paths", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string }>;
+
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        tree: [{ path: "src/index.ts", mode: "100644", type: "blob", content: "export {};\n" }],
+      }),
+    });
+    expect(tree.status).toBe(201);
+    const treeBody = (await tree.json()) as {
+      sha: string;
+      tree: Array<{ path: string; type: string; sha: string }>;
+    };
+    const srcTree = treeBody.tree.find((entry) => entry.path === "src");
+    expect(srcTree).toEqual(expect.objectContaining({ type: "tree", sha: expect.stringMatching(/^[0-9a-f]{40}$/) }));
+    expect(treeBody.tree.some((entry) => entry.path === "src/index.ts")).toBe(false);
+
+    const commit = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Create nested tree", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    expect(commit.status).toBe(201);
+    const commitBody = (await commit.json()) as { sha: string };
+    const updateRef = await app.request(`${base}/repos/octocat/hello-world/git/refs/heads/main`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ sha: commitBody.sha }),
+    });
+    expect(updateRef.status).toBe(200);
+
+    const root = await app.request(`${base}/repos/octocat/hello-world/contents`, { headers: authHeaders() });
+    const rootBody = (await root.json()) as Array<{ name: string; type: string; sha: string; git_url: string | null }>;
+    const src = rootBody.find((entry) => entry.name === "src");
+    expect(src).toEqual(
+      expect.objectContaining({ type: "dir", sha: srcTree!.sha, git_url: expect.stringContaining(srcTree!.sha) }),
+    );
+    const subtree = await app.request(src!.git_url!, { headers: authHeaders() });
+    expect(subtree.status).toBe(200);
+    expect((await subtree.json()) as { tree: unknown[] }).toEqual(
+      expect.objectContaining({ tree: [expect.objectContaining({ path: "index.ts", type: "blob" })] }),
+    );
   });
 });
 
@@ -290,6 +414,80 @@ describe("GitHub commits routes", () => {
     expect(body.stats.additions).toBe(2);
   });
 
+  it("paginates a single commit file list and serves its raw URLs", async () => {
+    const commits = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await commits.json()) as Array<{ sha: string }>;
+    const gitCommit = await app.request(`${base}/repos/octocat/hello-world/git/commits/${head.sha}`, {
+      headers: authHeaders(),
+    });
+    const gitCommitBody = (await gitCommit.json()) as { tree: { sha: string } };
+    const tree = await app.request(`${base}/repos/octocat/hello-world/git/trees`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        base_tree: gitCommitBody.tree.sha,
+        tree: ["a.txt", "b.txt", "c.txt"].map((path) => ({
+          path,
+          mode: "100644",
+          type: "blob",
+          content: `${path}\n`,
+        })),
+      }),
+    });
+    const treeBody = (await tree.json()) as { sha: string };
+    const created = await app.request(`${base}/repos/octocat/hello-world/git/commits`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Add three files", tree: treeBody.sha, parents: [head.sha] }),
+    });
+    const createdBody = (await created.json()) as { sha: string };
+
+    const first = await app.request(`${base}/repos/octocat/hello-world/commits/${createdBody.sha}?per_page=2&page=1`, {
+      headers: authHeaders(),
+    });
+    expect(first.status).toBe(200);
+    expect(first.headers.get("link")).toContain('rel="next"');
+    const firstBody = (await first.json()) as {
+      stats: { additions: number };
+      files: Array<{ filename: string; raw_url: string }>;
+    };
+    expect(firstBody.stats.additions).toBe(3);
+    expect(firstBody.files.map((file) => file.filename)).toEqual(["a.txt", "b.txt"]);
+    const raw = await app.request(firstBody.files[0].raw_url, { headers: authHeaders() });
+    expect(raw.status).toBe(200);
+    expect(await raw.text()).toBe("a.txt\n");
+
+    const second = await app.request(`${base}/repos/octocat/hello-world/commits/${createdBody.sha}?per_page=2&page=2`, {
+      headers: authHeaders(),
+    });
+    expect(second.status).toBe(200);
+    expect(second.headers.get("link")).toContain('rel="prev"');
+    const secondBody = (await second.json()) as {
+      stats: { additions: number };
+      files: Array<{ filename: string }>;
+    };
+    expect(secondBody.stats.additions).toBe(3);
+    expect(secondBody.files.map((file) => file.filename)).toEqual(["c.txt"]);
+  });
+
+  it("reports trailing-newline-only changes in commit diffs", async () => {
+    const created = await putFile(app, "newline.txt", "x");
+    const createdBody = (await created.json()) as { content: { sha: string } };
+    const updated = await putFile(app, "newline.txt", "x\n", { sha: createdBody.content.sha });
+    const updatedBody = (await updated.json()) as { commit: { sha: string } };
+
+    const commit = await app.request(`${base}/repos/octocat/hello-world/commits/${updatedBody.commit.sha}`, {
+      headers: authHeaders(),
+    });
+    const commitBody = (await commit.json()) as {
+      stats: { additions: number; deletions: number };
+      files: Array<{ additions: number; deletions: number; patch?: string }>;
+    };
+    expect(commitBody.stats).toEqual(expect.objectContaining({ additions: 1, deletions: 1 }));
+    expect(commitBody.files[0]).toEqual(expect.objectContaining({ additions: 1, deletions: 1 }));
+    expect(commitBody.files[0].patch).toContain("No newline at end of file");
+  });
+
   it("keeps Git Data and REST commit response shapes distinct", async () => {
     const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
     const [head] = (await list.json()) as Array<{ sha: string }>;
@@ -319,13 +517,31 @@ describe("GitHub commits routes", () => {
     expect(restBody).not.toHaveProperty("tree");
   });
 
-  it("resolves a commit by branch name and by sha prefix", async () => {
+  it("resolves documented branch, tag, and sha commit references", async () => {
     const created = await putFile(app, "notes.txt", "one\n");
     const createdBody = (await created.json()) as { commit: { sha: string } };
 
     const byBranch = await app.request(`${base}/repos/octocat/hello-world/commits/main`, { headers: authHeaders() });
     expect(byBranch.status).toBe(200);
     expect(((await byBranch.json()) as { sha: string }).sha).toBe(createdBody.commit.sha);
+
+    const byHeadRef = await app.request(`${base}/repos/octocat/hello-world/commits/heads/main`, {
+      headers: authHeaders(),
+    });
+    expect(byHeadRef.status).toBe(200);
+    expect(((await byHeadRef.json()) as { sha: string }).sha).toBe(createdBody.commit.sha);
+
+    const tag = await app.request(`${base}/repos/octocat/hello-world/git/refs`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ref: "refs/tags/v1", sha: createdBody.commit.sha }),
+    });
+    expect(tag.status).toBe(201);
+    const byTagRef = await app.request(`${base}/repos/octocat/hello-world/commits/tags/v1`, {
+      headers: authHeaders(),
+    });
+    expect(byTagRef.status).toBe(200);
+    expect(((await byTagRef.json()) as { sha: string }).sha).toBe(createdBody.commit.sha);
 
     const byPrefix = await app.request(
       `${base}/repos/octocat/hello-world/commits/${createdBody.commit.sha.slice(0, 8)}`,

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "@emulators/core";
+import { Store } from "@emulators/core";
+import { WebhookDispatcher } from "@emulators/core";
+import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
+import { githubPlugin, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4000";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("test-token", { login: "octocat", id: 1, scopes: ["repo", "user", "admin:org"] });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap));
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ login: "octocat" }],
+    repos: [
+      { owner: "octocat", name: "hello-world" },
+      { owner: "octocat", name: "empty-repo", auto_init: false },
+    ],
+  });
+
+  return { app, store, webhooks, tokenMap };
+}
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: "Bearer test-token" };
+}
+
+function jsonHeaders(): Record<string, string> {
+  return { ...authHeaders(), "Content-Type": "application/json" };
+}
+
+async function putFile(app: Hono, path: string, text: string, extra: Record<string, unknown> = {}) {
+  return app.request(`${base}/repos/octocat/hello-world/contents/${path}`, {
+    method: "PUT",
+    headers: jsonHeaders(),
+    body: JSON.stringify({
+      message: `Update ${path}`,
+      content: Buffer.from(text, "utf8").toString("base64"),
+      ...extra,
+    }),
+  });
+}
+
+describe("GitHub contents routes", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("returns the auto-init README via /contents/{path}", async () => {
+    const res = await app.request(`${base}/repos/octocat/hello-world/contents/README.md`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { type: string; encoding: string; content: string; sha: string; path: string };
+    expect(body.type).toBe("file");
+    expect(body.path).toBe("README.md");
+    expect(Buffer.from(body.content, "base64").toString("utf8")).toBe("# hello-world\n");
+    expect(body.sha).toBeTruthy();
+  });
+
+  it("serves the URL shape that code search results advertise (?ref=HEAD)", async () => {
+    const res = await app.request(`${base}/repos/octocat/hello-world/contents/README.md?ref=HEAD`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns the README via /readme", async () => {
+    const res = await app.request(`${base}/repos/octocat/hello-world/readme`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { name: string; content: string };
+    expect(body.name).toBe("README.md");
+  });
+
+  it("lists the repo root and subdirectories", async () => {
+    expect((await putFile(app, "src/index.ts", "export {};\n")).status).toBe(201);
+
+    const root = await app.request(`${base}/repos/octocat/hello-world/contents`, { headers: authHeaders() });
+    expect(root.status).toBe(200);
+    const rootBody = (await root.json()) as Array<{ name: string; type: string }>;
+    expect(rootBody.find((e) => e.name === "README.md")?.type).toBe("file");
+    expect(rootBody.find((e) => e.name === "src")?.type).toBe("dir");
+
+    const dir = await app.request(`${base}/repos/octocat/hello-world/contents/src`, { headers: authHeaders() });
+    expect(dir.status).toBe(200);
+    const dirBody = (await dir.json()) as Array<{ path: string; type: string }>;
+    expect(dirBody).toHaveLength(1);
+    expect(dirBody[0].path).toBe("src/index.ts");
+  });
+
+  it("404s on a missing path", async () => {
+    const res = await app.request(`${base}/repos/octocat/hello-world/contents/nope.txt`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("creates, updates, and deletes a file through PUT/DELETE /contents", async () => {
+    const created = await putFile(app, "notes.txt", "one\n");
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as {
+      content: { sha: string };
+      commit: { sha: string; parents: unknown[] };
+    };
+    expect(createdBody.content.sha).toBeTruthy();
+    expect(createdBody.commit.parents).toHaveLength(1);
+
+    // Update without sha -> 422; wrong sha -> 409.
+    expect((await putFile(app, "notes.txt", "two\n")).status).toBe(422);
+    expect((await putFile(app, "notes.txt", "two\n", { sha: "0".repeat(40) })).status).toBe(409);
+
+    const updated = await putFile(app, "notes.txt", "two\n", { sha: createdBody.content.sha });
+    expect(updated.status).toBe(200);
+    const updatedBody = (await updated.json()) as { content: { sha: string } };
+
+    const read = await app.request(`${base}/repos/octocat/hello-world/contents/notes.txt`, { headers: authHeaders() });
+    const readBody = (await read.json()) as { content: string };
+    expect(Buffer.from(readBody.content, "base64").toString("utf8")).toBe("two\n");
+
+    const deleted = await app.request(`${base}/repos/octocat/hello-world/contents/notes.txt`, {
+      method: "DELETE",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ message: "Delete notes.txt", sha: updatedBody.content.sha }),
+    });
+    expect(deleted.status).toBe(200);
+    const deletedBody = (await deleted.json()) as { content: null; commit: { sha: string } };
+    expect(deletedBody.content).toBeNull();
+
+    const gone = await app.request(`${base}/repos/octocat/hello-world/contents/notes.txt`, { headers: authHeaders() });
+    expect(gone.status).toBe(404);
+  });
+
+  it("reads a file at an older ref", async () => {
+    const created = await putFile(app, "notes.txt", "one\n");
+    const createdBody = (await created.json()) as { content: { sha: string }; commit: { sha: string } };
+    await putFile(app, "notes.txt", "two\n", { sha: createdBody.content.sha });
+
+    const res = await app.request(
+      `${base}/repos/octocat/hello-world/contents/notes.txt?ref=${createdBody.commit.sha}`,
+      { headers: authHeaders() },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string };
+    expect(Buffer.from(body.content, "base64").toString("utf8")).toBe("one\n");
+  });
+});
+
+describe("GitHub commits routes", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("lists commits newest first", async () => {
+    await putFile(app, "a.txt", "a\n");
+    await putFile(app, "b.txt", "b\n");
+
+    const res = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ sha: string; commit: { message: string } }>;
+    expect(body).toHaveLength(3);
+    expect(body[0].commit.message).toBe("Update b.txt");
+    expect(body[2].commit.message).toBe("Initial commit");
+  });
+
+  it("filters commits by path", async () => {
+    await putFile(app, "a.txt", "a\n");
+    await putFile(app, "b.txt", "b\n");
+
+    const res = await app.request(`${base}/repos/octocat/hello-world/commits?path=b.txt`, {
+      headers: authHeaders(),
+    });
+    const body = (await res.json()) as Array<{ commit: { message: string } }>;
+    expect(body).toHaveLength(1);
+    expect(body[0].commit.message).toBe("Update b.txt");
+  });
+
+  it("409s on an empty repository", async () => {
+    const res = await app.request(`${base}/repos/octocat/empty-repo/commits`, { headers: authHeaders() });
+    expect(res.status).toBe(409);
+  });
+
+  it("returns a single commit with files and stats", async () => {
+    const created = await putFile(app, "notes.txt", "one\ntwo\n");
+    const createdBody = (await created.json()) as { commit: { sha: string } };
+
+    const res = await app.request(`${base}/repos/octocat/hello-world/commits/${createdBody.commit.sha}`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sha: string;
+      stats: { additions: number; deletions: number; total: number };
+      files: Array<{ filename: string; status: string; additions: number; patch?: string }>;
+    };
+    expect(body.sha).toBe(createdBody.commit.sha);
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0].filename).toBe("notes.txt");
+    expect(body.files[0].status).toBe("added");
+    expect(body.files[0].additions).toBe(2);
+    expect(body.files[0].patch).toContain("+one");
+    expect(body.stats.additions).toBe(2);
+  });
+
+  it("resolves a commit by branch name and by sha prefix", async () => {
+    const created = await putFile(app, "notes.txt", "one\n");
+    const createdBody = (await created.json()) as { commit: { sha: string } };
+
+    const byBranch = await app.request(`${base}/repos/octocat/hello-world/commits/main`, { headers: authHeaders() });
+    expect(byBranch.status).toBe(200);
+    expect(((await byBranch.json()) as { sha: string }).sha).toBe(createdBody.commit.sha);
+
+    const byPrefix = await app.request(
+      `${base}/repos/octocat/hello-world/commits/${createdBody.commit.sha.slice(0, 8)}`,
+      { headers: authHeaders() },
+    );
+    expect(byPrefix.status).toBe(200);
+    expect(((await byPrefix.json()) as { sha: string }).sha).toBe(createdBody.commit.sha);
+  });
+
+  it("compares base...head", async () => {
+    const first = await putFile(app, "notes.txt", "one\n");
+    const firstBody = (await first.json()) as { content: { sha: string }; commit: { sha: string } };
+    await putFile(app, "notes.txt", "one\ntwo\n", { sha: firstBody.content.sha });
+
+    const res = await app.request(`${base}/repos/octocat/hello-world/compare/${firstBody.commit.sha}...main`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      ahead_by: number;
+      behind_by: number;
+      total_commits: number;
+      commits: Array<{ commit: { message: string } }>;
+      files: Array<{ filename: string; status: string; patch?: string }>;
+      merge_base_commit: { sha: string };
+    };
+    expect(body.status).toBe("ahead");
+    expect(body.ahead_by).toBe(1);
+    expect(body.behind_by).toBe(0);
+    expect(body.total_commits).toBe(1);
+    expect(body.commits[0].commit.message).toBe("Update notes.txt");
+    expect(body.merge_base_commit.sha).toBe(firstBody.commit.sha);
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0].filename).toBe("notes.txt");
+    expect(body.files[0].status).toBe("modified");
+    expect(body.files[0].patch).toContain("+two");
+  });
+
+  it("reports identical for the same ref on both sides", async () => {
+    const res = await app.request(`${base}/repos/octocat/hello-world/compare/main...main`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; ahead_by: number; files: unknown[] };
+    expect(body.status).toBe("identical");
+    expect(body.ahead_by).toBe(0);
+    expect(body.files).toHaveLength(0);
+  });
+
+  it("does not shadow /commits/{sha}/comments", async () => {
+    const list = await app.request(`${base}/repos/octocat/hello-world/commits`, { headers: authHeaders() });
+    const [head] = (await list.json()) as Array<{ sha: string }>;
+    const res = await app.request(`${base}/repos/octocat/hello-world/commits/${head.sha}/comments`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect(Array.isArray(await res.json())).toBe(true);
+  });
+});
+
+describe("GitHub repository-by-id route", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("looks up a repo by numeric id", async () => {
+    const byName = await app.request(`${base}/repos/octocat/hello-world`, { headers: authHeaders() });
+    const repo = (await byName.json()) as { id: number };
+
+    const byId = await app.request(`${base}/repositories/${repo.id}`, { headers: authHeaders() });
+    expect(byId.status).toBe(200);
+    const body = (await byId.json()) as { full_name: string };
+    expect(body.full_name).toBe("octocat/hello-world");
+  });
+
+  it("404s on an unknown id", async () => {
+    const res = await app.request(`${base}/repositories/999999`, { headers: authHeaders() });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("search result URLs resolve against the contents API", () => {
+  it("GET on a code-search result url returns the file", async () => {
+    const { app } = createTestApp();
+    const search = await app.request(`${base}/search/code?q=hello-world`, { headers: authHeaders() });
+    expect(search.status).toBe(200);
+    const searchBody = (await search.json()) as { items: Array<{ url: string }> };
+    expect(searchBody.items.length).toBeGreaterThan(0);
+
+    const res = await app.request(searchBody.items[0].url, { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { type: string };
+    expect(body.type).toBe("file");
+  });
+});

--- a/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
+++ b/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
@@ -383,6 +383,44 @@ describe("app webhook_url delivery", () => {
     expect(headers["X-Hub-Signature-256"]).toBe(`sha256=${expectedHmac}`);
   });
 
+  it("distinguishes user and organization installations with the same account ID", async () => {
+    const { app, webhooks } = createTestApp({
+      users: [{ login: "octocat" }],
+      orgs: [{ login: "first-org" }, { login: "second-org" }, { login: "acme" }],
+      repos: [{ owner: "acme", name: "project" }],
+      apps: [
+        {
+          app_id: 701,
+          slug: "user-app",
+          name: "User App",
+          private_key: "fake-key",
+          events: ["push"],
+          webhook_url: "https://user.example/webhook",
+          installations: [{ installation_id: 81, account: "octocat", repository_selection: "all" }],
+        },
+        {
+          app_id: 702,
+          slug: "org-app",
+          name: "Organization App",
+          private_key: "fake-key",
+          events: ["push"],
+          webhook_url: "https://org.example/webhook",
+          installations: [{ installation_id: 82, account: "acme", repository_selection: "all" }],
+        },
+      ],
+    });
+
+    const installation = await app.request(`${base}/repos/acme/project/installation`, { headers: authHeaders() });
+    expect(installation.status).toBe(200);
+    expect(await installation.json()).toEqual(expect.objectContaining({ id: 82, target_type: "Organization" }));
+
+    mockFetch.mockClear();
+    await webhooks.dispatch("push", undefined, { ref: "refs/heads/main" }, "acme", "project");
+
+    expect(mockFetch.mock.calls.some((call) => call[0] === "https://org.example/webhook")).toBe(true);
+    expect(mockFetch.mock.calls.some((call) => call[0] === "https://user.example/webhook")).toBe(false);
+  });
+
   it("does not deliver to app when webhook_url is null", async () => {
     const { app } = createTestApp({
       users: [{ login: "octocat" }],

--- a/packages/@emulators/github/src/entities.ts
+++ b/packages/@emulators/github/src/entities.ts
@@ -297,7 +297,7 @@ export interface GitHubTree extends Entity {
   tree: Array<{
     path: string;
     mode: string;
-    type: "blob" | "tree";
+    type: "blob" | "tree" | "commit";
     sha: string;
     size?: number;
   }>;

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -1,6 +1,82 @@
+import { createHash } from "crypto";
 import type { GitHubStore } from "./store.js";
-import type { GitHubCommit, GitHubRepo, GitHubUser } from "./entities.js";
-import { formatUser } from "./helpers.js";
+import type { GitHubBlob, GitHubCommit, GitHubRepo, GitHubTree, GitHubUser } from "./entities.js";
+import { formatUser, generateNodeId } from "./helpers.js";
+
+function gitObjectSha(type: "blob" | "tree", content: Buffer): string {
+  const header = Buffer.from(`${type} ${content.byteLength}\0`, "utf8");
+  return createHash("sha1").update(header).update(content).digest("hex");
+}
+
+export function blobBytes(blob: GitHubBlob): Buffer {
+  return blob.encoding === "base64" ? Buffer.from(blob.content, "base64") : Buffer.from(blob.content, "utf8");
+}
+
+export function findOrCreateBlob(gh: GitHubStore, repoId: number, content: Buffer): GitHubBlob {
+  const existing = gh.blobs.findBy("repo_id", repoId).find((blob) => blobBytes(blob).equals(content));
+  if (existing) return existing;
+
+  const sha = gitObjectSha("blob", content);
+  const sameSha = gh.blobs.findBy("repo_id", repoId).find((blob) => blob.sha === sha);
+  if (sameSha) return sameSha;
+
+  const text = content.toString("utf8");
+  const isText = !text.includes("\0") && Buffer.from(text, "utf8").equals(content);
+  const blob = gh.blobs.insert({
+    repo_id: repoId,
+    sha,
+    node_id: "",
+    content: isText ? text : content.toString("base64"),
+    encoding: isText ? "utf-8" : "base64",
+    size: content.byteLength,
+  } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
+  gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
+  return gh.blobs.get(blob.id)!;
+}
+
+type GitTreeEntry = GitHubTree["tree"][number];
+
+function sameTreeEntries(left: GitTreeEntry[], right: GitTreeEntry[]): boolean {
+  if (left.length !== right.length) return false;
+  const byPath = new Map(left.map((entry) => [entry.path, entry]));
+  return right.every((entry) => {
+    const candidate = byPath.get(entry.path);
+    return candidate?.mode === entry.mode && candidate.type === entry.type && candidate.sha === entry.sha;
+  });
+}
+
+function treeContent(entries: GitTreeEntry[]): Buffer {
+  const ordered = [...entries].sort((left, right) => {
+    const leftName = left.type === "tree" ? `${left.path}/` : left.path;
+    const rightName = right.type === "tree" ? `${right.path}/` : right.path;
+    return Buffer.compare(Buffer.from(leftName, "utf8"), Buffer.from(rightName, "utf8"));
+  });
+  return Buffer.concat(
+    ordered.flatMap((entry) => [
+      Buffer.from(`${entry.mode.replace(/^0+/, "")} ${entry.path}\0`, "utf8"),
+      Buffer.from(entry.sha, "hex"),
+    ]),
+  );
+}
+
+export function findOrCreateTree(gh: GitHubStore, repoId: number, entries: GitTreeEntry[]): GitHubTree {
+  const existing = gh.trees.findBy("repo_id", repoId).find((tree) => sameTreeEntries(tree.tree, entries));
+  if (existing) return existing;
+
+  const sha = gitObjectSha("tree", treeContent(entries));
+  const sameSha = gh.trees.findBy("repo_id", repoId).find((tree) => tree.sha === sha);
+  if (sameSha) return sameSha;
+
+  const tree = gh.trees.insert({
+    repo_id: repoId,
+    sha,
+    node_id: "",
+    tree: [...entries].sort((left, right) => left.path.localeCompare(right.path)),
+    truncated: false,
+  } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
+  gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
+  return gh.trees.get(tree.id)!;
+}
 
 export function findCommitBySha(gh: GitHubStore, repoId: number, sha: string): GitHubCommit | undefined {
   return gh.commits.findBy("repo_id", repoId).find((c) => c.sha === sha);

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -1,5 +1,5 @@
 import type { GitHubStore } from "./store.js";
-import type { GitHubCommit, GitHubRepo } from "./entities.js";
+import type { GitHubCommit, GitHubRepo, GitHubUser } from "./entities.js";
 import { formatUser } from "./helpers.js";
 
 export function findCommitBySha(gh: GitHubStore, repoId: number, sha: string): GitHubCommit | undefined {
@@ -140,6 +140,24 @@ export function encodeContentPath(path: string): string {
     .split("/")
     .map((part) => encodeURIComponent(part))
     .join("/");
+}
+
+function commitEmailMatchesUser(email: string, user: GitHubUser): boolean {
+  const normalized = email.toLowerCase();
+  const login = user.login.toLowerCase();
+  if (user.email?.toLowerCase() === normalized) return true;
+  if (normalized === `${login}@localhost`) return true;
+  if (normalized === `${login}@users.noreply.github.com`) return true;
+  return normalized.endsWith(`+${login}@users.noreply.github.com`);
+}
+
+export function resolveCommitUser(gh: GitHubStore, email: string): GitHubUser | undefined {
+  return gh.users.all().find((user) => commitEmailMatchesUser(email, user));
+}
+
+export function commitIdentityMatches(gh: GitHubStore, email: string, query: string): boolean {
+  if (email.toLowerCase() === query.toLowerCase()) return true;
+  return resolveCommitUser(gh, email)?.login.toLowerCase() === query.toLowerCase();
 }
 
 type Op = { type: "eq" | "del" | "ins"; text: string };
@@ -345,7 +363,8 @@ export function formatFileDiff(diff: FileDiff, repo: GitHubRepo, headSha: string
 /** REST commit object (the /repos/{owner}/{repo}/commits shape, without stats/files). */
 export function formatCommitItem(gh: GitHubStore, repo: GitHubRepo, c: GitHubCommit, baseUrl: string) {
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
-  const user = c.user_id ? gh.users.get(c.user_id) : null;
+  const authorUser = resolveCommitUser(gh, c.author_email);
+  const committerUser = resolveCommitUser(gh, c.committer_email);
   return {
     sha: c.sha,
     node_id: c.node_id,
@@ -361,8 +380,8 @@ export function formatCommitItem(gh: GitHubStore, repo: GitHubRepo, c: GitHubCom
     url: `${repoUrl}/commits/${c.sha}`,
     html_url: `${baseUrl}/${repo.full_name}/commit/${c.sha}`,
     comments_url: `${repoUrl}/commits/${c.sha}/comments`,
-    author: user ? formatUser(user, baseUrl) : null,
-    committer: user ? formatUser(user, baseUrl) : null,
+    author: authorUser ? formatUser(authorUser, baseUrl) : null,
+    committer: committerUser ? formatUser(committerUser, baseUrl) : null,
     parents: c.parent_shas.map((sha) => ({
       sha,
       url: `${repoUrl}/commits/${sha}`,

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -54,7 +54,6 @@ export interface FlatTree {
 export function flattenTree(gh: GitHubStore, repoId: number, treeSha: string): FlatTree {
   const blobs: FlatTree["blobs"] = new Map();
   const dirs: FlatTree["dirs"] = new Map();
-  const visited = new Set<string>();
 
   const registerParentDirs = (path: string) => {
     const parts = path.split("/");
@@ -64,11 +63,11 @@ export function flattenTree(gh: GitHubStore, repoId: number, treeSha: string): F
     }
   };
 
-  const walk = (sha: string, prefix: string) => {
-    if (visited.has(sha)) return;
-    visited.add(sha);
+  const walk = (sha: string, prefix: string, ancestors: Set<string>) => {
+    if (ancestors.has(sha)) return;
     const tree = gh.trees.findBy("repo_id", repoId).find((t) => t.sha === sha);
     if (!tree) return;
+    const nextAncestors = new Set(ancestors).add(sha);
     for (const e of tree.tree) {
       const path = prefix ? `${prefix}/${e.path}` : e.path;
       if (e.type === "blob") {
@@ -77,12 +76,12 @@ export function flattenTree(gh: GitHubStore, repoId: number, treeSha: string): F
       } else {
         dirs.set(path, e.sha);
         registerParentDirs(path);
-        walk(e.sha, path);
+        walk(e.sha, path, nextAncestors);
       }
     }
   };
 
-  walk(treeSha, "");
+  walk(treeSha, "", new Set());
   return { blobs, dirs };
 }
 
@@ -108,9 +107,18 @@ export function listAncestors(gh: GitHubStore, repoId: number, headSha: string):
 export function blobText(gh: GitHubStore, repoId: number, sha: string): string | null {
   const blob = gh.blobs.findBy("repo_id", repoId).find((b) => b.sha === sha);
   if (!blob) return null;
-  const text = blob.encoding === "base64" ? Buffer.from(blob.content, "base64").toString("utf8") : blob.content;
-  if (text.includes("\0")) return null;
+  if (blob.encoding !== "base64") return blob.content.includes("\0") ? null : blob.content;
+  const bytes = Buffer.from(blob.content, "base64");
+  const text = bytes.toString("utf8");
+  if (text.includes("\0") || !Buffer.from(text, "utf8").equals(bytes)) return null;
   return text;
+}
+
+export function encodeContentPath(path: string): string {
+  return path
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
 }
 
 type Op = { type: "eq" | "del" | "ins"; text: string };
@@ -289,6 +297,7 @@ export function diffTrees(
 
 export function formatFileDiff(diff: FileDiff, repo: GitHubRepo, headSha: string, baseUrl: string) {
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
+  const encodedPath = encodeContentPath(diff.filename);
   return {
     sha: diff.sha,
     filename: diff.filename,
@@ -296,9 +305,9 @@ export function formatFileDiff(diff: FileDiff, repo: GitHubRepo, headSha: string
     additions: diff.additions,
     deletions: diff.deletions,
     changes: diff.changes,
-    blob_url: `${baseUrl}/${repo.full_name}/blob/${headSha}/${diff.filename}`,
-    raw_url: `${baseUrl}/${repo.full_name}/raw/${headSha}/${diff.filename}`,
-    contents_url: `${repoUrl}/contents/${diff.filename}?ref=${headSha}`,
+    blob_url: `${baseUrl}/${repo.full_name}/blob/${headSha}/${encodedPath}`,
+    raw_url: `${baseUrl}/${repo.full_name}/raw/${headSha}/${encodedPath}`,
+    contents_url: `${repoUrl}/contents/${encodedPath}?ref=${headSha}`,
     ...(diff.patch !== undefined ? { patch: diff.patch } : {}),
   };
 }

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -1,0 +1,354 @@
+import type { GitHubStore } from "./store.js";
+import type { GitHubCommit, GitHubRepo } from "./entities.js";
+import { formatUser } from "./helpers.js";
+
+export function findCommitBySha(gh: GitHubStore, repoId: number, sha: string): GitHubCommit | undefined {
+  return gh.commits.findBy("repo_id", repoId).find((c) => c.sha === sha);
+}
+
+function peelToCommit(gh: GitHubStore, repoId: number, sha: string): GitHubCommit | undefined {
+  const commit = findCommitBySha(gh, repoId, sha);
+  if (commit) return commit;
+  const tag = gh.tags.findBy("repo_id", repoId).find((t) => t.sha === sha);
+  if (tag) return peelToCommit(gh, repoId, tag.object_sha);
+  return undefined;
+}
+
+/** Resolve a ref expression (branch, tag, full ref, sha, sha prefix, or HEAD) to a commit. */
+export function resolveRefToCommit(gh: GitHubStore, repo: GitHubRepo, refParam?: string): GitHubCommit | undefined {
+  const ref = !refParam || refParam === "HEAD" ? repo.default_branch : refParam;
+
+  const branch = gh.branches.findBy("repo_id", repo.id).find((b) => b.name === ref);
+  if (branch) return peelToCommit(gh, repo.id, branch.sha);
+
+  const refs = gh.refs.findBy("repo_id", repo.id);
+  const refRec =
+    refs.find((r) => r.ref === (ref.startsWith("refs/") ? ref : `refs/heads/${ref}`)) ??
+    refs.find((r) => r.ref === `refs/tags/${ref}`);
+  if (refRec) return peelToCommit(gh, repo.id, refRec.sha);
+
+  const tag = gh.tags.findBy("repo_id", repo.id).find((t) => t.tag === ref);
+  if (tag) return peelToCommit(gh, repo.id, tag.object_sha);
+
+  const commits = gh.commits.findBy("repo_id", repo.id);
+  const exact = commits.find((c) => c.sha === ref);
+  if (exact) return exact;
+  if (/^[0-9a-f]{4,39}$/.test(ref)) {
+    return commits.find((c) => c.sha.startsWith(ref));
+  }
+  return undefined;
+}
+
+export interface FlatTree {
+  /** Full slash-separated blob path -> entry. */
+  blobs: Map<string, { mode: string; sha: string; size?: number }>;
+  /** Full slash-separated directory path -> tree sha ("" when synthesized from flat paths). */
+  dirs: Map<string, string>;
+}
+
+/**
+ * Flatten a tree into full-path blob and directory maps. Handles both nested
+ * subtree entries and flat trees whose entry paths contain slashes (the shape
+ * POST /git/trees produces).
+ */
+export function flattenTree(gh: GitHubStore, repoId: number, treeSha: string): FlatTree {
+  const blobs: FlatTree["blobs"] = new Map();
+  const dirs: FlatTree["dirs"] = new Map();
+  const visited = new Set<string>();
+
+  const registerParentDirs = (path: string) => {
+    const parts = path.split("/");
+    for (let i = 1; i < parts.length; i++) {
+      const dir = parts.slice(0, i).join("/");
+      if (!dirs.has(dir)) dirs.set(dir, "");
+    }
+  };
+
+  const walk = (sha: string, prefix: string) => {
+    if (visited.has(sha)) return;
+    visited.add(sha);
+    const tree = gh.trees.findBy("repo_id", repoId).find((t) => t.sha === sha);
+    if (!tree) return;
+    for (const e of tree.tree) {
+      const path = prefix ? `${prefix}/${e.path}` : e.path;
+      if (e.type === "blob") {
+        blobs.set(path, { mode: e.mode, sha: e.sha, size: e.size });
+        registerParentDirs(path);
+      } else {
+        dirs.set(path, e.sha);
+        registerParentDirs(path);
+        walk(e.sha, path);
+      }
+    }
+  };
+
+  walk(treeSha, "");
+  return { blobs, dirs };
+}
+
+/** All commits reachable from head (inclusive), newest first. */
+export function listAncestors(gh: GitHubStore, repoId: number, headSha: string): GitHubCommit[] {
+  const out: GitHubCommit[] = [];
+  const seen = new Set<string>();
+  const stack = [headSha];
+  while (stack.length) {
+    const sha = stack.pop()!;
+    if (seen.has(sha)) continue;
+    seen.add(sha);
+    const commit = findCommitBySha(gh, repoId, sha);
+    if (!commit) continue;
+    out.push(commit);
+    for (const p of commit.parent_shas) stack.push(p);
+  }
+  return out.sort((a, b) =>
+    a.committer_date === b.committer_date ? b.id - a.id : a.committer_date < b.committer_date ? 1 : -1,
+  );
+}
+
+export function blobText(gh: GitHubStore, repoId: number, sha: string): string | null {
+  const blob = gh.blobs.findBy("repo_id", repoId).find((b) => b.sha === sha);
+  if (!blob) return null;
+  const text = blob.encoding === "base64" ? Buffer.from(blob.content, "base64").toString("utf8") : blob.content;
+  if (text.includes("\0")) return null;
+  return text;
+}
+
+type Op = { type: "eq" | "del" | "ins"; text: string };
+
+function lcsOps(a: string[], b: string[]): Op[] {
+  const n = a.length;
+  const m = b.length;
+  const dp: Uint32Array[] = [];
+  for (let i = 0; i <= n; i++) dp.push(new Uint32Array(m + 1));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const ops: Op[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ type: "eq", text: a[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      ops.push({ type: "del", text: a[i] });
+      i++;
+    } else {
+      ops.push({ type: "ins", text: b[j] });
+      j++;
+    }
+  }
+  while (i < n) ops.push({ type: "del", text: a[i++] });
+  while (j < m) ops.push({ type: "ins", text: b[j++] });
+  return ops;
+}
+
+function diffOps(a: string[], b: string[]): Op[] {
+  let start = 0;
+  while (start < a.length && start < b.length && a[start] === b[start]) start++;
+  let endA = a.length;
+  let endB = b.length;
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+    endA--;
+    endB--;
+  }
+  const midA = a.slice(start, endA);
+  const midB = b.slice(start, endB);
+  const mid: Op[] =
+    midA.length * midB.length > 250_000
+      ? [...midA.map((text): Op => ({ type: "del", text })), ...midB.map((text): Op => ({ type: "ins", text }))]
+      : lcsOps(midA, midB);
+  return [
+    ...a.slice(0, start).map((text): Op => ({ type: "eq", text })),
+    ...mid,
+    ...a.slice(endA).map((text): Op => ({ type: "eq", text })),
+  ];
+}
+
+const PATCH_CONTEXT = 3;
+const PATCH_MAX_LINES = 10_000;
+
+function opsToPatch(ops: Array<Op & { oldLine: number; newLine: number }>): string | undefined {
+  const changeIdx = ops.map((o, i) => (o.type === "eq" ? -1 : i)).filter((i) => i >= 0);
+  if (!changeIdx.length) return undefined;
+
+  const groups: Array<[number, number]> = [];
+  let gs = changeIdx[0];
+  let ge = changeIdx[0];
+  for (const idx of changeIdx.slice(1)) {
+    if (idx - ge - 1 <= PATCH_CONTEXT * 2) {
+      ge = idx;
+    } else {
+      groups.push([gs, ge]);
+      gs = idx;
+      ge = idx;
+    }
+  }
+  groups.push([gs, ge]);
+
+  const chunks: string[] = [];
+  for (const [s, e] of groups) {
+    const lo = Math.max(0, s - PATCH_CONTEXT);
+    const hi = Math.min(ops.length - 1, e + PATCH_CONTEXT);
+    const slice = ops.slice(lo, hi + 1);
+    const oldCount = slice.filter((o) => o.type !== "ins").length;
+    const newCount = slice.filter((o) => o.type !== "del").length;
+    const oldStart = oldCount === 0 ? slice[0].oldLine - 1 : slice[0].oldLine;
+    const newStart = newCount === 0 ? slice[0].newLine - 1 : slice[0].newLine;
+    chunks.push(`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`);
+    for (const o of slice) {
+      chunks.push(`${o.type === "eq" ? " " : o.type === "del" ? "-" : "+"}${o.text}`);
+    }
+  }
+  return chunks.join("\n");
+}
+
+export interface TextDiff {
+  additions: number;
+  deletions: number;
+  patch?: string;
+}
+
+export function diffText(oldText: string | null, newText: string | null): TextDiff {
+  const splitLines = (t: string | null) => (t === null || t === "" ? [] : t.replace(/\n$/, "").split("\n"));
+  const a = splitLines(oldText);
+  const b = splitLines(newText);
+  const ops = diffOps(a, b);
+
+  let additions = 0;
+  let deletions = 0;
+  let oldLine = 1;
+  let newLine = 1;
+  const annotated = ops.map((o) => {
+    const entry = { ...o, oldLine, newLine };
+    if (o.type === "eq") {
+      oldLine++;
+      newLine++;
+    } else if (o.type === "del") {
+      deletions++;
+      oldLine++;
+    } else {
+      additions++;
+      newLine++;
+    }
+    return entry;
+  });
+
+  const patch = a.length + b.length > PATCH_MAX_LINES ? undefined : opsToPatch(annotated);
+  return { additions, deletions, patch };
+}
+
+export interface FileDiff {
+  sha: string;
+  filename: string;
+  status: "added" | "removed" | "modified";
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch?: string;
+}
+
+/** Diff two trees by flattened blob paths. Pass null for baseTreeSha to diff from an empty tree. */
+export function diffTrees(
+  gh: GitHubStore,
+  repoId: number,
+  baseTreeSha: string | null,
+  headTreeSha: string,
+): FileDiff[] {
+  const base = baseTreeSha ? flattenTree(gh, repoId, baseTreeSha) : { blobs: new Map(), dirs: new Map() };
+  const head = flattenTree(gh, repoId, headTreeSha);
+
+  const paths = [...new Set([...base.blobs.keys(), ...head.blobs.keys()])].sort();
+  const out: FileDiff[] = [];
+  for (const path of paths) {
+    const before = base.blobs.get(path);
+    const after = head.blobs.get(path);
+    if (before && after && before.sha === after.sha) continue;
+
+    const status: FileDiff["status"] = !before ? "added" : !after ? "removed" : "modified";
+    const oldText = before ? blobText(gh, repoId, before.sha) : "";
+    const newText = after ? blobText(gh, repoId, after.sha) : "";
+    const binary = oldText === null || newText === null;
+    const diff = binary ? { additions: 0, deletions: 0, patch: undefined } : diffText(oldText, newText);
+
+    out.push({
+      sha: (after ?? before)!.sha,
+      filename: path,
+      status,
+      additions: diff.additions,
+      deletions: diff.deletions,
+      changes: diff.additions + diff.deletions,
+      patch: diff.patch,
+    });
+  }
+  return out;
+}
+
+export function formatFileDiff(diff: FileDiff, repo: GitHubRepo, headSha: string, baseUrl: string) {
+  const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
+  return {
+    sha: diff.sha,
+    filename: diff.filename,
+    status: diff.status,
+    additions: diff.additions,
+    deletions: diff.deletions,
+    changes: diff.changes,
+    blob_url: `${baseUrl}/${repo.full_name}/blob/${headSha}/${diff.filename}`,
+    raw_url: `${baseUrl}/${repo.full_name}/raw/${headSha}/${diff.filename}`,
+    contents_url: `${repoUrl}/contents/${diff.filename}?ref=${headSha}`,
+    ...(diff.patch !== undefined ? { patch: diff.patch } : {}),
+  };
+}
+
+/** REST commit object (the /repos/{owner}/{repo}/commits shape, without stats/files). */
+export function formatCommitItem(gh: GitHubStore, repo: GitHubRepo, c: GitHubCommit, baseUrl: string) {
+  const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
+  const user = c.user_id ? gh.users.get(c.user_id) : null;
+  return {
+    sha: c.sha,
+    node_id: c.node_id,
+    commit: {
+      author: { name: c.author_name, email: c.author_email, date: c.author_date },
+      committer: { name: c.committer_name, email: c.committer_email, date: c.committer_date },
+      message: c.message,
+      tree: { sha: c.tree_sha, url: `${repoUrl}/git/trees/${c.tree_sha}` },
+      url: `${repoUrl}/git/commits/${c.sha}`,
+      comment_count: 0,
+      verification: { verified: false, reason: "unsigned", signature: null, payload: null, verified_at: null },
+    },
+    url: `${repoUrl}/commits/${c.sha}`,
+    html_url: `${baseUrl}/${repo.full_name}/commit/${c.sha}`,
+    comments_url: `${repoUrl}/commits/${c.sha}/comments`,
+    author: user ? formatUser(user, baseUrl) : null,
+    committer: user ? formatUser(user, baseUrl) : null,
+    parents: c.parent_shas.map((sha) => ({
+      sha,
+      url: `${repoUrl}/commits/${sha}`,
+      html_url: `${baseUrl}/${repo.full_name}/commit/${sha}`,
+    })),
+  };
+}
+
+/** Git-data commit object (the /git/commits shape) used in contents write responses. */
+export function formatGitCommit(repo: GitHubRepo, c: GitHubCommit, baseUrl: string) {
+  const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
+  return {
+    sha: c.sha,
+    node_id: c.node_id,
+    url: `${repoUrl}/git/commits/${c.sha}`,
+    html_url: `${baseUrl}/${repo.full_name}/commit/${c.sha}`,
+    author: { name: c.author_name, email: c.author_email, date: c.author_date },
+    committer: { name: c.committer_name, email: c.committer_email, date: c.committer_date },
+    message: c.message,
+    tree: { sha: c.tree_sha, url: `${repoUrl}/git/trees/${c.tree_sha}` },
+    parents: c.parent_shas.map((sha) => ({
+      sha,
+      url: `${repoUrl}/git/commits/${sha}`,
+      html_url: `${baseUrl}/${repo.full_name}/commit/${sha}`,
+    })),
+    verification: { verified: false, reason: "unsigned", signature: null, payload: null, verified_at: null },
+  };
+}

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -343,9 +343,16 @@ export function diffTrees(
   return out;
 }
 
-export function formatFileDiff(diff: FileDiff, repo: GitHubRepo, headSha: string, baseUrl: string) {
+export function formatFileDiff(
+  diff: FileDiff,
+  repo: GitHubRepo,
+  baseSha: string | null,
+  headSha: string,
+  baseUrl: string,
+) {
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
   const encodedPath = encodeContentPath(diff.filename);
+  const contentSha = diff.status === "removed" && baseSha ? baseSha : headSha;
   return {
     sha: diff.sha,
     filename: diff.filename,
@@ -353,9 +360,9 @@ export function formatFileDiff(diff: FileDiff, repo: GitHubRepo, headSha: string
     additions: diff.additions,
     deletions: diff.deletions,
     changes: diff.changes,
-    blob_url: `${baseUrl}/${repo.full_name}/blob/${headSha}/${encodedPath}`,
-    raw_url: `${baseUrl}/${repo.full_name}/raw/${headSha}/${encodedPath}`,
-    contents_url: `${repoUrl}/contents/${encodedPath}?ref=${headSha}`,
+    blob_url: `${baseUrl}/${repo.full_name}/blob/${contentSha}/${encodedPath}`,
+    raw_url: `${baseUrl}/${repo.full_name}/raw/${contentSha}/${encodedPath}`,
+    contents_url: `${repoUrl}/contents/${encodedPath}?ref=${contentSha}`,
     ...(diff.patch !== undefined ? { patch: diff.patch } : {}),
   };
 }

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -158,7 +158,7 @@ export function resolveBranchToCommit(gh: GitHubStore, repo: GitHubRepo, branchN
 }
 
 export interface FlatTree {
-  /** Full slash-separated blob path -> entry. */
+  /** Full slash-separated non-tree path -> entry. */
   blobs: Map<string, { mode: string; sha: string; size?: number }>;
   /** Full slash-separated directory path -> tree sha ("" when synthesized from flat paths). */
   dirs: Map<string, string>;
@@ -188,7 +188,7 @@ export function flattenTree(gh: GitHubStore, repoId: number, treeSha: string): F
     const nextAncestors = new Set(ancestors).add(sha);
     for (const e of tree.tree) {
       const path = prefix ? `${prefix}/${e.path}` : e.path;
-      if (e.type === "blob") {
+      if (e.type !== "tree") {
         blobs.set(path, { mode: e.mode, sha: e.sha, size: e.size });
         registerParentDirs(path);
       } else {

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -159,7 +159,7 @@ export function resolveBranchToCommit(gh: GitHubStore, repo: GitHubRepo, branchN
 
 export interface FlatTree {
   /** Full slash-separated non-tree path -> entry. */
-  blobs: Map<string, { mode: string; sha: string; size?: number }>;
+  blobs: Map<string, { mode: string; type: "blob" | "commit"; sha: string; size?: number }>;
   /** Full slash-separated directory path -> tree sha ("" when synthesized from flat paths). */
   dirs: Map<string, string>;
 }
@@ -189,7 +189,7 @@ export function flattenTree(gh: GitHubStore, repoId: number, treeSha: string): F
     for (const e of tree.tree) {
       const path = prefix ? `${prefix}/${e.path}` : e.path;
       if (e.type !== "tree") {
-        blobs.set(path, { mode: e.mode, sha: e.sha, size: e.size });
+        blobs.set(path, { mode: e.mode, type: e.type, sha: e.sha, size: e.size });
         registerParentDirs(path);
       } else {
         dirs.set(path, e.sha);

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -304,7 +304,7 @@ export function diffTrees(
   for (const path of paths) {
     const before = base.blobs.get(path);
     const after = head.blobs.get(path);
-    if (before && after && before.sha === after.sha) continue;
+    if (before && after && before.sha === after.sha && before.mode === after.mode) continue;
 
     const status: FileDiff["status"] = !before ? "added" : !after ? "removed" : "modified";
     const oldText = before ? blobText(gh, repoId, before.sha) : "";

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -3,7 +3,7 @@ import type { GitHubStore } from "./store.js";
 import type { GitHubBlob, GitHubCommit, GitHubRepo, GitHubTree, GitHubUser } from "./entities.js";
 import { formatUser, generateNodeId } from "./helpers.js";
 
-function gitObjectSha(type: "blob" | "tree", content: Buffer): string {
+function gitObjectSha(type: "blob" | "tree" | "commit", content: Buffer): string {
   const header = Buffer.from(`${type} ${content.byteLength}\0`, "utf8");
   return createHash("sha1").update(header).update(content).digest("hex");
 }
@@ -61,6 +61,50 @@ export function findOrCreateTree(gh: GitHubStore, repoId: number, entries: GitTr
   } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
   gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
   return gh.trees.get(tree.id)!;
+}
+
+export interface GitCommitData {
+  message: string;
+  author_name: string;
+  author_email: string;
+  author_date: string;
+  committer_name: string;
+  committer_email: string;
+  committer_date: string;
+  tree_sha: string;
+  parent_shas: string[];
+  user_id: number | null;
+}
+
+function gitIdentityDate(date: string): string {
+  const milliseconds = Date.parse(date);
+  if (!Number.isFinite(milliseconds)) throw new Error(`Invalid Git identity date: ${date}`);
+  const zone = date.match(/(Z|([+-])(\d{2}):?(\d{2}))$/i);
+  const offset = !zone || zone[1].toUpperCase() === "Z" ? "+0000" : `${zone[2]}${zone[3]}${zone[4]}`;
+  return `${Math.floor(milliseconds / 1000)} ${offset}`;
+}
+
+function gitCommitContent(data: GitCommitData): Buffer {
+  const headers = [`tree ${data.tree_sha}`, ...data.parent_shas.map((sha) => `parent ${sha}`)];
+  headers.push(`author ${data.author_name} <${data.author_email}> ${gitIdentityDate(data.author_date)}`);
+  headers.push(`committer ${data.committer_name} <${data.committer_email}> ${gitIdentityDate(data.committer_date)}`);
+  const message = data.message.endsWith("\n") ? data.message : `${data.message}\n`;
+  return Buffer.from(`${headers.join("\n")}\n\n${message}`, "utf8");
+}
+
+export function findOrCreateCommit(gh: GitHubStore, repoId: number, data: GitCommitData): GitHubCommit {
+  const sha = gitObjectSha("commit", gitCommitContent(data));
+  const existing = gh.commits.findBy("repo_id", repoId).find((commit) => commit.sha === sha);
+  if (existing) return existing;
+
+  const commit = gh.commits.insert({
+    repo_id: repoId,
+    sha,
+    node_id: "",
+    ...data,
+  } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
+  gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
+  return gh.commits.get(commit.id)!;
 }
 
 export function findCommitBySha(gh: GitHubStore, repoId: number, sha: string): GitHubCommit | undefined {
@@ -159,23 +203,42 @@ export function flattenTree(gh: GitHubStore, repoId: number, treeSha: string): F
   return { blobs, dirs };
 }
 
-/** All commits reachable from head (inclusive), newest first. */
+/** All commits reachable from head in child-before-parent date order. */
 export function listAncestors(gh: GitHubStore, repoId: number, headSha: string): GitHubCommit[] {
-  const out: GitHubCommit[] = [];
-  const seen = new Set<string>();
+  const reachable = new Map<string, GitHubCommit>();
   const stack = [headSha];
   while (stack.length) {
     const sha = stack.pop()!;
-    if (seen.has(sha)) continue;
-    seen.add(sha);
+    if (reachable.has(sha)) continue;
     const commit = findCommitBySha(gh, repoId, sha);
     if (!commit) continue;
-    out.push(commit);
+    reachable.set(sha, commit);
     for (const p of commit.parent_shas) stack.push(p);
   }
-  return out.sort((a, b) =>
-    a.committer_date === b.committer_date ? b.id - a.id : a.committer_date < b.committer_date ? 1 : -1,
-  );
+
+  const childCounts = new Map([...reachable.keys()].map((sha) => [sha, 0]));
+  for (const commit of reachable.values()) {
+    for (const parentSha of commit.parent_shas) {
+      if (reachable.has(parentSha)) childCounts.set(parentSha, childCounts.get(parentSha)! + 1);
+    }
+  }
+
+  const eligible = [...reachable.values()].filter((commit) => childCounts.get(commit.sha) === 0);
+  const out: GitHubCommit[] = [];
+  while (eligible.length) {
+    eligible.sort((a, b) =>
+      a.committer_date === b.committer_date ? b.id - a.id : a.committer_date < b.committer_date ? 1 : -1,
+    );
+    const commit = eligible.shift()!;
+    out.push(commit);
+    for (const parentSha of commit.parent_shas) {
+      if (!reachable.has(parentSha)) continue;
+      const remainingChildren = childCounts.get(parentSha)! - 1;
+      childCounts.set(parentSha, remainingChildren);
+      if (remainingChildren === 0) eligible.push(reachable.get(parentSha)!);
+    }
+  }
+  return out;
 }
 
 export function blobText(gh: GitHubStore, repoId: number, sha: string): string | null {
@@ -447,7 +510,8 @@ export function diffText(oldText: string | null, newText: string | null): TextDi
 export interface FileDiff {
   sha: string;
   filename: string;
-  status: "added" | "removed" | "modified";
+  status: "added" | "removed" | "modified" | "renamed";
+  previous_filename?: string;
   additions: number;
   deletions: number;
   changes: number;
@@ -466,7 +530,37 @@ export function diffTrees(
 
   const paths = [...new Set([...base.blobs.keys(), ...head.blobs.keys()])].sort();
   const out: FileDiff[] = [];
+  const pairedPaths = new Set<string>();
+  const addedBySha = new Map<string, string[]>();
   for (const path of paths) {
+    if (base.blobs.has(path)) continue;
+    const entry = head.blobs.get(path);
+    if (!entry) continue;
+    const candidates = addedBySha.get(entry.sha) ?? [];
+    candidates.push(path);
+    addedBySha.set(entry.sha, candidates);
+  }
+  for (const previousPath of paths) {
+    const before = base.blobs.get(previousPath);
+    if (!before || head.blobs.has(previousPath)) continue;
+    const candidates = addedBySha.get(before.sha)?.filter((path) => !pairedPaths.has(path)) ?? [];
+    const filename = candidates.find((path) => head.blobs.get(path)?.mode === before.mode) ?? candidates[0];
+    if (!filename) continue;
+    pairedPaths.add(previousPath);
+    pairedPaths.add(filename);
+    out.push({
+      sha: before.sha,
+      filename,
+      previous_filename: previousPath,
+      status: "renamed",
+      additions: 0,
+      deletions: 0,
+      changes: 0,
+    });
+  }
+
+  for (const path of paths) {
+    if (pairedPaths.has(path)) continue;
     const before = base.blobs.get(path);
     const after = head.blobs.get(path);
     if (before && after && before.sha === after.sha && before.mode === after.mode) continue;
@@ -487,7 +581,7 @@ export function diffTrees(
       patch: diff.patch,
     });
   }
-  return out;
+  return out.sort((left, right) => left.filename.localeCompare(right.filename));
 }
 
 export function formatFileDiff(
@@ -510,6 +604,7 @@ export function formatFileDiff(
     blob_url: `${baseUrl}/${repo.full_name}/blob/${contentSha}/${encodedPath}`,
     raw_url: `${baseUrl}/${repo.full_name}/raw/${contentSha}/${encodedPath}`,
     contents_url: `${repoUrl}/contents/${encodedPath}?ref=${contentSha}`,
+    ...(diff.previous_filename !== undefined ? { previous_filename: diff.previous_filename } : {}),
     ...(diff.patch !== undefined ? { patch: diff.patch } : {}),
   };
 }

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -13,9 +13,6 @@ export function blobBytes(blob: GitHubBlob): Buffer {
 }
 
 export function findOrCreateBlob(gh: GitHubStore, repoId: number, content: Buffer): GitHubBlob {
-  const existing = gh.blobs.findBy("repo_id", repoId).find((blob) => blobBytes(blob).equals(content));
-  if (existing) return existing;
-
   const sha = gitObjectSha("blob", content);
   const sameSha = gh.blobs.findBy("repo_id", repoId).find((blob) => blob.sha === sha);
   if (sameSha) return sameSha;
@@ -36,15 +33,6 @@ export function findOrCreateBlob(gh: GitHubStore, repoId: number, content: Buffe
 
 type GitTreeEntry = GitHubTree["tree"][number];
 
-function sameTreeEntries(left: GitTreeEntry[], right: GitTreeEntry[]): boolean {
-  if (left.length !== right.length) return false;
-  const byPath = new Map(left.map((entry) => [entry.path, entry]));
-  return right.every((entry) => {
-    const candidate = byPath.get(entry.path);
-    return candidate?.mode === entry.mode && candidate.type === entry.type && candidate.sha === entry.sha;
-  });
-}
-
 function treeContent(entries: GitTreeEntry[]): Buffer {
   const ordered = [...entries].sort((left, right) => {
     const leftName = left.type === "tree" ? `${left.path}/` : left.path;
@@ -60,9 +48,6 @@ function treeContent(entries: GitTreeEntry[]): Buffer {
 }
 
 export function findOrCreateTree(gh: GitHubStore, repoId: number, entries: GitTreeEntry[]): GitHubTree {
-  const existing = gh.trees.findBy("repo_id", repoId).find((tree) => sameTreeEntries(tree.tree, entries));
-  if (existing) return existing;
-
   const sha = gitObjectSha("tree", treeContent(entries));
   const sameSha = gh.trees.findBy("repo_id", repoId).find((tree) => tree.sha === sha);
   if (sameSha) return sameSha;
@@ -110,14 +95,6 @@ export function resolveRefToCommit(gh: GitHubStore, repo: GitHubRepo, refParam?:
       : [`refs/heads/${ref}`, `refs/tags/${ref}`];
   const refRec = candidates.map((candidate) => refs.find((r) => r.ref === candidate)).find(Boolean);
   if (refRec) return peelToCommit(gh, repo.id, refRec.sha);
-
-  const tagName = ref.startsWith("refs/tags/")
-    ? ref.slice("refs/tags/".length)
-    : ref.startsWith("tags/")
-      ? ref.slice("tags/".length)
-      : ref;
-  const tag = gh.tags.findBy("repo_id", repo.id).find((t) => t.tag === tagName);
-  if (tag) return peelToCommit(gh, repo.id, tag.object_sha);
 
   const commits = gh.commits.findBy("repo_id", repo.id);
   const exact = commits.find((c) => c.sha === ref);
@@ -542,6 +519,9 @@ export function formatCommitItem(gh: GitHubStore, repo: GitHubRepo, c: GitHubCom
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
   const authorUser = resolveCommitUser(gh, c.author_email);
   const committerUser = resolveCommitUser(gh, c.committer_email);
+  const commentCount = gh.comments
+    .findBy("repo_id", repo.id)
+    .filter((comment) => comment.comment_type === "commit" && comment.commit_sha === c.sha).length;
   return {
     sha: c.sha,
     node_id: c.node_id,
@@ -551,7 +531,7 @@ export function formatCommitItem(gh: GitHubStore, repo: GitHubRepo, c: GitHubCom
       message: c.message,
       tree: { sha: c.tree_sha, url: `${repoUrl}/git/trees/${c.tree_sha}` },
       url: `${repoUrl}/git/commits/${c.sha}`,
-      comment_count: 0,
+      comment_count: commentCount,
       verification: { verified: false, reason: "unsigned", signature: null, payload: null, verified_at: null },
     },
     url: `${repoUrl}/commits/${c.sha}`,

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -269,6 +269,96 @@ function lcsOps(a: string[], b: string[]): Op[] {
   return ops;
 }
 
+function myersBisectOps(a: string[], b: string[]): Op[] {
+  const n = a.length;
+  const m = b.length;
+  const maxD = Math.ceil((n + m) / 2);
+  const offset = maxD;
+  const vectorLength = maxD * 2;
+  const forward = new Int32Array(vectorLength);
+  const reverse = new Int32Array(vectorLength);
+  forward.fill(-1);
+  reverse.fill(-1);
+  forward[offset + 1] = 0;
+  reverse[offset + 1] = 0;
+
+  const delta = n - m;
+  const frontOverlaps = delta % 2 !== 0;
+  let forwardStart = 0;
+  let forwardEnd = 0;
+  let reverseStart = 0;
+  let reverseEnd = 0;
+
+  const split = (x: number, y: number): Op[] => {
+    if ((x === 0 && y === 0) || (x === n && y === m)) {
+      return [...a.map((text): Op => ({ type: "del", text })), ...b.map((text): Op => ({ type: "ins", text }))];
+    }
+    return [...diffOps(a.slice(0, x), b.slice(0, y)), ...diffOps(a.slice(x), b.slice(y))];
+  };
+
+  for (let d = 0; d < maxD; d++) {
+    for (let k = -d + forwardStart; k <= d - forwardEnd; k += 2) {
+      const index = offset + k;
+      let x: number;
+      if (k === -d || (k !== d && forward[index - 1] < forward[index + 1])) {
+        x = forward[index + 1];
+      } else {
+        x = forward[index - 1] + 1;
+      }
+      let y = x - k;
+      while (x < n && y < m && a[x] === b[y]) {
+        x++;
+        y++;
+      }
+      forward[index] = x;
+
+      if (x > n) {
+        forwardEnd += 2;
+      } else if (y > m) {
+        forwardStart += 2;
+      } else if (frontOverlaps) {
+        const reverseIndex = offset + delta - k;
+        if (reverseIndex >= 0 && reverseIndex < vectorLength && reverse[reverseIndex] !== -1) {
+          const reverseX = n - reverse[reverseIndex];
+          if (x >= reverseX) return split(x, y);
+        }
+      }
+    }
+
+    for (let k = -d + reverseStart; k <= d - reverseEnd; k += 2) {
+      const index = offset + k;
+      let x: number;
+      if (k === -d || (k !== d && reverse[index - 1] < reverse[index + 1])) {
+        x = reverse[index + 1];
+      } else {
+        x = reverse[index - 1] + 1;
+      }
+      let y = x - k;
+      while (x < n && y < m && a[n - x - 1] === b[m - y - 1]) {
+        x++;
+        y++;
+      }
+      reverse[index] = x;
+
+      if (x > n) {
+        reverseEnd += 2;
+      } else if (y > m) {
+        reverseStart += 2;
+      } else if (!frontOverlaps) {
+        const forwardIndex = offset + delta - k;
+        if (forwardIndex >= 0 && forwardIndex < vectorLength && forward[forwardIndex] !== -1) {
+          const forwardX = forward[forwardIndex];
+          const forwardY = offset + forwardX - forwardIndex;
+          const reverseX = n - x;
+          if (forwardX >= reverseX) return split(forwardX, forwardY);
+        }
+      }
+    }
+  }
+
+  return [...a.map((text): Op => ({ type: "del", text })), ...b.map((text): Op => ({ type: "ins", text }))];
+}
+
 function diffOps(a: string[], b: string[]): Op[] {
   let start = 0;
   while (start < a.length && start < b.length && a[start] === b[start]) start++;
@@ -280,10 +370,14 @@ function diffOps(a: string[], b: string[]): Op[] {
   }
   const midA = a.slice(start, endA);
   const midB = b.slice(start, endB);
-  const mid: Op[] =
-    midA.length * midB.length > 250_000
-      ? [...midA.map((text): Op => ({ type: "del", text })), ...midB.map((text): Op => ({ type: "ins", text }))]
-      : lcsOps(midA, midB);
+  let mid: Op[];
+  if (!midA.length) {
+    mid = midB.map((text): Op => ({ type: "ins", text }));
+  } else if (!midB.length) {
+    mid = midA.map((text): Op => ({ type: "del", text }));
+  } else {
+    mid = midA.length * midB.length > 250_000 ? myersBisectOps(midA, midB) : lcsOps(midA, midB);
+  }
   return [
     ...a.slice(0, start).map((text): Op => ({ type: "eq", text })),
     ...mid,

--- a/packages/@emulators/github/src/git-helpers.ts
+++ b/packages/@emulators/github/src/git-helpers.ts
@@ -18,16 +18,29 @@ function peelToCommit(gh: GitHubStore, repoId: number, sha: string): GitHubCommi
 export function resolveRefToCommit(gh: GitHubStore, repo: GitHubRepo, refParam?: string): GitHubCommit | undefined {
   const ref = !refParam || refParam === "HEAD" ? repo.default_branch : refParam;
 
-  const branch = gh.branches.findBy("repo_id", repo.id).find((b) => b.name === ref);
-  if (branch) return peelToCommit(gh, repo.id, branch.sha);
+  const branchName = ref.startsWith("refs/heads/")
+    ? ref.slice("refs/heads/".length)
+    : ref.startsWith("heads/")
+      ? ref.slice("heads/".length)
+      : ref;
+  const branch = resolveBranchToCommit(gh, repo, branchName);
+  if (branch && !ref.startsWith("tags/") && !ref.startsWith("refs/tags/")) return branch;
 
   const refs = gh.refs.findBy("repo_id", repo.id);
-  const refRec =
-    refs.find((r) => r.ref === (ref.startsWith("refs/") ? ref : `refs/heads/${ref}`)) ??
-    refs.find((r) => r.ref === `refs/tags/${ref}`);
+  const candidates = ref.startsWith("refs/")
+    ? [ref]
+    : ref.startsWith("heads/") || ref.startsWith("tags/")
+      ? [`refs/${ref}`]
+      : [`refs/heads/${ref}`, `refs/tags/${ref}`];
+  const refRec = candidates.map((candidate) => refs.find((r) => r.ref === candidate)).find(Boolean);
   if (refRec) return peelToCommit(gh, repo.id, refRec.sha);
 
-  const tag = gh.tags.findBy("repo_id", repo.id).find((t) => t.tag === ref);
+  const tagName = ref.startsWith("refs/tags/")
+    ? ref.slice("refs/tags/".length)
+    : ref.startsWith("tags/")
+      ? ref.slice("tags/".length)
+      : ref;
+  const tag = gh.tags.findBy("repo_id", repo.id).find((t) => t.tag === tagName);
   if (tag) return peelToCommit(gh, repo.id, tag.object_sha);
 
   const commits = gh.commits.findBy("repo_id", repo.id);
@@ -37,6 +50,14 @@ export function resolveRefToCommit(gh: GitHubStore, repo: GitHubRepo, refParam?:
     return commits.find((c) => c.sha.startsWith(ref));
   }
   return undefined;
+}
+
+/** Resolve only an existing branch name to its head commit. */
+export function resolveBranchToCommit(gh: GitHubStore, repo: GitHubRepo, branchName: string): GitHubCommit | undefined {
+  const branch = gh.branches.findBy("repo_id", repo.id).find((b) => b.name === branchName);
+  const ref = gh.refs.findBy("repo_id", repo.id).find((r) => r.ref === `refs/heads/${branchName}`);
+  const sha = ref?.sha ?? branch?.sha;
+  return sha ? peelToCommit(gh, repo.id, sha) : undefined;
 }
 
 export interface FlatTree {
@@ -208,7 +229,10 @@ function opsToPatch(ops: Array<Op & { oldLine: number; newLine: number }>): stri
     const newStart = newCount === 0 ? slice[0].newLine - 1 : slice[0].newLine;
     chunks.push(`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`);
     for (const o of slice) {
-      chunks.push(`${o.type === "eq" ? " " : o.type === "del" ? "-" : "+"}${o.text}`);
+      const terminated = o.text.endsWith("\n");
+      const text = terminated ? o.text.slice(0, -1) : o.text;
+      chunks.push(`${o.type === "eq" ? " " : o.type === "del" ? "-" : "+"}${text}`);
+      if (!terminated) chunks.push("\\ No newline at end of file");
     }
   }
   return chunks.join("\n");
@@ -221,7 +245,13 @@ export interface TextDiff {
 }
 
 export function diffText(oldText: string | null, newText: string | null): TextDiff {
-  const splitLines = (t: string | null) => (t === null || t === "" ? [] : t.replace(/\n$/, "").split("\n"));
+  const splitLines = (t: string | null) => {
+    if (t === null || t === "") return [];
+    const terminated = t.endsWith("\n");
+    const lines = t.split("\n");
+    if (terminated) lines.pop();
+    return lines.map((line, index) => (terminated || index < lines.length - 1 ? `${line}\n` : line));
+  };
   const a = splitLines(oldText);
   const b = splitLines(newText);
   const ops = diffOps(a, b);

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -13,6 +13,8 @@ import { commentsRoutes } from "./routes/comments.js";
 import { reviewsRoutes } from "./routes/reviews.js";
 import { labelsAndMilestonesRoutes } from "./routes/labels.js";
 import { branchesAndGitRoutes } from "./routes/branches.js";
+import { contentsRoutes } from "./routes/contents.js";
+import { commitsRoutes } from "./routes/commits.js";
 import { orgsAndTeamsRoutes } from "./routes/orgs.js";
 import { releasesRoutes } from "./routes/releases.js";
 import { webhooksRoutes } from "./routes/webhooks.js";
@@ -249,6 +251,18 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
       if (r.auto_init !== false) {
         const sha = generateSha();
         const treeSha = generateSha();
+        const readme = `# ${r.name}\n${r.description ? `\n${r.description}\n` : ""}`;
+        const readmeSize = Buffer.byteLength(readme, "utf8");
+
+        const blob = gh.blobs.insert({
+          repo_id: repo.id,
+          sha: generateSha(),
+          node_id: "",
+          content: readme,
+          encoding: "utf-8",
+          size: readmeSize,
+        });
+        gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
 
         const commit = gh.commits.insert({
           repo_id: repo.id,
@@ -271,7 +285,7 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
           repo_id: repo.id,
           sha: treeSha,
           node_id: "",
-          tree: [{ path: "README.md", mode: "100644", type: "blob", sha: generateSha(), size: 20 }],
+          tree: [{ path: "README.md", mode: "100644", type: "blob", sha: blob.sha, size: readmeSize }],
           truncated: false,
         });
         gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
@@ -493,6 +507,10 @@ export const githubPlugin: ServicePlugin = {
     metaRoutes(ctx);
     oauthRoutes(ctx);
     appsRoutes(ctx);
+    contentsRoutes(ctx);
+    // Registered last: the catch-all /commits/:ref{.+} route must not shadow
+    // /commits/:sha/comments (comments.ts) or /commits/:ref/check-* (checks.ts).
+    commitsRoutes(ctx);
   },
   seed(store: Store, baseUrl: string): void {
     seedDefaults(store, baseUrl);

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -25,6 +25,7 @@ import { rateLimitRoutes } from "./routes/rate-limit.js";
 import { metaRoutes } from "./routes/meta.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { appsRoutes } from "./routes/apps.js";
+import { findOrCreateBlob, findOrCreateTree } from "./git-helpers.js";
 
 export { getGitHubStore, type GitHubStore } from "./store.js";
 export * from "./entities.js";
@@ -250,19 +251,12 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
 
       if (r.auto_init !== false) {
         const sha = generateSha();
-        const treeSha = generateSha();
         const readme = `# ${r.name}\n${r.description ? `\n${r.description}\n` : ""}`;
         const readmeSize = Buffer.byteLength(readme, "utf8");
-
-        const blob = gh.blobs.insert({
-          repo_id: repo.id,
-          sha: generateSha(),
-          node_id: "",
-          content: readme,
-          encoding: "utf-8",
-          size: readmeSize,
-        });
-        gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
+        const blob = findOrCreateBlob(gh, repo.id, Buffer.from(readme, "utf8"));
+        const tree = findOrCreateTree(gh, repo.id, [
+          { path: "README.md", mode: "100644", type: "blob", sha: blob.sha, size: readmeSize },
+        ]);
 
         const commit = gh.commits.insert({
           repo_id: repo.id,
@@ -275,20 +269,11 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
           committer_name: r.owner,
           committer_email: `${r.owner}@localhost`,
           committer_date: repo.created_at,
-          tree_sha: treeSha,
+          tree_sha: tree.sha,
           parent_shas: [],
           user_id: owner.id,
         });
         gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
-
-        const tree = gh.trees.insert({
-          repo_id: repo.id,
-          sha: treeSha,
-          node_id: "",
-          tree: [{ path: "README.md", mode: "100644", type: "blob", sha: blob.sha, size: readmeSize }],
-          truncated: false,
-        });
-        gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
 
         gh.branches.insert({
           repo_id: repo.id,

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -372,14 +372,16 @@ function findInstallationsForRepo(
   repoName: string | undefined,
   event: string,
 ): GitHubAppInstallation[] {
-  const ownerEntity = gh.users.findOneBy("login", ownerLogin) ?? gh.orgs.findOneBy("login", ownerLogin);
-  if (!ownerEntity) return [];
-
   const repoEntity = repoName ? gh.repos.findOneBy("full_name", `${ownerLogin}/${repoName}`) : null;
+  const ownerUser = gh.users.findOneBy("login", ownerLogin);
+  const ownerOrg = gh.orgs.findOneBy("login", ownerLogin);
+  const ownerId = repoEntity?.owner_id ?? ownerUser?.id ?? ownerOrg?.id;
+  const ownerType = repoEntity?.owner_type ?? (ownerUser ? "User" : ownerOrg ? "Organization" : undefined);
+  if (ownerId === undefined || ownerType === undefined) return [];
 
   const results: GitHubAppInstallation[] = [];
   for (const inst of gh.appInstallations.all()) {
-    if (inst.account_id !== ownerEntity.id) continue;
+    if (inst.account_id !== ownerId || inst.account_type !== ownerType) continue;
     if (inst.suspended_at) continue;
 
     const ghApp = gh.apps.all().find((a) => a.app_id === inst.app_id);

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -4,7 +4,7 @@ import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteCo
 import { getGitHubStore } from "./store.js";
 import type { GitHubStore } from "./store.js";
 import type { GitHubAppInstallation } from "./entities.js";
-import { generateNodeId, generateSha } from "./helpers.js";
+import { generateNodeId } from "./helpers.js";
 import { usersRoutes } from "./routes/users.js";
 import { reposRoutes } from "./routes/repos.js";
 import { issuesRoutes } from "./routes/issues.js";
@@ -25,7 +25,7 @@ import { rateLimitRoutes } from "./routes/rate-limit.js";
 import { metaRoutes } from "./routes/meta.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { appsRoutes } from "./routes/apps.js";
-import { findOrCreateBlob, findOrCreateTree } from "./git-helpers.js";
+import { findOrCreateBlob, findOrCreateCommit, findOrCreateTree } from "./git-helpers.js";
 
 export { getGitHubStore, type GitHubStore } from "./store.js";
 export * from "./entities.js";
@@ -250,7 +250,6 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
       gh.repos.update(repo.id, { node_id: generateNodeId("Repository", repo.id) });
 
       if (r.auto_init !== false) {
-        const sha = generateSha();
         const readme = `# ${r.name}\n${r.description ? `\n${r.description}\n` : ""}`;
         const readmeSize = Buffer.byteLength(readme, "utf8");
         const blob = findOrCreateBlob(gh, repo.id, Buffer.from(readme, "utf8"));
@@ -258,10 +257,7 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
           { path: "README.md", mode: "100644", type: "blob", sha: blob.sha, size: readmeSize },
         ]);
 
-        const commit = gh.commits.insert({
-          repo_id: repo.id,
-          sha,
-          node_id: "",
+        const commit = findOrCreateCommit(gh, repo.id, {
           message: "Initial commit",
           author_name: r.owner,
           author_email: `${r.owner}@localhost`,
@@ -273,19 +269,18 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
           parent_shas: [],
           user_id: owner.id,
         });
-        gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
 
         gh.branches.insert({
           repo_id: repo.id,
           name: defaultBranch,
-          sha,
+          sha: commit.sha,
           protected: false,
         });
 
         const refRow = gh.refs.insert({
           repo_id: repo.id,
           ref: `refs/heads/${defaultBranch}`,
-          sha,
+          sha: commit.sha,
           node_id: "",
         });
         gh.refs.update(refRow.id, { node_id: generateNodeId("Ref", refRow.id) });

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -2,6 +2,7 @@ import type { AuthUser } from "@emulators/core";
 import { ApiError, notFound, unauthorized, forbidden } from "@emulators/core";
 import type { GitHubStore } from "./store.js";
 import type { GitHubRepo, GitHubUser } from "./entities.js";
+import { generateNodeId } from "./helpers.js";
 
 export { notFound as notFoundResponse };
 
@@ -25,9 +26,48 @@ export function getActorUser(gh: GitHubStore, authUser: AuthUser): GitHubUser | 
   return gh.users.findOneBy("login", authUser.login);
 }
 
+function installationCanAccessRepo(authUser: AuthUser, repo: GitHubRepo): boolean {
+  const installation = authUser.installation;
+  if (!installation) return false;
+  if (repo.owner_id !== installation.accountId || repo.owner_type !== installation.accountType) return false;
+  return installation.repositorySelection === "all" || installation.repositoryIds.includes(repo.id);
+}
+
+function installationActor(gh: GitHubStore, authUser: AuthUser): GitHubUser {
+  const installation = authUser.installation!;
+  const app = gh.apps.findOneBy("app_id", installation.appId);
+  const login = `${app?.slug ?? `app-${installation.appId}`}[bot]`;
+  const existing = gh.users.findOneBy("login", login);
+  if (existing) return existing;
+
+  const actor = gh.users.insert({
+    login,
+    node_id: "",
+    avatar_url: "",
+    gravatar_id: "",
+    type: "Bot",
+    site_admin: false,
+    name: app?.name ?? "GitHub App",
+    company: null,
+    blog: "",
+    location: null,
+    email: `${installation.appId}+${login}@users.noreply.github.com`,
+    hireable: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+  });
+  gh.users.update(actor.id, { node_id: generateNodeId("Bot", actor.id) });
+  return gh.users.get(actor.id)!;
+}
+
 export function canAccessRepo(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): boolean {
   if (!repo.private) return true;
   if (!authUser) return false;
+  if (authUser.installation) return installationCanAccessRepo(authUser, repo);
   const user = getActorUser(gh, authUser);
   if (!user) return false;
   if (repo.owner_type === "User" && repo.owner_id === user.id) return true;
@@ -89,6 +129,11 @@ export function hasRepoContentsWrite(gh: GitHubStore, user: GitHubUser, repo: Gi
 }
 
 export function assertRepoContentsWrite(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {
+  if (authUser?.installation) {
+    if (!installationCanAccessRepo(authUser, repo)) throw forbidden();
+    if (authUser.installation.permissions.contents !== "write") throw forbidden();
+    return installationActor(gh, authUser);
+  }
   const user = assertAuthenticatedUser(gh, authUser);
   if (hasRepoContentsWrite(gh, user, repo)) return user;
   throw forbidden();

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -81,6 +81,14 @@ export function assertRepoRead(gh: GitHubStore, authUser: AuthUser | undefined, 
   throw forbidden();
 }
 
+export function assertRepoContentsRead(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): void {
+  assertRepoRead(gh, authUser, repo);
+  if (!repo.private || !authUser?.installation) return;
+  const permission = authUser.installation.permissions.contents;
+  if (permission === "read" || permission === "write") return;
+  throw forbidden();
+}
+
 export function assertAuthenticatedUser(gh: GitHubStore, authUser: AuthUser | undefined): GitHubUser {
   if (!authUser) throw unauthorized();
   const user = getActorUser(gh, authUser);

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -55,6 +55,45 @@ export function hasRepoAdmin(gh: GitHubStore, user: GitHubUser, repo: GitHubRepo
   return collab?.permission === "admin" || collab?.permission === "maintain";
 }
 
+function grantsRepoWrite(permission: string): boolean {
+  return permission === "push" || permission === "write" || permission === "maintain" || permission === "admin";
+}
+
+export function hasRepoContentsWrite(gh: GitHubStore, user: GitHubUser, repo: GitHubRepo): boolean {
+  if (repo.owner_type === "User" && repo.owner_id === user.id) return true;
+
+  const collaborator = gh.collaborators.findBy("repo_id", repo.id).find((c) => c.user_id === user.id);
+  if (collaborator && grantsRepoWrite(collaborator.permission)) return true;
+
+  if (repo.owner_type !== "Organization") return false;
+  const memberships = gh.teamMembers.findBy("user_id", user.id).filter((membership) => {
+    return gh.teams.get(membership.team_id)?.org_id === repo.owner_id;
+  });
+  if (!memberships.length) return false;
+
+  // Organization administrators are represented as maintainers of the members team by the emulator.
+  const isOrgAdmin = memberships.some((membership) => {
+    const team = gh.teams.get(membership.team_id);
+    return team?.slug === "members" && membership.role === "maintainer";
+  });
+  if (isOrgAdmin) return true;
+
+  const org = gh.orgs.get(repo.owner_id);
+  if (org && grantsRepoWrite(org.default_repository_permission)) return true;
+
+  return memberships.some((membership) => {
+    const team = gh.teams.get(membership.team_id);
+    if (!team || !grantsRepoWrite(team.permission)) return false;
+    return gh.teamRepos.findBy("team_id", team.id).some((link) => link.repo_id === repo.id);
+  });
+}
+
+export function assertRepoContentsWrite(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {
+  const user = assertAuthenticatedUser(gh, authUser);
+  if (hasRepoContentsWrite(gh, user, repo)) return user;
+  throw forbidden();
+}
+
 export function assertRepoAdmin(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {
   if (!authUser) throw unauthorized();
   const user = getActorUser(gh, authUser);

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -218,12 +218,38 @@ function branchRestrictionsAllow(
   });
 }
 
+function introducedRangeContainsMerge(gh: GitHubStore, repoId: number, currentSha: string, targetSha: string): boolean {
+  const commits = new Map(gh.commits.findBy("repo_id", repoId).map((commit) => [commit.sha, commit]));
+  const currentReachable = new Set<string>();
+  const currentStack = [currentSha];
+  while (currentStack.length) {
+    const sha = currentStack.pop()!;
+    if (currentReachable.has(sha)) continue;
+    currentReachable.add(sha);
+    const commit = commits.get(sha);
+    if (commit) currentStack.push(...commit.parent_shas);
+  }
+
+  const visited = new Set<string>();
+  const targetStack = [targetSha];
+  while (targetStack.length) {
+    const sha = targetStack.pop()!;
+    if (visited.has(sha) || currentReachable.has(sha)) continue;
+    visited.add(sha);
+    const commit = commits.get(sha);
+    if (!commit) continue;
+    if (commit.parent_shas.length > 1) return true;
+    targetStack.push(...commit.parent_shas);
+  }
+  return false;
+}
+
 export function assertBranchUpdateAllowed(
   gh: GitHubStore,
   user: GitHubUser,
   repo: GitHubRepo,
   branchName: string,
-  options: { force?: boolean; parentCount?: number; deletion?: boolean; targetSha?: string } = {},
+  options: { force?: boolean; parentCount?: number; deletion?: boolean; currentSha?: string; targetSha?: string } = {},
 ): void {
   const protection = gh.branchProtections
     .findBy("repo_id", repo.id)
@@ -254,7 +280,11 @@ export function assertBranchUpdateAllowed(
       (requiredContexts.length > 0 && !requiredChecksPassed) ||
       protection.required_signatures);
   const invalidHistory =
-    options.deletion !== true && protection.required_linear_history && (options.parentCount ?? 1) > 1;
+    options.deletion !== true &&
+    protection.required_linear_history &&
+    (options.currentSha && options.targetSha
+      ? introducedRangeContainsMerge(gh, repo.id, options.currentSha, options.targetSha)
+      : (options.parentCount ?? 1) > 1);
   const blockedForcePush = options.deletion !== true && options.force === true && !protection.allow_force_pushes;
 
   if (restricted || blockedDeletion || requirementsBlockDirectUpdate || invalidHistory || blockedForcePush) {

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -1,5 +1,5 @@
 import type { AuthUser } from "@emulators/core";
-import { notFound, unauthorized, forbidden } from "@emulators/core";
+import { ApiError, notFound, unauthorized, forbidden } from "@emulators/core";
 import type { GitHubStore } from "./store.js";
 import type { GitHubRepo, GitHubUser } from "./entities.js";
 
@@ -92,6 +92,67 @@ export function assertRepoContentsWrite(gh: GitHubStore, authUser: AuthUser | un
   const user = assertAuthenticatedUser(gh, authUser);
   if (hasRepoContentsWrite(gh, user, repo)) return user;
   throw forbidden();
+}
+
+function hasBranchProtectionBypass(gh: GitHubStore, user: GitHubUser, repo: GitHubRepo): boolean {
+  if (user.site_admin) return true;
+  if (repo.owner_type === "User") return repo.owner_id === user.id;
+
+  const isOrgAdmin = gh.teamMembers.findBy("user_id", user.id).some((membership) => {
+    const team = gh.teams.get(membership.team_id);
+    return team?.org_id === repo.owner_id && team.slug === "members" && membership.role === "maintainer";
+  });
+  if (isOrgAdmin) return true;
+
+  return gh.collaborators
+    .findBy("repo_id", repo.id)
+    .some((collaborator) => collaborator.user_id === user.id && collaborator.permission === "admin");
+}
+
+function branchRestrictionsAllow(
+  gh: GitHubStore,
+  user: GitHubUser,
+  repo: GitHubRepo,
+  users: string[],
+  teams: string[],
+) {
+  const login = user.login.toLowerCase();
+  if (users.some((allowed) => allowed.toLowerCase() === login)) return true;
+  if (repo.owner_type !== "Organization") return false;
+
+  const allowedTeams = new Set(teams.map((team) => team.toLowerCase()));
+  return gh.teamMembers.findBy("user_id", user.id).some((membership) => {
+    const team = gh.teams.get(membership.team_id);
+    return team?.org_id === repo.owner_id && allowedTeams.has(team.slug.toLowerCase());
+  });
+}
+
+export function assertBranchUpdateAllowed(
+  gh: GitHubStore,
+  user: GitHubUser,
+  repo: GitHubRepo,
+  branchName: string,
+  options: { force?: boolean; parentCount?: number } = {},
+): void {
+  const protection = gh.branchProtections
+    .findBy("repo_id", repo.id)
+    .find((candidate) => candidate.branch_name === branchName);
+  if (!protection) return;
+  if (hasBranchProtectionBypass(gh, user, repo) && !protection.enforce_admins) return;
+
+  const restricted =
+    protection.restrictions &&
+    !branchRestrictionsAllow(gh, user, repo, protection.restrictions.users, protection.restrictions.teams);
+  const requirementsBlockDirectUpdate =
+    protection.required_pull_request_reviews !== null ||
+    Boolean(protection.required_status_checks?.contexts.length) ||
+    protection.required_signatures;
+  const invalidHistory = protection.required_linear_history && (options.parentCount ?? 1) > 1;
+  const blockedForcePush = options.force === true && !protection.allow_force_pushes;
+
+  if (restricted || requirementsBlockDirectUpdate || invalidHistory || blockedForcePush) {
+    throw new ApiError(409, `Protected branch update failed for refs/heads/${branchName}.`);
+  }
 }
 
 export function assertRepoAdmin(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -132,7 +132,7 @@ export function assertBranchUpdateAllowed(
   user: GitHubUser,
   repo: GitHubRepo,
   branchName: string,
-  options: { force?: boolean; parentCount?: number } = {},
+  options: { force?: boolean; parentCount?: number; deletion?: boolean } = {},
 ): void {
   const protection = gh.branchProtections
     .findBy("repo_id", repo.id)
@@ -143,14 +143,17 @@ export function assertBranchUpdateAllowed(
   const restricted =
     protection.restrictions &&
     !branchRestrictionsAllow(gh, user, repo, protection.restrictions.users, protection.restrictions.teams);
+  const blockedDeletion = options.deletion === true && !protection.allow_deletions;
   const requirementsBlockDirectUpdate =
-    protection.required_pull_request_reviews !== null ||
-    Boolean(protection.required_status_checks?.contexts.length) ||
-    protection.required_signatures;
-  const invalidHistory = protection.required_linear_history && (options.parentCount ?? 1) > 1;
-  const blockedForcePush = options.force === true && !protection.allow_force_pushes;
+    options.deletion !== true &&
+    (protection.required_pull_request_reviews !== null ||
+      Boolean(protection.required_status_checks?.contexts.length) ||
+      protection.required_signatures);
+  const invalidHistory =
+    options.deletion !== true && protection.required_linear_history && (options.parentCount ?? 1) > 1;
+  const blockedForcePush = options.deletion !== true && options.force === true && !protection.allow_force_pushes;
 
-  if (restricted || requirementsBlockDirectUpdate || invalidHistory || blockedForcePush) {
+  if (restricted || blockedDeletion || requirementsBlockDirectUpdate || invalidHistory || blockedForcePush) {
     throw new ApiError(409, `Protected branch update failed for refs/heads/${branchName}.`);
   }
 }

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -81,11 +81,16 @@ export function assertRepoRead(gh: GitHubStore, authUser: AuthUser | undefined, 
   throw forbidden();
 }
 
-export function assertRepoContentsRead(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): void {
-  assertRepoRead(gh, authUser, repo);
-  if (!repo.private || !authUser?.installation) return;
+export function canReadRepoContents(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): boolean {
+  if (!canAccessRepo(gh, authUser, repo)) return false;
+  if (!repo.private || !authUser?.installation) return true;
   const permission = authUser.installation.permissions.contents;
-  if (permission === "read" || permission === "write") return;
+  return permission === "read" || permission === "write";
+}
+
+export function assertRepoContentsRead(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): void {
+  if (canReadRepoContents(gh, authUser, repo)) return;
+  if (!authUser) throw unauthorized();
   throw forbidden();
 }
 
@@ -140,11 +145,13 @@ export function assertRepoContentsWrite(gh: GitHubStore, authUser: AuthUser | un
   if (authUser?.installation) {
     if (!installationCanAccessRepo(authUser, repo)) throw forbidden();
     if (authUser.installation.permissions.contents !== "write") throw forbidden();
+    if (repo.archived) throw new ApiError(403, "Repository was archived so is read-only.");
     return installationActor(gh, authUser);
   }
   const user = assertAuthenticatedUser(gh, authUser);
-  if (hasRepoContentsWrite(gh, user, repo)) return user;
-  throw forbidden();
+  if (!hasRepoContentsWrite(gh, user, repo)) throw forbidden();
+  if (repo.archived) throw new ApiError(403, "Repository was archived so is read-only.");
+  return user;
 }
 
 function hasBranchProtectionBypass(gh: GitHubStore, user: GitHubUser, repo: GitHubRepo): boolean {

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -97,6 +97,7 @@ function canAccessRepoWithPermission(
   permissions: string[],
   required: "read" | "write",
 ): boolean {
+  if (required === "write" && authUser?.installation && !installationCanAccessRepo(authUser, repo)) return false;
   if (!canAccessRepo(gh, authUser, repo)) return false;
   if (required === "write" && !authUser) return false;
   if (!authUser?.installation || (!repo.private && required === "read")) return true;
@@ -130,6 +131,12 @@ export function assertAuthenticatedUser(gh: GitHubStore, authUser: AuthUser | un
   const user = getActorUser(gh, authUser);
   if (!user) throw unauthorized();
   return user;
+}
+
+export function assertAuthenticatedActor(gh: GitHubStore, authUser: AuthUser | undefined): GitHubUser {
+  if (!authUser) throw unauthorized();
+  if (authUser.installation) return installationActor(gh, authUser);
+  return assertAuthenticatedUser(gh, authUser);
 }
 
 export function hasRepoAdmin(gh: GitHubStore, user: GitHubUser, repo: GitHubRepo): boolean {

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -223,7 +223,7 @@ export function assertBranchUpdateAllowed(
   user: GitHubUser,
   repo: GitHubRepo,
   branchName: string,
-  options: { force?: boolean; parentCount?: number; deletion?: boolean } = {},
+  options: { force?: boolean; parentCount?: number; deletion?: boolean; targetSha?: string } = {},
 ): void {
   const protection = gh.branchProtections
     .findBy("repo_id", repo.id)
@@ -235,10 +235,23 @@ export function assertBranchUpdateAllowed(
     protection.restrictions &&
     !branchRestrictionsAllow(gh, user, repo, protection.restrictions.users, protection.restrictions.teams);
   const blockedDeletion = options.deletion === true && !protection.allow_deletions;
+  const requiredContexts = protection.required_status_checks?.contexts ?? [];
+  const successfulConclusions = new Set(["success", "neutral", "skipped"]);
+  const requiredChecksPassed = requiredContexts.every((context) => {
+    if (!options.targetSha) return false;
+    const latest = gh.checkRuns
+      .findBy("repo_id", repo.id)
+      .filter((run) => run.head_sha === options.targetSha && run.name === context)
+      .sort((left, right) => {
+        if (left.updated_at !== right.updated_at) return right.updated_at.localeCompare(left.updated_at);
+        return right.id - left.id;
+      })[0];
+    return latest?.status === "completed" && latest.conclusion !== null && successfulConclusions.has(latest.conclusion);
+  });
   const requirementsBlockDirectUpdate =
     options.deletion !== true &&
     (protection.required_pull_request_reviews !== null ||
-      Boolean(protection.required_status_checks?.contexts.length) ||
+      (requiredContexts.length > 0 && !requiredChecksPassed) ||
       protection.required_signatures);
   const invalidHistory =
     options.deletion !== true && protection.required_linear_history && (options.parentCount ?? 1) > 1;

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -81,17 +81,48 @@ export function assertRepoRead(gh: GitHubStore, authUser: AuthUser | undefined, 
   throw forbidden();
 }
 
-export function canReadRepoContents(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): boolean {
+function hasInstallationPermission(authUser: AuthUser, permissions: string[], required: "read" | "write"): boolean {
+  const requiredRank = required === "write" ? 2 : 1;
+  return permissions.some((name) => {
+    const granted = authUser.installation?.permissions[name];
+    const grantedRank = granted === "write" ? 2 : granted === "read" ? 1 : 0;
+    return grantedRank >= requiredRank;
+  });
+}
+
+function canAccessRepoWithPermission(
+  gh: GitHubStore,
+  authUser: AuthUser | undefined,
+  repo: GitHubRepo,
+  permissions: string[],
+  required: "read" | "write",
+): boolean {
   if (!canAccessRepo(gh, authUser, repo)) return false;
-  if (!repo.private || !authUser?.installation) return true;
-  const permission = authUser.installation.permissions.contents;
-  return permission === "read" || permission === "write";
+  if (required === "write" && !authUser) return false;
+  if (!authUser?.installation || (!repo.private && required === "read")) return true;
+  return hasInstallationPermission(authUser, permissions, required);
+}
+
+export function assertRepoPermission(
+  gh: GitHubStore,
+  authUser: AuthUser | undefined,
+  repo: GitHubRepo,
+  permissions: string | string[],
+  required: "read" | "write" = "read",
+): void {
+  const accepted = Array.isArray(permissions) ? permissions : [permissions];
+  if (!canAccessRepoWithPermission(gh, authUser, repo, accepted, required)) {
+    if (!authUser) throw unauthorized();
+    throw forbidden();
+  }
+}
+
+export function canReadRepoContents(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): boolean {
+  return canAccessRepoWithPermission(gh, authUser, repo, ["contents"], "read");
 }
 
 export function assertRepoContentsRead(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): void {
-  if (canReadRepoContents(gh, authUser, repo)) return;
-  if (!authUser) throw unauthorized();
-  throw forbidden();
+  assertRepoPermission(gh, authUser, repo, "contents");
 }
 
 export function assertAuthenticatedUser(gh: GitHubStore, authUser: AuthUser | undefined): GitHubUser {

--- a/packages/@emulators/github/src/routes/actions.ts
+++ b/packages/@emulators/github/src/routes/actions.ts
@@ -69,10 +69,9 @@ function resolveWorkflow(gh: GitHubStore, repoId: number, param: string): GitHub
     const w = gh.workflows.get(asNum);
     if (w && w.repo_id === repoId) return w;
   }
-  const decoded = decodeURIComponent(trimmed);
   return gh.workflows
     .findBy("repo_id", repoId)
-    .find((w) => w.path === decoded || w.path.endsWith(`/${decoded}`) || w.name === decoded);
+    .find((w) => w.path === trimmed || w.path.endsWith(`/${trimmed}`) || w.name === trimmed);
 }
 
 function resolveRefToBranchAndSha(gh: GitHubStore, repo: GitHubRepo, ref: string): { branch: string; sha: string } {

--- a/packages/@emulators/github/src/routes/actions.ts
+++ b/packages/@emulators/github/src/routes/actions.ts
@@ -16,7 +16,7 @@ import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timest
 import {
   assertAuthenticatedUser,
   assertRepoAdmin,
-  assertRepoRead,
+  assertRepoPermission,
   getActorUser,
   notFoundResponse,
   ownerLoginOf,
@@ -287,7 +287,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const workflows = gh.workflows.findBy("repo_id", repo.id).sort((a, b) => a.path.localeCompare(b.path));
     return c.json({
       total_count: workflows.length,
@@ -300,7 +300,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const w = resolveWorkflow(gh, repo.id, c.req.param("workflow_id")!);
     if (!w) throw notFoundResponse();
     return c.json(formatWorkflow(w, repo, gh, baseUrl));
@@ -336,7 +336,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     const actor = assertAuthenticatedUser(gh, c.get("authUser"));
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const w = resolveWorkflow(gh, repo.id, c.req.param("workflow_id")!);
     if (!w) throw notFoundResponse();
     if (w.state !== "active") {
@@ -398,7 +398,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const { page, per_page } = parsePagination(c);
     const actor = c.req.query("actor") ?? undefined;
     const branch = c.req.query("branch") ?? undefined;
@@ -420,7 +420,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const runId = parseInt(c.req.param("run_id")!, 10);
     const run = gh.workflowRuns.get(runId);
     if (!run || run.repo_id !== repo.id) throw notFoundResponse();
@@ -432,7 +432,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const w = resolveWorkflow(gh, repo.id, c.req.param("workflow_id")!);
     if (!w) throw notFoundResponse();
     const { page, per_page } = parsePagination(c);
@@ -456,7 +456,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions", "write");
     const runId = parseInt(c.req.param("run_id")!, 10);
     const run = gh.workflowRuns.get(runId);
     if (!run || run.repo_id !== repo.id) throw notFoundResponse();
@@ -483,7 +483,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions", "write");
     const runId = parseInt(c.req.param("run_id")!, 10);
     const parent = gh.workflowRuns.get(runId);
     if (!parent || parent.repo_id !== repo.id) throw notFoundResponse();
@@ -545,7 +545,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const runId = parseInt(c.req.param("run_id")!, 10);
     const run = gh.workflowRuns.get(runId);
     if (!run || run.repo_id !== repo.id) throw notFoundResponse();
@@ -559,7 +559,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const runId = parseInt(c.req.param("run_id")!, 10);
     const run = gh.workflowRuns.get(runId);
     if (!run || run.repo_id !== repo.id) throw notFoundResponse();
@@ -575,7 +575,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const jobId = parseInt(c.req.param("job_id")!, 10);
     const job = gh.jobs.get(jobId);
     if (!job || job.repo_id !== repo.id) throw notFoundResponse();
@@ -587,7 +587,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const jobId = parseInt(c.req.param("job_id")!, 10);
     const job = gh.jobs.get(jobId);
     if (!job || job.repo_id !== repo.id) throw notFoundResponse();
@@ -601,7 +601,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const { page, per_page } = parsePagination(c);
     const all = gh.artifacts.findBy("repo_id", repo.id).sort((a, b) => b.created_at.localeCompare(a.created_at));
     const total = all.length;
@@ -618,7 +618,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const runId = parseInt(c.req.param("run_id")!, 10);
     const run = gh.workflowRuns.get(runId);
     if (!run || run.repo_id !== repo.id) throw notFoundResponse();
@@ -634,7 +634,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
     const artifactId = parseInt(c.req.param("artifact_id")!, 10);
     const a = gh.artifacts.get(artifactId);
     if (!a || a.repo_id !== repo.id) throw notFoundResponse();
@@ -659,7 +659,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "secrets");
     const secrets = listRepoSecrets(gh, repo.id).sort((a, b) => a.name.localeCompare(b.name));
     return c.json({
       total_count: secrets.length,
@@ -676,7 +676,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "secrets");
     const name = c.req.param("secret_name")!;
     const s = findRepoSecret(gh, repo.id, name);
     if (!s) throw notFoundResponse();

--- a/packages/@emulators/github/src/routes/actions.ts
+++ b/packages/@emulators/github/src/routes/actions.ts
@@ -336,7 +336,7 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     const actor = assertAuthenticatedUser(gh, c.get("authUser"));
-    assertRepoPermission(gh, c.get("authUser"), repo, "actions");
+    assertRepoPermission(gh, c.get("authUser"), repo, "actions", "write");
     const w = resolveWorkflow(gh, repo.id, c.req.param("workflow_id")!);
     if (!w) throw notFoundResponse();
     if (w.state !== "active") {

--- a/packages/@emulators/github/src/routes/actions.ts
+++ b/packages/@emulators/github/src/routes/actions.ts
@@ -14,7 +14,7 @@ import type {
 } from "../entities.js";
 import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
 import {
-  assertAuthenticatedUser,
+  assertAuthenticatedActor,
   assertRepoAdmin,
   assertRepoPermission,
   getActorUser,
@@ -335,8 +335,9 @@ export function actionsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const actor = assertAuthenticatedUser(gh, c.get("authUser"));
-    assertRepoPermission(gh, c.get("authUser"), repo, "actions", "write");
+    const authUser = c.get("authUser");
+    assertRepoPermission(gh, authUser, repo, "actions", "write");
+    const actor = assertAuthenticatedActor(gh, authUser);
     const w = resolveWorkflow(gh, repo.id, c.req.param("workflow_id")!);
     if (!w) throw notFoundResponse();
     if (w.state !== "active") {

--- a/packages/@emulators/github/src/routes/apps.ts
+++ b/packages/@emulators/github/src/routes/apps.ts
@@ -117,19 +117,41 @@ export function appsRoutes({ app, store, baseUrl, tokenMap }: RouteContext): voi
 
     let requestedPermissions = inst.permissions;
     let requestedRepoIds = inst.repository_ids;
+    let tokenRepositorySelection = inst.repository_selection;
 
     try {
       const body = (await c.req.json()) as Record<string, unknown>;
       if (body.permissions && typeof body.permissions === "object") {
-        requestedPermissions = body.permissions as Record<string, string>;
+        const requested = body.permissions as Record<string, unknown>;
+        requestedPermissions = Object.fromEntries(
+          Object.entries(requested).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+        );
       }
       if (Array.isArray(body.repository_ids)) {
-        requestedRepoIds = (body.repository_ids as number[]).filter(
-          (id) => inst.repository_selection === "all" || inst.repository_ids.includes(id),
-        );
+        requestedRepoIds = (body.repository_ids as unknown[]).filter((id): id is number => typeof id === "number");
+        tokenRepositorySelection = "selected";
       }
     } catch {
       // No body or invalid JSON, use installation defaults
+    }
+
+    const permissionRank = (permission: string | undefined) =>
+      permission === "write" ? 2 : permission === "read" ? 1 : 0;
+    const invalidPermission = Object.entries(requestedPermissions).some(
+      ([name, permission]) =>
+        permissionRank(permission) === 0 || permissionRank(permission) > permissionRank(inst.permissions[name]),
+    );
+    if (invalidPermission) {
+      return c.json({ message: "The permissions requested are not granted to this installation." }, 422);
+    }
+
+    const unavailableRepo = requestedRepoIds.some((id) => {
+      const repo = gh.repos.get(id);
+      if (!repo || repo.owner_id !== inst.account_id || repo.owner_type !== inst.account_type) return true;
+      return inst.repository_selection === "selected" && !inst.repository_ids.includes(id);
+    });
+    if (unavailableRepo) {
+      return c.json({ message: "The repositories requested are not accessible to this installation." }, 422);
     }
 
     const token = "ghs_" + randomBytes(20).toString("base64url");
@@ -140,6 +162,15 @@ export function appsRoutes({ app, store, baseUrl, tokenMap }: RouteContext): voi
         login: inst.account_login,
         id: inst.account_id,
         scopes: Object.entries(requestedPermissions).map(([k, v]) => `${k}:${v}`),
+        installation: {
+          installationId: inst.installation_id,
+          appId: inst.app_id,
+          accountId: inst.account_id,
+          accountType: inst.account_type,
+          permissions: requestedPermissions,
+          repositoryIds: requestedRepoIds,
+          repositorySelection: tokenRepositorySelection,
+        },
       });
     }
 
@@ -159,8 +190,8 @@ export function appsRoutes({ app, store, baseUrl, tokenMap }: RouteContext): voi
         token,
         expires_at: expiresAt,
         permissions: requestedPermissions,
-        repository_selection: inst.repository_selection,
-        ...(inst.repository_selection === "selected" ? { repositories: repos } : {}),
+        repository_selection: tokenRepositorySelection,
+        ...(tokenRepositorySelection === "selected" ? { repositories: repos } : {}),
       },
       201,
     );

--- a/packages/@emulators/github/src/routes/apps.ts
+++ b/packages/@emulators/github/src/routes/apps.ts
@@ -242,10 +242,12 @@ export function appsRoutes({ app, store, baseUrl, tokenMap }: RouteContext): voi
       return c.json({ message: "Not Found", documentation_url: "https://docs.github.com/rest" }, 404);
     }
 
-    const ownerEntity = gh.users.findOneBy("login", owner) ?? gh.orgs.findOneBy("login", owner);
-
     for (const inst of gh.appInstallations.all()) {
-      if (inst.repository_selection === "all" && ownerEntity && inst.account_id === ownerEntity.id) {
+      if (
+        inst.repository_selection === "all" &&
+        inst.account_id === repo.owner_id &&
+        inst.account_type === repo.owner_type
+      ) {
         const ghApp = gh.apps.all().find((a) => a.app_id === inst.app_id);
         return c.json(formatInstallation(inst, ghApp, baseUrl));
       }

--- a/packages/@emulators/github/src/routes/apps.ts
+++ b/packages/@emulators/github/src/routes/apps.ts
@@ -127,8 +127,44 @@ export function appsRoutes({ app, store, baseUrl, tokenMap }: RouteContext): voi
           Object.entries(requested).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
         );
       }
-      if (Array.isArray(body.repository_ids)) {
-        requestedRepoIds = (body.repository_ids as unknown[]).filter((id): id is number => typeof id === "number");
+
+      if (body.repositories !== undefined && body.repository_ids !== undefined) {
+        return c.json({ message: "Only one of repositories or repository_ids may be specified." }, 422);
+      }
+
+      if (body.repositories !== undefined) {
+        if (
+          !Array.isArray(body.repositories) ||
+          body.repositories.length > 500 ||
+          body.repositories.some((name) => typeof name !== "string")
+        ) {
+          return c.json({ message: "The repositories field must contain up to 500 repository names." }, 422);
+        }
+
+        const accountRepos = gh.repos
+          .all()
+          .filter((repo) => repo.owner_id === inst.account_id && repo.owner_type === inst.account_type);
+        const resolvedIds: number[] = [];
+        for (const name of body.repositories as string[]) {
+          const repo = accountRepos.find((candidate) => candidate.name.toLowerCase() === name.toLowerCase());
+          if (!repo) {
+            return c.json({ message: "The repositories requested are not accessible to this installation." }, 422);
+          }
+          resolvedIds.push(repo.id);
+        }
+        requestedRepoIds = [...new Set(resolvedIds)];
+        tokenRepositorySelection = "selected";
+      }
+
+      if (body.repository_ids !== undefined) {
+        if (
+          !Array.isArray(body.repository_ids) ||
+          body.repository_ids.length > 500 ||
+          body.repository_ids.some((id) => typeof id !== "number")
+        ) {
+          return c.json({ message: "The repository_ids field must contain up to 500 repository IDs." }, 422);
+        }
+        requestedRepoIds = [...new Set(body.repository_ids as number[])];
         tokenRepositorySelection = "selected";
       }
     } catch {

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -22,9 +22,10 @@ import {
   timestamp,
 } from "../helpers.js";
 import {
+  assertBranchUpdateAllowed,
   assertRepoAdmin,
+  assertRepoContentsWrite,
   assertRepoRead,
-  assertRepoWrite,
   getActorUser,
   notFoundResponse,
   ownerLoginOf,
@@ -695,7 +696,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const user = assertRepoWrite(gh, c.get("authUser"), repo);
+    const user = assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const body = (await parseJsonBody(c)) as { ref?: unknown; sha?: unknown };
     if (typeof body.ref !== "string" || !body.ref.startsWith("refs/")) {
       throw new ApiError(422, "Invalid ref");
@@ -710,6 +711,11 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     }
     if (gh.refs.findBy("repo_id", repo.id).some((r) => r.ref === fullRef)) {
       throw new ApiError(422, "Reference already exists");
+    }
+    if (fullRef.startsWith("refs/heads/")) {
+      const branchName = fullRef.slice("refs/heads/".length);
+      const commit = findCommitBySha(gh, repo.id, sha);
+      assertBranchUpdateAllowed(gh, user, repo, branchName, { parentCount: commit?.parent_shas.length });
     }
     const refRow = gh.refs.insert({
       repo_id: repo.id,
@@ -742,7 +748,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const refParam = c.req.param("ref")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const user = assertRepoWrite(gh, c.get("authUser"), repo);
+    const user = assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const fullRef = fullRefFromParam(refParam);
     const r = gh.refs.findBy("repo_id", repo.id).find((x) => x.ref === fullRef);
     if (!r) throw notFoundResponse();
@@ -765,6 +771,14 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       if (!isDescendantOf(gh, repo.id, oldSha, newSha)) {
         throw new ApiError(422, "Update is not a fast-forward");
       }
+    }
+    if (fullRef.startsWith("refs/heads/")) {
+      const branchName = fullRef.slice("refs/heads/".length);
+      const commit = findCommitBySha(gh, repo.id, newSha);
+      assertBranchUpdateAllowed(gh, user, repo, branchName, {
+        force,
+        parentCount: commit?.parent_shas.length,
+      });
     }
     gh.refs.update(r.id, { sha: newSha });
     syncBranchFromRef(gh, repo, fullRef, newSha);
@@ -791,7 +805,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const refParam = c.req.param("ref")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoWrite(gh, c.get("authUser"), repo);
+    assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const fullRef = fullRefFromParam(refParam);
     const r = gh.refs.findBy("repo_id", repo.id).find((x) => x.ref === fullRef);
     if (!r) throw notFoundResponse();
@@ -819,7 +833,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoWrite(gh, c.get("authUser"), repo);
+    assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const body = await parseJsonBody(c);
     if (typeof body.message !== "string") throw new ApiError(422, "message is required");
     if (typeof body.tree !== "string") throw new ApiError(422, "tree is required");
@@ -909,7 +923,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoWrite(gh, c.get("authUser"), repo);
+    assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const body = await parseJsonBody(c);
     if (!Array.isArray(body.tree)) throw new ApiError(422, "tree array is required");
     const items = body.tree as Array<{
@@ -1013,7 +1027,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoWrite(gh, c.get("authUser"), repo);
+    assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const body = (await parseJsonBody(c)) as {
       content?: unknown;
       encoding?: unknown;
@@ -1103,7 +1117,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoWrite(gh, c.get("authUser"), repo);
+    assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const body = await parseJsonBody(c);
     if (typeof body.tag !== "string") throw new ApiError(422, "tag is required");
     if (typeof body.message !== "string") throw new ApiError(422, "message is required");

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -147,17 +147,12 @@ function expandTreeEntries(
   const out: GitHubTree["tree"] = [];
   for (const e of entries) {
     const path = prefix ? `${prefix}/${e.path}` : e.path;
-    if (e.type === "blob") {
-      out.push({ ...e, path });
-    } else if (e.type === "tree" && recursive) {
+    out.push({ ...e, path });
+    if (e.type === "tree" && recursive) {
       const sub = findTreeBySha(gh, repoId, e.sha);
       if (sub) {
         out.push(...expandTreeEntries(gh, repoId, sub.tree, true, path));
-      } else {
-        out.push({ ...e, path });
       }
-    } else {
-      out.push({ ...e, path });
     }
   }
   return out.sort((a, b) => a.path.localeCompare(b.path));
@@ -927,7 +922,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     assertRepoContentsRead(gh, c.get("authUser"), repo);
     const tree = findTreeBySha(gh, repo.id, treeSha);
     if (!tree) throw notFoundResponse();
-    const recursive = c.req.query("recursive") === "1" || c.req.query("recursive") === "true";
+    const recursive = c.req.query("recursive") !== undefined;
     const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
     const entries = recursive
       ? expandTreeEntries(gh, repo.id, tree.tree, true)

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -3,7 +3,6 @@ import { ApiError, parseJsonBody, parsePagination, setLinkHeader } from "@emulat
 import { getGitHubStore } from "../store.js";
 import type { GitHubStore } from "../store.js";
 import type {
-  GitHubBlob,
   GitHubBranch,
   GitHubBranchProtection,
   GitHubCommit,
@@ -24,13 +23,13 @@ import {
 import {
   assertBranchUpdateAllowed,
   assertRepoAdmin,
+  assertRepoContentsRead,
   assertRepoContentsWrite,
   assertRepoRead,
-  getActorUser,
   notFoundResponse,
   ownerLoginOf,
 } from "../route-helpers.js";
-import { formatGitCommit } from "../git-helpers.js";
+import { findOrCreateBlob, findOrCreateTree, formatGitCommit } from "../git-helpers.js";
 
 function findBranchByName(gh: GitHubStore, repoId: number, name: string) {
   return gh.branches.findBy("repo_id", repoId).find((b) => b.name === name);
@@ -165,24 +164,32 @@ function expandTreeEntries(
 }
 
 type GitTreeEntry = GitHubTree["tree"][number];
+type GitTreeUpdate = Omit<GitTreeEntry, "sha"> & { sha: string | null };
 
 interface PendingGitTree {
   baseSha?: string;
   mode: string;
   files: Map<string, GitTreeEntry>;
   dirs: Map<string, PendingGitTree>;
+  deletions: Set<string>;
 }
 
 function persistGitTreeHierarchy(
   gh: GitHubStore,
   repoId: number,
   baseSha: string | undefined,
-  updates: GitTreeEntry[],
+  updates: GitTreeUpdate[],
 ): GitHubTree {
-  const root: PendingGitTree = { baseSha, mode: "040000", files: new Map(), dirs: new Map() };
+  const root: PendingGitTree = {
+    baseSha,
+    mode: "040000",
+    files: new Map(),
+    dirs: new Map(),
+    deletions: new Set(),
+  };
 
   const baseEntry = (pending: PendingGitTree, name: string) => {
-    if (!pending.baseSha) return undefined;
+    if (!pending.baseSha || pending.deletions.has(name)) return undefined;
     return findTreeBySha(gh, repoId, pending.baseSha)?.tree.find((entry) => entry.path === name);
   };
 
@@ -201,14 +208,29 @@ function persistGitTreeHierarchy(
           mode: existing?.mode ?? "040000",
           files: new Map(),
           dirs: new Map(),
+          deletions: new Set(),
         };
         current.files.delete(part);
+        current.deletions.delete(part);
         current.dirs.set(part, child);
       }
       current = child;
     }
 
     const name = parts.at(-1)!;
+    if (update.sha === null) {
+      const existing =
+        current.files.get(name) ??
+        (current.dirs.has(name) ? { type: "tree" as const } : undefined) ??
+        baseEntry(current, name);
+      if (!existing) throw new ApiError(422, `Cannot delete ${update.path} because it does not exist`);
+      current.files.delete(name);
+      current.dirs.delete(name);
+      current.deletions.add(name);
+      continue;
+    }
+
+    current.deletions.delete(name);
     if (update.type === "tree") {
       current.files.delete(name);
       current.dirs.set(name, {
@@ -216,15 +238,16 @@ function persistGitTreeHierarchy(
         mode: update.mode,
         files: new Map(),
         dirs: new Map(),
+        deletions: new Set(),
       });
     } else {
       current.dirs.delete(name);
-      current.files.set(name, { ...update, path: name });
+      current.files.set(name, { ...update, path: name, sha: update.sha });
     }
   }
 
   const write = (pending: PendingGitTree): GitHubTree => {
-    if (pending.baseSha && pending.files.size === 0 && pending.dirs.size === 0) {
+    if (pending.baseSha && pending.files.size === 0 && pending.dirs.size === 0 && pending.deletions.size === 0) {
       const unchanged = findTreeBySha(gh, repoId, pending.baseSha);
       if (!unchanged) throw new ApiError(422, "Invalid tree");
       return unchanged;
@@ -240,16 +263,9 @@ function persistGitTreeHierarchy(
       entries.set(name, { path: name, mode: child.mode, type: "tree", sha: subtree.sha });
     }
     for (const [name, entry] of pending.files) entries.set(name, { ...entry, path: name });
+    for (const name of pending.deletions) entries.delete(name);
 
-    const tree = gh.trees.insert({
-      repo_id: repoId,
-      sha: generateSha(),
-      node_id: "",
-      tree: [...entries.values()].sort((a, b) => a.path.localeCompare(b.path)),
-      truncated: false,
-    } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
-    gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
-    return gh.trees.get(tree.id)!;
+    return findOrCreateTree(gh, repoId, [...entries.values()]);
   };
 
   return write(root);
@@ -829,7 +845,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const commitSha = c.req.param("commit_sha")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     const commit = findCommitBySha(gh, repo.id, commitSha);
     if (!commit) throw notFoundResponse();
     return c.json(formatGitCommit(repo, commit, baseUrl));
@@ -840,7 +856,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoContentsWrite(gh, c.get("authUser"), repo);
+    const actor = assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const body = await parseJsonBody(c);
     if (typeof body.message !== "string") throw new ApiError(422, "message is required");
     if (typeof body.tree !== "string") throw new ApiError(422, "tree is required");
@@ -858,9 +874,8 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     let committer_email: string;
     let committer_date: string;
     const now = timestamp();
-    const actor = getActorUser(gh, c.get("authUser")!);
-    const defaultName = actor?.name ?? actor?.login ?? "user";
-    const defaultEmail = actor?.email ?? `${actor?.login ?? "user"}@users.noreply.github.com`;
+    const defaultName = actor.name ?? actor.login;
+    const defaultEmail = actor.email ?? `${actor.login}@users.noreply.github.com`;
     if (body.author && typeof body.author === "object" && body.author !== null) {
       const a = body.author as Record<string, unknown>;
       author_name = typeof a.name === "string" ? a.name : defaultName;
@@ -894,7 +909,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       committer_date,
       tree_sha: treeSha,
       parent_shas: parents,
-      user_id: actor?.id ?? null,
+      user_id: actor.id,
     } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
     gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
     const saved = gh.commits.get(commit.id)!;
@@ -909,7 +924,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const treeSha = c.req.param("tree_sha")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     const tree = findTreeBySha(gh, repo.id, treeSha);
     if (!tree) throw notFoundResponse();
     const recursive = c.req.query("recursive") === "1" || c.req.query("recursive") === "true";
@@ -937,13 +952,13 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       path?: string;
       mode?: string;
       type?: string;
-      sha?: string;
+      sha?: string | null;
       content?: string;
     }>;
     const baseTreeSha = typeof body.base_tree === "string" ? body.base_tree : undefined;
     if (baseTreeSha && !findTreeBySha(gh, repo.id, baseTreeSha)) throw new ApiError(422, "Invalid base_tree");
 
-    const updates: GitTreeEntry[] = [];
+    const updates: GitTreeUpdate[] = [];
 
     for (const raw of items) {
       if (
@@ -966,19 +981,15 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       if (raw.type === "tree" && raw.content !== undefined) {
         throw new ApiError(422, "Tree entries must reference a tree sha");
       }
+      if (raw.sha === null) {
+        updates.push({ path: raw.path, mode: raw.mode, type: raw.type, sha: null });
+        continue;
+      }
       let sha = raw.sha;
       let size: number | undefined;
       if (raw.content !== undefined) {
         const buf = Buffer.from(String(raw.content), "utf8");
-        const blob = gh.blobs.insert({
-          repo_id: repo.id,
-          sha: generateSha(),
-          node_id: "",
-          content: String(raw.content),
-          encoding: "utf-8",
-          size: buf.byteLength,
-        } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
-        gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
+        const blob = findOrCreateBlob(gh, repo.id, buf);
         sha = blob.sha;
         size = blob.size;
       }
@@ -1014,7 +1025,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const fileSha = c.req.param("file_sha")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     const blob = findBlobBySha(gh, repo.id, fileSha);
     if (!blob) throw notFoundResponse();
     const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
@@ -1041,40 +1052,8 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     };
     if (typeof body.content !== "string") throw new ApiError(422, "content is required");
     const enc = body.encoding === "base64" || body.encoding === "utf-8" ? body.encoding : "utf-8";
-    if (enc === "base64") {
-      const blob = gh.blobs.insert({
-        repo_id: repo.id,
-        sha: generateSha(),
-        node_id: "",
-        content: body.content,
-        encoding: "base64",
-        size: Buffer.from(body.content, "base64").length,
-      } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
-      gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
-      const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
-      const saved = gh.blobs.get(blob.id)!;
-      return c.json(
-        {
-          sha: saved.sha,
-          node_id: saved.node_id,
-          url: `${repoUrl}/git/blobs/${saved.sha}`,
-          size: saved.size,
-        },
-        201,
-      );
-    }
-    const raw = body.content;
-    const size = Buffer.byteLength(raw, "utf8");
-    const blob = gh.blobs.insert({
-      repo_id: repo.id,
-      sha: generateSha(),
-      node_id: "",
-      content: raw,
-      encoding: "utf-8",
-      size,
-    } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
-    gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
-    const saved = gh.blobs.get(blob.id)!;
+    const content = enc === "base64" ? Buffer.from(body.content, "base64") : Buffer.from(body.content, "utf8");
+    const saved = findOrCreateBlob(gh, repo.id, content);
     const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
     return c.json(
       {

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -28,7 +28,13 @@ import {
   notFoundResponse,
   ownerLoginOf,
 } from "../route-helpers.js";
-import { findOrCreateBlob, findOrCreateCommit, findOrCreateTree, formatGitCommit } from "../git-helpers.js";
+import {
+  findOrCreateBlob,
+  findOrCreateCommit,
+  findOrCreateTree,
+  formatGitCommit,
+  resolveRefToCommit,
+} from "../git-helpers.js";
 
 function findBranchByName(gh: GitHubStore, repoId: number, name: string) {
   return gh.branches.findBy("repo_id", repoId).find((b) => b.name === name);
@@ -187,14 +193,15 @@ function persistGitTreeHierarchy(
     return findTreeBySha(gh, repoId, pending.baseSha)?.tree.find((entry) => entry.path === name);
   };
 
-  for (const update of updates) {
+  const orderedUpdates = [...updates].sort((left, right) => left.path.split("/").length - right.path.split("/").length);
+  for (const update of orderedUpdates) {
     const parts = update.path.split("/");
     let current = root;
     for (const part of parts.slice(0, -1)) {
       let child = current.dirs.get(part);
       if (!child) {
         const existing = current.files.get(part) ?? baseEntry(current, part);
-        if (existing?.type === "blob") {
+        if (existing && existing.type !== "tree") {
           throw new ApiError(422, `${update.path} conflicts with an existing file`);
         }
         child = {
@@ -924,7 +931,9 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoContentsRead(gh, c.get("authUser"), repo);
-    const tree = findTreeBySha(gh, repo.id, treeSha);
+    const commit = resolveRefToCommit(gh, repo, treeSha);
+    const tree =
+      findTreeBySha(gh, repo.id, treeSha) ?? (commit ? findTreeBySha(gh, repo.id, commit.tree_sha) : undefined);
     if (!tree) throw notFoundResponse();
     const recursive = c.req.query("recursive") !== undefined;
     const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
@@ -963,9 +972,9 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       if (
         typeof raw.path !== "string" ||
         typeof raw.mode !== "string" ||
-        (raw.type !== "blob" && raw.type !== "tree")
+        (raw.type !== "blob" && raw.type !== "tree" && raw.type !== "commit")
       ) {
-        throw new ApiError(422, "Each tree entry needs path, mode, type (blob|tree)");
+        throw new ApiError(422, "Each tree entry needs path, mode, type (blob|tree|commit)");
       }
       if (
         !raw.path ||
@@ -977,8 +986,15 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       if (raw.sha !== undefined && raw.content !== undefined) {
         throw new ApiError(422, "Cannot pass both sha and content");
       }
-      if (raw.type === "tree" && raw.content !== undefined) {
-        throw new ApiError(422, "Tree entries must reference a tree sha");
+      const validMode =
+        (raw.type === "blob" && ["100644", "100755", "120000"].includes(raw.mode)) ||
+        (raw.type === "tree" && raw.mode === "040000") ||
+        (raw.type === "commit" && raw.mode === "160000");
+      if (!validMode) {
+        throw new ApiError(422, "Invalid mode for tree entry type");
+      }
+      if (raw.type !== "blob" && raw.content !== undefined) {
+        throw new ApiError(422, "Only blob entries may specify content");
       }
       if (raw.sha === null) {
         updates.push({ path: raw.path, mode: raw.mode, type: raw.type, sha: null });
@@ -997,8 +1013,10 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
         const blob = findBlobBySha(gh, repo.id, sha);
         if (!blob) throw new ApiError(422, "Invalid blob sha");
         size ??= blob.size;
-      } else if (!findTreeBySha(gh, repo.id, sha)) {
+      } else if (raw.type === "tree" && !findTreeBySha(gh, repo.id, sha)) {
         throw new ApiError(422, "Invalid tree sha");
+      } else if (raw.type === "commit" && !/^[0-9a-f]{40}$/i.test(sha)) {
+        throw new ApiError(422, "Invalid commit sha");
       }
       updates.push({ path: raw.path, mode: raw.mode, type: raw.type, sha, size });
     }

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -805,10 +805,17 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const refParam = c.req.param("ref")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoContentsWrite(gh, c.get("authUser"), repo);
+    const user = assertRepoContentsWrite(gh, c.get("authUser"), repo);
     const fullRef = fullRefFromParam(refParam);
     const r = gh.refs.findBy("repo_id", repo.id).find((x) => x.ref === fullRef);
     if (!r) throw notFoundResponse();
+    if (fullRef.startsWith("refs/heads/")) {
+      const branchName = fullRef.slice("refs/heads/".length);
+      if (branchName === repo.default_branch) {
+        throw new ApiError(422, "Cannot delete the default branch");
+      }
+      assertBranchUpdateAllowed(gh, user, repo, branchName, { deletion: true });
+    }
     gh.refs.delete(r.id);
     deleteBranchForHeadRef(gh, repo.id, fullRef);
     return c.body(null, 204);

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -798,6 +798,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       assertBranchUpdateAllowed(gh, user, repo, branchName, {
         force,
         parentCount: commit?.parent_shas.length,
+        currentSha: oldSha,
         targetSha: commit?.sha,
       });
     }

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -417,7 +417,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.get("/repos/:owner/:repo/branches/:branch{.+}/protection/required_status_checks", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);
@@ -441,7 +441,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.patch("/repos/:owner/:repo/branches/:branch{.+}/protection/required_status_checks", async (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoAdmin(gh, c.get("authUser"), repo);
@@ -470,7 +470,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.get("/repos/:owner/:repo/branches/:branch{.+}/protection/enforce_admins", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);
@@ -488,7 +488,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.get("/repos/:owner/:repo/branches/:branch{.+}/protection/required_pull_request_reviews", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);
@@ -509,7 +509,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.patch("/repos/:owner/:repo/branches/:branch{.+}/protection/required_pull_request_reviews", async (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoAdmin(gh, c.get("authUser"), repo);
@@ -546,7 +546,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.get("/repos/:owner/:repo/branches/:branch{.+}/protection", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);
@@ -558,7 +558,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.put("/repos/:owner/:repo/branches/:branch{.+}/protection", async (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoAdmin(gh, c.get("authUser"), repo);
@@ -595,7 +595,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.delete("/repos/:owner/:repo/branches/:branch{.+}/protection", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branch = decodeURIComponent(c.req.param("branch")!);
+    const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoAdmin(gh, c.get("authUser"), repo);
@@ -609,7 +609,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
   app.get("/repos/:owner/:repo/branches/:branch{.+}", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const branchName = decodeURIComponent(c.req.param("branch")!);
+    const branchName = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -11,7 +11,6 @@ import type {
   GitHubRepo,
   GitHubTag,
   GitHubTree,
-  GitHubUser,
 } from "../entities.js";
 import {
   formatBranch,
@@ -23,7 +22,6 @@ import {
   timestamp,
 } from "../helpers.js";
 import {
-  assertAuthenticatedUser,
   assertRepoAdmin,
   assertRepoRead,
   assertRepoWrite,
@@ -31,6 +29,7 @@ import {
   notFoundResponse,
   ownerLoginOf,
 } from "../route-helpers.js";
+import { formatGitCommit } from "../git-helpers.js";
 
 function findBranchByName(gh: GitHubStore, repoId: number, name: string) {
   return gh.branches.findBy("repo_id", repoId).find((b) => b.name === name);
@@ -162,43 +161,6 @@ function expandTreeEntries(
     }
   }
   return out.sort((a, b) => a.path.localeCompare(b.path));
-}
-
-function formatCommitJson(gh: GitHubStore, repo: GitHubRepo, c: GitHubCommit, baseUrl: string) {
-  const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
-  const htmlUrl = `${baseUrl}/${repo.full_name}/commit/${c.sha}`;
-  const authorUser = c.user_id ? gh.users.get(c.user_id) : null;
-  return {
-    sha: c.sha,
-    node_id: c.node_id,
-    url: `${repoUrl}/git/commits/${c.sha}`,
-    html_url: htmlUrl,
-    author: authorUser ? formatUser(authorUser, baseUrl) : null,
-    committer: authorUser ? formatUser(authorUser, baseUrl) : null,
-    parents: c.parent_shas.map((sha) => ({
-      sha,
-      url: `${repoUrl}/git/commits/${sha}`,
-    })),
-    stats: { total: 0, additions: 0, deletions: 0 },
-    files: [],
-    commit: {
-      author: {
-        name: c.author_name,
-        email: c.author_email,
-        date: c.author_date,
-      },
-      committer: {
-        name: c.committer_name,
-        email: c.committer_email,
-        date: c.committer_date,
-      },
-      message: c.message,
-      tree: { sha: c.tree_sha, url: `${repoUrl}/git/trees/${c.tree_sha}` },
-      url: `${repoUrl}/git/commits/${c.sha}`,
-      comment_count: 0,
-      verification: { verified: false, reason: "unsigned", signature: null, payload: null, verified_at: null },
-    },
-  };
 }
 
 function protectionEntityToGitHub(gh: GitHubStore, repo: GitHubRepo, bp: GitHubBranchProtection, baseUrl: string) {
@@ -758,7 +720,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     assertRepoRead(gh, c.get("authUser"), repo);
     const commit = findCommitBySha(gh, repo.id, commitSha);
     if (!commit) throw notFoundResponse();
-    return c.json(formatCommitJson(gh, repo, commit, baseUrl));
+    return c.json(formatGitCommit(repo, commit, baseUrl));
   });
 
   app.post("/repos/:owner/:repo/git/commits", async (c) => {
@@ -824,7 +786,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
     gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
     const saved = gh.commits.get(commit.id)!;
-    return c.json(formatCommitJson(gh, repo, saved, baseUrl), 201);
+    return c.json(formatGitCommit(repo, saved, baseUrl), 201);
   });
 
   // --- Git trees ---

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -25,7 +25,7 @@ import {
   assertRepoAdmin,
   assertRepoContentsRead,
   assertRepoContentsWrite,
-  assertRepoRead,
+  assertRepoPermission,
   notFoundResponse,
   ownerLoginOf,
 } from "../route-helpers.js";
@@ -432,7 +432,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "administration");
     const bp = gh.branchProtections.findBy("repo_id", repo.id).find((p) => p.branch_name === branch);
     if (!bp || !bp.required_status_checks) throw notFoundResponse();
     const encBranch = encodeURIComponent(branch);
@@ -485,7 +485,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "administration");
     const bp = gh.branchProtections.findBy("repo_id", repo.id).find((p) => p.branch_name === branch);
     if (!bp) throw notFoundResponse();
     const encBranch = encodeURIComponent(branch);
@@ -503,7 +503,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "administration");
     const bp = gh.branchProtections.findBy("repo_id", repo.id).find((p) => p.branch_name === branch);
     if (!bp || !bp.required_pull_request_reviews) throw notFoundResponse();
     const encBranch = encodeURIComponent(branch);
@@ -561,7 +561,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const branch = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "administration");
     const bp = gh.branchProtections.findBy("repo_id", repo.id).find((p) => p.branch_name === branch);
     if (!bp) throw notFoundResponse();
     return c.json(protectionEntityToGitHub(gh, repo, bp, baseUrl));
@@ -624,7 +624,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const branchName = c.req.param("branch")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     const branch = findBranchByName(gh, repo.id, branchName);
     if (!branch) throw notFoundResponse();
     const commit = findCommitBySha(gh, repo.id, branch.sha);
@@ -659,7 +659,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     let list = [...gh.branches.findBy("repo_id", repo.id)].sort((a, b) => a.name.localeCompare(b.name));
     const prot = c.req.query("protected");
     if (prot === "true") list = list.filter((b) => b.protected);
@@ -680,7 +680,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const refParam = c.req.param("ref")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     const fullRef = fullRefFromParam(refParam);
     const r = gh.refs.findBy("repo_id", repo.id).find((x) => x.ref === fullRef);
     if (!r) throw notFoundResponse();
@@ -693,7 +693,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const refParam = c.req.param("ref")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     const prefix = fullRefFromParam(refParam);
     const matches = gh.refs
       .findBy("repo_id", repo.id)
@@ -1069,7 +1069,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const tagSha = c.req.param("tag_sha")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
     const tag = findTagObjectBySha(gh, repo.id, tagSha);
     if (!tag) throw notFoundResponse();
     const repoUrl = `${baseUrl}/repos/${repo.full_name}`;

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -5,7 +5,6 @@ import type { GitHubStore } from "../store.js";
 import type {
   GitHubBranch,
   GitHubBranchProtection,
-  GitHubCommit,
   GitHubRef,
   GitHubRepo,
   GitHubTag,
@@ -29,7 +28,7 @@ import {
   notFoundResponse,
   ownerLoginOf,
 } from "../route-helpers.js";
-import { findOrCreateBlob, findOrCreateTree, formatGitCommit } from "../git-helpers.js";
+import { findOrCreateBlob, findOrCreateCommit, findOrCreateTree, formatGitCommit } from "../git-helpers.js";
 
 function findBranchByName(gh: GitHubStore, repoId: number, name: string) {
   return gh.branches.findBy("repo_id", repoId).find((b) => b.name === name);
@@ -726,7 +725,10 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     if (fullRef.startsWith("refs/heads/")) {
       const branchName = fullRef.slice("refs/heads/".length);
       const commit = findCommitBySha(gh, repo.id, sha);
-      assertBranchUpdateAllowed(gh, user, repo, branchName, { parentCount: commit?.parent_shas.length });
+      assertBranchUpdateAllowed(gh, user, repo, branchName, {
+        parentCount: commit?.parent_shas.length,
+        targetSha: commit?.sha,
+      });
     }
     const refRow = gh.refs.insert({
       repo_id: repo.id,
@@ -789,6 +791,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       assertBranchUpdateAllowed(gh, user, repo, branchName, {
         force,
         parentCount: commit?.parent_shas.length,
+        targetSha: commit?.sha,
       });
     }
     gh.refs.update(r.id, { sha: newSha });
@@ -873,6 +876,9 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     const defaultEmail = actor.email ?? `${actor.login}@users.noreply.github.com`;
     if (body.author && typeof body.author === "object" && body.author !== null) {
       const a = body.author as Record<string, unknown>;
+      if (a.date !== undefined && (typeof a.date !== "string" || !Number.isFinite(Date.parse(a.date)))) {
+        throw new ApiError(422, "author.date must be an ISO 8601 timestamp");
+      }
       author_name = typeof a.name === "string" ? a.name : defaultName;
       author_email = typeof a.email === "string" ? a.email : defaultEmail;
       author_date = typeof a.date === "string" ? a.date : now;
@@ -883,6 +889,9 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
     }
     if (body.committer && typeof body.committer === "object" && body.committer !== null) {
       const a = body.committer as Record<string, unknown>;
+      if (a.date !== undefined && (typeof a.date !== "string" || !Number.isFinite(Date.parse(a.date)))) {
+        throw new ApiError(422, "committer.date must be an ISO 8601 timestamp");
+      }
       committer_name = typeof a.name === "string" ? a.name : defaultName;
       committer_email = typeof a.email === "string" ? a.email : defaultEmail;
       committer_date = typeof a.date === "string" ? a.date : now;
@@ -891,10 +900,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       committer_email = author_email;
       committer_date = author_date;
     }
-    const commit = gh.commits.insert({
-      repo_id: repo.id,
-      sha: generateSha(),
-      node_id: "",
+    const saved = findOrCreateCommit(gh, repo.id, {
       message: body.message as string,
       author_name,
       author_email,
@@ -905,9 +911,7 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       tree_sha: treeSha,
       parent_shas: parents,
       user_id: actor.id,
-    } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
-    gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
-    const saved = gh.commits.get(commit.id)!;
+    });
     return c.json(formatGitCommit(repo, saved, baseUrl), 201);
   });
 

--- a/packages/@emulators/github/src/routes/branches.ts
+++ b/packages/@emulators/github/src/routes/branches.ts
@@ -163,6 +163,97 @@ function expandTreeEntries(
   return out.sort((a, b) => a.path.localeCompare(b.path));
 }
 
+type GitTreeEntry = GitHubTree["tree"][number];
+
+interface PendingGitTree {
+  baseSha?: string;
+  mode: string;
+  files: Map<string, GitTreeEntry>;
+  dirs: Map<string, PendingGitTree>;
+}
+
+function persistGitTreeHierarchy(
+  gh: GitHubStore,
+  repoId: number,
+  baseSha: string | undefined,
+  updates: GitTreeEntry[],
+): GitHubTree {
+  const root: PendingGitTree = { baseSha, mode: "040000", files: new Map(), dirs: new Map() };
+
+  const baseEntry = (pending: PendingGitTree, name: string) => {
+    if (!pending.baseSha) return undefined;
+    return findTreeBySha(gh, repoId, pending.baseSha)?.tree.find((entry) => entry.path === name);
+  };
+
+  for (const update of updates) {
+    const parts = update.path.split("/");
+    let current = root;
+    for (const part of parts.slice(0, -1)) {
+      let child = current.dirs.get(part);
+      if (!child) {
+        const existing = current.files.get(part) ?? baseEntry(current, part);
+        if (existing?.type === "blob") {
+          throw new ApiError(422, `${update.path} conflicts with an existing file`);
+        }
+        child = {
+          baseSha: existing?.type === "tree" ? existing.sha : undefined,
+          mode: existing?.mode ?? "040000",
+          files: new Map(),
+          dirs: new Map(),
+        };
+        current.files.delete(part);
+        current.dirs.set(part, child);
+      }
+      current = child;
+    }
+
+    const name = parts.at(-1)!;
+    if (update.type === "tree") {
+      current.files.delete(name);
+      current.dirs.set(name, {
+        baseSha: update.sha,
+        mode: update.mode,
+        files: new Map(),
+        dirs: new Map(),
+      });
+    } else {
+      current.dirs.delete(name);
+      current.files.set(name, { ...update, path: name });
+    }
+  }
+
+  const write = (pending: PendingGitTree): GitHubTree => {
+    if (pending.baseSha && pending.files.size === 0 && pending.dirs.size === 0) {
+      const unchanged = findTreeBySha(gh, repoId, pending.baseSha);
+      if (!unchanged) throw new ApiError(422, "Invalid tree");
+      return unchanged;
+    }
+    const entries = new Map<string, GitTreeEntry>();
+    if (pending.baseSha) {
+      const base = findTreeBySha(gh, repoId, pending.baseSha);
+      if (!base) throw new ApiError(422, "Invalid tree");
+      for (const entry of base.tree) entries.set(entry.path, entry);
+    }
+    for (const [name, child] of pending.dirs) {
+      const subtree = write(child);
+      entries.set(name, { path: name, mode: child.mode, type: "tree", sha: subtree.sha });
+    }
+    for (const [name, entry] of pending.files) entries.set(name, { ...entry, path: name });
+
+    const tree = gh.trees.insert({
+      repo_id: repoId,
+      sha: generateSha(),
+      node_id: "",
+      tree: [...entries.values()].sort((a, b) => a.path.localeCompare(b.path)),
+      truncated: false,
+    } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
+    gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
+    return gh.trees.get(tree.id)!;
+  };
+
+  return write(root);
+}
+
 function protectionEntityToGitHub(gh: GitHubStore, repo: GitHubRepo, bp: GitHubBranchProtection, baseUrl: string) {
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
   const encBranch = encodeURIComponent(bp.branch_name);
@@ -828,16 +919,10 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       sha?: string;
       content?: string;
     }>;
-    const pathMap = new Map<string, { mode: string; type: "blob" | "tree"; sha: string; size?: number }>();
-
     const baseTreeSha = typeof body.base_tree === "string" ? body.base_tree : undefined;
-    if (baseTreeSha) {
-      const base = findTreeBySha(gh, repo.id, baseTreeSha);
-      if (!base) throw new ApiError(422, "Invalid base_tree");
-      for (const e of base.tree) {
-        pathMap.set(e.path, { mode: e.mode, type: e.type, sha: e.sha, size: e.size });
-      }
-    }
+    if (baseTreeSha && !findTreeBySha(gh, repo.id, baseTreeSha)) throw new ApiError(422, "Invalid base_tree");
+
+    const updates: GitTreeEntry[] = [];
 
     for (const raw of items) {
       if (
@@ -847,10 +932,21 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
       ) {
         throw new ApiError(422, "Each tree entry needs path, mode, type (blob|tree)");
       }
+      if (
+        !raw.path ||
+        raw.path.includes("\0") ||
+        raw.path.split("/").some((part) => part === "" || part === "." || part === "..")
+      ) {
+        throw new ApiError(422, "Invalid tree path");
+      }
       if (raw.sha !== undefined && raw.content !== undefined) {
         throw new ApiError(422, "Cannot pass both sha and content");
       }
+      if (raw.type === "tree" && raw.content !== undefined) {
+        throw new ApiError(422, "Tree entries must reference a tree sha");
+      }
       let sha = raw.sha;
+      let size: number | undefined;
       if (raw.content !== undefined) {
         const buf = Buffer.from(String(raw.content), "utf8");
         const blob = gh.blobs.insert({
@@ -863,28 +959,20 @@ export function branchesAndGitRoutes({ app, store, webhooks, baseUrl }: RouteCon
         } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
         gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
         sha = blob.sha;
+        size = blob.size;
       }
       if (typeof sha !== "string") throw new ApiError(422, "sha or content required");
-      pathMap.set(raw.path, { mode: raw.mode, type: raw.type, sha });
+      if (raw.type === "blob") {
+        const blob = findBlobBySha(gh, repo.id, sha);
+        if (!blob) throw new ApiError(422, "Invalid blob sha");
+        size ??= blob.size;
+      } else if (!findTreeBySha(gh, repo.id, sha)) {
+        throw new ApiError(422, "Invalid tree sha");
+      }
+      updates.push({ path: raw.path, mode: raw.mode, type: raw.type, sha, size });
     }
 
-    const treeEntries: GitHubTree["tree"] = [...pathMap.entries()].map(([path, v]) => ({
-      path,
-      mode: v.mode,
-      type: v.type,
-      sha: v.sha,
-      size: v.size,
-    }));
-
-    const tree = gh.trees.insert({
-      repo_id: repo.id,
-      sha: generateSha(),
-      node_id: "",
-      tree: treeEntries,
-      truncated: false,
-    } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
-    gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
-    const saved = gh.trees.get(tree.id)!;
+    const saved = persistGitTreeHierarchy(gh, repo.id, baseTreeSha, updates);
     const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
     return c.json(
       {

--- a/packages/@emulators/github/src/routes/checks.ts
+++ b/packages/@emulators/github/src/routes/checks.ts
@@ -11,7 +11,7 @@ import type {
   GitHubCheckAnnotation,
 } from "../entities.js";
 import { formatRepo, formatUser, generateNodeId, lookupRepo, timestamp } from "../helpers.js";
-import { assertRepoRead, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import { assertRepoPermission, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
 
 const CONCLUSION_RANK: Record<string, number> = {
   success: 0,
@@ -337,7 +337,7 @@ export function checksRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "checks");
     const suiteId = parseInt(c.req.param("check_suite_id")!, 10);
     const suite = gh.checkSuites.get(suiteId);
     if (!suite || suite.repo_id !== repo.id) throw notFoundResponse();
@@ -349,7 +349,7 @@ export function checksRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "checks");
     const suiteId = parseInt(c.req.param("check_suite_id")!, 10);
     const suite = gh.checkSuites.get(suiteId);
     if (!suite || suite.repo_id !== repo.id) throw notFoundResponse();
@@ -397,7 +397,7 @@ export function checksRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "checks");
     const ref = c.req.param("ref")!;
     const headSha = resolveRefToHeadSha(gh, repo, ref);
     if (!headSha) throw notFoundResponse();
@@ -639,7 +639,7 @@ export function checksRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "checks");
     const runId = parseInt(c.req.param("check_run_id")!, 10);
     const run = gh.checkRuns.get(runId);
     if (!run || run.repo_id !== repo.id) throw notFoundResponse();
@@ -651,7 +651,7 @@ export function checksRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "checks");
     const runId = parseInt(c.req.param("check_run_id")!, 10);
     const run = gh.checkRuns.get(runId);
     if (!run || run.repo_id !== repo.id) throw notFoundResponse();
@@ -713,7 +713,7 @@ export function checksRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "checks");
     const ref = c.req.param("ref")!;
     const headSha = resolveRefToHeadSha(gh, repo, ref);
     if (!headSha) throw notFoundResponse();

--- a/packages/@emulators/github/src/routes/comments.ts
+++ b/packages/@emulators/github/src/routes/comments.ts
@@ -13,7 +13,13 @@ import {
   generateNodeId,
   lookupRepo,
 } from "../helpers.js";
-import { assertRepoRead, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import {
+  assertRepoContentsRead,
+  assertRepoPermission,
+  assertRepoWrite,
+  notFoundResponse,
+  ownerLoginOf,
+} from "../route-helpers.js";
 
 function findIssueByNumber(gh: GitHubStore, repoId: number, number: number): GitHubIssue | undefined {
   return gh.issues.findBy("repo_id", repoId).find((i) => i.number === number);
@@ -84,7 +90,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, ["issues", "pull_requests"]);
     if (!repo.has_issues) throw notFoundResponse();
 
     const commentId = parseInt(c.req.param("comment_id")!, 10);
@@ -187,7 +193,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, ["issues", "pull_requests"]);
     if (!repo.has_issues) throw notFoundResponse();
 
     const { page, per_page } = parsePagination(c);
@@ -216,7 +222,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const commentId = parseInt(c.req.param("comment_id")!, 10);
     if (!Number.isFinite(commentId)) throw notFoundResponse();
@@ -314,7 +320,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const { page, per_page } = parsePagination(c);
     const { sort, direction } = parseCommentSort(c, "asc");
@@ -338,7 +344,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const commentId = parseInt(c.req.param("comment_id")!, 10);
     if (!Number.isFinite(commentId)) throw notFoundResponse();
@@ -399,7 +405,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const { page, per_page } = parsePagination(c);
     const { sort, direction } = parseCommentSort(c, "asc");
@@ -423,7 +429,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, ["issues", "pull_requests"]);
     if (!repo.has_issues) throw notFoundResponse();
 
     const issueNumber = parseInt(c.req.param("issue_number")!, 10);
@@ -516,7 +522,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const pullNumber = parseInt(c.req.param("pull_number")!, 10);
     if (!Number.isFinite(pullNumber)) throw notFoundResponse();
@@ -652,7 +658,7 @@ export function commentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const commitSha = c.req.param("commit_sha")!;
     const commit = findCommitInRepo(gh, repo.id, commitSha);

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -1,0 +1,158 @@
+import type { RouteContext } from "@emulators/core";
+import { ApiError, parsePagination, setLinkHeader } from "@emulators/core";
+import { getGitHubStore } from "../store.js";
+import type { GitHubStore } from "../store.js";
+import type { GitHubCommit, GitHubRepo } from "../entities.js";
+import { lookupRepo } from "../helpers.js";
+import { assertRepoRead, notFoundResponse } from "../route-helpers.js";
+import {
+  diffTrees,
+  findCommitBySha,
+  flattenTree,
+  formatCommitItem,
+  formatFileDiff,
+  listAncestors,
+  resolveRefToCommit,
+} from "../git-helpers.js";
+
+function blobShaAt(gh: GitHubStore, repoId: number, treeSha: string, path: string): string | undefined {
+  return flattenTree(gh, repoId, treeSha).blobs.get(path)?.sha;
+}
+
+/** A commit "touches" a path when the blob sha at that path differs from its first parent's. */
+function commitTouchesPath(gh: GitHubStore, repoId: number, commit: GitHubCommit, path: string): boolean {
+  const current = blobShaAt(gh, repoId, commit.tree_sha, path);
+  const parent = commit.parent_shas[0] ? findCommitBySha(gh, repoId, commit.parent_shas[0]) : undefined;
+  const previous = parent ? blobShaAt(gh, repoId, parent.tree_sha, path) : undefined;
+  return current !== previous;
+}
+
+function matchesAuthor(gh: GitHubStore, commit: GitHubCommit, author: string): boolean {
+  if (commit.author_name === author || commit.author_email === author) return true;
+  const user = commit.user_id ? gh.users.get(commit.user_id) : null;
+  return user?.login === author;
+}
+
+function formatFullCommit(gh: GitHubStore, repo: GitHubRepo, commit: GitHubCommit, baseUrl: string) {
+  const parent = commit.parent_shas[0] ? findCommitBySha(gh, repo.id, commit.parent_shas[0]) : undefined;
+  const files = diffTrees(gh, repo.id, parent?.tree_sha ?? null, commit.tree_sha);
+  const additions = files.reduce((sum, f) => sum + f.additions, 0);
+  const deletions = files.reduce((sum, f) => sum + f.deletions, 0);
+  return {
+    ...formatCommitItem(gh, repo, commit, baseUrl),
+    stats: { total: additions + deletions, additions, deletions },
+    files: files.map((f) => formatFileDiff(f, repo, commit.sha, baseUrl)),
+  };
+}
+
+export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
+  const gh = getGitHubStore(store);
+
+  app.get("/repos/:owner/:repo/commits", (c) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    assertRepoRead(gh, c.get("authUser"), repo);
+
+    if (gh.commits.findBy("repo_id", repo.id).length === 0) {
+      throw new ApiError(409, "Git Repository is empty.");
+    }
+
+    const shaParam = c.req.query("sha");
+    const head = resolveRefToCommit(gh, repo, shaParam);
+    if (!head) throw notFoundResponse();
+
+    let history = listAncestors(gh, repo.id, head.sha);
+
+    const path = c.req.query("path");
+    if (path) {
+      history = history.filter((commit) => commitTouchesPath(gh, repo.id, commit, path));
+    }
+    const author = c.req.query("author");
+    if (author) {
+      history = history.filter((commit) => matchesAuthor(gh, commit, author));
+    }
+    const since = c.req.query("since");
+    if (since) {
+      history = history.filter((commit) => commit.committer_date >= since);
+    }
+    const until = c.req.query("until");
+    if (until) {
+      history = history.filter((commit) => commit.committer_date <= until);
+    }
+
+    const { page, per_page } = parsePagination(c);
+    const total = history.length;
+    const start = (page - 1) * per_page;
+    const slice = history.slice(start, start + per_page);
+
+    setLinkHeader(c, total, page, per_page);
+    return c.json(slice.map((commit) => formatCommitItem(gh, repo, commit, baseUrl)));
+  });
+
+  app.get("/repos/:owner/:repo/compare/:basehead{.+}", (c) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const basehead = decodeURIComponent(c.req.param("basehead")!);
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    assertRepoRead(gh, c.get("authUser"), repo);
+
+    const sep = basehead.indexOf("...");
+    if (sep === -1) throw notFoundResponse();
+    const base = resolveRefToCommit(gh, repo, basehead.slice(0, sep));
+    const head = resolveRefToCommit(gh, repo, basehead.slice(sep + 3));
+    if (!base || !head) throw notFoundResponse();
+
+    const baseAncestors = new Set(listAncestors(gh, repo.id, base.sha).map((x) => x.sha));
+    const headAncestry = listAncestors(gh, repo.id, head.sha);
+    const headAncestors = new Set(headAncestry.map((x) => x.sha));
+
+    // Newest common ancestor (listAncestors is sorted newest first).
+    const mergeBase = headAncestry.find((x) => baseAncestors.has(x.sha)) ?? base;
+    const aheadCommits = headAncestry.filter((x) => !baseAncestors.has(x.sha)).reverse();
+    const behindBy = listAncestors(gh, repo.id, base.sha).filter((x) => !headAncestors.has(x.sha)).length;
+
+    const status =
+      base.sha === head.sha || (aheadCommits.length === 0 && behindBy === 0)
+        ? "identical"
+        : aheadCommits.length > 0 && behindBy === 0
+          ? "ahead"
+          : aheadCommits.length === 0
+            ? "behind"
+            : "diverged";
+
+    const files = diffTrees(gh, repo.id, mergeBase.tree_sha, head.tree_sha);
+    const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
+
+    return c.json({
+      url: `${repoUrl}/compare/${basehead}`,
+      html_url: `${baseUrl}/${repo.full_name}/compare/${basehead}`,
+      permalink_url: `${baseUrl}/${repo.full_name}/compare/${base.sha.slice(0, 12)}...${head.sha.slice(0, 12)}`,
+      diff_url: `${baseUrl}/${repo.full_name}/compare/${basehead}.diff`,
+      patch_url: `${baseUrl}/${repo.full_name}/compare/${basehead}.patch`,
+      base_commit: formatCommitItem(gh, repo, base, baseUrl),
+      merge_base_commit: formatCommitItem(gh, repo, mergeBase, baseUrl),
+      status,
+      ahead_by: aheadCommits.length,
+      behind_by: behindBy,
+      total_commits: aheadCommits.length,
+      commits: aheadCommits.map((commit) => formatCommitItem(gh, repo, commit, baseUrl)),
+      files: files.map((f) => formatFileDiff(f, repo, head.sha, baseUrl)),
+    });
+  });
+
+  app.get("/repos/:owner/:repo/commits/:ref{.+}", (c) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const refParam = decodeURIComponent(c.req.param("ref")!);
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    assertRepoRead(gh, c.get("authUser"), repo);
+
+    const commit = resolveRefToCommit(gh, repo, refParam);
+    if (!commit) throw notFoundResponse();
+    return c.json(formatFullCommit(gh, repo, commit, baseUrl));
+  });
+}

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -16,16 +16,26 @@ import {
   resolveRefToCommit,
 } from "../git-helpers.js";
 
-function blobAt(gh: GitHubStore, repoId: number, treeSha: string, path: string) {
-  return flattenTree(gh, repoId, treeSha).blobs.get(path);
+function blobsAtPath(gh: GitHubStore, repoId: number, treeSha: string, path: string) {
+  const prefix = `${path.replace(/\/+$/, "")}/`;
+  return new Map(
+    [...flattenTree(gh, repoId, treeSha).blobs].filter(
+      ([candidate]) => candidate === path || candidate.startsWith(prefix),
+    ),
+  );
 }
 
-/** A commit "touches" a path when its blob identity or mode differs from its first parent's. */
+/** A commit "touches" a path when that blob or any descendant differs from its first parent's. */
 function commitTouchesPath(gh: GitHubStore, repoId: number, commit: GitHubCommit, path: string): boolean {
-  const current = blobAt(gh, repoId, commit.tree_sha, path);
+  const current = blobsAtPath(gh, repoId, commit.tree_sha, path);
   const parent = commit.parent_shas[0] ? findCommitBySha(gh, repoId, commit.parent_shas[0]) : undefined;
-  const previous = parent ? blobAt(gh, repoId, parent.tree_sha, path) : undefined;
-  return current?.sha !== previous?.sha || current?.mode !== previous?.mode;
+  const previous = parent ? blobsAtPath(gh, repoId, parent.tree_sha, path) : new Map();
+  const candidates = new Set([...current.keys(), ...previous.keys()]);
+  return [...candidates].some((candidate) => {
+    const after = current.get(candidate);
+    const before = previous.get(candidate);
+    return after?.sha !== before?.sha || after?.mode !== before?.mode;
+  });
 }
 
 function parseDateFilter(value: string): number | undefined {
@@ -63,6 +73,7 @@ function formatFullCommit(
   repo: GitHubRepo,
   commit: GitHubCommit,
   baseUrl: string,
+  baseSha: string | null,
   allFiles: ReturnType<typeof diffTrees>,
   pageFiles: ReturnType<typeof diffTrees>,
 ) {
@@ -71,7 +82,7 @@ function formatFullCommit(
   return {
     ...formatCommitItem(gh, repo, commit, baseUrl),
     stats: { total: additions + deletions, additions, deletions },
-    files: pageFiles.map((f) => formatFileDiff(f, repo, commit.sha, baseUrl)),
+    files: pageFiles.map((f) => formatFileDiff(f, repo, baseSha, commit.sha, baseUrl)),
   };
 }
 
@@ -190,7 +201,7 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
       behind_by: behindBy,
       total_commits: aheadCommits.length,
       commits: commits.map((commit) => formatCommitItem(gh, repo, commit, baseUrl)),
-      files: files.map((f) => formatFileDiff(f, repo, head.sha, baseUrl)),
+      files: files.map((f) => formatFileDiff(f, repo, mergeBase.sha, head.sha, baseUrl)),
     });
   });
 
@@ -212,6 +223,6 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
     const start = (page - 1) * per_page;
     const pageFiles = listedFiles.slice(start, start + per_page);
     setLinkHeader(c, listedFiles.length, page, per_page);
-    return c.json(formatFullCommit(gh, repo, commit, baseUrl, allFiles, pageFiles));
+    return c.json(formatFullCommit(gh, repo, commit, baseUrl, parent?.sha ?? null, allFiles, pageFiles));
   });
 }

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -28,9 +28,39 @@ function commitTouchesPath(gh: GitHubStore, repoId: number, commit: GitHubCommit
 }
 
 function matchesAuthor(gh: GitHubStore, commit: GitHubCommit, author: string): boolean {
-  if (commit.author_name === author || commit.author_email === author) return true;
+  if (commit.author_name === author || commit.author_email.toLowerCase() === author.toLowerCase()) return true;
   const user = commit.user_id ? gh.users.get(commit.user_id) : null;
-  return user?.login === author;
+  return user?.login.toLowerCase() === author.toLowerCase();
+}
+
+function parseDateFilter(value: string): number | undefined {
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? date : undefined;
+}
+
+function ancestorDistances(gh: GitHubStore, repoId: number, startSha: string): Map<string, number> {
+  const distances = new Map<string, number>();
+  const queue: Array<{ sha: string; distance: number }> = [{ sha: startSha, distance: 0 }];
+  for (let i = 0; i < queue.length; i++) {
+    const { sha, distance } = queue[i];
+    const known = distances.get(sha);
+    if (known !== undefined && known <= distance) continue;
+    distances.set(sha, distance);
+    const commit = findCommitBySha(gh, repoId, sha);
+    if (!commit) continue;
+    for (const parent of commit.parent_shas) queue.push({ sha: parent, distance: distance + 1 });
+  }
+  return distances;
+}
+
+function findMergeBase(gh: GitHubStore, repoId: number, baseSha: string, headSha: string): GitHubCommit | undefined {
+  const fromBase = ancestorDistances(gh, repoId, baseSha);
+  const fromHead = ancestorDistances(gh, repoId, headSha);
+  return [...fromBase.keys()]
+    .filter((sha) => fromHead.has(sha))
+    .map((sha) => ({ commit: findCommitBySha(gh, repoId, sha), score: fromBase.get(sha)! + fromHead.get(sha)! }))
+    .filter((candidate): candidate is { commit: GitHubCommit; score: number } => candidate.commit !== undefined)
+    .sort((a, b) => a.score - b.score || b.commit.id - a.commit.id)[0]?.commit;
 }
 
 function formatFullCommit(gh: GitHubStore, repo: GitHubRepo, commit: GitHubCommit, baseUrl: string) {
@@ -75,11 +105,16 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
     }
     const since = c.req.query("since");
     if (since) {
-      history = history.filter((commit) => commit.committer_date >= since);
+      const sinceDate = parseDateFilter(since);
+      history =
+        sinceDate === undefined ? [] : history.filter((commit) => Date.parse(commit.committer_date) >= sinceDate);
     }
     const until = c.req.query("until");
     if (until) {
-      history = history.filter((commit) => commit.committer_date <= until);
+      const untilDate = parseDateFilter(until);
+      if (untilDate !== undefined) {
+        history = history.filter((commit) => Date.parse(commit.committer_date) <= untilDate);
+      }
     }
 
     const { page, per_page } = parsePagination(c);
@@ -109,8 +144,8 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
     const headAncestry = listAncestors(gh, repo.id, head.sha);
     const headAncestors = new Set(headAncestry.map((x) => x.sha));
 
-    // Newest common ancestor (listAncestors is sorted newest first).
-    const mergeBase = headAncestry.find((x) => baseAncestors.has(x.sha)) ?? base;
+    const mergeBase = findMergeBase(gh, repo.id, base.sha, head.sha);
+    if (!mergeBase) throw notFoundResponse();
     const aheadCommits = headAncestry.filter((x) => !baseAncestors.has(x.sha)).reverse();
     const behindBy = listAncestors(gh, repo.id, base.sha).filter((x) => !headAncestors.has(x.sha)).length;
 
@@ -123,7 +158,19 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
             ? "behind"
             : "diverged";
 
-    const files = diffTrees(gh, repo.id, mergeBase.tree_sha, head.tree_sha);
+    const allFiles = diffTrees(gh, repo.id, mergeBase.tree_sha, head.tree_sha);
+    const hasPagination = c.req.query("page") !== undefined || c.req.query("per_page") !== undefined;
+    let commits = aheadCommits;
+    let files = allFiles.slice(0, 300);
+    if (hasPagination) {
+      const { page, per_page } = parsePagination(c);
+      const start = (page - 1) * per_page;
+      commits = aheadCommits.slice(start, start + per_page);
+      files = page === 1 ? files : [];
+      setLinkHeader(c, aheadCommits.length, page, per_page);
+    } else if (commits.length > 250) {
+      commits = [...commits.slice(0, 249), commits.at(-1)!];
+    }
     const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
 
     return c.json({
@@ -138,7 +185,7 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
       ahead_by: aheadCommits.length,
       behind_by: behindBy,
       total_commits: aheadCommits.length,
-      commits: aheadCommits.map((commit) => formatCommitItem(gh, repo, commit, baseUrl)),
+      commits: commits.map((commit) => formatCommitItem(gh, repo, commit, baseUrl)),
       files: files.map((f) => formatFileDiff(f, repo, head.sha, baseUrl)),
     });
   });

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -6,6 +6,7 @@ import type { GitHubCommit, GitHubRepo } from "../entities.js";
 import { lookupRepo } from "../helpers.js";
 import { assertRepoRead, notFoundResponse } from "../route-helpers.js";
 import {
+  commitIdentityMatches,
   diffTrees,
   findCommitBySha,
   flattenTree,
@@ -25,12 +26,6 @@ function commitTouchesPath(gh: GitHubStore, repoId: number, commit: GitHubCommit
   const parent = commit.parent_shas[0] ? findCommitBySha(gh, repoId, commit.parent_shas[0]) : undefined;
   const previous = parent ? blobShaAt(gh, repoId, parent.tree_sha, path) : undefined;
   return current !== previous;
-}
-
-function matchesAuthor(gh: GitHubStore, commit: GitHubCommit, author: string): boolean {
-  if (commit.author_name === author || commit.author_email.toLowerCase() === author.toLowerCase()) return true;
-  const user = commit.user_id ? gh.users.get(commit.user_id) : null;
-  return user?.login.toLowerCase() === author.toLowerCase();
 }
 
 function parseDateFilter(value: string): number | undefined {
@@ -106,7 +101,11 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
     }
     const author = c.req.query("author");
     if (author) {
-      history = history.filter((commit) => matchesAuthor(gh, commit, author));
+      history = history.filter((commit) => commitIdentityMatches(gh, commit.author_email, author));
+    }
+    const committer = c.req.query("committer");
+    if (committer) {
+      history = history.filter((commit) => commitIdentityMatches(gh, commit.committer_email, committer));
     }
     const since = c.req.query("since");
     if (since) {

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -16,16 +16,16 @@ import {
   resolveRefToCommit,
 } from "../git-helpers.js";
 
-function blobShaAt(gh: GitHubStore, repoId: number, treeSha: string, path: string): string | undefined {
-  return flattenTree(gh, repoId, treeSha).blobs.get(path)?.sha;
+function blobAt(gh: GitHubStore, repoId: number, treeSha: string, path: string) {
+  return flattenTree(gh, repoId, treeSha).blobs.get(path);
 }
 
-/** A commit "touches" a path when the blob sha at that path differs from its first parent's. */
+/** A commit "touches" a path when its blob identity or mode differs from its first parent's. */
 function commitTouchesPath(gh: GitHubStore, repoId: number, commit: GitHubCommit, path: string): boolean {
-  const current = blobShaAt(gh, repoId, commit.tree_sha, path);
+  const current = blobAt(gh, repoId, commit.tree_sha, path);
   const parent = commit.parent_shas[0] ? findCommitBySha(gh, repoId, commit.parent_shas[0]) : undefined;
-  const previous = parent ? blobShaAt(gh, repoId, parent.tree_sha, path) : undefined;
-  return current !== previous;
+  const previous = parent ? blobAt(gh, repoId, parent.tree_sha, path) : undefined;
+  return current?.sha !== previous?.sha || current?.mode !== previous?.mode;
 }
 
 function parseDateFilter(value: string): number | undefined {

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -134,7 +134,7 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
   app.get("/repos/:owner/:repo/compare/:basehead{.+}", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const basehead = decodeURIComponent(c.req.param("basehead")!);
+    const basehead = c.req.param("basehead")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);
@@ -198,7 +198,7 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
   app.get("/repos/:owner/:repo/commits/:ref{.+}", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
-    const refParam = decodeURIComponent(c.req.param("ref")!);
+    const refParam = c.req.param("ref")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -63,15 +63,20 @@ function findMergeBase(gh: GitHubStore, repoId: number, baseSha: string, headSha
     .sort((a, b) => a.score - b.score || b.commit.id - a.commit.id)[0]?.commit;
 }
 
-function formatFullCommit(gh: GitHubStore, repo: GitHubRepo, commit: GitHubCommit, baseUrl: string) {
-  const parent = commit.parent_shas[0] ? findCommitBySha(gh, repo.id, commit.parent_shas[0]) : undefined;
-  const files = diffTrees(gh, repo.id, parent?.tree_sha ?? null, commit.tree_sha);
-  const additions = files.reduce((sum, f) => sum + f.additions, 0);
-  const deletions = files.reduce((sum, f) => sum + f.deletions, 0);
+function formatFullCommit(
+  gh: GitHubStore,
+  repo: GitHubRepo,
+  commit: GitHubCommit,
+  baseUrl: string,
+  allFiles: ReturnType<typeof diffTrees>,
+  pageFiles: ReturnType<typeof diffTrees>,
+) {
+  const additions = allFiles.reduce((sum, f) => sum + f.additions, 0);
+  const deletions = allFiles.reduce((sum, f) => sum + f.deletions, 0);
   return {
     ...formatCommitItem(gh, repo, commit, baseUrl),
     stats: { total: additions + deletions, additions, deletions },
-    files: files.map((f) => formatFileDiff(f, repo, commit.sha, baseUrl)),
+    files: pageFiles.map((f) => formatFileDiff(f, repo, commit.sha, baseUrl)),
   };
 }
 
@@ -200,6 +205,14 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
 
     const commit = resolveRefToCommit(gh, repo, refParam);
     if (!commit) throw notFoundResponse();
-    return c.json(formatFullCommit(gh, repo, commit, baseUrl));
+    const parent = commit.parent_shas[0] ? findCommitBySha(gh, repo.id, commit.parent_shas[0]) : undefined;
+    const allFiles = diffTrees(gh, repo.id, parent?.tree_sha ?? null, commit.tree_sha);
+    const listedFiles = allFiles.slice(0, 3_000);
+    const hasPagination = c.req.query("page") !== undefined || c.req.query("per_page") !== undefined;
+    const { page, per_page } = hasPagination ? parsePagination(c) : { page: 1, per_page: 300 };
+    const start = (page - 1) * per_page;
+    const pageFiles = listedFiles.slice(start, start + per_page);
+    setLinkHeader(c, listedFiles.length, page, per_page);
+    return c.json(formatFullCommit(gh, repo, commit, baseUrl, allFiles, pageFiles));
   });
 }

--- a/packages/@emulators/github/src/routes/commits.ts
+++ b/packages/@emulators/github/src/routes/commits.ts
@@ -4,7 +4,7 @@ import { getGitHubStore } from "../store.js";
 import type { GitHubStore } from "../store.js";
 import type { GitHubCommit, GitHubRepo } from "../entities.js";
 import { lookupRepo } from "../helpers.js";
-import { assertRepoRead, notFoundResponse } from "../route-helpers.js";
+import { assertRepoContentsRead, notFoundResponse } from "../route-helpers.js";
 import {
   commitIdentityMatches,
   diffTrees,
@@ -94,7 +94,7 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     if (gh.commits.findBy("repo_id", repo.id).length === 0) {
       throw new ApiError(409, "Git Repository is empty.");
@@ -147,7 +147,7 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
     const basehead = c.req.param("basehead")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const sep = basehead.indexOf("...");
     if (sep === -1) throw notFoundResponse();
@@ -211,7 +211,7 @@ export function commitsRoutes({ app, store, baseUrl }: RouteContext): void {
     const refParam = c.req.param("ref")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const commit = resolveRefToCommit(gh, repo, refParam);
     if (!commit) throw notFoundResponse();

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -1,0 +1,419 @@
+import type { AppEnv, Context, RouteContext } from "@emulators/core";
+import { ApiError, parseJsonBody } from "@emulators/core";
+import { getGitHubStore } from "../store.js";
+import type { GitHubStore } from "../store.js";
+import type {
+  GitHubBlob,
+  GitHubBranch,
+  GitHubCommit,
+  GitHubRef,
+  GitHubRepo,
+  GitHubTree,
+  GitHubUser,
+} from "../entities.js";
+import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
+import { assertRepoRead, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import { flattenTree, formatGitCommit, resolveRefToCommit, type FlatTree } from "../git-helpers.js";
+
+function normalizePath(raw: string): string {
+  return decodeURIComponent(raw).replace(/^\/+|\/+$/g, "");
+}
+
+function contentLinks(repo: GitHubRepo, baseUrl: string, path: string, ref: string, blobSha?: string) {
+  const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
+  const self = `${repoUrl}/contents/${path}?ref=${encodeURIComponent(ref)}`;
+  const html = `${baseUrl}/${repo.full_name}/blob/${ref}/${path}`;
+  const git = blobSha ? `${repoUrl}/git/blobs/${blobSha}` : null;
+  return { self, html, git };
+}
+
+function formatFileContent(
+  gh: GitHubStore,
+  repo: GitHubRepo,
+  baseUrl: string,
+  path: string,
+  ref: string,
+  entry: { mode: string; sha: string; size?: number },
+  withContent: boolean,
+) {
+  const blob = gh.blobs.findBy("repo_id", repo.id).find((b) => b.sha === entry.sha);
+  const size = blob?.size ?? entry.size ?? 0;
+  const links = contentLinks(repo, baseUrl, path, ref, entry.sha);
+  const base = {
+    type: "file",
+    size,
+    name: path.split("/").pop()!,
+    path,
+    sha: entry.sha,
+    url: links.self,
+    git_url: links.git,
+    html_url: links.html,
+    download_url: `${baseUrl}/${repo.full_name}/raw/${ref}/${path}`,
+    _links: { self: links.self, git: links.git, html: links.html },
+  };
+  if (!withContent) return base;
+  const content = blob
+    ? blob.encoding === "base64"
+      ? blob.content
+      : Buffer.from(blob.content, "utf8").toString("base64")
+    : "";
+  return { ...base, content, encoding: "base64" };
+}
+
+function formatDirListing(
+  gh: GitHubStore,
+  repo: GitHubRepo,
+  baseUrl: string,
+  dirPath: string,
+  ref: string,
+  flat: FlatTree,
+) {
+  const prefix = dirPath ? `${dirPath}/` : "";
+  const files: Array<Record<string, unknown>> = [];
+  const dirNames = new Set<string>();
+
+  for (const [path, entry] of flat.blobs) {
+    if (!path.startsWith(prefix)) continue;
+    const rest = path.slice(prefix.length);
+    if (!rest) continue;
+    const slash = rest.indexOf("/");
+    if (slash === -1) {
+      files.push(formatFileContent(gh, repo, baseUrl, path, ref, entry, false));
+    } else {
+      dirNames.add(rest.slice(0, slash));
+    }
+  }
+
+  const dirs = [...dirNames].map((name) => {
+    const path = prefix + name;
+    const links = contentLinks(repo, baseUrl, path, ref);
+    return {
+      type: "dir",
+      size: 0,
+      name,
+      path,
+      sha: flat.dirs.get(path) ?? "",
+      url: links.self,
+      git_url: null,
+      html_url: `${baseUrl}/${repo.full_name}/tree/${ref}/${path}`,
+      download_url: null,
+      _links: { self: links.self, git: null, html: `${baseUrl}/${repo.full_name}/tree/${ref}/${path}` },
+    };
+  });
+
+  return [...dirs, ...files].sort((a, b) => String(a.name).localeCompare(String(b.name)));
+}
+
+function decodeBodyContent(content: string): { text: string | null; base64: string } {
+  const buf = Buffer.from(content, "base64");
+  const text = buf.toString("utf8");
+  // Round-trips cleanly -> store as searchable utf-8 text; otherwise keep base64.
+  if (!text.includes("\0") && Buffer.from(text, "utf8").equals(buf)) {
+    return { text, base64: content };
+  }
+  return { text: null, base64: buf.toString("base64") };
+}
+
+interface CommitFilesParams {
+  repo: GitHubRepo;
+  branchName: string;
+  message: string;
+  actor: GitHubUser;
+  author?: { name?: string; email?: string; date?: string };
+  committer?: { name?: string; email?: string; date?: string };
+  /** path -> new entry, or null to delete the path */
+  changes: Map<string, { mode: string; sha: string; size: number } | null>;
+  headCommit: GitHubCommit | null;
+}
+
+function commitFiles(gh: GitHubStore, params: CommitFilesParams): GitHubCommit {
+  const { repo, branchName, headCommit, actor } = params;
+
+  const entries = new Map<string, { mode: string; sha: string; size?: number }>();
+  if (headCommit) {
+    for (const [path, entry] of flattenTree(gh, repo.id, headCommit.tree_sha).blobs) {
+      entries.set(path, entry);
+    }
+  }
+  for (const [path, change] of params.changes) {
+    if (change === null) entries.delete(path);
+    else entries.set(path, change);
+  }
+
+  const tree = gh.trees.insert({
+    repo_id: repo.id,
+    sha: generateSha(),
+    node_id: "",
+    tree: [...entries.entries()].map(([path, e]) => ({
+      path,
+      mode: e.mode,
+      type: "blob" as const,
+      sha: e.sha,
+      size: e.size,
+    })),
+    truncated: false,
+  } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
+  gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
+
+  const now = timestamp();
+  const defaultName = actor.name ?? actor.login;
+  const defaultEmail = actor.email ?? `${actor.login}@users.noreply.github.com`;
+  const author = {
+    name: params.author?.name ?? defaultName,
+    email: params.author?.email ?? defaultEmail,
+    date: params.author?.date ?? now,
+  };
+  const committer = {
+    name: params.committer?.name ?? author.name,
+    email: params.committer?.email ?? author.email,
+    date: params.committer?.date ?? author.date,
+  };
+
+  const commit = gh.commits.insert({
+    repo_id: repo.id,
+    sha: generateSha(),
+    node_id: "",
+    message: params.message,
+    author_name: author.name,
+    author_email: author.email,
+    author_date: author.date,
+    committer_name: committer.name,
+    committer_email: committer.email,
+    committer_date: committer.date,
+    tree_sha: tree.sha,
+    parent_shas: headCommit ? [headCommit.sha] : [],
+    user_id: actor.id,
+  } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
+  gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
+  const saved = gh.commits.get(commit.id)!;
+
+  const fullRef = `refs/heads/${branchName}`;
+  const refRec = gh.refs.findBy("repo_id", repo.id).find((r) => r.ref === fullRef);
+  if (refRec) {
+    gh.refs.update(refRec.id, { sha: saved.sha });
+  } else {
+    const inserted = gh.refs.insert({
+      repo_id: repo.id,
+      ref: fullRef,
+      sha: saved.sha,
+      node_id: "",
+    } as Omit<GitHubRef, "id" | "created_at" | "updated_at">);
+    gh.refs.update(inserted.id, { node_id: generateNodeId("Ref", inserted.id) });
+  }
+
+  const branch = gh.branches.findBy("repo_id", repo.id).find((b) => b.name === branchName);
+  if (branch) {
+    gh.branches.update(branch.id, { sha: saved.sha });
+  } else {
+    gh.branches.insert({
+      repo_id: repo.id,
+      name: branchName,
+      sha: saved.sha,
+      protected: false,
+    } as Omit<GitHubBranch, "id" | "created_at" | "updated_at">);
+  }
+
+  gh.repos.update(repo.id, { pushed_at: now });
+  return saved;
+}
+
+export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext): void {
+  const gh = getGitHubStore(store);
+
+  const getContents = (c: Context<AppEnv>, path: string) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    assertRepoRead(gh, c.get("authUser"), repo);
+
+    const refParam = c.req.query("ref");
+    const commit = resolveRefToCommit(gh, repo, refParam);
+    if (!commit) throw notFoundResponse();
+    const ref = refParam && refParam !== "HEAD" ? refParam : repo.default_branch;
+
+    const flat = flattenTree(gh, repo.id, commit.tree_sha);
+    if (path === "") {
+      return c.json(formatDirListing(gh, repo, baseUrl, "", ref, flat));
+    }
+    const entry = flat.blobs.get(path);
+    if (entry) {
+      return c.json(formatFileContent(gh, repo, baseUrl, path, ref, entry, true));
+    }
+    const prefix = `${path}/`;
+    if (flat.dirs.has(path) || [...flat.blobs.keys()].some((p) => p.startsWith(prefix))) {
+      return c.json(formatDirListing(gh, repo, baseUrl, path, ref, flat));
+    }
+    throw notFoundResponse();
+  };
+
+  app.get("/repos/:owner/:repo/readme", (c) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    assertRepoRead(gh, c.get("authUser"), repo);
+
+    const refParam = c.req.query("ref");
+    const commit = resolveRefToCommit(gh, repo, refParam);
+    if (!commit) throw notFoundResponse();
+    const ref = refParam && refParam !== "HEAD" ? refParam : repo.default_branch;
+
+    const flat = flattenTree(gh, repo.id, commit.tree_sha);
+    const readmePath = [...flat.blobs.keys()].filter((p) => !p.includes("/") && /^readme(\.|$)/i.test(p)).sort()[0];
+    if (!readmePath) throw notFoundResponse();
+    return c.json(formatFileContent(gh, repo, baseUrl, readmePath, ref, flat.blobs.get(readmePath)!, true));
+  });
+
+  app.get("/repos/:owner/:repo/contents", (c) => getContents(c, ""));
+  app.get("/repos/:owner/:repo/contents/", (c) => getContents(c, ""));
+  app.get("/repos/:owner/:repo/contents/:path{.+}", (c) => getContents(c, normalizePath(c.req.param("path")!)));
+
+  app.put("/repos/:owner/:repo/contents/:path{.+}", async (c) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const path = normalizePath(c.req.param("path")!);
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    const user = assertRepoWrite(gh, c.get("authUser"), repo);
+    if (!path) throw new ApiError(422, "path is required");
+
+    const body = await parseJsonBody(c);
+    if (typeof body.message !== "string" || !body.message) throw new ApiError(422, "message is required");
+    if (typeof body.content !== "string") throw new ApiError(422, "content is required");
+
+    const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
+    const hasCommits = gh.commits.findBy("repo_id", repo.id).length > 0;
+    const headCommit = resolveRefToCommit(gh, repo, branchName) ?? null;
+    if (hasCommits && !headCommit) throw notFoundResponse();
+
+    const existing = headCommit ? flattenTree(gh, repo.id, headCommit.tree_sha).blobs.get(path) : undefined;
+    if (existing) {
+      if (typeof body.sha !== "string") {
+        throw new ApiError(422, `"sha" wasn't supplied. ${path} already exists.`);
+      }
+      if (body.sha !== existing.sha) {
+        throw new ApiError(409, `${path} does not match ${body.sha}`);
+      }
+    }
+
+    const decoded = decodeBodyContent(body.content);
+    const size =
+      decoded.text !== null ? Buffer.byteLength(decoded.text, "utf8") : Buffer.from(decoded.base64, "base64").length;
+    const blob = gh.blobs.insert({
+      repo_id: repo.id,
+      sha: generateSha(),
+      node_id: "",
+      content: decoded.text ?? decoded.base64,
+      encoding: decoded.text !== null ? "utf-8" : "base64",
+      size,
+    } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
+    gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
+
+    const commit = commitFiles(gh, {
+      repo,
+      branchName,
+      message: body.message,
+      actor: user,
+      author: body.author as CommitFilesParams["author"],
+      committer: body.committer as CommitFilesParams["committer"],
+      changes: new Map([[path, { mode: existing?.mode ?? "100644", sha: gh.blobs.get(blob.id)!.sha, size }]]),
+      headCommit,
+    });
+
+    webhooks.dispatch(
+      "push",
+      undefined,
+      {
+        ref: `refs/heads/${branchName}`,
+        before: headCommit?.sha ?? "0".repeat(40),
+        after: commit.sha,
+        repository: formatRepo(gh.repos.get(repo.id)!, gh, baseUrl),
+        sender: formatUser(user, baseUrl),
+        commits: [
+          {
+            id: commit.sha,
+            message: commit.message,
+            timestamp: commit.committer_date,
+            author: { name: commit.author_name, email: commit.author_email },
+            added: existing ? [] : [path],
+            removed: [],
+            modified: existing ? [path] : [],
+          },
+        ],
+      },
+      ownerLoginOf(gh, repo),
+      repo.name,
+    );
+
+    const entry = { mode: existing?.mode ?? "100644", sha: gh.blobs.get(blob.id)!.sha, size };
+    return c.json(
+      {
+        content: formatFileContent(gh, repo, baseUrl, path, branchName, entry, false),
+        commit: formatGitCommit(repo, commit, baseUrl),
+      },
+      existing ? 200 : 201,
+    );
+  });
+
+  app.delete("/repos/:owner/:repo/contents/:path{.+}", async (c) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const path = normalizePath(c.req.param("path")!);
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    const user = assertRepoWrite(gh, c.get("authUser"), repo);
+
+    const body = await parseJsonBody(c);
+    if (typeof body.message !== "string" || !body.message) throw new ApiError(422, "message is required");
+    if (typeof body.sha !== "string") throw new ApiError(422, "sha is required");
+
+    const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
+    const headCommit = resolveRefToCommit(gh, repo, branchName);
+    if (!headCommit) throw notFoundResponse();
+
+    const existing = flattenTree(gh, repo.id, headCommit.tree_sha).blobs.get(path);
+    if (!existing) throw notFoundResponse();
+    if (body.sha !== existing.sha) {
+      throw new ApiError(409, `${path} does not match ${body.sha}`);
+    }
+
+    const commit = commitFiles(gh, {
+      repo,
+      branchName,
+      message: body.message,
+      actor: user,
+      author: body.author as CommitFilesParams["author"],
+      committer: body.committer as CommitFilesParams["committer"],
+      changes: new Map([[path, null]]),
+      headCommit,
+    });
+
+    webhooks.dispatch(
+      "push",
+      undefined,
+      {
+        ref: `refs/heads/${branchName}`,
+        before: headCommit.sha,
+        after: commit.sha,
+        repository: formatRepo(gh.repos.get(repo.id)!, gh, baseUrl),
+        sender: formatUser(user, baseUrl),
+        commits: [
+          {
+            id: commit.sha,
+            message: commit.message,
+            timestamp: commit.committer_date,
+            author: { name: commit.author_name, email: commit.author_email },
+            added: [],
+            removed: [path],
+            modified: [],
+          },
+        ],
+      },
+      ownerLoginOf(gh, repo),
+      repo.name,
+    );
+
+    return c.json({ content: null, commit: formatGitCommit(repo, commit, baseUrl) });
+  });
+}

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -13,7 +13,14 @@ import type {
 } from "../entities.js";
 import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
 import { assertRepoRead, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
-import { encodeContentPath, flattenTree, formatGitCommit, resolveRefToCommit, type FlatTree } from "../git-helpers.js";
+import {
+  encodeContentPath,
+  flattenTree,
+  formatGitCommit,
+  resolveBranchToCommit,
+  resolveRefToCommit,
+  type FlatTree,
+} from "../git-helpers.js";
 
 function normalizePath(raw: string): string {
   let decoded: string;
@@ -72,6 +79,10 @@ function formatFileContent(
       : Buffer.from(blob.content, "utf8").toString("base64")
     : "";
   return { ...base, content, encoding: "base64" };
+}
+
+function blobBytes(blob: GitHubBlob): Buffer {
+  return blob.encoding === "base64" ? Buffer.from(blob.content, "base64") : Buffer.from(blob.content, "utf8");
 }
 
 function formatDirListing(
@@ -342,6 +353,28 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     throw notFoundResponse();
   };
 
+  app.get("/:owner/:repo/raw/:ref/:path{.+}", (c) => {
+    const owner = c.req.param("owner")!;
+    const repoName = c.req.param("repo")!;
+    const ref = c.req.param("ref")!;
+    const path = normalizePath(c.req.param("path")!);
+    const repo = lookupRepo(gh, owner, repoName);
+    if (!repo) throw notFoundResponse();
+    assertRepoRead(gh, c.get("authUser"), repo);
+
+    const commit = resolveRefToCommit(gh, repo, ref);
+    if (!commit) throw notFoundResponse();
+    const entry = flattenTree(gh, repo.id, commit.tree_sha).blobs.get(path);
+    if (!entry) throw notFoundResponse();
+    const blob = gh.blobs.findBy("repo_id", repo.id).find((candidate) => candidate.sha === entry.sha);
+    if (!blob) throw notFoundResponse();
+    const content = blobBytes(blob);
+    return c.body(content, 200, {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": String(content.byteLength),
+    });
+  });
+
   app.get("/repos/:owner/:repo/readme", (c) => {
     const owner = c.req.param("owner")!;
     const repoName = c.req.param("repo")!;
@@ -355,7 +388,16 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const ref = refParam && refParam !== "HEAD" ? refParam : repo.default_branch;
 
     const flat = flattenTree(gh, repo.id, commit.tree_sha);
-    const readmePath = [...flat.blobs.keys()].filter((p) => !p.includes("/") && /^readme(\.|$)/i.test(p)).sort()[0];
+    const findReadme = (dir: "" | ".github" | "docs") =>
+      [...flat.blobs.keys()]
+        .filter((path) => {
+          const slash = path.lastIndexOf("/");
+          const parent = slash === -1 ? "" : path.slice(0, slash);
+          const name = slash === -1 ? path : path.slice(slash + 1);
+          return parent === dir && /^readme(\.|$)/i.test(name);
+        })
+        .sort()[0];
+    const readmePath = findReadme(".github") ?? findReadme("") ?? findReadme("docs");
     if (!readmePath) throw notFoundResponse();
     return c.json(formatFileContent(gh, repo, baseUrl, readmePath, ref, flat.blobs.get(readmePath)!, true));
   });
@@ -385,7 +427,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
 
     const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
     const hasCommits = gh.commits.findBy("repo_id", repo.id).length > 0;
-    const headCommit = resolveRefToCommit(gh, repo, branchName) ?? null;
+    const headCommit = resolveBranchToCommit(gh, repo, branchName) ?? null;
     if (hasCommits && !headCommit) throw notFoundResponse();
 
     const flat = headCommit ? flattenTree(gh, repo.id, headCommit.tree_sha) : undefined;
@@ -490,7 +532,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const committer = parseCommitIdentity(body.committer, "committer");
 
     const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
-    const headCommit = resolveRefToCommit(gh, repo, branchName);
+    const headCommit = resolveBranchToCommit(gh, repo, branchName);
     if (!headCommit) throw notFoundResponse();
 
     const existing = flattenTree(gh, repo.id, headCommit.tree_sha).blobs.get(path);

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -12,7 +12,7 @@ import type {
   GitHubUser,
 } from "../entities.js";
 import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
-import { assertRepoRead, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import { assertRepoContentsWrite, assertRepoRead, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
 import {
   encodeContentPath,
   flattenTree,
@@ -23,13 +23,7 @@ import {
 } from "../git-helpers.js";
 
 function normalizePath(raw: string): string {
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(raw);
-  } catch {
-    throw new ApiError(422, "path is invalid");
-  }
-  const path = decoded.replace(/^\/+|\/+$/g, "");
+  const path = raw.replace(/^\/+|\/+$/g, "");
   if (path.includes("\0") || path.split("/").some((part) => part === "" || part === "." || part === "..")) {
     throw new ApiError(422, "path is invalid");
   }
@@ -412,7 +406,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const path = normalizePath(c.req.param("path")!);
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const user = assertRepoWrite(gh, c.get("authUser"), repo);
+    const user = assertRepoContentsWrite(gh, c.get("authUser"), repo);
     if (!path) throw new ApiError(422, "path is required");
 
     const body = await parseJsonBody(c);
@@ -519,7 +513,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const path = normalizePath(c.req.param("path")!);
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const user = assertRepoWrite(gh, c.get("authUser"), repo);
+    const user = assertRepoContentsWrite(gh, c.get("authUser"), repo);
     if (!path) throw new ApiError(422, "path is required");
 
     const body = await parseJsonBody(c);

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -13,16 +13,28 @@ import type {
 } from "../entities.js";
 import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
 import { assertRepoRead, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
-import { flattenTree, formatGitCommit, resolveRefToCommit, type FlatTree } from "../git-helpers.js";
+import { encodeContentPath, flattenTree, formatGitCommit, resolveRefToCommit, type FlatTree } from "../git-helpers.js";
 
 function normalizePath(raw: string): string {
-  return decodeURIComponent(raw).replace(/^\/+|\/+$/g, "");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new ApiError(422, "path is invalid");
+  }
+  const path = decoded.replace(/^\/+|\/+$/g, "");
+  if (path.includes("\0") || path.split("/").some((part) => part === "" || part === "." || part === "..")) {
+    throw new ApiError(422, "path is invalid");
+  }
+  return path;
 }
 
 function contentLinks(repo: GitHubRepo, baseUrl: string, path: string, ref: string, blobSha?: string) {
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
-  const self = `${repoUrl}/contents/${path}?ref=${encodeURIComponent(ref)}`;
-  const html = `${baseUrl}/${repo.full_name}/blob/${ref}/${path}`;
+  const encodedPath = encodeContentPath(path);
+  const encodedRef = encodeURIComponent(ref);
+  const self = `${repoUrl}/contents/${encodedPath}?ref=${encodedRef}`;
+  const html = `${baseUrl}/${repo.full_name}/blob/${encodedRef}/${encodedPath}`;
   const git = blobSha ? `${repoUrl}/git/blobs/${blobSha}` : null;
   return { self, html, git };
 }
@@ -39,6 +51,8 @@ function formatFileContent(
   const blob = gh.blobs.findBy("repo_id", repo.id).find((b) => b.sha === entry.sha);
   const size = blob?.size ?? entry.size ?? 0;
   const links = contentLinks(repo, baseUrl, path, ref, entry.sha);
+  const encodedPath = encodeContentPath(path);
+  const encodedRef = encodeURIComponent(ref);
   const base = {
     type: "file",
     size,
@@ -48,7 +62,7 @@ function formatFileContent(
     url: links.self,
     git_url: links.git,
     html_url: links.html,
-    download_url: `${baseUrl}/${repo.full_name}/raw/${ref}/${path}`,
+    download_url: `${baseUrl}/${repo.full_name}/raw/${encodedRef}/${encodedPath}`,
     _links: { self: links.self, git: links.git, html: links.html },
   };
   if (!withContent) return base;
@@ -87,17 +101,22 @@ function formatDirListing(
   const dirs = [...dirNames].map((name) => {
     const path = prefix + name;
     const links = contentLinks(repo, baseUrl, path, ref);
+    const treeSha = flat.dirs.get(path) || null;
+    const gitUrl = treeSha ? `${baseUrl}/repos/${repo.full_name}/git/trees/${treeSha}` : null;
+    const encodedPath = encodeContentPath(path);
+    const encodedRef = encodeURIComponent(ref);
+    const htmlUrl = `${baseUrl}/${repo.full_name}/tree/${encodedRef}/${encodedPath}`;
     return {
       type: "dir",
       size: 0,
       name,
       path,
-      sha: flat.dirs.get(path) ?? "",
+      sha: treeSha ?? "",
       url: links.self,
-      git_url: null,
-      html_url: `${baseUrl}/${repo.full_name}/tree/${ref}/${path}`,
+      git_url: gitUrl,
+      html_url: htmlUrl,
       download_url: null,
-      _links: { self: links.self, git: null, html: `${baseUrl}/${repo.full_name}/tree/${ref}/${path}` },
+      _links: { self: links.self, git: gitUrl, html: htmlUrl },
     };
   });
 
@@ -105,13 +124,102 @@ function formatDirListing(
 }
 
 function decodeBodyContent(content: string): { text: string | null; base64: string } {
-  const buf = Buffer.from(content, "base64");
+  const normalized = content.replace(/\s/g, "");
+  if (
+    normalized.length % 4 === 1 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized) ||
+    normalized.slice(0, -2).includes("=")
+  ) {
+    throw new ApiError(422, "content is not valid Base64");
+  }
+  const buf = Buffer.from(normalized, "base64");
+  if (buf.toString("base64").replace(/=+$/, "") !== normalized.replace(/=+$/, "")) {
+    throw new ApiError(422, "content is not valid Base64");
+  }
   const text = buf.toString("utf8");
-  // Round-trips cleanly -> store as searchable utf-8 text; otherwise keep base64.
   if (!text.includes("\0") && Buffer.from(text, "utf8").equals(buf)) {
-    return { text, base64: content };
+    return { text, base64: normalized };
   }
   return { text: null, base64: buf.toString("base64") };
+}
+
+interface CommitIdentity {
+  name: string;
+  email: string;
+  date?: string;
+}
+
+function parseCommitIdentity(value: unknown, field: "author" | "committer"): CommitIdentity | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ApiError(422, `${field} must be an object`);
+  }
+  const input = value as Record<string, unknown>;
+  if (typeof input.name !== "string" || !input.name) {
+    throw new ApiError(422, `${field}.name is required`);
+  }
+  if (typeof input.email !== "string" || !input.email) {
+    throw new ApiError(422, `${field}.email is required`);
+  }
+  if (input.date !== undefined && (typeof input.date !== "string" || !Number.isFinite(Date.parse(input.date)))) {
+    throw new ApiError(422, `${field}.date must be an ISO 8601 timestamp`);
+  }
+  return {
+    name: input.name,
+    email: input.email,
+    ...(typeof input.date === "string" ? { date: input.date } : {}),
+  };
+}
+
+type FileTreeEntry = { mode: string; sha: string; size?: number };
+
+interface PendingTree {
+  files: Map<string, FileTreeEntry>;
+  dirs: Map<string, PendingTree>;
+}
+
+function persistTree(gh: GitHubStore, repoId: number, entries: Map<string, FileTreeEntry>): GitHubTree {
+  const root: PendingTree = { files: new Map(), dirs: new Map() };
+
+  for (const [path, entry] of entries) {
+    const parts = path.split("/");
+    let current = root;
+    for (const part of parts.slice(0, -1)) {
+      if (current.files.has(part)) throw new ApiError(422, `${path} conflicts with an existing file`);
+      let child = current.dirs.get(part);
+      if (!child) {
+        child = { files: new Map(), dirs: new Map() };
+        current.dirs.set(part, child);
+      }
+      current = child;
+    }
+    const name = parts.at(-1)!;
+    if (current.dirs.has(name)) throw new ApiError(422, `${path} conflicts with an existing directory`);
+    current.files.set(name, entry);
+  }
+
+  const write = (pending: PendingTree): GitHubTree => {
+    const treeEntries: GitHubTree["tree"] = [];
+    for (const [name, child] of [...pending.dirs].sort(([a], [b]) => a.localeCompare(b))) {
+      const subtree = write(child);
+      treeEntries.push({ path: name, mode: "040000", type: "tree", sha: subtree.sha });
+    }
+    for (const [name, entry] of [...pending.files].sort(([a], [b]) => a.localeCompare(b))) {
+      treeEntries.push({ path: name, mode: entry.mode, type: "blob", sha: entry.sha, size: entry.size });
+    }
+
+    const tree = gh.trees.insert({
+      repo_id: repoId,
+      sha: generateSha(),
+      node_id: "",
+      tree: treeEntries,
+      truncated: false,
+    } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
+    gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
+    return gh.trees.get(tree.id)!;
+  };
+
+  return write(root);
 }
 
 interface CommitFilesParams {
@@ -119,8 +227,8 @@ interface CommitFilesParams {
   branchName: string;
   message: string;
   actor: GitHubUser;
-  author?: { name?: string; email?: string; date?: string };
-  committer?: { name?: string; email?: string; date?: string };
+  author?: CommitIdentity;
+  committer?: CommitIdentity;
   /** path -> new entry, or null to delete the path */
   changes: Map<string, { mode: string; sha: string; size: number } | null>;
   headCommit: GitHubCommit | null;
@@ -140,33 +248,20 @@ function commitFiles(gh: GitHubStore, params: CommitFilesParams): GitHubCommit {
     else entries.set(path, change);
   }
 
-  const tree = gh.trees.insert({
-    repo_id: repo.id,
-    sha: generateSha(),
-    node_id: "",
-    tree: [...entries.entries()].map(([path, e]) => ({
-      path,
-      mode: e.mode,
-      type: "blob" as const,
-      sha: e.sha,
-      size: e.size,
-    })),
-    truncated: false,
-  } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
-  gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
+  const tree = persistTree(gh, repo.id, entries);
 
   const now = timestamp();
   const defaultName = actor.name ?? actor.login;
   const defaultEmail = actor.email ?? `${actor.login}@users.noreply.github.com`;
-  const author = {
-    name: params.author?.name ?? defaultName,
-    email: params.author?.email ?? defaultEmail,
-    date: params.author?.date ?? now,
-  };
   const committer = {
-    name: params.committer?.name ?? author.name,
-    email: params.committer?.email ?? author.email,
-    date: params.committer?.date ?? author.date,
+    name: params.committer?.name ?? defaultName,
+    email: params.committer?.email ?? defaultEmail,
+    date: params.committer?.date ?? now,
+  };
+  const author = {
+    name: params.author?.name ?? params.committer?.name ?? defaultName,
+    email: params.author?.email ?? params.committer?.email ?? defaultEmail,
+    date: params.author?.date ?? params.committer?.date ?? now,
   };
 
   const commit = gh.commits.insert({
@@ -281,19 +376,39 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const body = await parseJsonBody(c);
     if (typeof body.message !== "string" || !body.message) throw new ApiError(422, "message is required");
     if (typeof body.content !== "string") throw new ApiError(422, "content is required");
+    if (body.branch !== undefined && (typeof body.branch !== "string" || !body.branch)) {
+      throw new ApiError(422, "branch must be a non-empty string");
+    }
+    if (body.sha !== undefined && typeof body.sha !== "string") throw new ApiError(422, "sha must be a string");
+    const author = parseCommitIdentity(body.author, "author");
+    const committer = parseCommitIdentity(body.committer, "committer");
 
     const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
     const hasCommits = gh.commits.findBy("repo_id", repo.id).length > 0;
     const headCommit = resolveRefToCommit(gh, repo, branchName) ?? null;
     if (hasCommits && !headCommit) throw notFoundResponse();
 
-    const existing = headCommit ? flattenTree(gh, repo.id, headCommit.tree_sha).blobs.get(path) : undefined;
+    const flat = headCommit ? flattenTree(gh, repo.id, headCommit.tree_sha) : undefined;
+    const existing = flat?.blobs.get(path);
     if (existing) {
       if (typeof body.sha !== "string") {
         throw new ApiError(422, `"sha" wasn't supplied. ${path} already exists.`);
       }
       if (body.sha !== existing.sha) {
         throw new ApiError(409, `${path} does not match ${body.sha}`);
+      }
+    } else {
+      if (body.sha !== undefined) throw new ApiError(422, `${path} does not exist`);
+      const parts = path.split("/");
+      for (let i = 1; i < parts.length; i++) {
+        const parent = parts.slice(0, i).join("/");
+        if (flat?.blobs.has(parent)) throw new ApiError(422, `${path} conflicts with an existing file`);
+      }
+      if (
+        flat?.dirs.has(path) ||
+        [...(flat?.blobs.keys() ?? [])].some((candidate) => candidate.startsWith(`${path}/`))
+      ) {
+        throw new ApiError(422, `${path} conflicts with an existing directory`);
       }
     }
 
@@ -315,8 +430,8 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
       branchName,
       message: body.message,
       actor: user,
-      author: body.author as CommitFilesParams["author"],
-      committer: body.committer as CommitFilesParams["committer"],
+      author,
+      committer,
       changes: new Map([[path, { mode: existing?.mode ?? "100644", sha: gh.blobs.get(blob.id)!.sha, size }]]),
       headCommit,
     });
@@ -363,10 +478,16 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
     const user = assertRepoWrite(gh, c.get("authUser"), repo);
+    if (!path) throw new ApiError(422, "path is required");
 
     const body = await parseJsonBody(c);
     if (typeof body.message !== "string" || !body.message) throw new ApiError(422, "message is required");
     if (typeof body.sha !== "string") throw new ApiError(422, "sha is required");
+    if (body.branch !== undefined && (typeof body.branch !== "string" || !body.branch)) {
+      throw new ApiError(422, "branch must be a non-empty string");
+    }
+    const author = parseCommitIdentity(body.author, "author");
+    const committer = parseCommitIdentity(body.committer, "committer");
 
     const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
     const headCommit = resolveRefToCommit(gh, repo, branchName);
@@ -383,8 +504,8 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
       branchName,
       message: body.message,
       actor: user,
-      author: body.author as CommitFilesParams["author"],
-      committer: body.committer as CommitFilesParams["committer"],
+      author,
+      committer,
       changes: new Map([[path, null]]),
       headCommit,
     });

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -12,7 +12,13 @@ import type {
   GitHubUser,
 } from "../entities.js";
 import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
-import { assertRepoContentsWrite, assertRepoRead, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import {
+  assertBranchUpdateAllowed,
+  assertRepoContentsWrite,
+  assertRepoRead,
+  notFoundResponse,
+  ownerLoginOf,
+} from "../route-helpers.js";
 import {
   encodeContentPath,
   flattenTree,
@@ -423,6 +429,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const hasCommits = gh.commits.findBy("repo_id", repo.id).length > 0;
     const headCommit = resolveBranchToCommit(gh, repo, branchName) ?? null;
     if (hasCommits && !headCommit) throw notFoundResponse();
+    assertBranchUpdateAllowed(gh, user, repo, branchName, { parentCount: headCommit ? 1 : 0 });
 
     const flat = headCommit ? flattenTree(gh, repo.id, headCommit.tree_sha) : undefined;
     const existing = flat?.blobs.get(path);
@@ -528,6 +535,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
     const headCommit = resolveBranchToCommit(gh, repo, branchName);
     if (!headCommit) throw notFoundResponse();
+    assertBranchUpdateAllowed(gh, user, repo, branchName, { parentCount: 1 });
 
     const existing = flattenTree(gh, repo.id, headCommit.tree_sha).blobs.get(path);
     if (!existing) throw notFoundResponse();

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -2,25 +2,20 @@ import type { AppEnv, Context, RouteContext } from "@emulators/core";
 import { ApiError, parseJsonBody } from "@emulators/core";
 import { getGitHubStore } from "../store.js";
 import type { GitHubStore } from "../store.js";
-import type {
-  GitHubBlob,
-  GitHubBranch,
-  GitHubCommit,
-  GitHubRef,
-  GitHubRepo,
-  GitHubTree,
-  GitHubUser,
-} from "../entities.js";
+import type { GitHubBranch, GitHubCommit, GitHubRef, GitHubRepo, GitHubTree, GitHubUser } from "../entities.js";
 import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
 import {
   assertBranchUpdateAllowed,
+  assertRepoContentsRead,
   assertRepoContentsWrite,
-  assertRepoRead,
   notFoundResponse,
   ownerLoginOf,
 } from "../route-helpers.js";
 import {
+  blobBytes,
   encodeContentPath,
+  findOrCreateBlob,
+  findOrCreateTree,
   flattenTree,
   formatGitCommit,
   resolveBranchToCommit,
@@ -79,10 +74,6 @@ function formatFileContent(
       : Buffer.from(blob.content, "utf8").toString("base64")
     : "";
   return { ...base, content, encoding: "base64" };
-}
-
-function blobBytes(blob: GitHubBlob): Buffer {
-  return blob.encoding === "base64" ? Buffer.from(blob.content, "base64") : Buffer.from(blob.content, "utf8");
 }
 
 function formatDirListing(
@@ -219,15 +210,7 @@ function persistTree(gh: GitHubStore, repoId: number, entries: Map<string, FileT
       treeEntries.push({ path: name, mode: entry.mode, type: "blob", sha: entry.sha, size: entry.size });
     }
 
-    const tree = gh.trees.insert({
-      repo_id: repoId,
-      sha: generateSha(),
-      node_id: "",
-      tree: treeEntries,
-      truncated: false,
-    } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
-    gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
-    return gh.trees.get(tree.id)!;
+    return findOrCreateTree(gh, repoId, treeEntries);
   };
 
   return write(root);
@@ -331,7 +314,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const refParam = c.req.query("ref");
     const commit = resolveRefToCommit(gh, repo, refParam);
@@ -360,7 +343,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const path = normalizePath(c.req.param("path")!);
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const commit = resolveRefToCommit(gh, repo, ref);
     if (!commit) throw notFoundResponse();
@@ -380,7 +363,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const refParam = c.req.query("ref");
     const commit = resolveRefToCommit(gh, repo, refParam);
@@ -456,17 +439,9 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     }
 
     const decoded = decodeBodyContent(body.content);
-    const size =
-      decoded.text !== null ? Buffer.byteLength(decoded.text, "utf8") : Buffer.from(decoded.base64, "base64").length;
-    const blob = gh.blobs.insert({
-      repo_id: repo.id,
-      sha: generateSha(),
-      node_id: "",
-      content: decoded.text ?? decoded.base64,
-      encoding: decoded.text !== null ? "utf-8" : "base64",
-      size,
-    } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
-    gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
+    const bytes = decoded.text !== null ? Buffer.from(decoded.text, "utf8") : Buffer.from(decoded.base64, "base64");
+    const blob = findOrCreateBlob(gh, repo.id, bytes);
+    const size = blob.size;
 
     const commit = commitFiles(gh, {
       repo,
@@ -475,7 +450,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
       actor: user,
       author,
       committer,
-      changes: new Map([[path, { mode: existing?.mode ?? "100644", sha: gh.blobs.get(blob.id)!.sha, size }]]),
+      changes: new Map([[path, { mode: existing?.mode ?? "100644", sha: blob.sha, size }]]),
       headCommit,
     });
 
@@ -504,7 +479,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
       repo.name,
     );
 
-    const entry = { mode: existing?.mode ?? "100644", sha: gh.blobs.get(blob.id)!.sha, size };
+    const entry = { mode: existing?.mode ?? "100644", sha: blob.sha, size };
     return c.json(
       {
         content: formatFileContent(gh, repo, baseUrl, path, branchName, entry, false),

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -8,6 +8,7 @@ import {
   assertBranchUpdateAllowed,
   assertRepoContentsRead,
   assertRepoContentsWrite,
+  assertRepoPermission,
   notFoundResponse,
   ownerLoginOf,
 } from "../route-helpers.js";
@@ -30,6 +31,10 @@ function normalizePath(raw: string): string {
     throw new ApiError(422, "path is invalid");
   }
   return path;
+}
+
+function isWorkflowPath(path: string): boolean {
+  return path.startsWith(".github/workflows/");
 }
 
 function contentLinks(repo: GitHubRepo, baseUrl: string, path: string, ref: string, blobSha?: string) {
@@ -174,7 +179,7 @@ function parseCommitIdentity(value: unknown, field: "author" | "committer"): Com
   };
 }
 
-type FileTreeEntry = { mode: string; sha: string; size?: number };
+type FileTreeEntry = { mode: string; type: "blob" | "commit"; sha: string; size?: number };
 
 interface PendingTree {
   files: Map<string, FileTreeEntry>;
@@ -208,7 +213,7 @@ function persistTree(gh: GitHubStore, repoId: number, entries: Map<string, FileT
       treeEntries.push({ path: name, mode: "040000", type: "tree", sha: subtree.sha });
     }
     for (const [name, entry] of [...pending.files].sort(([a], [b]) => a.localeCompare(b))) {
-      treeEntries.push({ path: name, mode: entry.mode, type: "blob", sha: entry.sha, size: entry.size });
+      treeEntries.push({ path: name, mode: entry.mode, type: entry.type, sha: entry.sha, size: entry.size });
     }
 
     return findOrCreateTree(gh, repoId, treeEntries);
@@ -225,14 +230,14 @@ interface CommitFilesParams {
   author?: CommitIdentity;
   committer?: CommitIdentity;
   /** path -> new entry, or null to delete the path */
-  changes: Map<string, { mode: string; sha: string; size: number } | null>;
+  changes: Map<string, FileTreeEntry | null>;
   headCommit: GitHubCommit | null;
 }
 
 function commitFiles(gh: GitHubStore, params: CommitFilesParams): GitHubCommit {
   const { repo, branchName, headCommit, actor } = params;
 
-  const entries = new Map<string, { mode: string; sha: string; size?: number }>();
+  const entries = new Map<string, FileTreeEntry>();
   if (headCommit) {
     for (const [path, entry] of flattenTree(gh, repo.id, headCommit.tree_sha).blobs) {
       entries.set(path, entry);
@@ -391,8 +396,10 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const path = normalizePath(c.req.param("path")!);
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const user = assertRepoContentsWrite(gh, c.get("authUser"), repo);
+    const authUser = c.get("authUser");
+    const user = assertRepoContentsWrite(gh, authUser, repo);
     if (!path) throw new ApiError(422, "path is required");
+    if (isWorkflowPath(path)) assertRepoPermission(gh, authUser, repo, "workflows", "write");
 
     const body = await parseJsonBody(c);
     if (typeof body.message !== "string" || !body.message) throw new ApiError(422, "message is required");
@@ -446,7 +453,17 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
       actor: user,
       author,
       committer,
-      changes: new Map([[path, { mode: existing?.mode ?? "100644", sha: blob.sha, size }]]),
+      changes: new Map([
+        [
+          path,
+          {
+            mode: existing?.type === "blob" ? existing.mode : "100644",
+            type: "blob" as const,
+            sha: blob.sha,
+            size,
+          },
+        ],
+      ]),
       headCommit,
     });
 
@@ -475,7 +492,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
       repo.name,
     );
 
-    const entry = { mode: existing?.mode ?? "100644", sha: blob.sha, size };
+    const entry = { mode: existing?.type === "blob" ? existing.mode : "100644", sha: blob.sha, size };
     return c.json(
       {
         content: formatFileContent(gh, repo, baseUrl, path, branchName, entry, false),
@@ -491,8 +508,10 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const path = normalizePath(c.req.param("path")!);
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const user = assertRepoContentsWrite(gh, c.get("authUser"), repo);
+    const authUser = c.get("authUser");
+    const user = assertRepoContentsWrite(gh, authUser, repo);
     if (!path) throw new ApiError(422, "path is required");
+    if (isWorkflowPath(path)) assertRepoPermission(gh, authUser, repo, "workflows", "write");
 
     const body = await parseJsonBody(c);
     if (typeof body.message !== "string" || !body.message) throw new ApiError(422, "message is required");

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -3,7 +3,7 @@ import { ApiError, parseJsonBody } from "@emulators/core";
 import { getGitHubStore } from "../store.js";
 import type { GitHubStore } from "../store.js";
 import type { GitHubBranch, GitHubCommit, GitHubRef, GitHubRepo, GitHubTree, GitHubUser } from "../entities.js";
-import { formatRepo, formatUser, generateNodeId, generateSha, lookupRepo, timestamp } from "../helpers.js";
+import { formatRepo, formatUser, generateNodeId, lookupRepo, timestamp } from "../helpers.js";
 import {
   assertBranchUpdateAllowed,
   assertRepoContentsRead,
@@ -15,6 +15,7 @@ import {
   blobBytes,
   encodeContentPath,
   findOrCreateBlob,
+  findOrCreateCommit,
   findOrCreateTree,
   flattenTree,
   formatGitCommit,
@@ -258,10 +259,7 @@ function commitFiles(gh: GitHubStore, params: CommitFilesParams): GitHubCommit {
     date: params.author?.date ?? params.committer?.date ?? now,
   };
 
-  const commit = gh.commits.insert({
-    repo_id: repo.id,
-    sha: generateSha(),
-    node_id: "",
+  const saved = findOrCreateCommit(gh, repo.id, {
     message: params.message,
     author_name: author.name,
     author_email: author.email,
@@ -272,9 +270,7 @@ function commitFiles(gh: GitHubStore, params: CommitFilesParams): GitHubCommit {
     tree_sha: tree.sha,
     parent_shas: headCommit ? [headCommit.sha] : [],
     user_id: actor.id,
-  } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
-  gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
-  const saved = gh.commits.get(commit.id)!;
+  });
 
   const fullRef = `refs/heads/${branchName}`;
   const refRec = gh.refs.findBy("repo_id", repo.id).find((r) => r.ref === fullRef);

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -37,6 +37,8 @@ function isWorkflowPath(path: string): boolean {
   return path.startsWith(".github/workflows/");
 }
 
+type FileTreeEntry = { mode: string; type: "blob" | "commit"; sha: string; size?: number };
+
 function contentLinks(repo: GitHubRepo, baseUrl: string, path: string, ref: string, blobSha?: string) {
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
   const encodedPath = encodeContentPath(path);
@@ -47,24 +49,161 @@ function contentLinks(repo: GitHubRepo, baseUrl: string, path: string, ref: stri
   return { self, html, git };
 }
 
+function findBlob(gh: GitHubStore, repoId: number, sha: string) {
+  return gh.blobs.findBy("repo_id", repoId).find((blob) => blob.sha === sha);
+}
+
+function blobBase64(blob: ReturnType<typeof findBlob>): string {
+  if (!blob) return "";
+  return blob.encoding === "base64" ? blob.content : Buffer.from(blob.content, "utf8").toString("base64");
+}
+
+function resolveSymlinkPath(path: string, target: string): string | undefined {
+  if (!target || target.startsWith("/") || target.includes("\0")) return undefined;
+  const parts = path.split("/").slice(0, -1);
+  for (const part of target.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (!parts.length) return undefined;
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+  return parts.join("/");
+}
+
+function resolveSymlinkEntry(
+  gh: GitHubStore,
+  repoId: number,
+  path: string,
+  entry: FileTreeEntry,
+  flat: FlatTree,
+): FileTreeEntry | undefined {
+  if (entry.mode !== "120000" || entry.type !== "blob") return undefined;
+  const link = findBlob(gh, repoId, entry.sha);
+  if (!link) return undefined;
+  const targetPath = resolveSymlinkPath(path, blobBytes(link).toString("utf8"));
+  if (!targetPath) return undefined;
+  const target = flat.blobs.get(targetPath);
+  return target?.type === "blob" && (target.mode === "100644" || target.mode === "100755") ? target : undefined;
+}
+
+function submoduleUrls(gh: GitHubStore, repoId: number, flat: FlatTree): Map<string, string> {
+  const result = new Map<string, string>();
+  const entry = flat.blobs.get(".gitmodules");
+  if (!entry || entry.type !== "blob") return result;
+  const blob = findBlob(gh, repoId, entry.sha);
+  if (!blob) return result;
+
+  let current: { path?: string; url?: string } | undefined;
+  const save = () => {
+    if (current?.path && current.url) result.set(current.path, current.url);
+  };
+  for (const line of blobBytes(blob).toString("utf8").split(/\r?\n/)) {
+    if (/^\s*\[submodule\s+"(?:[^"\\]|\\.)*"\]\s*(?:[#;].*)?$/.test(line)) {
+      save();
+      current = {};
+      continue;
+    }
+    if (!current) continue;
+    const property = line.match(/^\s*(path|url)\s*=\s*(.*?)\s*$/);
+    if (!property) continue;
+    current[property[1] as "path" | "url"] = property[2];
+  }
+  save();
+  return result;
+}
+
+function githubSubmoduleFullName(repo: GitHubRepo, url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  const hosted = url.match(
+    /^(?:(?:https?|git):\/\/github\.com\/|ssh:\/\/git@github\.com\/|git@github\.com:)([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
+  );
+  if (hosted) return `${hosted[1]}/${hosted[2]}`;
+  const relative = url.match(/^\.\.\/([^/]+?)(?:\.git)?\/?$/);
+  if (relative) return `${repo.full_name.split("/")[0]}/${relative[1]}`;
+  return undefined;
+}
+
 function formatFileContent(
   gh: GitHubStore,
   repo: GitHubRepo,
   baseUrl: string,
   path: string,
   ref: string,
-  entry: { mode: string; sha: string; size?: number },
+  entry: FileTreeEntry,
   withContent: boolean,
+  flat?: FlatTree,
 ) {
-  const blob = gh.blobs.findBy("repo_id", repo.id).find((b) => b.sha === entry.sha);
-  const size = blob?.size ?? entry.size ?? 0;
-  const links = contentLinks(repo, baseUrl, path, ref, entry.sha);
+  const name = path.split("/").pop()!;
   const encodedPath = encodeContentPath(path);
   const encodedRef = encodeURIComponent(ref);
+  const self = contentLinks(repo, baseUrl, path, ref).self;
+
+  if (entry.type === "commit" || entry.mode === "160000") {
+    const submoduleUrl = flat ? submoduleUrls(gh, repo.id, flat).get(path) : undefined;
+    const fullName = githubSubmoduleFullName(repo, submoduleUrl);
+    const gitUrl = fullName ? `${baseUrl}/repos/${fullName}/git/trees/${entry.sha}` : null;
+    const htmlUrl = fullName ? `${baseUrl}/${fullName}/tree/${entry.sha}` : null;
+    return {
+      type: withContent ? "submodule" : "file",
+      submodule_git_url: submoduleUrl ?? null,
+      size: 0,
+      name,
+      path,
+      sha: entry.sha,
+      url: self,
+      git_url: gitUrl,
+      html_url: htmlUrl,
+      download_url: null,
+      _links: { self, git: gitUrl, html: htmlUrl },
+    };
+  }
+
+  const blob = findBlob(gh, repo.id, entry.sha);
+  if (entry.mode === "120000") {
+    const target = blob ? blobBytes(blob).toString("utf8") : "";
+    const resolved = flat ? resolveSymlinkEntry(gh, repo.id, path, entry, flat) : undefined;
+    if (!resolved) {
+      const links = contentLinks(repo, baseUrl, path, ref, entry.sha);
+      return {
+        type: "symlink",
+        target,
+        size: blob?.size ?? entry.size ?? 0,
+        name,
+        path,
+        sha: entry.sha,
+        url: links.self,
+        git_url: links.git,
+        html_url: links.html,
+        download_url: `${baseUrl}/${repo.full_name}/raw/${encodedRef}/${encodedPath}`,
+        _links: { self: links.self, git: links.git, html: links.html },
+      };
+    }
+    const targetBlob = findBlob(gh, repo.id, resolved.sha);
+    const links = contentLinks(repo, baseUrl, path, ref, entry.sha);
+    const base = {
+      type: "file",
+      size: targetBlob?.size ?? resolved.size ?? 0,
+      name,
+      path,
+      sha: entry.sha,
+      url: links.self,
+      git_url: links.git,
+      html_url: links.html,
+      download_url: `${baseUrl}/${repo.full_name}/raw/${encodedRef}/${encodedPath}`,
+      _links: { self: links.self, git: links.git, html: links.html },
+    };
+    return withContent ? { ...base, content: blobBase64(targetBlob), encoding: "base64" } : base;
+  }
+
+  const size = blob?.size ?? entry.size ?? 0;
+  const links = contentLinks(repo, baseUrl, path, ref, entry.sha);
   const base = {
     type: "file",
     size,
-    name: path.split("/").pop()!,
+    name,
     path,
     sha: entry.sha,
     url: links.self,
@@ -74,12 +213,7 @@ function formatFileContent(
     _links: { self: links.self, git: links.git, html: links.html },
   };
   if (!withContent) return base;
-  const content = blob
-    ? blob.encoding === "base64"
-      ? blob.content
-      : Buffer.from(blob.content, "utf8").toString("base64")
-    : "";
-  return { ...base, content, encoding: "base64" };
+  return { ...base, content: blobBase64(blob), encoding: "base64" };
 }
 
 function formatDirListing(
@@ -100,7 +234,7 @@ function formatDirListing(
     if (!rest) continue;
     const slash = rest.indexOf("/");
     if (slash === -1) {
-      files.push(formatFileContent(gh, repo, baseUrl, path, ref, entry, false));
+      files.push(formatFileContent(gh, repo, baseUrl, path, ref, entry, false, flat));
     } else {
       dirNames.add(rest.slice(0, slash));
     }
@@ -178,8 +312,6 @@ function parseCommitIdentity(value: unknown, field: "author" | "committer"): Com
     ...(typeof input.date === "string" ? { date: input.date } : {}),
   };
 }
-
-type FileTreeEntry = { mode: string; type: "blob" | "commit"; sha: string; size?: number };
 
 interface PendingTree {
   files: Map<string, FileTreeEntry>;
@@ -328,7 +460,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     }
     const entry = flat.blobs.get(path);
     if (entry) {
-      return c.json(formatFileContent(gh, repo, baseUrl, path, ref, entry, true));
+      return c.json(formatFileContent(gh, repo, baseUrl, path, ref, entry, true, flat));
     }
     const prefix = `${path}/`;
     if (flat.dirs.has(path) || [...flat.blobs.keys()].some((p) => p.startsWith(prefix))) {
@@ -348,9 +480,11 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
 
     const commit = resolveRefToCommit(gh, repo, ref);
     if (!commit) throw notFoundResponse();
-    const entry = flattenTree(gh, repo.id, commit.tree_sha).blobs.get(path);
+    const flat = flattenTree(gh, repo.id, commit.tree_sha);
+    const entry = flat.blobs.get(path);
     if (!entry) throw notFoundResponse();
-    const blob = gh.blobs.findBy("repo_id", repo.id).find((candidate) => candidate.sha === entry.sha);
+    const resolved = resolveSymlinkEntry(gh, repo.id, path, entry, flat);
+    const blob = findBlob(gh, repo.id, resolved?.sha ?? entry.sha);
     if (!blob) throw notFoundResponse();
     const content = blobBytes(blob);
     return c.body(content, 200, {
@@ -383,7 +517,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
         .sort()[0];
     const readmePath = findReadme(".github") ?? findReadme("") ?? findReadme("docs");
     if (!readmePath) throw notFoundResponse();
-    return c.json(formatFileContent(gh, repo, baseUrl, readmePath, ref, flat.blobs.get(readmePath)!, true));
+    return c.json(formatFileContent(gh, repo, baseUrl, readmePath, ref, flat.blobs.get(readmePath)!, true, flat));
   });
 
   app.get("/repos/:owner/:repo/contents", (c) => getContents(c, ""));
@@ -412,9 +546,11 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const committer = parseCommitIdentity(body.committer, "committer");
 
     const branchName = typeof body.branch === "string" && body.branch ? body.branch : repo.default_branch;
-    const hasCommits = gh.commits.findBy("repo_id", repo.id).length > 0;
+    const hasBranches =
+      gh.refs.findBy("repo_id", repo.id).some((ref) => ref.ref.startsWith("refs/heads/")) ||
+      gh.branches.findBy("repo_id", repo.id).length > 0;
     const headCommit = resolveBranchToCommit(gh, repo, branchName) ?? null;
-    if (hasCommits && !headCommit) throw notFoundResponse();
+    if (hasBranches && !headCommit) throw notFoundResponse();
     assertBranchUpdateAllowed(gh, user, repo, branchName, { parentCount: headCommit ? 1 : 0 });
 
     const flat = headCommit ? flattenTree(gh, repo.id, headCommit.tree_sha) : undefined;
@@ -492,7 +628,12 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
       repo.name,
     );
 
-    const entry = { mode: existing?.type === "blob" ? existing.mode : "100644", sha: blob.sha, size };
+    const entry: FileTreeEntry = {
+      mode: existing?.type === "blob" ? existing.mode : "100644",
+      type: "blob",
+      sha: blob.sha,
+      size,
+    };
     return c.json(
       {
         content: formatFileContent(gh, repo, baseUrl, path, branchName, entry, false),

--- a/packages/@emulators/github/src/routes/issues.ts
+++ b/packages/@emulators/github/src/routes/issues.ts
@@ -2,7 +2,7 @@ import type { Context } from "@emulators/core";
 import type { RouteContext } from "@emulators/core";
 import { ApiError, parseJsonBody, parsePagination, setLinkHeader } from "@emulators/core";
 import { getGitHubStore } from "../store.js";
-import { assertIssueWrite, assertRepoRead, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import { assertIssueWrite, assertRepoPermission, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
 import type { GitHubStore } from "../store.js";
 import type { GitHubIssue, GitHubIssueEvent, GitHubLabel, GitHubRepo, GitHubUser } from "../entities.js";
 import {
@@ -207,7 +207,7 @@ export function issuesRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "issues");
     if (!repo.has_issues) throw notFoundResponse();
 
     const { page, per_page } = parsePagination(c);
@@ -361,7 +361,7 @@ export function issuesRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "issues");
     if (!repo.has_issues) throw notFoundResponse();
 
     const issueNumber = parseInt(c.req.param("issue_number")!, 10);
@@ -747,7 +747,7 @@ export function issuesRoutes({ app, store, webhooks, baseUrl }: RouteContext): v
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "issues");
     if (!repo.has_issues) throw notFoundResponse();
 
     const issueNumber = parseInt(c.req.param("issue_number")!, 10);

--- a/packages/@emulators/github/src/routes/labels.ts
+++ b/packages/@emulators/github/src/routes/labels.ts
@@ -249,8 +249,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);
 
-    const rawName = c.req.param("name")!;
-    const name = decodeURIComponent(rawName);
+    const name = c.req.param("name")!;
     const label = gh.labels.findBy("repo_id", repo.id).find((l) => l.name === name);
     if (!label) throw notFoundResponse();
     return c.json(formatLabel(label, repo, baseUrl));
@@ -263,8 +262,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     if (!repo) throw notFoundResponse();
     const actor = assertIssueWrite(gh, c.get("authUser"), repo);
 
-    const rawName = c.req.param("name")!;
-    const name = decodeURIComponent(rawName);
+    const name = c.req.param("name")!;
     let label = gh.labels.findBy("repo_id", repo.id).find((l) => l.name === name);
     if (!label) throw notFoundResponse();
     const labelId = label.id;
@@ -313,8 +311,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     if (!repo) throw notFoundResponse();
     const actor = assertIssueWrite(gh, c.get("authUser"), repo);
 
-    const rawName = c.req.param("name")!;
-    const name = decodeURIComponent(rawName);
+    const name = c.req.param("name")!;
     const label = gh.labels.findBy("repo_id", repo.id).find((l) => l.name === name);
     if (!label) throw notFoundResponse();
 
@@ -497,8 +494,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     const issue = findIssueByNumber(gh, repo.id, issueNumber);
     if (!issue) throw notFoundResponse();
 
-    const rawLabelName = c.req.param("name")!;
-    const labelName = decodeURIComponent(rawLabelName);
+    const labelName = c.req.param("name")!;
     const label = gh.labels.findBy("repo_id", repo.id).find((l) => l.name === labelName);
     if (!label || !issue.label_ids.includes(label.id)) throw notFoundResponse();
 

--- a/packages/@emulators/github/src/routes/labels.ts
+++ b/packages/@emulators/github/src/routes/labels.ts
@@ -23,7 +23,7 @@ import {
   lookupRepo,
   timestamp,
 } from "../helpers.js";
-import { assertIssueWrite, assertRepoRead, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import { assertIssueWrite, assertRepoPermission, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
 
 function findIssueByNumber(gh: GitHubStore, repoId: number, issueNumber: number): GitHubIssue | undefined {
   return gh.issues.findBy("repo_id", repoId).find((i) => i.number === issueNumber);
@@ -184,7 +184,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, ["issues", "pull_requests"]);
 
     const { page, per_page } = parsePagination(c);
     const list = gh.labels.findBy("repo_id", repo.id).slice();
@@ -247,7 +247,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, ["issues", "pull_requests"]);
 
     const name = c.req.param("name")!;
     const label = gh.labels.findBy("repo_id", repo.id).find((l) => l.name === name);
@@ -340,7 +340,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, ["issues", "pull_requests"]);
     if (!repo.has_issues) throw notFoundResponse();
 
     const issueNumber = parseInt(c.req.param("issue_number")!, 10);
@@ -548,7 +548,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "issues");
     if (!repo.has_issues) throw notFoundResponse();
 
     const stateQ = c.req.query("state") ?? "open";
@@ -646,7 +646,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "issues");
     if (!repo.has_issues) throw notFoundResponse();
 
     const n = parseInt(c.req.param("milestone_number")!, 10);
@@ -790,7 +790,7 @@ export function labelsAndMilestonesRoutes({ app, store, webhooks, baseUrl }: Rou
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "issues");
     if (!repo.has_issues) throw notFoundResponse();
 
     const n = parseInt(c.req.param("milestone_number")!, 10);

--- a/packages/@emulators/github/src/routes/pulls.ts
+++ b/packages/@emulators/github/src/routes/pulls.ts
@@ -28,6 +28,7 @@ import {
   lookupRepo,
   timestamp,
 } from "../helpers.js";
+import { findOrCreateCommit } from "../git-helpers.js";
 
 function findPull(gh: GitHubStore, repoId: number, pullNumber: number): GitHubPullRequest | undefined {
   return gh.pullRequests.findBy("repo_id", repoId).find((p) => p.number === pullNumber);
@@ -145,10 +146,7 @@ function insertCommit(
   const login = u?.login ?? "user";
   const email = u?.email ?? `${login}@users.noreply.github.com`;
   const now = timestamp();
-  const row = gh.commits.insert({
-    repo_id: repo.id,
-    sha: generateSha(),
-    node_id: "",
+  return findOrCreateCommit(gh, repo.id, {
     message: opts.message,
     author_name: authorName,
     author_email: email,
@@ -159,9 +157,7 @@ function insertCommit(
     tree_sha: opts.treeSha,
     parent_shas: opts.parentShas,
     user_id: u?.id ?? null,
-  } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
-  gh.commits.update(row.id, { node_id: generateNodeId("Commit", row.id) });
-  return gh.commits.get(row.id)!;
+  });
 }
 
 function formatCommitApi(commit: GitHubCommit, repo: GitHubRepo, baseUrl: string) {

--- a/packages/@emulators/github/src/routes/pulls.ts
+++ b/packages/@emulators/github/src/routes/pulls.ts
@@ -3,7 +3,7 @@ import { ApiError, parseJsonBody, parsePagination, setLinkHeader } from "@emulat
 import { getGitHubStore } from "../store.js";
 import {
   assertAuthenticatedUser,
-  assertRepoRead,
+  assertRepoPermission,
   assertRepoWrite,
   notFoundResponse,
   ownerLoginOf,
@@ -310,7 +310,7 @@ export function pullsRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const stateQ = c.req.query("state") ?? "open";
     const state: "open" | "closed" | "all" =
@@ -472,7 +472,7 @@ export function pullsRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const pullNumber = parseInt(c.req.param("pull_number")!, 10);
     if (!Number.isFinite(pullNumber)) throw notFoundResponse();
@@ -728,7 +728,7 @@ export function pullsRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const pullNumber = parseInt(c.req.param("pull_number")!, 10);
     if (!Number.isFinite(pullNumber)) throw notFoundResponse();
@@ -754,7 +754,7 @@ export function pullsRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const pullNumber = parseInt(c.req.param("pull_number")!, 10);
     if (!Number.isFinite(pullNumber)) throw notFoundResponse();

--- a/packages/@emulators/github/src/routes/releases.ts
+++ b/packages/@emulators/github/src/routes/releases.ts
@@ -153,7 +153,7 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     if (!repo) throw notFoundResponse();
     assertRepoRead(gh, c.get("authUser"), repo);
 
-    const tag = decodeURIComponent(c.req.param("tag")!);
+    const tag = c.req.param("tag")!;
     const release = findReleaseByTag(gh, repo.id, tag);
     if (!release) throw notFoundResponse();
     assertReleaseVisible(gh, c.get("authUser"), release);

--- a/packages/@emulators/github/src/routes/releases.ts
+++ b/packages/@emulators/github/src/routes/releases.ts
@@ -12,7 +12,14 @@ import {
   lookupRepo,
   timestamp,
 } from "../helpers.js";
-import { assertRepoRead, assertRepoWrite, getActorUser, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import {
+  assertRepoContentsRead,
+  assertRepoPermission,
+  assertRepoWrite,
+  getActorUser,
+  notFoundResponse,
+  ownerLoginOf,
+} from "../route-helpers.js";
 
 /** Draft releases are omitted for anonymous API clients; any authenticated user may see them once repo read is allowed. */
 function isAuthenticatedActor(gh: GitHubStore, authUser: AuthUser | undefined): boolean {
@@ -87,7 +94,7 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const authUser = c.get("authUser");
     const showDrafts = isAuthenticatedActor(gh, authUser);
@@ -113,7 +120,9 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    const authUser = c.get("authUser");
+    assertRepoPermission(gh, authUser, repo, "contents", "write");
+    if (!authUser?.installation) assertRepoWrite(gh, authUser, repo);
 
     const body = await parseJsonBody(c);
     const tagName = typeof body.tag_name === "string" ? body.tag_name : "";
@@ -130,7 +139,7 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const candidates = releasesForRepo(gh, repo.id).filter((r) => !r.draft && !r.prerelease && r.published_at);
     if (candidates.length === 0) throw notFoundResponse();
@@ -151,7 +160,7 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const tag = c.req.param("tag")!;
     const release = findReleaseByTag(gh, repo.id, tag);
@@ -168,7 +177,7 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const assetId = parseInt(c.req.param("asset_id")!, 10);
     if (!Number.isFinite(assetId)) throw notFoundResponse();
@@ -293,7 +302,7 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const releaseId = parseInt(c.req.param("release_id")!, 10);
     if (!Number.isFinite(releaseId)) throw notFoundResponse();
@@ -381,7 +390,7 @@ export function releasesRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoContentsRead(gh, c.get("authUser"), repo);
 
     const releaseId = parseInt(c.req.param("release_id")!, 10);
     if (!Number.isFinite(releaseId)) throw notFoundResponse();

--- a/packages/@emulators/github/src/routes/repos.ts
+++ b/packages/@emulators/github/src/routes/repos.ts
@@ -10,18 +10,10 @@ import {
   ownerLoginOf,
 } from "../route-helpers.js";
 import type { GitHubStore } from "../store.js";
-import type {
-  GitHubBranch,
-  GitHubCollaborator,
-  GitHubCommit,
-  GitHubRef,
-  GitHubRepo,
-  GitHubTag,
-  GitHubUser,
-} from "../entities.js";
+import type { GitHubBranch, GitHubCollaborator, GitHubRef, GitHubRepo, GitHubTag, GitHubUser } from "../entities.js";
 import type { Collection, Entity } from "@emulators/core";
-import { formatRepo, formatUser, generateNodeId, generateSha, lookupOwner, lookupRepo, timestamp } from "../helpers.js";
-import { findOrCreateBlob, findOrCreateTree } from "../git-helpers.js";
+import { formatRepo, formatUser, generateNodeId, lookupOwner, lookupRepo, timestamp } from "../helpers.js";
+import { findOrCreateBlob, findOrCreateCommit, findOrCreateTree } from "../git-helpers.js";
 
 const LICENSE_TEMPLATES: Record<string, { key: string; name: string; spdx_id: string }> = {
   mit: { key: "mit", name: "MIT License", spdx_id: "MIT" },
@@ -64,10 +56,7 @@ function seedInitialGit(gh: GitHubStore, repo: GitHubRepo, actor: GitHubUser | n
   const email = actor?.email ?? `${login}@users.noreply.github.com`;
   const now = timestamp();
 
-  const commit = gh.commits.insert({
-    repo_id: repoId,
-    sha: generateSha(),
-    node_id: "",
+  const commit = findOrCreateCommit(gh, repoId, {
     message: "Initial commit",
     author_name: authorName,
     author_email: email,
@@ -78,8 +67,7 @@ function seedInitialGit(gh: GitHubStore, repo: GitHubRepo, actor: GitHubUser | n
     tree_sha: tree.sha,
     parent_shas: [],
     user_id: actor?.id ?? null,
-  } as Omit<GitHubCommit, "id" | "created_at" | "updated_at">);
-  gh.commits.update(commit.id, { node_id: generateNodeId("Commit", commit.id) });
+  });
 
   gh.branches.insert({
     repo_id: repoId,

--- a/packages/@emulators/github/src/routes/repos.ts
+++ b/packages/@emulators/github/src/routes/repos.ts
@@ -317,6 +317,15 @@ export function reposRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     return c.json(formatRepo(repo, gh, baseUrl));
   });
 
+  app.get("/repositories/:id", (c) => {
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id)) throw notFoundResponse();
+    const repo = gh.repos.get(id);
+    if (!repo) throw notFoundResponse();
+    assertRepoRead(gh, c.get("authUser"), repo);
+    return c.json(formatRepo(repo, gh, baseUrl));
+  });
+
   app.post("/user/repos", async (c) => {
     const authUser = c.get("authUser");
     const user = assertAuthenticatedUser(gh, authUser);

--- a/packages/@emulators/github/src/routes/repos.ts
+++ b/packages/@emulators/github/src/routes/repos.ts
@@ -11,18 +11,17 @@ import {
 } from "../route-helpers.js";
 import type { GitHubStore } from "../store.js";
 import type {
-  GitHubBlob,
   GitHubBranch,
   GitHubCollaborator,
   GitHubCommit,
   GitHubRef,
   GitHubRepo,
   GitHubTag,
-  GitHubTree,
   GitHubUser,
 } from "../entities.js";
 import type { Collection, Entity } from "@emulators/core";
 import { formatRepo, formatUser, generateNodeId, generateSha, lookupOwner, lookupRepo, timestamp } from "../helpers.js";
+import { findOrCreateBlob, findOrCreateTree } from "../git-helpers.js";
 
 const LICENSE_TEMPLATES: Record<string, { key: string; name: string; spdx_id: string }> = {
   mit: { key: "mit", name: "MIT License", spdx_id: "MIT" },
@@ -57,24 +56,8 @@ function seedInitialGit(gh: GitHubStore, repo: GitHubRepo, actor: GitHubUser | n
   const readme = `# ${readmeTitle ?? repo.name}\n`;
   const size = Buffer.byteLength(readme, "utf8");
 
-  const blob = gh.blobs.insert({
-    repo_id: repoId,
-    sha: generateSha(),
-    node_id: "",
-    content: readme,
-    encoding: "utf-8",
-    size,
-  } as Omit<GitHubBlob, "id" | "created_at" | "updated_at">);
-  gh.blobs.update(blob.id, { node_id: generateNodeId("Blob", blob.id) });
-
-  const tree = gh.trees.insert({
-    repo_id: repoId,
-    sha: generateSha(),
-    node_id: "",
-    tree: [{ path: "README.md", mode: "100644", type: "blob", sha: blob.sha }],
-    truncated: false,
-  } as Omit<GitHubTree, "id" | "created_at" | "updated_at">);
-  gh.trees.update(tree.id, { node_id: generateNodeId("Tree", tree.id) });
+  const blob = findOrCreateBlob(gh, repoId, Buffer.from(readme, "utf8"));
+  const tree = findOrCreateTree(gh, repoId, [{ path: "README.md", mode: "100644", type: "blob", sha: blob.sha, size }]);
 
   const authorName = actor?.name ?? actor?.login ?? "User";
   const login = actor?.login ?? "user";

--- a/packages/@emulators/github/src/routes/reviews.ts
+++ b/packages/@emulators/github/src/routes/reviews.ts
@@ -15,7 +15,7 @@ import {
   lookupRepo,
   timestamp,
 } from "../helpers.js";
-import { assertRepoRead, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
+import { assertRepoPermission, assertRepoWrite, notFoundResponse, ownerLoginOf } from "../route-helpers.js";
 
 function findPull(gh: GitHubStore, repoId: number, pullNumber: number): GitHubPullRequest | undefined {
   return gh.pullRequests.findBy("repo_id", repoId).find((p) => p.number === pullNumber);
@@ -111,7 +111,7 @@ export function reviewsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const pullNumber = parseInt(c.req.param("pull_number")!, 10);
     if (!Number.isFinite(pullNumber)) throw notFoundResponse();
@@ -224,7 +224,7 @@ export function reviewsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const pullNumber = parseInt(c.req.param("pull_number")!, 10);
     const reviewId = parseInt(c.req.param("review_id")!, 10);
@@ -356,7 +356,7 @@ export function reviewsRoutes({ app, store, webhooks, baseUrl }: RouteContext): 
     const repoName = c.req.param("repo")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    assertRepoRead(gh, c.get("authUser"), repo);
+    assertRepoPermission(gh, c.get("authUser"), repo, "pull_requests");
 
     const pullNumber = parseInt(c.req.param("pull_number")!, 10);
     const reviewId = parseInt(c.req.param("review_id")!, 10);

--- a/packages/@emulators/github/src/routes/search.ts
+++ b/packages/@emulators/github/src/routes/search.ts
@@ -13,6 +13,13 @@ import type {
 } from "../entities.js";
 import { formatIssue, formatOrgBrief, formatPullRequest, formatRepo, formatUser, lookupRepo } from "../helpers.js";
 import { canAccessRepo } from "../route-helpers.js";
+import {
+  commitIdentityMatches,
+  encodeContentPath,
+  flattenTree,
+  resolveBranchToCommit,
+  resolveCommitUser,
+} from "../git-helpers.js";
 
 /** Parsed GitHub-style search query (q parameter). */
 export interface ParsedSearchQuery {
@@ -595,32 +602,10 @@ function blobText(blob: GitHubBlob): string {
   return blob.content;
 }
 
-function buildBlobPathIndex(gh: GitHubStore): Map<string, string> {
-  const byRepo = new Map<number, Map<string, string>>();
-  for (const tree of gh.trees.all()) {
-    let map = byRepo.get(tree.repo_id);
-    if (!map) {
-      map = new Map();
-      byRepo.set(tree.repo_id, map);
-    }
-    for (const e of tree.tree) {
-      if (e.type === "blob") {
-        if (!map.has(e.sha)) map.set(e.sha, e.path);
-      }
-    }
-  }
-  const key = (repoId: number, sha: string) => `${repoId}:${sha}`;
-  const flat = new Map<string, string>();
-  for (const [repoId, m] of byRepo) {
-    for (const [sha, path] of m) {
-      flat.set(key(repoId, sha), path);
-    }
-  }
-  return flat;
-}
-
 function formatSearchCommit(gh: GitHubStore, commit: GitHubCommit, repo: GitHubRepo, baseUrl: string) {
   const repoUrl = `${baseUrl}/repos/${repo.full_name}`;
+  const author = resolveCommitUser(gh, commit.author_email);
+  const committer = resolveCommitUser(gh, commit.committer_email);
   return {
     sha: commit.sha,
     node_id: commit.node_id,
@@ -642,8 +627,8 @@ function formatSearchCommit(gh: GitHubStore, commit: GitHubCommit, repo: GitHubR
       },
       message: commit.message,
     },
-    author: null as null,
-    committer: null as null,
+    author: author ? formatUser(author, baseUrl) : null,
+    committer: committer ? formatUser(committer, baseUrl) : null,
     parents: commit.parent_shas.map((sha) => ({
       sha,
       url: `${repoUrl}/commits/${sha}`,
@@ -657,14 +642,8 @@ function loginMatchesCommitAuthor(
   commit: GitHubCommit,
   role: "author" | "committer",
 ): boolean {
-  const u = gh.users.findOneBy("login", login);
-  const email = (role === "author" ? commit.author_email : commit.committer_email).toLowerCase();
-  if (u) {
-    if (u.email && u.email.toLowerCase() === email) return true;
-    if (commit.user_id != null && commit.user_id === u.id) return true;
-  }
-  const expect = `${login.toLowerCase()}@users.noreply.github.com`;
-  return email === expect || email.startsWith(`${login.toLowerCase()}+`);
+  const email = role === "author" ? commit.author_email : commit.committer_email;
+  return commitIdentityMatches(gh, email, login);
 }
 
 export function searchRoutes({ app, store, baseUrl }: RouteContext): void {
@@ -875,17 +854,6 @@ export function searchRoutes({ app, store, baseUrl }: RouteContext): void {
     const parsed = parseSearchQuery(q);
     const { page, per_page } = parsePagination(c);
     const authUser = c.get("authUser");
-    const blobs = gh.blobs.all();
-    if (blobs.length === 0) {
-      setLinkHeader(c, 0, 1, per_page);
-      return c.json({
-        total_count: 0,
-        incomplete_results: false,
-        items: [],
-      });
-    }
-
-    const pathIdx = buildBlobPathIndex(gh);
     const text = parsed.text.trim();
     const repoSpecs = parsed.qualifiers.get("repo") ?? [];
     const langs = parsed.qualifiers.get("language") ?? [];
@@ -901,9 +869,7 @@ export function searchRoutes({ app, store, baseUrl }: RouteContext): void {
       repo: GitHubRepo;
     }> = [];
 
-    for (const blob of blobs) {
-      const repo = gh.repos.get(blob.repo_id);
-      if (!repo) continue;
+    for (const repo of gh.repos.all()) {
       if (!repoVisibleForSearch(repo, gh, authUser)) continue;
       if (repoSpecs.length) {
         const ok = repoSpecs.some((rs) => {
@@ -917,31 +883,36 @@ export function searchRoutes({ app, store, baseUrl }: RouteContext): void {
         if (!lang || !langs.some((l) => l.toLowerCase() === lang.toLowerCase())) continue;
       }
 
-      const path = pathIdx.get(`${blob.repo_id}:${blob.sha}`) ?? `unknown/${blob.sha.slice(0, 7)}`;
-      const base = path.split("/").pop() ?? path;
-      if (paths.length && !paths.some((p) => path.toLowerCase().includes(p.toLowerCase()))) continue;
-      if (filenames.length && !filenames.some((p) => base.toLowerCase().includes(p.toLowerCase()))) continue;
+      const head = resolveBranchToCommit(gh, repo, repo.default_branch);
+      if (!head) continue;
+      for (const [path, entry] of flattenTree(gh, repo.id, head.tree_sha).blobs) {
+        const blob = gh.blobs.findBy("repo_id", repo.id).find((candidate) => candidate.sha === entry.sha);
+        if (!blob) continue;
+        const base = path.split("/").pop() ?? path;
+        if (paths.length && !paths.some((p) => path.toLowerCase().includes(p.toLowerCase()))) continue;
+        if (filenames.length && !filenames.some((p) => base.toLowerCase().includes(p.toLowerCase()))) continue;
 
-      const content = blobText(blob);
-      if (text.length) {
-        const inFile = content.toLowerCase().includes(text.toLowerCase());
-        const inPath = path.toLowerCase().includes(text.toLowerCase());
-        let hit = false;
-        if (!inScopes.length) hit = inFile || inPath;
-        else {
-          if (inScopes.includes("file") && inFile) hit = true;
-          if (inScopes.includes("path") && inPath) hit = true;
+        const content = blobText(blob);
+        if (text.length) {
+          const inFile = content.toLowerCase().includes(text.toLowerCase());
+          const inPath = path.toLowerCase().includes(text.toLowerCase());
+          let hit = false;
+          if (!inScopes.length) hit = inFile || inPath;
+          else {
+            if (inScopes.includes("file") && inFile) hit = true;
+            if (inScopes.includes("path") && inPath) hit = true;
+          }
+          if (!hit) continue;
         }
-        if (!hit) continue;
-      }
 
-      matches.push({
-        name: path.split("/").pop() ?? blob.sha,
-        path,
-        sha: blob.sha,
-        score: text.length ? (content.toLowerCase().includes(text.toLowerCase()) ? 2 : 1) : 1,
-        repo,
-      });
+        matches.push({
+          name: path.split("/").pop() ?? blob.sha,
+          path,
+          sha: blob.sha,
+          score: text.length ? (content.toLowerCase().includes(text.toLowerCase()) ? 2 : 1) : 1,
+          repo,
+        });
+      }
     }
 
     matches.sort((a, b) => b.score - a.score);
@@ -951,13 +922,14 @@ export function searchRoutes({ app, store, baseUrl }: RouteContext): void {
 
     const items = slice.map((m) => {
       const repoUrl = `${baseUrl}/repos/${m.repo.full_name}`;
+      const encodedPath = encodeContentPath(m.path);
       return {
         name: m.name,
         path: m.path,
         sha: m.sha,
-        url: `${repoUrl}/contents/${m.path}?ref=HEAD`,
+        url: `${repoUrl}/contents/${encodedPath}?ref=HEAD`,
         git_url: `${repoUrl}/git/blobs/${m.sha}`,
-        html_url: `${baseUrl}/${m.repo.full_name}/blob/HEAD/${m.path}`,
+        html_url: `${baseUrl}/${m.repo.full_name}/blob/HEAD/${encodedPath}`,
         repository: formatRepo(m.repo, gh, baseUrl),
         score: 1,
       };

--- a/packages/@emulators/github/src/routes/search.ts
+++ b/packages/@emulators/github/src/routes/search.ts
@@ -12,7 +12,7 @@ import type {
   GitHubUser,
 } from "../entities.js";
 import { formatIssue, formatOrgBrief, formatPullRequest, formatRepo, formatUser, lookupRepo } from "../helpers.js";
-import { canAccessRepo } from "../route-helpers.js";
+import { canAccessRepo, canReadRepoContents } from "../route-helpers.js";
 import {
   commitIdentityMatches,
   encodeContentPath,
@@ -870,7 +870,7 @@ export function searchRoutes({ app, store, baseUrl }: RouteContext): void {
     }> = [];
 
     for (const repo of gh.repos.all()) {
-      if (!repoVisibleForSearch(repo, gh, authUser)) continue;
+      if (!canReadRepoContents(gh, authUser, repo)) continue;
       if (repoSpecs.length) {
         const ok = repoSpecs.some((rs) => {
           const r = resolveRepoQualifier(gh, rs);
@@ -962,7 +962,7 @@ export function searchRoutes({ app, store, baseUrl }: RouteContext): void {
     for (const commit of gh.commits.all()) {
       const repo = gh.repos.get(commit.repo_id);
       if (!repo) continue;
-      if (!repoVisibleForSearch(repo, gh, authUser)) continue;
+      if (!canReadRepoContents(gh, authUser, repo)) continue;
       if (repoSpecs.length) {
         const ok = repoSpecs.some((rs) => {
           const r = resolveRepoQualifier(gh, rs);

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -22,7 +22,7 @@ Framework adapters:
   Docs: https://emulate.dev/docs/nextjs and https://emulate.dev/docs/nuxt
 
 GitHub API coverage:
-  Includes repository contents, commit history, commit details, and ref comparisons.
+  Includes repository contents, raw downloads, commit history, commit details, and ref comparisons.
 `,
   );
 

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -20,6 +20,9 @@ program
 Framework adapters:
   Embed emulators in app routes with @emulators/adapter-next or @emulators/adapter-nuxt.
   Docs: https://emulate.dev/docs/nextjs and https://emulate.dev/docs/nuxt
+
+GitHub API coverage:
+  Includes repository contents, commit history, commit details, and ref comparisons.
 `,
   );
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -244,6 +244,9 @@ curl -X DELETE http://localhost:4001/repos/octocat/hello-world \
 # Read a file or list a directory at a branch, tag, or commit
 curl "http://localhost:4001/repos/octocat/hello-world/contents/README.md?ref=main"
 
+# Download raw file content from the URL advertised by contents and commit responses
+curl http://localhost:4001/octocat/hello-world/raw/main/README.md
+
 # Create or update a file and commit the change
 curl -X PUT http://localhost:4001/repos/octocat/hello-world/contents/notes.txt \
   -H "Authorization: Bearer $TOKEN" \

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -210,6 +210,9 @@ curl http://localhost:4001/user/emails -H "Authorization: Bearer $TOKEN"
 # Get repo
 curl http://localhost:4001/repos/octocat/hello-world
 
+# Get repo by numeric ID
+curl http://localhost:4001/repositories/1
+
 # Create user repo
 curl -X POST http://localhost:4001/user/repos \
   -H "Authorization: Bearer $TOKEN" \
@@ -233,6 +236,24 @@ curl -X DELETE http://localhost:4001/repos/octocat/hello-world \
   -H "Authorization: Bearer $TOKEN"
 
 # Topics, languages, contributors, forks, collaborators, tags, transfer
+```
+
+### Contents & Commit History
+
+```bash
+# Read a file or list a directory at a branch, tag, or commit
+curl "http://localhost:4001/repos/octocat/hello-world/contents/README.md?ref=main"
+
+# Create or update a file and commit the change
+curl -X PUT http://localhost:4001/repos/octocat/hello-world/contents/notes.txt \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Update notes", "content": "aGVsbG8K"}'
+
+# List commits, get a commit with file stats, or compare refs
+curl http://localhost:4001/repos/octocat/hello-world/commits
+curl http://localhost:4001/repos/octocat/hello-world/commits/main
+curl http://localhost:4001/repos/octocat/hello-world/compare/v1.0.0...main
 ```
 
 ### Issues


### PR DESCRIPTION
- Add stateful contents and README APIs with commit-producing file writes and branch isolation
- Serve advertised raw file URLs and honor GitHub README precedence
- Add commit history, documented ref forms, distinct REST and Git Data shapes, file pagination, and comparisons
- Preserve traversable nested Git trees and trailing-newline diff semantics
- Document and test the expanded GitHub API coverage

Fixes #190.