### PR TITLE
Add Airtable emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All services start with sensible defaults. No config file needed:
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
 - **Twilio** on `http://localhost:4013`
+- **Airtable** on `http://localhost:4014`
 
 ## CLI
 
@@ -423,6 +424,29 @@ aws:
     roles:
       - role_name: lambda-execution-role
         description: Role for Lambda function execution
+  airtable:
+    user:
+      email: dev@example.com
+      name: Local Developer
+    bases:
+      - id: appLocalDevExample
+        name: Product
+        tables:
+          - name: Tasks
+            fields:
+              - { name: Name, type: singleLineText }
+              - name: Status
+                type: singleSelect
+                options:
+                  choices:
+                    - { name: Todo }
+                    - { name: Doing }
+                    - { name: Done }
+              - { name: Estimate, type: number }
+            views:
+              - { name: All Tasks, type: grid }
+            records:
+              - { Name: Ship the emulator, Status: Doing, Estimate: 3 }
 ```
 
 ## OAuth & Integrations
@@ -923,6 +947,41 @@ To test inbound SMS webhooks, configure a seeded phone number `sms_url`, then ca
 
 Current Twilio limits: no carrier delivery, A2P 10DLC, toll-free verification, real phone number purchasing, exact rate limits, Studio, Flex, TaskRouter, Video, Sync, Segment, SendGrid, Conversations SDK websocket behavior, or complete TwiML interpreter.
 
+## Airtable API
+
+Stateful Airtable Data API emulation with user-defined bases, tables, fields, and views, plus records and record comments. Records are validated against the seeded schema (unknown fields error; select choices are enforced unless `typecast` is set), and lists support a pragmatic `filterByFormula` subset, `sort`, seeded `view` filters, field selection, `offset` pagination, and `returnFieldsByFieldId`.
+
+### Records
+
+- `GET /v0/:baseId/:tableIdOrName` - list (filterByFormula, sort, fields, view, pageSize, maxRecords, offset, cellFormat, returnFieldsByFieldId)
+- `POST /v0/:baseId/:tableIdOrName/listRecords` - body-based list for long formulas
+- `GET /v0/:baseId/:tableIdOrName/:recordId` - get one record
+- `POST /v0/:baseId/:tableIdOrName` - create a single `{fields}` record or a `{records}` batch (up to 10, with optional `typecast`)
+- `PATCH /v0/:baseId/:tableIdOrName` - batch update, or upsert via `performUpsert.fieldsToMergeOn`
+- `PUT /v0/:baseId/:tableIdOrName` - batch replace
+- `PATCH` / `PUT /v0/:baseId/:tableIdOrName/:recordId` - update (merge) or replace one record
+- `DELETE /v0/:baseId/:tableIdOrName/:recordId` - delete one record
+- `DELETE /v0/:baseId/:tableIdOrName?records[]=...` - batch delete (up to 10)
+
+Tables and fields are addressable by id or name. `filterByFormula` references fields by name (a `{fldXXX}` id token errors, matching Airtable); computed fields filter on their stored value.
+
+### Record Comments
+
+- `GET /v0/:baseId/:tableIdOrName/:recordId/comments` - list comments (threaded, `offset` paginated)
+- `POST /v0/:baseId/:tableIdOrName/:recordId/comments` - add a comment (`{text}`, with `@[usrXXX]` mentions parsed)
+- `DELETE /v0/:baseId/:tableIdOrName/:recordId/comments/:commentId` - delete a comment
+
+### Meta And Inspector
+
+- `GET /v0/meta/whoami` - token identity (id, email, scopes)
+- `GET /v0/meta/bases` - accessible bases
+- `GET /v0/meta/bases/:baseId/tables` - base schema (tables, fields, views)
+- `GET /` - tabbed local inspector for bases, tables, records, and identity
+
+Auth is relaxed by default so any bearer token works. Point Airtable.js at the emulator with `endpointUrl` (or the `AIRTABLE_ENDPOINT_URL` env var) and pyairtable with `endpoint_url`.
+
+Current Airtable limits: `filterByFormula` implements a documented function subset (unsupported functions return `INVALID_FILTER_BY_FORMULA`); computed fields (formula, rollup, lookup) are stored, not recomputed; view filters are seeded rather than discovered; webhooks, attachment uploads, and Meta write endpoints are not implemented.
+
 ## Apple Sign In
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
@@ -1205,6 +1264,7 @@ packages/
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
+    airtable/       # Airtable Data API, records, comments, Meta schema
 apps/
   web/              # Documentation site (Next.js)
 ```
@@ -1232,3 +1292,5 @@ Tokens are configured in the seed config and map to users. Pass them as `Authori
 **Microsoft**: OIDC authorization code flow with PKCE support. Also supports client credentials grants. Microsoft Graph `/v1.0/me` available.
 
 **AWS**: Bearer tokens or IAM access key credentials. Default key pair always seeded: `AKIAIOSFODNN7EXAMPLE` / `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`.
+
+**Airtable**: Relaxed by default so any `Authorization: Bearer <token>` works; `whoami` returns the seeded identity. Set `airtable.strict_tokens: true` to enforce seeded PATs and their scopes.

--- a/README.md
+++ b/README.md
@@ -1293,4 +1293,4 @@ Tokens are configured in the seed config and map to users. Pass them as `Authori
 
 **AWS**: Bearer tokens or IAM access key credentials. Default key pair always seeded: `AKIAIOSFODNN7EXAMPLE` / `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`.
 
-**Airtable**: Relaxed by default so any `Authorization: Bearer <token>` works; `whoami` returns the seeded identity. Set `airtable.strict_tokens: true` to enforce seeded PATs and their scopes.
+**Airtable**: Relaxed by default so any `Authorization: Bearer <token>` works; `whoami` returns the seeded identity and scopes.

--- a/apps/web/app/docs/airtable/layout.tsx
+++ b/apps/web/app/docs/airtable/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("airtable");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/airtable/page.mdx
+++ b/apps/web/app/docs/airtable/page.mdx
@@ -38,7 +38,7 @@ Tables and fields are addressable by id or name. `filterByFormula` references fi
 
 ## Auth
 
-Relaxed by default so any `Authorization: Bearer <token>` works; `whoami` returns the seeded identity. Set `airtable.strict_tokens: true` in seed config to enforce seeded PATs and their scopes.
+Relaxed by default so any `Authorization: Bearer <token>` works; `whoami` returns the seeded identity and scopes.
 
 Point clients at the emulator without code changes: Airtable.js via `endpointUrl` (or the `AIRTABLE_ENDPOINT_URL` env var), pyairtable via `endpoint_url`.
 

--- a/apps/web/app/docs/airtable/page.mdx
+++ b/apps/web/app/docs/airtable/page.mdx
@@ -1,0 +1,81 @@
+# Airtable API
+
+Stateful Airtable Data API emulation with user-defined bases, tables, fields, and views, plus records and record comments. Records are validated against the seeded schema, and lists support a pragmatic `filterByFormula` subset, `sort`, seeded `view` filters, field selection, `offset` pagination, and `returnFieldsByFieldId`.
+
+## Start
+
+```bash
+npx emulate --service airtable
+```
+
+When Airtable is the only enabled service, it starts on `http://localhost:4000`. When all services are started, it uses `http://localhost:4014`.
+
+## Records
+
+- `GET /v0/:baseId/:tableIdOrName` - list records (`filterByFormula`, `sort`, `fields`, `view`, `pageSize`, `maxRecords`, `offset`, `cellFormat`, `returnFieldsByFieldId`)
+- `POST /v0/:baseId/:tableIdOrName/listRecords` - body-based list for long formulas
+- `GET /v0/:baseId/:tableIdOrName/:recordId` - get one record
+- `POST /v0/:baseId/:tableIdOrName` - create a single `{fields}` record or a `{records}` batch (up to 10, with optional `typecast`)
+- `PATCH /v0/:baseId/:tableIdOrName` - batch update, or upsert via `performUpsert.fieldsToMergeOn`
+- `PUT /v0/:baseId/:tableIdOrName` - batch replace
+- `PATCH` / `PUT /v0/:baseId/:tableIdOrName/:recordId` - update (merge) or replace one record
+- `DELETE /v0/:baseId/:tableIdOrName/:recordId` - delete one record
+- `DELETE /v0/:baseId/:tableIdOrName?records[]=...` - batch delete (up to 10)
+
+Tables and fields are addressable by id or name. `filterByFormula` references fields by name (a `{fldXXX}` id token errors, matching Airtable); computed fields filter on their stored value.
+
+## Record Comments
+
+- `GET /v0/:baseId/:tableIdOrName/:recordId/comments` - list comments (threaded, `offset` paginated)
+- `POST /v0/:baseId/:tableIdOrName/:recordId/comments` - add a comment (`{text}`, with `@[usrXXX]` mentions parsed)
+- `DELETE /v0/:baseId/:tableIdOrName/:recordId/comments/:commentId` - delete a comment
+
+## Meta
+
+- `GET /v0/meta/whoami` - token identity (id, email, scopes)
+- `GET /v0/meta/bases` - accessible bases
+- `GET /v0/meta/bases/:baseId/tables` - base schema (tables, fields, views)
+
+## Auth
+
+Relaxed by default so any `Authorization: Bearer <token>` works; `whoami` returns the seeded identity. Set `airtable.strict_tokens: true` in seed config to enforce seeded PATs and their scopes.
+
+Point clients at the emulator without code changes: Airtable.js via `endpointUrl` (or the `AIRTABLE_ENDPOINT_URL` env var), pyairtable via `endpoint_url`.
+
+## Seed Config
+
+```yaml
+airtable:
+  user:
+    email: dev@example.com
+    name: Local Developer
+  bases:
+    - id: appLocalDevExample
+      name: Product
+      tables:
+        - name: Tasks
+          fields:
+            - { name: Name, type: singleLineText }
+            - name: Status
+              type: singleSelect
+              options:
+                choices:
+                  - { name: Todo }
+                  - { name: Doing }
+                  - { name: Done }
+            - { name: Estimate, type: number }
+          views:
+            - { name: All Tasks, type: grid }
+          records:
+            - { Name: Ship the emulator, Status: Doing, Estimate: 3 }
+```
+
+Records seeded against a table with no declared `fields` infer their schema from the first record that carries each key. Base, table, and field ids pass through verbatim, so a config that mirrors a real base's ids lets code that hardcodes those ids run unchanged.
+
+## Inspector
+
+- `GET /` - tabbed inspector for bases, tables, records, and identity
+
+## Current Limits
+
+`filterByFormula` implements a documented function subset (unsupported functions return `INVALID_FILTER_BY_FORMULA`); computed fields (formula, rollup, lookup) are stored, not recomputed; view filters are seeded rather than discovered; webhooks, attachment uploads, and Meta write endpoints are not implemented.

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -15,6 +15,7 @@ export const allDocsPages: NavItem[] = [
   { name: "Slack API", href: "/docs/slack" },
   { name: "Linear API", href: "/docs/linear" },
   { name: "Twilio API", href: "/docs/twilio" },
+  { name: "Airtable API", href: "/docs/airtable" },
   { name: "Apple Sign In", href: "/docs/apple" },
   { name: "Microsoft Entra ID", href: "/docs/microsoft" },
   { name: "AWS", href: "/docs/aws" },

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -10,6 +10,7 @@ export const PAGE_TITLES: Record<string, string> = {
   slack: "Slack API",
   linear: "Linear API",
   twilio: "Twilio API",
+  airtable: "Airtable API",
   apple: "Apple Sign In",
   microsoft: "Microsoft Entra ID",
   aws: "AWS",

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -128,3 +128,27 @@ google:
       mime_type: application/vnd.google-apps.folder
       parent_ids:
         - root
+
+airtable:
+  user:
+    email: dev@example.com
+    name: Local Developer
+  bases:
+    - id: appLocalDevExample
+      name: Product
+      tables:
+        - name: Tasks
+          fields:
+            - { name: Name, type: singleLineText }
+            - name: Status
+              type: singleSelect
+              options:
+                choices:
+                  - { name: Todo }
+                  - { name: Doing }
+                  - { name: Done }
+            - { name: Estimate, type: number }
+          views:
+            - { name: All Tasks, type: grid }
+          records:
+            - { Name: Ship the emulator, Status: Doing, Estimate: 3 }

--- a/packages/@emulators/airtable/package.json
+++ b/packages/@emulators/airtable/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@emulators/airtable",
+  "version": "0.9.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/airtable"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/airtable/src/__tests__/airtable.test.ts
+++ b/packages/@emulators/airtable/src/__tests__/airtable.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  Hono,
+  Store,
+  WebhookDispatcher,
+  authMiddleware,
+  createApiErrorHandler,
+  createErrorHandler,
+  type TokenMap,
+} from "@emulators/core";
+import { airtablePlugin, seedFromConfig, type AirtableSeedConfig } from "../index.js";
+
+const BASE = "appTest0000000001";
+const TABLE = "tblTasks000000001";
+
+const SEED: AirtableSeedConfig = {
+  user: {
+    id: "usrTest0000000001",
+    email: "dev@example.com",
+    name: "Dev",
+    scopes: ["data.records:read", "data.records:write", "schema.bases:read"],
+  },
+  bases: [
+    {
+      id: BASE,
+      name: "Test Base",
+      tables: [
+        {
+          id: TABLE,
+          name: "Tasks",
+          fields: [
+            { id: "fldName0000000001", name: "Name", type: "singleLineText" },
+            {
+              id: "fldStatus00000001",
+              name: "Status",
+              type: "singleSelect",
+              options: {
+                choices: [
+                  { id: "selTodo00000000001", name: "Todo" },
+                  { id: "selDoing0000000001", name: "Doing" },
+                  { id: "selDone00000000001", name: "Done" },
+                ],
+              },
+            },
+            { id: "fldPriority000001", name: "Priority", type: "number" },
+            { id: "fldDone0000000001", name: "Done", type: "checkbox" },
+          ],
+          views: [{ id: "viwActive00000001", name: "Active", type: "grid", filter: '{Status}!="Done"' }],
+          records: [
+            { id: "recAlpha000000001", fields: { Name: "Alpha", Status: "Todo", Priority: 2, Done: false } },
+            { id: "recBeta0000000001", fields: { Name: "Beta", Status: "Doing", Priority: 1, Done: false } },
+            { id: "recGamma000000001", fields: { Name: "Gamma", Status: "Done", Priority: 3, Done: true } },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+interface ATRecord {
+  id: string;
+  createdTime: string;
+  fields: Record<string, unknown>;
+}
+interface ListResp {
+  records: ATRecord[];
+  offset?: string;
+}
+interface ObjError {
+  error: { type: string; message: string };
+}
+interface Comment {
+  id: string;
+  text: string;
+  author: { email: string };
+  mentioned?: Record<string, unknown>;
+}
+
+function makeApp(): Hono {
+  const store = new Store();
+  const app = new Hono();
+  const tokenMap: TokenMap = new Map();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap, undefined, { login: "dev@example.com", id: 1, scopes: [] }));
+  airtablePlugin.register(app, store, new WebhookDispatcher(), "http://localhost:4014", tokenMap);
+  seedFromConfig(store, "http://localhost:4014", SEED);
+  return app;
+}
+
+let app: Hono;
+beforeEach(() => {
+  app = makeApp();
+});
+
+async function req<T = unknown>(method: string, path: string, body?: unknown): Promise<{ status: number; body: T }> {
+  const res = await app.fetch(
+    new Request("http://localhost" + path, {
+      method,
+      headers: { Authorization: "Bearer patTest", "Content-Type": "application/json" },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    }),
+  );
+  const text = await res.text();
+  // Test boundary: the emulator's JSON response, shaped per the caller's T.
+  return { status: res.status, body: (text ? JSON.parse(text) : null) as T };
+}
+
+const enc = encodeURIComponent;
+const names = (list: ListResp): unknown[] => list.records.map((r) => r.fields.Name);
+
+describe("Airtable Meta API", () => {
+  it("whoami returns id, email, and scopes", async () => {
+    const { body } = await req<{ id: string; email: string; scopes: string[] }>("GET", "/v0/meta/whoami");
+    expect(body).toEqual({
+      id: "usrTest0000000001",
+      email: "dev@example.com",
+      scopes: ["data.records:read", "data.records:write", "schema.bases:read"],
+    });
+  });
+
+  it("lists bases", async () => {
+    const { body } = await req<{ bases: Array<{ id: string; name: string; permissionLevel: string }> }>(
+      "GET",
+      "/v0/meta/bases",
+    );
+    expect(body.bases).toEqual([{ id: BASE, name: "Test Base", permissionLevel: "create" }]);
+  });
+
+  it("returns the base schema with fields and views", async () => {
+    const { body } = await req<{
+      tables: Array<{ id: string; primaryFieldId: string; fields: unknown[]; views: unknown[] }>;
+    }>("GET", `/v0/meta/bases/${BASE}/tables`);
+    expect(body.tables).toHaveLength(1);
+    expect(body.tables[0].id).toBe(TABLE);
+    expect(body.tables[0].primaryFieldId).toBe("fldName0000000001");
+    expect(body.tables[0].fields).toHaveLength(4);
+    expect(body.tables[0].views).toEqual([{ id: "viwActive00000001", name: "Active", type: "grid" }]);
+  });
+
+  it("unknown base returns a bare-string 404", async () => {
+    const { status, body } = await req<{ error: string }>("GET", "/v0/meta/bases/appNope/tables");
+    expect(status).toBe(404);
+    expect(body).toEqual({ error: "NOT_FOUND" });
+  });
+});
+
+describe("Airtable list records", () => {
+  it("lists all records", async () => {
+    const { body } = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}`);
+    expect(body.records).toHaveLength(3);
+  });
+
+  it("addresses a table by name", async () => {
+    const { body } = await req<ListResp>("GET", `/v0/${BASE}/Tasks`);
+    expect(body.records).toHaveLength(3);
+  });
+
+  it("filters with filterByFormula", async () => {
+    const { body } = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?filterByFormula=${enc('{Status}="Doing"')}`);
+    expect(names(body)).toEqual(["Beta"]);
+  });
+
+  it("sorts ascending and descending", async () => {
+    const asc = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?sort[0][field]=Priority&sort[0][direction]=asc`);
+    expect(names(asc.body)).toEqual(["Beta", "Alpha", "Gamma"]);
+    const desc = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?sort[0][field]=Priority&sort[0][direction]=desc`);
+    expect(names(desc.body)).toEqual(["Gamma", "Alpha", "Beta"]);
+  });
+
+  it("restricts to a view's seeded filter", async () => {
+    const { body } = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?view=Active`);
+    expect(names(body).sort()).toEqual(["Alpha", "Beta"]);
+  });
+
+  it("selects fields and returns by field id", async () => {
+    const named = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?fields[]=Name`);
+    expect(Object.keys(named.body.records[0].fields)).toEqual(["Name"]);
+    const byId = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?fields[]=Name&returnFieldsByFieldId=true`);
+    expect(Object.keys(byId.body.records[0].fields)).toEqual(["fldName0000000001"]);
+  });
+
+  it("paginates with pageSize and offset", async () => {
+    const page1 = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?pageSize=2`);
+    expect(page1.body.records).toHaveLength(2);
+    expect(page1.body.offset).toBeTruthy();
+    const page2 = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?pageSize=2&offset=${enc(page1.body.offset ?? "")}`);
+    expect(page2.body.records).toHaveLength(1);
+    expect(page2.body.offset).toBeUndefined();
+  });
+
+  it("caps results with maxRecords", async () => {
+    const { body } = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}?maxRecords=1`);
+    expect(body.records).toHaveLength(1);
+  });
+
+  it("supports body-based POST /listRecords", async () => {
+    const { body } = await req<ListResp>("POST", `/v0/${BASE}/${TABLE}/listRecords`, {
+      filterByFormula: '{Status}="Todo"',
+      fields: ["Name"],
+    });
+    expect(names(body)).toEqual(["Alpha"]);
+  });
+});
+
+describe("Airtable get record", () => {
+  it("gets one record", async () => {
+    const { body } = await req<ATRecord>("GET", `/v0/${BASE}/${TABLE}/recAlpha000000001`);
+    expect(body.id).toBe("recAlpha000000001");
+    expect(body.fields.Name).toBe("Alpha");
+  });
+
+  it("unknown record returns a bare-string 404", async () => {
+    const { status, body } = await req<{ error: string }>("GET", `/v0/${BASE}/${TABLE}/recNope`);
+    expect(status).toBe(404);
+    expect(body).toEqual({ error: "NOT_FOUND" });
+  });
+});
+
+describe("Airtable create records", () => {
+  it("creates a single record", async () => {
+    const { status, body } = await req<ATRecord>("POST", `/v0/${BASE}/${TABLE}`, {
+      fields: { Name: "Delta", Status: "Todo" },
+    });
+    expect(status).toBe(200);
+    expect(body.id).toMatch(/^rec/);
+    expect(body.fields).toEqual({ Name: "Delta", Status: "Todo" });
+  });
+
+  it("creates a batch of records", async () => {
+    const { body } = await req<ListResp>("POST", `/v0/${BASE}/${TABLE}`, {
+      records: [{ fields: { Name: "E" } }, { fields: { Name: "F" } }],
+    });
+    expect(body.records).toHaveLength(2);
+  });
+
+  it("rejects a batch larger than 10", async () => {
+    const records = Array.from({ length: 11 }, (_, i) => ({ fields: { Name: `x${i}` } }));
+    const { status, body } = await req<ObjError>("POST", `/v0/${BASE}/${TABLE}`, { records });
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("INVALID_REQUEST_BODY");
+  });
+
+  it("rejects an unknown field", async () => {
+    const { status, body } = await req<ObjError>("POST", `/v0/${BASE}/${TABLE}`, { fields: { Nope: 1 } });
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("UNKNOWN_FIELD_NAME");
+  });
+
+  it("rejects a missing fields object", async () => {
+    const { status, body } = await req<ObjError>("POST", `/v0/${BASE}/${TABLE}`, {});
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("INVALID_REQUEST_MISSING_FIELDS");
+  });
+
+  it("rejects an invalid select choice without typecast", async () => {
+    const { status, body } = await req<ObjError>("POST", `/v0/${BASE}/${TABLE}`, {
+      fields: { Name: "G", Status: "Blocked" },
+    });
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("INVALID_MULTIPLE_CHOICE_OPTIONS");
+  });
+
+  it("accepts a new select choice with typecast", async () => {
+    const { status, body } = await req<ATRecord>("POST", `/v0/${BASE}/${TABLE}`, {
+      fields: { Name: "G", Status: "Blocked" },
+      typecast: true,
+    });
+    expect(status).toBe(200);
+    expect(body.fields.Status).toBe("Blocked");
+  });
+});
+
+describe("Airtable update records", () => {
+  it("PATCH merges only the given fields", async () => {
+    const { body } = await req<ATRecord>("PATCH", `/v0/${BASE}/${TABLE}/recAlpha000000001`, {
+      fields: { Status: "Done" },
+    });
+    expect(body.fields.Name).toBe("Alpha");
+    expect(body.fields.Status).toBe("Done");
+  });
+
+  it("PUT replaces the record, clearing unspecified fields", async () => {
+    const { body } = await req<ATRecord>("PUT", `/v0/${BASE}/${TABLE}/recAlpha000000001`, {
+      fields: { Name: "Alpha2" },
+    });
+    expect(body.fields.Name).toBe("Alpha2");
+    expect(body.fields.Status).toBeUndefined();
+  });
+
+  it("batch updates by id", async () => {
+    const { body } = await req<ListResp>("PATCH", `/v0/${BASE}/${TABLE}`, {
+      records: [
+        { id: "recAlpha000000001", fields: { Priority: 9 } },
+        { id: "recBeta0000000001", fields: { Priority: 8 } },
+      ],
+    });
+    expect(body.records).toHaveLength(2);
+    expect(body.records[0].fields.Priority).toBe(9);
+  });
+
+  it("upserts on fieldsToMergeOn (update existing, create new)", async () => {
+    const { body } = await req<ListResp & { createdRecords: string[]; updatedRecords: string[] }>(
+      "PATCH",
+      `/v0/${BASE}/${TABLE}`,
+      {
+        performUpsert: { fieldsToMergeOn: ["Name"] },
+        records: [{ fields: { Name: "Alpha", Priority: 5 } }, { fields: { Name: "Zeta", Priority: 7 } }],
+      },
+    );
+    expect(body.updatedRecords).toEqual(["recAlpha000000001"]);
+    expect(body.createdRecords).toHaveLength(1);
+    expect(body.records).toHaveLength(2);
+  });
+});
+
+describe("Airtable delete records", () => {
+  it("deletes a single record", async () => {
+    const { body } = await req<{ deleted: boolean; id: string }>("DELETE", `/v0/${BASE}/${TABLE}/recBeta0000000001`);
+    expect(body).toEqual({ deleted: true, id: "recBeta0000000001" });
+    const after = await req<ListResp>("GET", `/v0/${BASE}/${TABLE}`);
+    expect(after.body.records).toHaveLength(2);
+  });
+
+  it("batch deletes", async () => {
+    const { body } = await req<{ records: Array<{ deleted: boolean; id: string }> }>(
+      "DELETE",
+      `/v0/${BASE}/${TABLE}?records[]=recAlpha000000001&records[]=recGamma000000001`,
+    );
+    expect(body.records).toEqual([
+      { deleted: true, id: "recAlpha000000001" },
+      { deleted: true, id: "recGamma000000001" },
+    ]);
+  });
+});
+
+describe("Airtable error envelopes", () => {
+  it("unknown table returns 403 model-not-found", async () => {
+    const { status, body } = await req<ObjError>("GET", `/v0/${BASE}/tblNope`);
+    expect(status).toBe(403);
+    expect(body.error.type).toBe("INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND");
+  });
+
+  it("invalid formula returns 422", async () => {
+    const { status, body } = await req<ObjError>("GET", `/v0/${BASE}/${TABLE}?filterByFormula=NOTAFN(`);
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("INVALID_FILTER_BY_FORMULA");
+  });
+
+  it("a {fldXXX} id token in a formula is rejected", async () => {
+    const { status, body } = await req<ObjError>(
+      "GET",
+      `/v0/${BASE}/${TABLE}?filterByFormula=${enc('{fldName0000000001}="Alpha"')}`,
+    );
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("INVALID_FILTER_BY_FORMULA");
+  });
+
+  it("pageSize out of range returns 422", async () => {
+    const { status, body } = await req<ObjError>("GET", `/v0/${BASE}/${TABLE}?pageSize=200`);
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("INVALID_PAGE_SIZE_ARGUMENT");
+  });
+});
+
+describe("Airtable record comments", () => {
+  const REC = "recAlpha000000001";
+
+  it("posts a comment with author identity and mention parsing", async () => {
+    const { status, body } = await req<Comment>("POST", `/v0/${BASE}/${TABLE}/${REC}/comments`, {
+      text: "Nudge @[usrTest0000000001]",
+    });
+    expect(status).toBe(200);
+    expect(body.author.email).toBe("dev@example.com");
+    expect(body.mentioned).toHaveProperty("usrTest0000000001");
+  });
+
+  it("lists comments in thread order and deletes", async () => {
+    await req("POST", `/v0/${BASE}/${TABLE}/${REC}/comments`, { text: "first" });
+    await req("POST", `/v0/${BASE}/${TABLE}/${REC}/comments`, { text: "second" });
+    const list = await req<{ comments: Comment[] }>("GET", `/v0/${BASE}/${TABLE}/${REC}/comments`);
+    expect(list.body.comments.map((c) => c.text)).toEqual(["first", "second"]);
+    const del = await req<{ deleted: boolean }>(
+      "DELETE",
+      `/v0/${BASE}/${TABLE}/${REC}/comments/${list.body.comments[0].id}`,
+    );
+    expect(del.body.deleted).toBe(true);
+  });
+
+  it("rejects an empty comment", async () => {
+    const { status, body } = await req<ObjError>("POST", `/v0/${BASE}/${TABLE}/${REC}/comments`, {});
+    expect(status).toBe(422);
+    expect(body.error.type).toBe("INVALID_REQUEST_MISSING_FIELDS");
+  });
+});

--- a/packages/@emulators/airtable/src/__tests__/formula.test.ts
+++ b/packages/@emulators/airtable/src/__tests__/formula.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFormula,
+  evaluateFormula,
+  matchesFormula,
+  collectFieldRefs,
+  FormulaError,
+  type FormulaContext,
+} from "../formula.js";
+
+function ctx(cells: Record<string, unknown>, opts: Partial<FormulaContext> = {}): FormulaContext {
+  return {
+    field: (name) => cells[name],
+    recordId: opts.recordId ?? "recTEST0000000001",
+    createdTime: opts.createdTime ?? "2026-01-01T00:00:00.000Z",
+    now: opts.now ?? new Date("2026-07-20T12:00:00.000Z"),
+  };
+}
+
+function match(formula: string, cells: Record<string, unknown> = {}, opts: Partial<FormulaContext> = {}): boolean {
+  return matchesFormula(parseFormula(formula), ctx(cells, opts));
+}
+
+function evalF(formula: string, cells: Record<string, unknown> = {}, opts: Partial<FormulaContext> = {}): unknown {
+  return evaluateFormula(parseFormula(formula), ctx(cells, opts));
+}
+
+describe("formula: comparisons and field refs", () => {
+  it("string equality on a field value", () => {
+    expect(match('{Status}="Active"', { Status: "Active" })).toBe(true);
+    expect(match('{Status}="Active"', { Status: "Alum" })).toBe(false);
+  });
+
+  it("bare (unbraced) field references", () => {
+    expect(match('Status="Active"', { Status: "Active" })).toBe(true);
+  });
+
+  it("numeric comparisons coerce numeric strings", () => {
+    expect(match("{n} > 3", { n: 5 })).toBe(true);
+    expect(match("{n} > 3", { n: "5" })).toBe(true);
+    expect(match("{n} <= 3", { n: 3 })).toBe(true);
+    expect(match("{n} != 3", { n: 4 })).toBe(true);
+  });
+
+  it("reads a formula/computed field's stored value", () => {
+    // {Program} is a computed field in Airtable; filterByFormula filters on its value.
+    expect(match('{Program}="Member Residency"', { Program: "Member Residency" })).toBe(true);
+  });
+});
+
+describe("formula: logic", () => {
+  it("AND / OR / NOT", () => {
+    expect(match('AND({Status}="Active",{Location}="SF")', { Status: "Active", Location: "SF" })).toBe(true);
+    expect(match('AND({Status}="Active",{Location}="SF")', { Status: "Active", Location: "NYC" })).toBe(false);
+    expect(match('OR({Status}="Active",{Status}="Alum")', { Status: "Alum" })).toBe(true);
+    expect(match('NOT({Status}="Active")', { Status: "Alum" })).toBe(true);
+  });
+
+  it("IF returns branches", () => {
+    expect(evalF('IF({n}>3,"big","small")', { n: 5 })).toBe("big");
+    expect(evalF('IF({n}>3,"big","small")', { n: 1 })).toBe("small");
+  });
+});
+
+describe("formula: text and search (the search-records pattern)", () => {
+  it("FIND(LOWER(needle), LOWER(field)) > 0", () => {
+    const f = 'FIND(LOWER("finn"), LOWER({Name})) > 0';
+    expect(match(f, { Name: "Finnegan Marsh" })).toBe(true);
+    expect(match(f, { Name: "Someone Else" })).toBe(false);
+  });
+
+  it("FIND returns 0 when the needle is absent", () => {
+    expect(evalF('FIND("x", {Name})', { Name: "abc" })).toBe(0);
+    expect(evalF('FIND("b", {Name})', { Name: "abc" })).toBe(2);
+  });
+
+  it("string helpers", () => {
+    expect(evalF('UPPER("hi")')).toBe("HI");
+    expect(evalF('TRIM("  hi  ")')).toBe("hi");
+    expect(evalF('LEN("abc")')).toBe(3);
+    expect(evalF('CONCATENATE("a","b","c")')).toBe("abc");
+    expect(evalF('{a} & "-" & {b}', { a: "x", b: "y" })).toBe("x-y");
+  });
+
+  it("FIND over a linked/array field sees its joined display value", () => {
+    expect(match('FIND("UI", {Tags}) > 0', { Tags: ["Bug", "UI"] })).toBe(true);
+  });
+});
+
+describe("formula: blank and record id", () => {
+  it("BLANK() equality detects empty cells", () => {
+    expect(match("{Email}=BLANK()", { Email: "" })).toBe(true);
+    expect(match("{Email}=BLANK()", {})).toBe(true);
+    expect(match("NOT({Email}=BLANK())", { Email: "a@b.com" })).toBe(true);
+  });
+
+  it("RECORD_ID() and the OR(RECORD_ID()=...) get-many pattern", () => {
+    const f = "OR(RECORD_ID()='recA',RECORD_ID()='recB')";
+    expect(match(f, {}, { recordId: "recA" })).toBe(true);
+    expect(match(f, {}, { recordId: "recZ" })).toBe(false);
+  });
+});
+
+describe("formula: dates (the recent-activity pattern)", () => {
+  const now = new Date("2026-07-20T12:00:00.000Z");
+
+  it("TODAY / DATEADD / IS_AFTER window", () => {
+    const f = "IS_AFTER({Modified}, DATEADD(TODAY(), -7, 'days'))";
+    expect(match(f, { Modified: "2026-07-18T00:00:00.000Z" }, { now })).toBe(true);
+    expect(match(f, { Modified: "2026-07-01T00:00:00.000Z" }, { now })).toBe(false);
+  });
+
+  it("IS_SAME with a day unit", () => {
+    const f = "IS_SAME({d}, '2026-07-20T09:00:00.000Z', 'day')";
+    expect(match(f, { d: "2026-07-20T23:00:00.000Z" })).toBe(true);
+    expect(match(f, { d: "2026-07-21T00:00:00.000Z" })).toBe(false);
+  });
+
+  it("DATETIME_DIFF in days", () => {
+    expect(evalF("DATETIME_DIFF('2026-07-20', '2026-07-13', 'days')")).toBe(7);
+  });
+});
+
+describe("formula: arithmetic precedence and truthiness", () => {
+  it("multiplication before addition", () => {
+    expect(evalF("1 + 2 * 3")).toBe(7);
+    expect(evalF("(1 + 2) * 3")).toBe(9);
+  });
+
+  it("checkbox / numeric truthiness", () => {
+    expect(match("{Done}", { Done: true })).toBe(true);
+    expect(match("{Done}", { Done: false })).toBe(false);
+    expect(match("{n}", { n: 0 })).toBe(false);
+    expect(match("{n}", { n: 2 })).toBe(true);
+  });
+});
+
+describe("formula: introspection and errors", () => {
+  it("collectFieldRefs finds every referenced field", () => {
+    const refs = collectFieldRefs(parseFormula('AND({Status}="Active", FIND("x", {Name}) > 0)'));
+    expect(new Set(refs)).toEqual(new Set(["Status", "Name"]));
+  });
+
+  it("throws FormulaError on unbalanced parens", () => {
+    expect(() => parseFormula("AND({a}")).toThrow(FormulaError);
+  });
+
+  it("throws FormulaError on an unsupported function", () => {
+    expect(() => evaluateFormula(parseFormula("REGEX_MATCH({a},'x')"), ctx({ a: "x" }))).toThrow(FormulaError);
+  });
+});

--- a/packages/@emulators/airtable/src/entities.ts
+++ b/packages/@emulators/airtable/src/entities.ts
@@ -1,0 +1,100 @@
+import type { Entity } from "@emulators/core";
+
+/**
+ * Airtable is the first schema-defined service: bases, tables, fields, and views
+ * are user data, and the Data API validates records against them. Each entity keeps
+ * the kernel's numeric `id` internal and carries the real Airtable string id
+ * (`app…`/`tbl…`/`fld…`/`viw…`/`rec…`) as an indexed field, mirroring Linear's
+ * `linear_id` pattern.
+ */
+
+export interface AirtableBase extends Entity {
+  base_id: string;
+  name: string;
+  permission_level: string;
+}
+
+export interface AirtableSelectChoice {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+export interface AirtableFieldOptions {
+  choices?: AirtableSelectChoice[];
+  [key: string]: unknown;
+}
+
+export interface AirtableField extends Entity {
+  table_id: string;
+  field_id: string;
+  name: string;
+  type: string;
+  options?: AirtableFieldOptions | null;
+  position: number;
+}
+
+export interface AirtableViewSort {
+  field: string;
+  direction?: "asc" | "desc";
+}
+
+export interface AirtableView extends Entity {
+  table_id: string;
+  view_id: string;
+  name: string;
+  type: string;
+  // Seeded, not discoverable: the public schema API never returns a view's
+  // filter/sort/hidden-field config, so applying `view=` requires seeding it.
+  filter?: string | null;
+  sort?: AirtableViewSort[] | null;
+  fields?: string[] | null;
+}
+
+export interface AirtableTable extends Entity {
+  base_id: string;
+  table_id: string;
+  name: string;
+  primary_field_id: string;
+  description?: string | null;
+}
+
+export interface AirtableRecordEntity extends Entity {
+  base_id: string;
+  table_id: string;
+  record_id: string;
+  // Cell values keyed by canonical field name. Computed fields hold their
+  // stored/seeded value (never recomputed); linked fields hold record-id arrays.
+  cells: Record<string, unknown>;
+  created_time: string;
+}
+
+export interface AirtableCommentAuthor {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+export interface AirtableMention {
+  type: string;
+  id: string;
+  displayName?: string;
+  email?: string;
+}
+
+export interface AirtableComment extends Entity {
+  comment_id: string;
+  record_id: string;
+  text: string;
+  author: AirtableCommentAuthor;
+  created_time: string;
+  last_updated_time?: string | null;
+  mentioned?: Record<string, AirtableMention> | null;
+}
+
+export interface AirtableUser extends Entity {
+  user_id: string;
+  email: string;
+  name?: string;
+  scopes: string[];
+}

--- a/packages/@emulators/airtable/src/formula.ts
+++ b/packages/@emulators/airtable/src/formula.ts
@@ -1,0 +1,532 @@
+/**
+ * A pragmatic `filterByFormula` engine: recursive-descent parser + evaluator over a
+ * single record's cells. It covers the subset SPC's agents actually use (comparisons,
+ * AND/OR/NOT/IF, LOWER/FIND/SEARCH, RECORD_ID/BLANK, IS_AFTER/IS_SAME, DATEADD, TODAY,
+ * field refs) with Airtable's loose coercion and truthiness. Unsupported tokens throw
+ * `FormulaError`, which the records route maps to `422 INVALID_FILTER_BY_FORMULA`.
+ *
+ * Field refs resolve by NAME (Airtable's rule); a `{fldXXX}` id token won't match a
+ * field name and surfaces via `collectFieldRefs` so the route can reject it. Linked and
+ * computed fields are read as their stored cell value.
+ */
+
+export class FormulaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FormulaError";
+  }
+}
+
+export interface FormulaContext {
+  field(name: string): unknown;
+  recordId: string;
+  createdTime: string;
+  now: Date;
+}
+
+type NodeType = "num" | "str" | "field" | "call" | "binary" | "unary";
+
+interface FormulaNode {
+  type: NodeType;
+  value?: number | string;
+  name?: string;
+  op?: string;
+  args?: FormulaNode[];
+  operand?: FormulaNode;
+  left?: FormulaNode;
+  right?: FormulaNode;
+}
+
+type TokenType = "num" | "str" | "field" | "ident" | "op" | "lparen" | "rparen" | "comma" | "eof";
+
+interface Token {
+  type: TokenType;
+  value: string;
+}
+
+const MULTI_CHAR_OPS = ["!=", "<>", "<=", ">="];
+const SINGLE_CHAR_OPS: Record<string, true> = {
+  "=": true,
+  "<": true,
+  ">": true,
+  "&": true,
+  "+": true,
+  "-": true,
+  "*": true,
+  "/": true,
+};
+
+function tokenize(src: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  const n = src.length;
+
+  while (i < n) {
+    const ch = src[i];
+
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      let str = "";
+      i++;
+      while (i < n && src[i] !== quote) {
+        if (src[i] === "\\" && i + 1 < n) {
+          str += src[i + 1];
+          i += 2;
+        } else {
+          str += src[i];
+          i++;
+        }
+      }
+      if (i >= n) throw new FormulaError("Unterminated string literal");
+      i++;
+      tokens.push({ type: "str", value: str });
+      continue;
+    }
+
+    if (ch === "{") {
+      let name = "";
+      i++;
+      while (i < n && src[i] !== "}") {
+        if (src[i] === "\\" && i + 1 < n) {
+          name += src[i + 1];
+          i += 2;
+        } else {
+          name += src[i];
+          i++;
+        }
+      }
+      if (i >= n) throw new FormulaError("Unterminated field reference");
+      i++;
+      tokens.push({ type: "field", value: name });
+      continue;
+    }
+
+    if (ch >= "0" && ch <= "9") {
+      let num = "";
+      while (i < n && ((src[i] >= "0" && src[i] <= "9") || src[i] === ".")) {
+        num += src[i];
+        i++;
+      }
+      tokens.push({ type: "num", value: num });
+      continue;
+    }
+
+    const two = src.slice(i, i + 2);
+    if (MULTI_CHAR_OPS.includes(two)) {
+      tokens.push({ type: "op", value: two === "<>" ? "!=" : two });
+      i += 2;
+      continue;
+    }
+
+    if (SINGLE_CHAR_OPS[ch]) {
+      tokens.push({ type: "op", value: ch });
+      i++;
+      continue;
+    }
+
+    if (ch === "(") {
+      tokens.push({ type: "lparen", value: ch });
+      i++;
+      continue;
+    }
+    if (ch === ")") {
+      tokens.push({ type: "rparen", value: ch });
+      i++;
+      continue;
+    }
+    if (ch === ",") {
+      tokens.push({ type: "comma", value: ch });
+      i++;
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(ch)) {
+      let ident = "";
+      while (i < n && /[A-Za-z0-9_]/.test(src[i])) {
+        ident += src[i];
+        i++;
+      }
+      tokens.push({ type: "ident", value: ident });
+      continue;
+    }
+
+    throw new FormulaError(`Unexpected character '${ch}' in formula`);
+  }
+
+  tokens.push({ type: "eof", value: "" });
+  return tokens;
+}
+
+// Recursive-descent parser. Precedence low→high: comparison, concat(&), +-, */, unary.
+class Parser {
+  private pos = 0;
+  constructor(private readonly tokens: Token[]) {}
+
+  private peek(): Token {
+    return this.tokens[this.pos];
+  }
+
+  private next(): Token {
+    return this.tokens[this.pos++];
+  }
+
+  private expect(type: TokenType): Token {
+    const tok = this.next();
+    if (tok.type !== type) throw new FormulaError(`Expected ${type} but found '${tok.value || tok.type}'`);
+    return tok;
+  }
+
+  parse(): FormulaNode {
+    const node = this.parseComparison();
+    if (this.peek().type !== "eof") throw new FormulaError(`Unexpected token '${this.peek().value}'`);
+    return node;
+  }
+
+  private parseBinaryLevel(ops: Record<string, true>, next: () => FormulaNode): FormulaNode {
+    let left = next();
+    while (this.peek().type === "op" && ops[this.peek().value]) {
+      const op = this.next().value;
+      const right = next();
+      left = { type: "binary", op, left, right };
+    }
+    return left;
+  }
+
+  private parseComparison(): FormulaNode {
+    return this.parseBinaryLevel({ "=": true, "!=": true, "<": true, ">": true, "<=": true, ">=": true }, () =>
+      this.parseConcat(),
+    );
+  }
+
+  private parseConcat(): FormulaNode {
+    return this.parseBinaryLevel({ "&": true }, () => this.parseAdditive());
+  }
+
+  private parseAdditive(): FormulaNode {
+    return this.parseBinaryLevel({ "+": true, "-": true }, () => this.parseMultiplicative());
+  }
+
+  private parseMultiplicative(): FormulaNode {
+    return this.parseBinaryLevel({ "*": true, "/": true }, () => this.parseUnary());
+  }
+
+  private parseUnary(): FormulaNode {
+    if (this.peek().type === "op" && this.peek().value === "-") {
+      this.next();
+      return { type: "unary", op: "-", operand: this.parseUnary() };
+    }
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): FormulaNode {
+    const tok = this.peek();
+
+    if (tok.type === "num") {
+      this.next();
+      return { type: "num", value: Number(tok.value) };
+    }
+    if (tok.type === "str") {
+      this.next();
+      return { type: "str", value: tok.value };
+    }
+    if (tok.type === "field") {
+      this.next();
+      return { type: "field", name: tok.value };
+    }
+    if (tok.type === "lparen") {
+      this.next();
+      const node = this.parseComparison();
+      this.expect("rparen");
+      return node;
+    }
+    if (tok.type === "ident") {
+      this.next();
+      if (this.peek().type === "lparen") {
+        this.next();
+        const args: FormulaNode[] = [];
+        if (this.peek().type !== "rparen") {
+          args.push(this.parseComparison());
+          while (this.peek().type === "comma") {
+            this.next();
+            args.push(this.parseComparison());
+          }
+        }
+        this.expect("rparen");
+        return { type: "call", name: tok.value.toUpperCase(), args };
+      }
+      // Bare identifier is a field reference (Airtable allows unbraced names).
+      return { type: "field", name: tok.value };
+    }
+
+    throw new FormulaError(`Unexpected token '${tok.value || tok.type}'`);
+  }
+}
+
+export function parseFormula(src: string): FormulaNode {
+  return new Parser(tokenize(src)).parse();
+}
+
+export function collectFieldRefs(node: FormulaNode, out: string[] = []): string[] {
+  if (node.type === "field" && node.name) out.push(node.name);
+  if (node.operand) collectFieldRefs(node.operand, out);
+  if (node.left) collectFieldRefs(node.left, out);
+  if (node.right) collectFieldRefs(node.right, out);
+  for (const arg of node.args ?? []) collectFieldRefs(arg, out);
+  return out;
+}
+
+// ---- coercion (Airtable is loosely typed) ----
+
+function isBlank(v: unknown): boolean {
+  return v === null || v === undefined || v === "" || (Array.isArray(v) && v.length === 0);
+}
+
+function toStr(v: unknown): string {
+  if (isBlank(v)) return "";
+  if (Array.isArray(v)) return v.map(toStr).join(",");
+  if (typeof v === "boolean") return v ? "1" : "";
+  return String(v);
+}
+
+function toNum(v: unknown): number {
+  if (typeof v === "number") return v;
+  if (typeof v === "boolean") return v ? 1 : 0;
+  if (isBlank(v)) return 0;
+  const n = Number(toStr(v));
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function truthy(v: unknown): boolean {
+  if (typeof v === "boolean") return v;
+  if (typeof v === "number") return v !== 0;
+  if (isBlank(v)) return false;
+  if (Array.isArray(v)) return v.length > 0;
+  return toStr(v) !== "";
+}
+
+function looksNumeric(v: unknown): boolean {
+  if (typeof v === "number") return true;
+  if (typeof v === "string" && v.trim() !== "") return !Number.isNaN(Number(v));
+  return false;
+}
+
+function toMs(v: unknown): number {
+  if (v instanceof Date) return v.getTime();
+  if (typeof v === "number") return v;
+  const parsed = Date.parse(toStr(v));
+  if (Number.isNaN(parsed)) throw new FormulaError("Invalid date argument");
+  return parsed;
+}
+
+const UNIT_MS: Record<string, number> = {
+  milliseconds: 1,
+  seconds: 1000,
+  minutes: 60_000,
+  hours: 3_600_000,
+  days: 86_400_000,
+  weeks: 604_800_000,
+};
+
+function normalizeUnit(unit: string): string {
+  const u = unit.toLowerCase().replace(/s$/, "");
+  const map: Record<string, string> = {
+    millisecond: "milliseconds",
+    second: "seconds",
+    minute: "minutes",
+    hour: "hours",
+    day: "days",
+    week: "weeks",
+    month: "months",
+    year: "years",
+  };
+  return map[u] ?? unit.toLowerCase();
+}
+
+function dateAdd(baseMs: number, count: number, unit: string): number {
+  const u = normalizeUnit(unit);
+  if (u === "months" || u === "years") {
+    const d = new Date(baseMs);
+    if (u === "months") d.setUTCMonth(d.getUTCMonth() + count);
+    else d.setUTCFullYear(d.getUTCFullYear() + count);
+    return d.getTime();
+  }
+  return baseMs + count * (UNIT_MS[u] ?? 0);
+}
+
+function compare(a: unknown, b: unknown, op: string): boolean {
+  let cmp: number;
+  if (looksNumeric(a) && looksNumeric(b)) {
+    cmp = toNum(a) - toNum(b);
+  } else {
+    const sa = toStr(a);
+    const sb = toStr(b);
+    cmp = sa < sb ? -1 : sa > sb ? 1 : 0;
+  }
+  switch (op) {
+    case "=":
+      return cmp === 0;
+    case "!=":
+      return cmp !== 0;
+    case "<":
+      return cmp < 0;
+    case ">":
+      return cmp > 0;
+    case "<=":
+      return cmp <= 0;
+    case ">=":
+      return cmp >= 0;
+    default:
+      throw new FormulaError(`Unknown comparison operator '${op}'`);
+  }
+}
+
+// Eager functions: args already evaluated. Logic/date functions needing special
+// handling (short-circuit, ctx) are dispatched in evalCall.
+const EAGER_FUNCTIONS: Record<string, (args: unknown[]) => unknown> = {
+  LOWER: (a) => toStr(a[0]).toLowerCase(),
+  UPPER: (a) => toStr(a[0]).toUpperCase(),
+  TRIM: (a) => toStr(a[0]).trim(),
+  LEN: (a) => toStr(a[0]).length,
+  LEFT: (a) => toStr(a[0]).slice(0, toNum(a[1])),
+  RIGHT: (a) => toStr(a[0]).slice(-toNum(a[1]) || toStr(a[0]).length),
+  MID: (a) => toStr(a[0]).slice(Math.max(0, toNum(a[1]) - 1), Math.max(0, toNum(a[1]) - 1) + toNum(a[2])),
+  CONCATENATE: (a) => a.map(toStr).join(""),
+  SUBSTITUTE: (a) => toStr(a[0]).split(toStr(a[1])).join(toStr(a[2])),
+  VALUE: (a) => toNum(a[0]),
+  ABS: (a) => Math.abs(toNum(a[0])),
+  ROUND: (a) => {
+    const factor = 10 ** toNum(a[1] ?? 0);
+    return Math.round(toNum(a[0]) * factor) / factor;
+  },
+  MIN: (a) => Math.min(...a.map(toNum)),
+  MAX: (a) => Math.max(...a.map(toNum)),
+  SUM: (a) => a.reduce<number>((acc, v) => acc + toNum(v), 0),
+};
+
+function find(args: unknown[]): number {
+  const needle = toStr(args[0]);
+  const hay = toStr(args[1]);
+  const start = args[2] != null ? Math.max(0, toNum(args[2]) - 1) : 0;
+  const idx = hay.indexOf(needle, start);
+  return idx < 0 ? 0 : idx + 1;
+}
+
+function evalCall(node: FormulaNode, ctx: FormulaContext): unknown {
+  const name = node.name ?? "";
+  const args = node.args ?? [];
+
+  switch (name) {
+    case "AND":
+      return args.every((a) => truthy(evalNode(a, ctx)));
+    case "OR":
+      return args.some((a) => truthy(evalNode(a, ctx)));
+    case "NOT":
+      return !truthy(evalNode(args[0], ctx));
+    case "IF": {
+      const cond = truthy(evalNode(args[0], ctx));
+      return cond ? evalNode(args[1], ctx) : args.length > 2 ? evalNode(args[2], ctx) : "";
+    }
+    case "TRUE":
+      return 1;
+    case "FALSE":
+      return 0;
+    case "BLANK":
+      return "";
+    case "RECORD_ID":
+      return ctx.recordId;
+    case "CREATED_TIME":
+      return ctx.createdTime;
+    case "TODAY": {
+      const d = ctx.now;
+      return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())).toISOString();
+    }
+    case "NOW":
+      return ctx.now.toISOString();
+    case "FIND":
+      return find(args.map((a) => evalNode(a, ctx)));
+    case "SEARCH": {
+      const idx = find(args.map((a) => evalNode(a, ctx)));
+      return idx === 0 ? "" : idx;
+    }
+    case "DATEADD": {
+      const ms = dateAdd(toMs(evalNode(args[0], ctx)), toNum(evalNode(args[1], ctx)), toStr(evalNode(args[2], ctx)));
+      return new Date(ms).toISOString();
+    }
+    case "DATETIME_DIFF": {
+      const a = toMs(evalNode(args[0], ctx));
+      const b = toMs(evalNode(args[1], ctx));
+      const unit = normalizeUnit(toStr(evalNode(args[2] ?? { type: "str", value: "days" }, ctx)));
+      return Math.trunc((a - b) / (UNIT_MS[unit] ?? UNIT_MS.days));
+    }
+    case "IS_AFTER":
+      return toMs(evalNode(args[0], ctx)) > toMs(evalNode(args[1], ctx));
+    case "IS_BEFORE":
+      return toMs(evalNode(args[0], ctx)) < toMs(evalNode(args[1], ctx));
+    case "IS_SAME": {
+      const a = toMs(evalNode(args[0], ctx));
+      const b = toMs(evalNode(args[1], ctx));
+      if (args[2] != null) {
+        const unit = normalizeUnit(toStr(evalNode(args[2], ctx)));
+        return Math.floor(a / (UNIT_MS[unit] ?? 1)) === Math.floor(b / (UNIT_MS[unit] ?? 1));
+      }
+      return a === b;
+    }
+  }
+
+  const eager = EAGER_FUNCTIONS[name];
+  if (eager) return eager(args.map((a) => evalNode(a, ctx)));
+
+  throw new FormulaError(`Unsupported function '${name}()'`);
+}
+
+function evalBinary(node: FormulaNode, ctx: FormulaContext): unknown {
+  const op = node.op ?? "";
+  const left = evalNode(node.left as FormulaNode, ctx);
+  const right = evalNode(node.right as FormulaNode, ctx);
+  switch (op) {
+    case "&":
+      return toStr(left) + toStr(right);
+    case "+":
+      return toNum(left) + toNum(right);
+    case "-":
+      return toNum(left) - toNum(right);
+    case "*":
+      return toNum(left) * toNum(right);
+    case "/":
+      return toNum(right) === 0 ? 0 : toNum(left) / toNum(right);
+    default:
+      return compare(left, right, op);
+  }
+}
+
+function evalNode(node: FormulaNode, ctx: FormulaContext): unknown {
+  switch (node.type) {
+    case "num":
+      return node.value;
+    case "str":
+      return node.value;
+    case "field":
+      return ctx.field(node.name ?? "");
+    case "unary":
+      return -toNum(evalNode(node.operand as FormulaNode, ctx));
+    case "binary":
+      return evalBinary(node, ctx);
+    case "call":
+      return evalCall(node, ctx);
+    default:
+      throw new FormulaError("Malformed formula node");
+  }
+}
+
+export function evaluateFormula(node: FormulaNode, ctx: FormulaContext): unknown {
+  return evalNode(node, ctx);
+}
+
+export function matchesFormula(node: FormulaNode, ctx: FormulaContext): boolean {
+  return truthy(evalNode(node, ctx));
+}

--- a/packages/@emulators/airtable/src/helpers.ts
+++ b/packages/@emulators/airtable/src/helpers.ts
@@ -1,0 +1,41 @@
+import type { Context, ContentfulStatusCode } from "@emulators/core";
+
+/**
+ * Airtable uses two error envelope shapes, both confirmed against the live API:
+ *  - object form  `{"error":{"type","message"}}` for most errors
+ *  - bare-string  `{"error":"NOT_FOUND"}` for an unknown base or record
+ * The service owns these directly; it never uses the kernel's GitHub-shaped handler.
+ */
+export function airtableError(c: Context, status: number, type: string, message: string): Response {
+  return c.json({ error: { type, message } }, status as ContentfulStatusCode);
+}
+
+export function airtableNotFound(c: Context): Response {
+  return c.json({ error: "NOT_FOUND" }, 404);
+}
+
+export async function parseJsonBody(c: Context): Promise<Record<string, unknown>> {
+  try {
+    const body = await c.req.json();
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      return body as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+// Opaque, Airtable-shaped pagination token (`itr<rand>/<index>`). Clients treat it
+// as opaque and round-trip it verbatim; we only decode our own start index from it.
+export function encodeOffset(index: number): string {
+  return `itr${Math.random().toString(36).slice(2, 10)}/${index}`;
+}
+
+export function decodeOffset(token: string | undefined): number {
+  if (!token) return 0;
+  const slash = token.lastIndexOf("/");
+  const raw = slash >= 0 ? token.slice(slash + 1) : token;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+}

--- a/packages/@emulators/airtable/src/ids.ts
+++ b/packages/@emulators/airtable/src/ids.ts
@@ -1,0 +1,21 @@
+// Airtable ids are a type prefix + 14 base62 chars (e.g. `rec` + 14 = a 17-char
+// record id). Generated ids are only used when the seed config omits one; seeded
+// ids pass through verbatim so real base/table/field ids resolve unchanged.
+
+const ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+function randomSuffix(length = 14): string {
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+  }
+  return out;
+}
+
+export const generateBaseId = (): string => `app${randomSuffix()}`;
+export const generateTableId = (): string => `tbl${randomSuffix()}`;
+export const generateFieldId = (): string => `fld${randomSuffix()}`;
+export const generateViewId = (): string => `viw${randomSuffix()}`;
+export const generateRecordId = (): string => `rec${randomSuffix()}`;
+export const generateCommentId = (): string => `com${randomSuffix()}`;
+export const generateUserId = (): string => `usr${randomSuffix()}`;

--- a/packages/@emulators/airtable/src/index.ts
+++ b/packages/@emulators/airtable/src/index.ts
@@ -3,6 +3,7 @@ import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispa
 import { seedDefaults } from "./seed.js";
 import { metaRoutes } from "./routes/meta.js";
 import { recordRoutes } from "./routes/records.js";
+import { commentRoutes } from "./routes/comments.js";
 
 export { getAirtableStore, type AirtableStore } from "./store.js";
 export * from "./entities.js";
@@ -21,6 +22,7 @@ export const airtablePlugin: ServicePlugin = {
     const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
     metaRoutes(ctx);
     recordRoutes(ctx);
+    commentRoutes(ctx);
   },
   seed(store: Store): void {
     seedDefaults(store);

--- a/packages/@emulators/airtable/src/index.ts
+++ b/packages/@emulators/airtable/src/index.ts
@@ -1,6 +1,8 @@
 import type { Hono } from "@emulators/core";
-import type { AppEnv, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
 import { seedDefaults } from "./seed.js";
+import { metaRoutes } from "./routes/meta.js";
+import { recordRoutes } from "./routes/records.js";
 
 export { getAirtableStore, type AirtableStore } from "./store.js";
 export * from "./entities.js";
@@ -15,14 +17,10 @@ export {
 
 export const airtablePlugin: ServicePlugin = {
   name: "airtable",
-  register(
-    _app: Hono<AppEnv>,
-    _store: Store,
-    _webhooks: WebhookDispatcher,
-    _baseUrl: string,
-    _tokenMap?: TokenMap,
-  ): void {
-    // HTTP routes are wired in a subsequent commit.
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    metaRoutes(ctx);
+    recordRoutes(ctx);
   },
   seed(store: Store): void {
     seedDefaults(store);

--- a/packages/@emulators/airtable/src/index.ts
+++ b/packages/@emulators/airtable/src/index.ts
@@ -4,6 +4,7 @@ import { seedDefaults } from "./seed.js";
 import { metaRoutes } from "./routes/meta.js";
 import { recordRoutes } from "./routes/records.js";
 import { commentRoutes } from "./routes/comments.js";
+import { inspectorRoutes } from "./routes/inspector.js";
 
 export { getAirtableStore, type AirtableStore } from "./store.js";
 export * from "./entities.js";
@@ -23,6 +24,7 @@ export const airtablePlugin: ServicePlugin = {
     metaRoutes(ctx);
     recordRoutes(ctx);
     commentRoutes(ctx);
+    inspectorRoutes(ctx);
   },
   seed(store: Store): void {
     seedDefaults(store);

--- a/packages/@emulators/airtable/src/index.ts
+++ b/packages/@emulators/airtable/src/index.ts
@@ -1,0 +1,32 @@
+import type { Hono } from "@emulators/core";
+import type { AppEnv, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { seedDefaults } from "./seed.js";
+
+export { getAirtableStore, type AirtableStore } from "./store.js";
+export * from "./entities.js";
+export {
+  seedFromConfig,
+  type AirtableSeedConfig,
+  type AirtableSeedBase,
+  type AirtableSeedTable,
+  type AirtableSeedField,
+  type AirtableSeedView,
+} from "./seed.js";
+
+export const airtablePlugin: ServicePlugin = {
+  name: "airtable",
+  register(
+    _app: Hono<AppEnv>,
+    _store: Store,
+    _webhooks: WebhookDispatcher,
+    _baseUrl: string,
+    _tokenMap?: TokenMap,
+  ): void {
+    // HTTP routes are wired in a subsequent commit.
+  },
+  seed(store: Store): void {
+    seedDefaults(store);
+  },
+};
+
+export default airtablePlugin;

--- a/packages/@emulators/airtable/src/routes/comments.ts
+++ b/packages/@emulators/airtable/src/routes/comments.ts
@@ -1,0 +1,109 @@
+import type { Context, RouteContext, Store } from "@emulators/core";
+import { getAirtableStore } from "../store.js";
+import type { AirtableComment, AirtableCommentAuthor, AirtableMention, AirtableRecordEntity } from "../entities.js";
+import { airtableError, airtableNotFound, decodeOffset, encodeOffset, parseJsonBody } from "../helpers.js";
+import { resolveBase, resolveTable } from "../schema.js";
+import { generateCommentId } from "../ids.js";
+
+const MODEL_NOT_FOUND =
+  "Invalid permissions, or the requested model was not found. Check that both your user and your token have the required permissions, and that the model names and/or ids are correct.";
+const MENTION_RE = /@\[(usr[A-Za-z0-9]+)\]/g;
+
+/** Resolve base + table + record for a comment route, returning Airtable's distinct
+ * errors (bare-string 404 for base/record, 403 for table). */
+function resolveRecord(
+  c: Context,
+  store: Store,
+  baseId: string,
+  tableIdOrName: string,
+  recordId: string,
+): AirtableRecordEntity | Response {
+  if (!resolveBase(store, baseId)) return airtableNotFound(c);
+  const table = resolveTable(store, baseId, tableIdOrName);
+  if (!table) return airtableError(c, 403, "INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND", MODEL_NOT_FOUND);
+  const rec = getAirtableStore(store).records.findOneBy("record_id", recordId);
+  if (!rec || rec.table_id !== table.table_id) return airtableNotFound(c);
+  return rec;
+}
+
+function currentAuthor(store: Store): AirtableCommentAuthor {
+  const user = getAirtableStore(store).users.all()[0];
+  if (!user) return { id: "usrEmulatorDefault", email: "dev@example.com" };
+  return { id: user.user_id, email: user.email, name: user.name };
+}
+
+function parseMentions(store: Store, text: string): Record<string, AirtableMention> | null {
+  const users = getAirtableStore(store).users;
+  const mentioned: Record<string, AirtableMention> = {};
+  for (const m of text.matchAll(MENTION_RE)) {
+    const userId = m[1];
+    const user = users.findOneBy("user_id", userId);
+    mentioned[userId] = { type: "user", id: userId, displayName: user?.name, email: user?.email };
+  }
+  return Object.keys(mentioned).length > 0 ? mentioned : null;
+}
+
+function serializeComment(comment: AirtableComment) {
+  return {
+    id: comment.comment_id,
+    author: comment.author,
+    text: comment.text,
+    createdTime: comment.created_time,
+    lastUpdatedTime: comment.last_updated_time ?? null,
+    mentioned: comment.mentioned ?? undefined,
+  };
+}
+
+export function commentRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+
+  app.get("/v0/:baseId/:tableId/:recordId/comments", (c) => {
+    const rec = resolveRecord(c, store, c.req.param("baseId"), c.req.param("tableId"), c.req.param("recordId"));
+    if (rec instanceof Response) return rec;
+
+    const all = getAirtableStore(store)
+      .comments.findBy("record_id", rec.record_id)
+      .sort((a, b) => (a.created_time < b.created_time ? -1 : a.created_time > b.created_time ? 1 : a.id - b.id));
+
+    const pageSizeRaw = c.req.query("pageSize");
+    const pageSize = pageSizeRaw != null ? Number(pageSizeRaw) : 100;
+    const start = decodeOffset(c.req.query("offset"));
+    const page = all.slice(start, start + pageSize);
+    const nextOffset = start + pageSize < all.length ? encodeOffset(start + pageSize) : undefined;
+
+    const comments = page.map(serializeComment);
+    return c.json(nextOffset ? { comments, offset: nextOffset } : { comments });
+  });
+
+  app.post("/v0/:baseId/:tableId/:recordId/comments", async (c) => {
+    const rec = resolveRecord(c, store, c.req.param("baseId"), c.req.param("tableId"), c.req.param("recordId"));
+    if (rec instanceof Response) return rec;
+
+    const body = await parseJsonBody(c);
+    const text = typeof body.text === "string" ? body.text : "";
+    if (!text) {
+      return airtableError(c, 422, "INVALID_REQUEST_MISSING_FIELDS", 'Could not find field "text" in the request body');
+    }
+
+    const comment = getAirtableStore(store).comments.insert({
+      comment_id: generateCommentId(),
+      record_id: rec.record_id,
+      text,
+      author: currentAuthor(store),
+      created_time: new Date().toISOString(),
+      last_updated_time: null,
+      mentioned: parseMentions(store, text),
+    });
+
+    return c.json(serializeComment(comment));
+  });
+
+  app.delete("/v0/:baseId/:tableId/:recordId/comments/:commentId", (c) => {
+    const rec = resolveRecord(c, store, c.req.param("baseId"), c.req.param("tableId"), c.req.param("recordId"));
+    if (rec instanceof Response) return rec;
+    const comment = getAirtableStore(store).comments.findOneBy("comment_id", c.req.param("commentId"));
+    if (!comment || comment.record_id !== rec.record_id) return airtableNotFound(c);
+    getAirtableStore(store).comments.delete(comment.id);
+    return c.json({ id: comment.comment_id, deleted: true });
+  });
+}

--- a/packages/@emulators/airtable/src/routes/inspector.ts
+++ b/packages/@emulators/airtable/src/routes/inspector.ts
@@ -1,0 +1,116 @@
+import type { InspectorTab, RouteContext } from "@emulators/core";
+import { escapeHtml, renderInspectorPage } from "@emulators/core";
+import { getAirtableStore } from "../store.js";
+import { tableFields } from "../schema.js";
+
+const SERVICE_LABEL = "Airtable";
+
+const TABS: InspectorTab[] = [
+  { id: "bases", label: "Bases", href: "/?tab=bases" },
+  { id: "tables", label: "Tables", href: "/?tab=tables" },
+  { id: "records", label: "Records", href: "/?tab=records" },
+  { id: "auth", label: "Auth", href: "/?tab=auth" },
+];
+
+export function inspectorRoutes({ app, store }: RouteContext): void {
+  const s = () => getAirtableStore(store);
+
+  app.get("/", (c) => {
+    const requested = c.req.query("tab") ?? "bases";
+    const active = TABS.some((t) => t.id === requested) ? requested : "bases";
+    const body =
+      active === "tables"
+        ? tablesView()
+        : active === "records"
+          ? recordsView(c.req.query("table"))
+          : active === "auth"
+            ? authView()
+            : basesView();
+    return c.html(renderInspectorPage("Airtable Inspector", TABS, active, body, SERVICE_LABEL));
+  });
+
+  function basesView(): string {
+    const rows = s()
+      .bases.all()
+      .map((b) => [
+        escapeHtml(b.base_id),
+        escapeHtml(b.name),
+        escapeHtml(b.permission_level),
+        escapeHtml(String(s().tables.count((t) => t.base_id === b.base_id))),
+      ]);
+    return section("Bases", table(["Base ID", "Name", "Permission", "Tables"], rows, "No bases seeded."));
+  }
+
+  function tablesView(): string {
+    const rows = s()
+      .tables.all()
+      .map((t) => [
+        escapeHtml(s().bases.findOneBy("base_id", t.base_id)?.name ?? t.base_id),
+        escapeHtml(t.name),
+        escapeHtml(t.table_id),
+        escapeHtml(String(tableFields(store, t.table_id).length)),
+        escapeHtml(String(s().views.count((v) => v.table_id === t.table_id))),
+        escapeHtml(String(s().records.count((r) => r.table_id === t.table_id))),
+      ]);
+    return section(
+      "Tables",
+      table(["Base", "Name", "Table ID", "Fields", "Views", "Records"], rows, "No tables seeded."),
+    );
+  }
+
+  function recordsView(tableParam?: string): string {
+    const tables = s().tables.all();
+    if (tables.length === 0) return section("Records", table(["Record"], [], "No tables seeded."));
+    const selected = (tableParam && tables.find((t) => t.table_id === tableParam)) || tables[0];
+    const fields = tableFields(store, selected.table_id).slice(0, 6);
+
+    const tabs = tables
+      .map((t) => {
+        const label = escapeHtml(t.name);
+        return t.table_id === selected.table_id
+          ? `<strong>${label}</strong>`
+          : `<a href="/?tab=records&table=${escapeHtml(t.table_id)}">${label}</a>`;
+      })
+      .join(" · ");
+
+    const rows = s()
+      .records.findBy("table_id", selected.table_id)
+      .slice(0, 50)
+      .map((rec) => [escapeHtml(rec.record_id), ...fields.map((f) => escapeHtml(cellText(rec.cells[f.name])))]);
+
+    return section(
+      `Records — ${escapeHtml(selected.name)}`,
+      `<p class="empty">${tabs}</p>` + table(["Record ID", ...fields.map((f) => f.name)], rows, "No records."),
+    );
+  }
+
+  function authView(): string {
+    const rows = s()
+      .users.all()
+      .map((u) => [
+        escapeHtml(u.user_id),
+        escapeHtml(u.email),
+        escapeHtml(u.name ?? ""),
+        escapeHtml(u.scopes.join(", ")),
+      ]);
+    return section("Tokens / Identity", table(["User ID", "Email", "Name", "Scopes"], rows, "No users seeded."));
+  }
+}
+
+function cellText(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) return value.map((v) => String(v)).join(", ");
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function section(title: string, body: string): string {
+  return `<main class="inspector-main"><h2>${escapeHtml(title)}</h2>${body}</main>`;
+}
+
+function table(headers: string[], rows: string[][], empty: string): string {
+  if (rows.length === 0) return `<p class="empty">${escapeHtml(empty)}</p>`;
+  const head = headers.map((h) => `<th>${escapeHtml(h)}</th>`).join("");
+  const body = rows.map((row) => `<tr>${row.map((cell) => `<td>${cell}</td>`).join("")}</tr>`).join("");
+  return `<table class="inspector-table"><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+}

--- a/packages/@emulators/airtable/src/routes/meta.ts
+++ b/packages/@emulators/airtable/src/routes/meta.ts
@@ -1,0 +1,50 @@
+import type { RouteContext } from "@emulators/core";
+import { getAirtableStore } from "../store.js";
+import { airtableNotFound } from "../helpers.js";
+import { resolveBase, tableFields } from "../schema.js";
+
+export function metaRoutes({ app, store }: RouteContext): void {
+  const s = () => getAirtableStore(store);
+
+  // GET /v0/meta/whoami — the token's identity. Scopes are included so the agent2
+  // gateway's identity probe can read them.
+  app.get("/v0/meta/whoami", (c) => {
+    const user = s().users.all()[0];
+    if (!user) return c.json({ id: "usrEmulatorDefault", scopes: [] });
+    return c.json({ id: user.user_id, email: user.email, scopes: user.scopes });
+  });
+
+  // GET /v0/meta/bases — bases the token can access.
+  app.get("/v0/meta/bases", (c) => {
+    const bases = s()
+      .bases.all()
+      .map((b) => ({ id: b.base_id, name: b.name, permissionLevel: b.permission_level }));
+    return c.json({ bases });
+  });
+
+  // GET /v0/meta/bases/:baseId/tables — the base schema (tables, fields, views).
+  app.get("/v0/meta/bases/:baseId/tables", (c) => {
+    const baseId = c.req.param("baseId");
+    if (!resolveBase(store, baseId)) return airtableNotFound(c);
+
+    const tables = s()
+      .tables.findBy("base_id", baseId)
+      .map((t) => ({
+        id: t.table_id,
+        name: t.name,
+        primaryFieldId: t.primary_field_id,
+        description: t.description ?? undefined,
+        fields: tableFields(store, t.table_id).map((f) => ({
+          id: f.field_id,
+          name: f.name,
+          type: f.type,
+          options: f.options ?? undefined,
+        })),
+        views: s()
+          .views.findBy("table_id", t.table_id)
+          .map((v) => ({ id: v.view_id, name: v.name, type: v.type })),
+      }));
+
+    return c.json({ tables });
+  });
+}

--- a/packages/@emulators/airtable/src/routes/records.ts
+++ b/packages/@emulators/airtable/src/routes/records.ts
@@ -1,0 +1,512 @@
+import type { Context, RouteContext, Store } from "@emulators/core";
+import { getAirtableStore } from "../store.js";
+import type { AirtableRecordEntity, AirtableTable } from "../entities.js";
+import { airtableError, airtableNotFound, decodeOffset, encodeOffset, parseJsonBody } from "../helpers.js";
+import { findField, normalizeWriteCells, resolveBase, resolveTable, serializeRecord, tableFields } from "../schema.js";
+import { collectFieldRefs, FormulaError, matchesFormula, parseFormula } from "../formula.js";
+import { generateRecordId } from "../ids.js";
+
+const MODEL_NOT_FOUND =
+  "Invalid permissions, or the requested model was not found. Check that both your user and your token have the required permissions, and that the model names and/or ids are correct.";
+const BATCH_LIMIT = 10;
+
+interface ListParams {
+  fields?: string[];
+  filterByFormula?: string;
+  maxRecords?: number;
+  pageSize?: number;
+  offset?: string;
+  view?: string;
+  cellFormat?: string;
+  returnFieldsByFieldId?: boolean;
+  sort?: Array<{ field: string; direction?: string }>;
+}
+
+/** Resolve a base + table, returning the distinct Airtable errors: unknown base is a
+ * bare-string 404, unknown table is a 403 model-not-found. */
+function resolveTarget(
+  c: Context,
+  store: Store,
+  baseId: string,
+  tableIdOrName: string,
+): { table: AirtableTable } | Response {
+  if (!resolveBase(store, baseId)) return airtableNotFound(c);
+  const table = resolveTable(store, baseId, tableIdOrName);
+  if (!table) return airtableError(c, 403, "INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND", MODEL_NOT_FOUND);
+  return { table };
+}
+
+function boolOf(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+function readFieldsInput(item: unknown): Record<string, unknown> | null {
+  if (item && typeof item === "object" && "fields" in item) {
+    const fields = item.fields;
+    if (fields && typeof fields === "object" && !Array.isArray(fields)) {
+      return fields as Record<string, unknown>;
+    }
+  }
+  return null;
+}
+
+function readId(item: unknown): string | undefined {
+  if (item && typeof item === "object" && "id" in item && typeof item.id === "string") {
+    return item.id;
+  }
+  return undefined;
+}
+
+function compareCells(
+  a: AirtableRecordEntity,
+  b: AirtableRecordEntity,
+  keys: Array<{ name: string; dir: number }>,
+): number {
+  for (const { name, dir } of keys) {
+    const av = a.cells[name];
+    const bv = b.cells[name];
+    const aBlank = av === undefined || av === null || av === "";
+    const bBlank = bv === undefined || bv === null || bv === "";
+    if (aBlank && bBlank) continue;
+    if (aBlank) return 1;
+    if (bBlank) return -1;
+    let cmp: number;
+    if (typeof av === "number" && typeof bv === "number") {
+      cmp = av - bv;
+    } else {
+      const as = String(av);
+      const bs = String(bv);
+      cmp = as < bs ? -1 : as > bs ? 1 : 0;
+    }
+    if (cmp !== 0) return cmp * dir;
+  }
+  return 0;
+}
+
+interface FilterResult {
+  rows?: AirtableRecordEntity[];
+  error?: Response;
+}
+
+/** Parse + validate + apply a formula to `rows`. Field refs are validated against
+ * field NAMES (so `{fldXXX}` id tokens 422), matching Airtable. */
+function applyFormula(
+  c: Context,
+  formula: string,
+  fieldNames: Set<string>,
+  rows: AirtableRecordEntity[],
+): FilterResult {
+  let ast;
+  try {
+    ast = parseFormula(formula);
+  } catch (err) {
+    return {
+      error: airtableError(c, 422, "INVALID_FILTER_BY_FORMULA", err instanceof Error ? err.message : "Invalid formula"),
+    };
+  }
+
+  const unknown = collectFieldRefs(ast).filter((ref) => !fieldNames.has(ref));
+  if (unknown.length > 0) {
+    return { error: airtableError(c, 422, "INVALID_FILTER_BY_FORMULA", `Unknown field names: ${unknown.join(", ")}`) };
+  }
+
+  const now = new Date();
+  try {
+    const rowsOut = rows.filter((rec) =>
+      matchesFormula(ast, {
+        field: (name) => rec.cells[name],
+        recordId: rec.record_id,
+        createdTime: rec.created_time,
+        now,
+      }),
+    );
+    return { rows: rowsOut };
+  } catch (err) {
+    if (err instanceof FormulaError) {
+      return { error: airtableError(c, 422, "INVALID_FILTER_BY_FORMULA", err.message) };
+    }
+    throw err;
+  }
+}
+
+function runList(c: Context, store: Store, table: AirtableTable, p: ListParams): Response {
+  const fields = tableFields(store, table.table_id);
+  const fieldNames = new Set(fields.map((f) => f.name));
+
+  const pageSize = p.pageSize ?? 100;
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+    return airtableError(c, 422, "INVALID_PAGE_SIZE_ARGUMENT", "Page size argument should be between 0 and 100");
+  }
+  if (p.cellFormat && p.cellFormat !== "json") {
+    return airtableError(c, 422, "INVALID_CELL_FORMAT", 'The emulator only supports cellFormat "json"');
+  }
+
+  let rows = getAirtableStore(store).records.findBy("table_id", table.table_id);
+
+  let viewSort: Array<{ field: string; direction?: string }> | undefined;
+  let viewFields: string[] | undefined;
+  if (p.view) {
+    const view = getAirtableStore(store)
+      .views.findBy("table_id", table.table_id)
+      .find((v) => v.view_id === p.view || v.name === p.view);
+    if (!view) return airtableError(c, 422, "VIEW_NAME_NOT_FOUND", `The view "${p.view}" was not found`);
+    if (view.filter) {
+      const filtered = applyFormula(c, view.filter, fieldNames, rows);
+      if (filtered.error) return filtered.error;
+      rows = filtered.rows ?? rows;
+    }
+    viewSort = view.sort ?? undefined;
+    viewFields = view.fields ?? undefined;
+  }
+
+  if (p.filterByFormula) {
+    const filtered = applyFormula(c, p.filterByFormula, fieldNames, rows);
+    if (filtered.error) return filtered.error;
+    rows = filtered.rows ?? rows;
+  }
+
+  const sortSpec = p.sort && p.sort.length > 0 ? p.sort : viewSort;
+  if (sortSpec && sortSpec.length > 0) {
+    const keys: Array<{ name: string; dir: number }> = [];
+    for (const spec of sortSpec) {
+      const field = findField(fields, spec.field);
+      if (!field) return airtableError(c, 422, "UNKNOWN_FIELD_NAME", `Unknown field name: "${spec.field}"`);
+      keys.push({ name: field.name, dir: spec.direction === "desc" ? -1 : 1 });
+    }
+    rows = [...rows].sort((a, b) => compareCells(a, b, keys));
+  }
+
+  const capped = p.maxRecords && p.maxRecords > 0 ? rows.slice(0, p.maxRecords) : rows;
+  const start = decodeOffset(p.offset);
+  const page = capped.slice(start, start + pageSize);
+  const nextOffset = start + pageSize < capped.length ? encodeOffset(start + pageSize) : undefined;
+
+  const subset = p.fields ?? viewFields;
+  const records = page.map((rec) =>
+    serializeRecord(store, table, rec, { returnFieldsByFieldId: p.returnFieldsByFieldId, fieldsSubset: subset }),
+  );
+
+  return c.json(nextOffset ? { records, offset: nextOffset } : { records });
+}
+
+function listParamsFromQuery(c: Context): ListParams {
+  const sort: Array<{ field: string; direction?: string }> = [];
+  for (let i = 0; ; i++) {
+    const field = c.req.query(`sort[${i}][field]`);
+    if (!field) break;
+    sort.push({ field, direction: c.req.query(`sort[${i}][direction]`) });
+  }
+  const pageSize = c.req.query("pageSize");
+  const maxRecords = c.req.query("maxRecords");
+  return {
+    fields: c.req.queries("fields[]") ?? c.req.queries("fields"),
+    filterByFormula: c.req.query("filterByFormula"),
+    pageSize: pageSize != null ? Number(pageSize) : undefined,
+    maxRecords: maxRecords != null ? Number(maxRecords) : undefined,
+    offset: c.req.query("offset"),
+    view: c.req.query("view"),
+    cellFormat: c.req.query("cellFormat"),
+    returnFieldsByFieldId: c.req.query("returnFieldsByFieldId") === "true",
+    sort: sort.length > 0 ? sort : undefined,
+  };
+}
+
+function listParamsFromBody(body: Record<string, unknown>): ListParams {
+  const sort: Array<{ field: string; direction?: string }> = [];
+  if (Array.isArray(body.sort)) {
+    for (const s of body.sort) {
+      if (s && typeof s === "object" && "field" in s && typeof s.field === "string") {
+        const direction = "direction" in s && typeof s.direction === "string" ? s.direction : undefined;
+        sort.push({ field: s.field, direction });
+      }
+    }
+  }
+  return {
+    fields: Array.isArray(body.fields) ? body.fields.filter((f): f is string => typeof f === "string") : undefined,
+    filterByFormula: typeof body.filterByFormula === "string" ? body.filterByFormula : undefined,
+    pageSize: typeof body.pageSize === "number" ? body.pageSize : undefined,
+    maxRecords: typeof body.maxRecords === "number" ? body.maxRecords : undefined,
+    offset: typeof body.offset === "string" ? body.offset : undefined,
+    view: typeof body.view === "string" ? body.view : undefined,
+    cellFormat: typeof body.cellFormat === "string" ? body.cellFormat : undefined,
+    returnFieldsByFieldId: boolOf(body.returnFieldsByFieldId),
+    sort,
+  };
+}
+
+function createRecord(store: Store, table: AirtableTable, cells: Record<string, unknown>): AirtableRecordEntity {
+  return getAirtableStore(store).records.insert({
+    base_id: table.base_id,
+    table_id: table.table_id,
+    record_id: generateRecordId(),
+    cells,
+    created_time: new Date().toISOString(),
+  });
+}
+
+function findRecord(store: Store, table: AirtableTable, recordId: string): AirtableRecordEntity | undefined {
+  const rec = getAirtableStore(store).records.findOneBy("record_id", recordId);
+  return rec && rec.table_id === table.table_id ? rec : undefined;
+}
+
+export function recordRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+
+  app.get("/v0/:baseId/:tableId", (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    return runList(c, store, target.table, listParamsFromQuery(c));
+  });
+
+  app.post("/v0/:baseId/:tableId/listRecords", async (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    return runList(c, store, target.table, listParamsFromBody(await parseJsonBody(c)));
+  });
+
+  app.get("/v0/:baseId/:tableId/:recordId", (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    const rec = findRecord(store, target.table, c.req.param("recordId"));
+    if (!rec) return airtableNotFound(c);
+    return c.json(
+      serializeRecord(store, target.table, rec, {
+        returnFieldsByFieldId: c.req.query("returnFieldsByFieldId") === "true",
+      }),
+    );
+  });
+
+  app.post("/v0/:baseId/:tableId", async (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    return handleCreate(c, store, target.table, await parseJsonBody(c));
+  });
+
+  app.patch("/v0/:baseId/:tableId", async (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    return handleBatchUpdate(c, store, target.table, await parseJsonBody(c), false);
+  });
+
+  app.put("/v0/:baseId/:tableId", async (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    return handleBatchUpdate(c, store, target.table, await parseJsonBody(c), true);
+  });
+
+  app.patch("/v0/:baseId/:tableId/:recordId", async (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    return handleSingleUpdate(c, store, target.table, c.req.param("recordId"), await parseJsonBody(c), false);
+  });
+
+  app.put("/v0/:baseId/:tableId/:recordId", async (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    return handleSingleUpdate(c, store, target.table, c.req.param("recordId"), await parseJsonBody(c), true);
+  });
+
+  app.delete("/v0/:baseId/:tableId/:recordId", (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    const rec = findRecord(store, target.table, c.req.param("recordId"));
+    if (!rec) return airtableNotFound(c);
+    getAirtableStore(store).records.delete(rec.id);
+    return c.json({ deleted: true, id: rec.record_id });
+  });
+
+  app.delete("/v0/:baseId/:tableId", (c) => {
+    const target = resolveTarget(c, store, c.req.param("baseId"), c.req.param("tableId"));
+    if (target instanceof Response) return target;
+    const ids = c.req.queries("records[]") ?? c.req.queries("records") ?? [];
+    const deleted: Array<{ deleted: true; id: string }> = [];
+    for (const id of ids) {
+      const rec = findRecord(store, target.table, id);
+      if (!rec) return airtableNotFound(c);
+      getAirtableStore(store).records.delete(rec.id);
+      deleted.push({ deleted: true, id: rec.record_id });
+    }
+    return c.json({ records: deleted });
+  });
+}
+
+function serialize(store: Store, table: AirtableTable, rec: AirtableRecordEntity, returnFieldsByFieldId: boolean) {
+  return serializeRecord(store, table, rec, { returnFieldsByFieldId });
+}
+
+function handleCreate(c: Context, store: Store, table: AirtableTable, body: Record<string, unknown>): Response {
+  const returnFieldIds = boolOf(body.returnFieldsByFieldId);
+  const typecast = boolOf(body.typecast);
+
+  if (Array.isArray(body.records)) {
+    if (body.records.length > BATCH_LIMIT) {
+      return airtableError(
+        c,
+        422,
+        "INVALID_REQUEST_BODY",
+        `You may only create up to ${BATCH_LIMIT} records at a time`,
+      );
+    }
+    const created: AirtableRecordEntity[] = [];
+    for (const item of body.records) {
+      const incoming = readFieldsInput(item);
+      if (!incoming) {
+        return airtableError(
+          c,
+          422,
+          "INVALID_REQUEST_MISSING_FIELDS",
+          'Could not find field "fields" in the request body',
+        );
+      }
+      const normalized = normalizeWriteCells(store, table, incoming, typecast);
+      if (normalized.error) return airtableError(c, 422, normalized.error.type, normalized.error.message);
+      created.push(createRecord(store, table, normalized.cells ?? {}));
+    }
+    return c.json({ records: created.map((r) => serialize(store, table, r, returnFieldIds)) });
+  }
+
+  const incoming = readFieldsInput(body);
+  if (!incoming) {
+    return airtableError(c, 422, "INVALID_REQUEST_MISSING_FIELDS", 'Could not find field "fields" in the request body');
+  }
+  const normalized = normalizeWriteCells(store, table, incoming, typecast);
+  if (normalized.error) return airtableError(c, 422, normalized.error.type, normalized.error.message);
+  const rec = createRecord(store, table, normalized.cells ?? {});
+  return c.json(serialize(store, table, rec, returnFieldIds));
+}
+
+function handleSingleUpdate(
+  c: Context,
+  store: Store,
+  table: AirtableTable,
+  recordId: string,
+  body: Record<string, unknown>,
+  replace: boolean,
+): Response {
+  const rec = findRecord(store, table, recordId);
+  if (!rec) return airtableNotFound(c);
+
+  const incoming = readFieldsInput(body);
+  if (!incoming) {
+    return airtableError(c, 422, "INVALID_REQUEST_MISSING_FIELDS", 'Could not find field "fields" in the request body');
+  }
+  const normalized = normalizeWriteCells(store, table, incoming, boolOf(body.typecast));
+  if (normalized.error) return airtableError(c, 422, normalized.error.type, normalized.error.message);
+
+  const cells = replace ? (normalized.cells ?? {}) : { ...rec.cells, ...(normalized.cells ?? {}) };
+  const updated = getAirtableStore(store).records.update(rec.id, { cells });
+  return c.json(serialize(store, table, updated ?? rec, boolOf(body.returnFieldsByFieldId)));
+}
+
+function handleBatchUpdate(
+  c: Context,
+  store: Store,
+  table: AirtableTable,
+  body: Record<string, unknown>,
+  replace: boolean,
+): Response {
+  const returnFieldIds = boolOf(body.returnFieldsByFieldId);
+  const typecast = boolOf(body.typecast);
+
+  if (!Array.isArray(body.records)) {
+    return airtableError(
+      c,
+      422,
+      "INVALID_REQUEST_MISSING_FIELDS",
+      'Could not find field "records" in the request body',
+    );
+  }
+  if (body.records.length > BATCH_LIMIT) {
+    return airtableError(c, 422, "INVALID_REQUEST_BODY", `You may only update up to ${BATCH_LIMIT} records at a time`);
+  }
+
+  const upsert = readUpsert(body.performUpsert);
+  if (upsert) return handleUpsert(c, store, table, body.records, upsert, typecast, returnFieldIds);
+
+  const updated: AirtableRecordEntity[] = [];
+  for (const item of body.records) {
+    const id = readId(item);
+    const incoming = readFieldsInput(item);
+    if (!id || !incoming) {
+      return airtableError(c, 422, "INVALID_REQUEST_BODY", "Each record must have an id and a fields object");
+    }
+    const rec = findRecord(store, table, id);
+    if (!rec) return airtableNotFound(c);
+    const normalized = normalizeWriteCells(store, table, incoming, typecast);
+    if (normalized.error) return airtableError(c, 422, normalized.error.type, normalized.error.message);
+    const cells = replace ? (normalized.cells ?? {}) : { ...rec.cells, ...(normalized.cells ?? {}) };
+    const out = getAirtableStore(store).records.update(rec.id, { cells });
+    if (out) updated.push(out);
+  }
+  return c.json({ records: updated.map((r) => serialize(store, table, r, returnFieldIds)) });
+}
+
+function readUpsert(value: unknown): { fieldsToMergeOn: string[] } | null {
+  if (value && typeof value === "object" && "fieldsToMergeOn" in value && Array.isArray(value.fieldsToMergeOn)) {
+    return { fieldsToMergeOn: value.fieldsToMergeOn.filter((f): f is string => typeof f === "string") };
+  }
+  return null;
+}
+
+function handleUpsert(
+  c: Context,
+  store: Store,
+  table: AirtableTable,
+  records: unknown[],
+  upsert: { fieldsToMergeOn: string[] },
+  typecast: boolean,
+  returnFieldIds: boolean,
+): Response {
+  const mergeOn = upsert.fieldsToMergeOn;
+  if (mergeOn.length === 0 || mergeOn.length > 3) {
+    return airtableError(c, 422, "INVALID_REQUEST_BODY", "fieldsToMergeOn must contain between 1 and 3 fields");
+  }
+  const fields = tableFields(store, table.table_id);
+  const mergeNames: string[] = [];
+  for (const key of mergeOn) {
+    const field = findField(fields, key);
+    if (!field) return airtableError(c, 422, "UNKNOWN_FIELD_NAME", `Unknown field name: "${key}"`);
+    mergeNames.push(field.name);
+  }
+
+  const out: AirtableRecordEntity[] = [];
+  const createdRecords: string[] = [];
+  const updatedRecords: string[] = [];
+
+  for (const item of records) {
+    const incoming = readFieldsInput(item);
+    if (!incoming) {
+      return airtableError(
+        c,
+        422,
+        "INVALID_REQUEST_MISSING_FIELDS",
+        'Could not find field "fields" in the request body',
+      );
+    }
+    const normalized = normalizeWriteCells(store, table, incoming, typecast);
+    if (normalized.error) return airtableError(c, 422, normalized.error.type, normalized.error.message);
+    const cells = normalized.cells ?? {};
+
+    const existing = getAirtableStore(store)
+      .records.findBy("table_id", table.table_id)
+      .find((rec) => mergeNames.every((name) => String(rec.cells[name] ?? "") === String(cells[name] ?? "")));
+
+    if (existing) {
+      const merged = getAirtableStore(store).records.update(existing.id, { cells: { ...existing.cells, ...cells } });
+      if (merged) {
+        out.push(merged);
+        updatedRecords.push(merged.record_id);
+      }
+    } else {
+      const rec = createRecord(store, table, cells);
+      out.push(rec);
+      createdRecords.push(rec.record_id);
+    }
+  }
+
+  return c.json({
+    records: out.map((r) => serialize(store, table, r, returnFieldIds)),
+    createdRecords,
+    updatedRecords,
+  });
+}

--- a/packages/@emulators/airtable/src/schema.ts
+++ b/packages/@emulators/airtable/src/schema.ts
@@ -1,0 +1,157 @@
+import type { Store } from "@emulators/core";
+import { getAirtableStore } from "./store.js";
+import type { AirtableBase, AirtableField, AirtableSelectChoice, AirtableTable } from "./entities.js";
+import { generateFieldId } from "./ids.js";
+
+// Field types Airtable computes; writes to them are silently ignored (not errors).
+const COMPUTED_TYPES: Record<string, true> = {
+  formula: true,
+  rollup: true,
+  count: true,
+  lookup: true,
+  multipleLookupValues: true,
+  autoNumber: true,
+  createdTime: true,
+  lastModifiedTime: true,
+  createdBy: true,
+  lastModifiedBy: true,
+  button: true,
+  externalSyncSource: true,
+};
+
+const SELECT_TYPES: Record<string, true> = { singleSelect: true, multipleSelects: true };
+
+export function resolveBase(store: Store, baseId: string): AirtableBase | undefined {
+  return getAirtableStore(store).bases.findOneBy("base_id", baseId);
+}
+
+/** Resolve a table within a base by id first, then by name (both are valid in the URL). */
+export function resolveTable(store: Store, baseId: string, tableIdOrName: string): AirtableTable | undefined {
+  const s = getAirtableStore(store);
+  const byId = s.tables.findOneBy("table_id", tableIdOrName);
+  if (byId && byId.base_id === baseId) return byId;
+  return s.tables.findBy("base_id", baseId).find((t) => t.name === tableIdOrName);
+}
+
+export function tableFields(store: Store, tableId: string): AirtableField[] {
+  return getAirtableStore(store)
+    .fields.findBy("table_id", tableId)
+    .sort((a, b) => a.position - b.position);
+}
+
+export function findField(fields: AirtableField[], key: string): AirtableField | undefined {
+  return fields.find((f) => f.field_id === key || f.name === key);
+}
+
+export interface NormalizeResult {
+  cells?: Record<string, unknown>;
+  error?: { type: string; message: string };
+}
+
+/**
+ * Validate an incoming `fields` map (keyed by field name OR id) against the table
+ * schema and return cells keyed by canonical field name. Unknown fields 422; writes
+ * to computed fields are dropped; select choices are enforced unless `typecast` adds
+ * the missing option.
+ */
+export function normalizeWriteCells(
+  store: Store,
+  table: AirtableTable,
+  incoming: Record<string, unknown>,
+  typecast: boolean,
+): NormalizeResult {
+  const fields = tableFields(store, table.table_id);
+  const cells: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(incoming)) {
+    const field = findField(fields, key);
+    if (!field) {
+      return { error: { type: "UNKNOWN_FIELD_NAME", message: `Unknown field name: "${key}"` } };
+    }
+    if (COMPUTED_TYPES[field.type]) {
+      continue; // Airtable ignores writes to computed fields.
+    }
+    if (SELECT_TYPES[field.type] && value != null) {
+      const check = applySelectChoice(store, field, value, typecast);
+      if (check.error) return { error: check.error };
+    }
+    cells[field.name] = value;
+  }
+
+  return { cells };
+}
+
+function applySelectChoice(
+  store: Store,
+  field: AirtableField,
+  value: unknown,
+  typecast: boolean,
+): { error?: { type: string; message: string } } {
+  const options = field.options ?? {};
+  const choices: AirtableSelectChoice[] = Array.isArray(options.choices) ? options.choices : [];
+  const values = Array.isArray(value) ? value : [value];
+
+  for (const v of values) {
+    if (typeof v !== "string") continue;
+    if (choices.some((c) => c.name === v)) continue;
+    if (!typecast) {
+      return {
+        error: {
+          type: "INVALID_MULTIPLE_CHOICE_OPTIONS",
+          message: `Insufficient permissions to create new select option "${v}"`,
+        },
+      };
+    }
+    // typecast: add the new choice to the field's schema.
+    choices.push({ id: generateFieldId().replace(/^fld/, "sel"), name: v });
+  }
+
+  if (typecast) {
+    const s = getAirtableStore(store);
+    s.fields.update(field.id, { options: { ...options, choices } });
+  }
+  return {};
+}
+
+export interface SerializeOptions {
+  returnFieldsByFieldId?: boolean;
+  fieldsSubset?: string[];
+}
+
+export interface SerializedRecord {
+  id: string;
+  createdTime: string;
+  fields: Record<string, unknown>;
+}
+
+/** Shape a stored record for the API: `{ id, createdTime, fields }`, honoring
+ * `fields[]` selection and `returnFieldsByFieldId`. Empty cells are omitted. */
+export function serializeRecord(
+  store: Store,
+  table: AirtableTable,
+  record: { record_id: string; created_time: string; cells: Record<string, unknown> },
+  options: SerializeOptions = {},
+): SerializedRecord {
+  const fields = tableFields(store, table.table_id);
+  const byName = new Map(fields.map((f) => [f.name, f]));
+
+  let wanted: Set<string> | null = null;
+  if (options.fieldsSubset && options.fieldsSubset.length > 0) {
+    wanted = new Set();
+    for (const key of options.fieldsSubset) {
+      const field = findField(fields, key);
+      if (field) wanted.add(field.name);
+    }
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(record.cells)) {
+    if (value === undefined || value === null || value === "") continue;
+    if (wanted && !wanted.has(name)) continue;
+    const field = byName.get(name);
+    const key = options.returnFieldsByFieldId && field ? field.field_id : name;
+    out[key] = value;
+  }
+
+  return { id: record.record_id, createdTime: record.created_time, fields: out };
+}

--- a/packages/@emulators/airtable/src/seed.ts
+++ b/packages/@emulators/airtable/src/seed.ts
@@ -56,7 +56,6 @@ export interface AirtableSeedUser {
 export interface AirtableSeedConfig {
   user?: AirtableSeedUser;
   bases?: AirtableSeedBase[];
-  strict_tokens?: boolean;
   baseUrl?: string;
 }
 

--- a/packages/@emulators/airtable/src/seed.ts
+++ b/packages/@emulators/airtable/src/seed.ts
@@ -1,0 +1,237 @@
+import type { Store } from "@emulators/core";
+import { getAirtableStore } from "./store.js";
+import type { AirtableFieldOptions, AirtableViewSort } from "./entities.js";
+import {
+  generateBaseId,
+  generateFieldId,
+  generateRecordId,
+  generateTableId,
+  generateUserId,
+  generateViewId,
+} from "./ids.js";
+import { findField, tableFields } from "./schema.js";
+
+export interface AirtableSeedField {
+  id?: string;
+  name: string;
+  type?: string;
+  options?: AirtableFieldOptions;
+}
+
+export interface AirtableSeedView {
+  id?: string;
+  name: string;
+  type?: string;
+  filter?: string;
+  sort?: AirtableViewSort[];
+  fields?: string[];
+}
+
+export type AirtableSeedRecord = Record<string, unknown> | { id?: string; fields: Record<string, unknown> };
+
+export interface AirtableSeedTable {
+  id?: string;
+  name: string;
+  description?: string;
+  primary_field?: string;
+  fields?: AirtableSeedField[];
+  views?: AirtableSeedView[];
+  records?: AirtableSeedRecord[];
+}
+
+export interface AirtableSeedBase {
+  id?: string;
+  name: string;
+  permission_level?: string;
+  tables?: AirtableSeedTable[];
+}
+
+export interface AirtableSeedUser {
+  id?: string;
+  email?: string;
+  name?: string;
+  scopes?: string[];
+}
+
+export interface AirtableSeedConfig {
+  user?: AirtableSeedUser;
+  bases?: AirtableSeedBase[];
+  strict_tokens?: boolean;
+  baseUrl?: string;
+}
+
+const DEFAULT_SCOPES = ["data.records:read", "data.records:write", "schema.bases:read"];
+
+function inferFieldType(value: unknown): string {
+  if (typeof value === "number") return "number";
+  if (typeof value === "boolean") return "checkbox";
+  if (Array.isArray(value)) return "multipleSelects";
+  return "singleLineText";
+}
+
+function recordFieldsOf(record: AirtableSeedRecord): { id?: string; fields: Record<string, unknown> } {
+  if (record && typeof record === "object" && "fields" in record) {
+    const fieldsValue: unknown = record.fields;
+    if (fieldsValue && typeof fieldsValue === "object" && !Array.isArray(fieldsValue)) {
+      const id = "id" in record && typeof record.id === "string" ? record.id : undefined;
+      // Narrowed to a non-array object above; it is the record's cell map.
+      const fields = fieldsValue as Record<string, unknown>;
+      return { id, fields };
+    }
+  }
+  // Bare-map form: the record object itself is the cell map.
+  const bare: Record<string, unknown> = record;
+  return { fields: bare };
+}
+
+export function ensureUser(store: Store, user?: AirtableSeedUser) {
+  const s = getAirtableStore(store);
+  const email = user?.email ?? "dev@example.com";
+  const existing = s.users.findOneBy("email", email);
+  if (existing) return existing;
+  return s.users.insert({
+    user_id: user?.id ?? generateUserId(),
+    email,
+    name: user?.name,
+    scopes: user?.scopes ?? DEFAULT_SCOPES,
+  });
+}
+
+function seedTable(store: Store, baseId: string, table: AirtableSeedTable): void {
+  const s = getAirtableStore(store);
+  const tableId = table.id ?? generateTableId();
+
+  // Explicit fields, or inferred from the first record that carries each key.
+  const declared = table.fields ?? [];
+  const inferred: AirtableSeedField[] = [];
+  if (declared.length === 0 && table.records && table.records.length > 0) {
+    const seen: Record<string, true> = {};
+    for (const record of table.records) {
+      const { fields } = recordFieldsOf(record);
+      for (const [key, value] of Object.entries(fields)) {
+        if (seen[key]) continue;
+        seen[key] = true;
+        inferred.push({ name: key, type: inferFieldType(value) });
+      }
+    }
+  }
+  const fieldSpecs = declared.length > 0 ? declared : inferred;
+
+  let position = 0;
+  let primaryFieldId: string | undefined;
+  for (const spec of fieldSpecs) {
+    const fieldId = spec.id ?? generateFieldId();
+    if (position === 0) primaryFieldId = fieldId;
+    s.fields.insert({
+      table_id: tableId,
+      field_id: fieldId,
+      name: spec.name,
+      type: spec.type ?? "singleLineText",
+      options: spec.options ?? null,
+      position: position++,
+    });
+  }
+
+  const fields = tableFields(store, tableId);
+  if (table.primary_field) {
+    const primary = findField(fields, table.primary_field);
+    if (primary) primaryFieldId = primary.field_id;
+  }
+
+  s.tables.insert({
+    base_id: baseId,
+    table_id: tableId,
+    name: table.name,
+    primary_field_id: primaryFieldId ?? "",
+    description: table.description ?? null,
+  });
+
+  for (const view of table.views ?? []) {
+    s.views.insert({
+      table_id: tableId,
+      view_id: view.id ?? generateViewId(),
+      name: view.name,
+      type: view.type ?? "grid",
+      filter: view.filter ?? null,
+      sort: view.sort ?? null,
+      fields: view.fields ?? null,
+    });
+  }
+
+  for (const record of table.records ?? []) {
+    const { id, fields: rawFields } = recordFieldsOf(record);
+    const cells: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawFields)) {
+      const field = findField(fields, key);
+      cells[field ? field.name : key] = value;
+    }
+    s.records.insert({
+      base_id: baseId,
+      table_id: tableId,
+      record_id: id ?? generateRecordId(),
+      cells,
+      created_time: new Date().toISOString(),
+    });
+  }
+}
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: AirtableSeedConfig): void {
+  ensureUser(store, config.user);
+  const s = getAirtableStore(store);
+  for (const base of config.bases ?? []) {
+    const baseId = base.id ?? generateBaseId();
+    s.bases.insert({
+      base_id: baseId,
+      name: base.name,
+      permission_level: base.permission_level ?? "create",
+    });
+    for (const table of base.tables ?? []) {
+      seedTable(store, baseId, table);
+    }
+  }
+}
+
+// Deterministic default so zero-config `--service airtable` is explorable and
+// `reset()` is stable (fixed ids across replays).
+export function seedDefaults(store: Store): void {
+  if (getAirtableStore(store).bases.all().length > 0) return;
+  ensureUser(store, { id: "usrLocalDevAccount", email: "dev@example.com", name: "Local Developer" });
+  seedFromConfig(store, "", {
+    bases: [
+      {
+        id: "appEmulateExample1",
+        name: "Example Base",
+        tables: [
+          {
+            id: "tblExampleTasks01",
+            name: "Tasks",
+            fields: [
+              { id: "fldExampleTaskName", name: "Name", type: "singleLineText" },
+              {
+                id: "fldExampleTaskStat",
+                name: "Status",
+                type: "singleSelect",
+                options: {
+                  choices: [
+                    { id: "selTodo000000001", name: "Todo" },
+                    { id: "selDoing00000001", name: "Doing" },
+                    { id: "selDone000000001", name: "Done" },
+                  ],
+                },
+              },
+              { id: "fldExampleTaskDone", name: "Done", type: "checkbox" },
+            ],
+            views: [{ id: "viwExampleTasksAll", name: "All Tasks", type: "grid" }],
+            records: [
+              {
+                id: "recExampleTask0001",
+                fields: { Name: "Ship the Airtable emulator", Status: "Doing", Done: false },
+              },
+              { id: "recExampleTask0002", fields: { Name: "Write conformance tests", Status: "Todo", Done: false } },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/packages/@emulators/airtable/src/store.ts
+++ b/packages/@emulators/airtable/src/store.ts
@@ -1,0 +1,32 @@
+import { Store, type Collection } from "@emulators/core";
+import type {
+  AirtableBase,
+  AirtableComment,
+  AirtableField,
+  AirtableRecordEntity,
+  AirtableTable,
+  AirtableUser,
+  AirtableView,
+} from "./entities.js";
+
+export interface AirtableStore {
+  bases: Collection<AirtableBase>;
+  tables: Collection<AirtableTable>;
+  fields: Collection<AirtableField>;
+  views: Collection<AirtableView>;
+  records: Collection<AirtableRecordEntity>;
+  comments: Collection<AirtableComment>;
+  users: Collection<AirtableUser>;
+}
+
+export function getAirtableStore(store: Store): AirtableStore {
+  return {
+    bases: store.collection<AirtableBase>("airtable.bases", ["base_id"]),
+    tables: store.collection<AirtableTable>("airtable.tables", ["base_id", "table_id", "name"]),
+    fields: store.collection<AirtableField>("airtable.fields", ["table_id", "field_id", "name"]),
+    views: store.collection<AirtableView>("airtable.views", ["table_id", "view_id"]),
+    records: store.collection<AirtableRecordEntity>("airtable.records", ["base_id", "table_id", "record_id"]),
+    comments: store.collection<AirtableComment>("airtable.comments", ["record_id", "comment_id"]),
+    users: store.collection<AirtableUser>("airtable.users", ["user_id", "email"]),
+  };
+}

--- a/packages/@emulators/airtable/tsconfig.json
+++ b/packages/@emulators/airtable/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/airtable/tsup.config.ts
+++ b/packages/@emulators/airtable/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/@emulators/airtable/vitest.config.ts
+++ b/packages/@emulators/airtable/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -72,6 +72,7 @@
     "@emulators/clerk": "workspace:*",
     "@emulators/linear": "workspace:*",
     "@emulators/twilio": "workspace:*",
+    "@emulators/airtable": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -29,6 +29,7 @@ const SERVICE_NAME_LIST = [
   "clerk",
   "linear",
   "twilio",
+  "airtable",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -625,6 +626,55 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
         conversations: {
           services: [{ friendly_name: "Local Conversations" }],
         },
+      },
+    },
+  },
+  airtable: {
+    label: "Airtable Data API emulator",
+    endpoints: "records CRUD, filterByFormula, sort, views, batch, upsert, comments, Meta schema, inspector",
+    async load() {
+      const mod = await import("@emulators/airtable");
+      return { plugin: mod.airtablePlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback(cfg) {
+      const user = cfg?.user;
+      const email =
+        user && typeof user === "object" && "email" in user && typeof user.email === "string"
+          ? user.email
+          : "dev@example.com";
+      return { login: email, id: 1, scopes: [] };
+    },
+    initConfig: {
+      airtable: {
+        user: { email: "dev@example.com", name: "Local Developer" },
+        bases: [
+          {
+            id: "appLocalDevExample",
+            name: "Product",
+            tables: [
+              {
+                name: "Tasks",
+                fields: [
+                  { name: "Name", type: "singleLineText" },
+                  {
+                    name: "Status",
+                    type: "singleSelect",
+                    options: {
+                      choices: [
+                        { id: "selTodo00000000001", name: "Todo" },
+                        { id: "selDoing0000000001", name: "Doing" },
+                        { id: "selDone00000000001", name: "Done" },
+                      ],
+                    },
+                  },
+                  { name: "Estimate", type: "number" },
+                ],
+                views: [{ name: "All Tasks", type: "grid" }],
+                records: [{ fields: { Name: "Ship the emulator", Status: "Doing", Estimate: 3 } }],
+              },
+            ],
+          },
+        ],
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,6 +556,22 @@ importers:
         specifier: ^5.7
         version: 5.9.3
 
+  packages/@emulators/airtable:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/@emulators/apple:
     dependencies:
       '@emulators/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -860,6 +860,9 @@ importers:
         specifier: ^2
         version: 2.8.3
     devDependencies:
+      '@emulators/airtable':
+        specifier: workspace:*
+        version: link:../@emulators/airtable
       '@emulators/apple':
         specifier: workspace:*
         version: link:../@emulators/apple

--- a/skills/airtable/SKILL.md
+++ b/skills/airtable/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: airtable
+description: Emulated Airtable Data API for local development and testing. Use when the user needs to test Airtable integrations locally, emulate bases, tables, fields, views, records, record comments, filterByFormula queries, or work with the Airtable REST API (or the Airtable.js / pyairtable SDKs) without hitting the real Airtable service. Triggers include "Airtable API", "emulate Airtable", "mock Airtable", "test filterByFormula", "Airtable records", "Airtable comments", "local Airtable", or any task requiring a local Airtable API.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# Airtable API Emulator
+
+Stateful Airtable Data API emulation with user-defined bases, tables, fields, and views, plus records and record comments. Records are validated against the seeded schema (unknown fields error; select choices are enforced unless `typecast` is set).
+
+## Start
+
+```bash
+# Airtable only
+npx emulate --service airtable
+```
+
+Default URL: `http://localhost:4014` when all services are started, or `http://localhost:4000` when Airtable is the only service.
+
+## Auth
+
+Relaxed by default: any non-empty bearer token works.
+
+```bash
+curl "$AIRTABLE_EMULATOR_URL/v0/meta/bases" \
+  -H "Authorization: Bearer pat_test_token"
+```
+
+Point SDKs at the emulator with no other code changes:
+
+```bash
+# Airtable.js
+AIRTABLE_ENDPOINT_URL=http://localhost:4014
+# pyairtable
+Api("pat_test_token", endpoint_url="http://localhost:4014")
+```
+
+Set `airtable.strict_tokens: true` in seed config to enforce the seeded PATs and their scopes (`data.records:read`, `data.records:write`, `schema.bases:read`).
+
+## Records
+
+| Operation | Route |
+|-----------|-------|
+| List | `GET /v0/:baseId/:tableIdOrName` |
+| List (body) | `POST /v0/:baseId/:tableIdOrName/listRecords` |
+| Get | `GET /v0/:baseId/:tableIdOrName/:recordId` |
+| Create / batch | `POST /v0/:baseId/:tableIdOrName` |
+| Update / upsert | `PATCH /v0/:baseId/:tableIdOrName` |
+| Replace | `PUT /v0/:baseId/:tableIdOrName` |
+| Update one | `PATCH /v0/:baseId/:tableIdOrName/:recordId` |
+| Replace one | `PUT /v0/:baseId/:tableIdOrName/:recordId` |
+| Delete one | `DELETE /v0/:baseId/:tableIdOrName/:recordId` |
+| Batch delete | `DELETE /v0/:baseId/:tableIdOrName?records[]=...` |
+
+List query params: `filterByFormula`, `sort[i][field]` / `sort[i][direction]`, `fields[]`, `view`, `pageSize` (max 100), `maxRecords`, `offset`, `cellFormat` (`json`), `returnFieldsByFieldId`. Batch create/update/upsert cap at 10 records; upsert uses `performUpsert.fieldsToMergeOn` (max 3).
+
+Tables and fields are addressable by id or name. `filterByFormula` references fields by name; a `{fldXXX}` id token errors, matching Airtable. Computed fields (formula, rollup, lookup) filter on their stored value.
+
+## filterByFormula
+
+Supported: `AND`, `OR`, `NOT`, `IF`, comparisons (`= != < > <= >=`), `&`, arithmetic, `LOWER`, `UPPER`, `TRIM`, `LEN`, `FIND`, `SEARCH`, `LEFT`, `RIGHT`, `MID`, `CONCATENATE`, `SUBSTITUTE`, `VALUE`, `ROUND`, `ABS`, `MIN`, `MAX`, `SUM`, `RECORD_ID`, `BLANK`, `TRUE`, `FALSE`, `CREATED_TIME`, `TODAY`, `NOW`, `DATEADD`, `DATETIME_DIFF`, `IS_AFTER`, `IS_BEFORE`, `IS_SAME`. Unsupported functions return `INVALID_FILTER_BY_FORMULA`.
+
+## Record Comments
+
+| Operation | Route |
+|-----------|-------|
+| List | `GET /v0/:baseId/:tableIdOrName/:recordId/comments` |
+| Add | `POST /v0/:baseId/:tableIdOrName/:recordId/comments` |
+| Delete | `DELETE /v0/:baseId/:tableIdOrName/:recordId/comments/:commentId` |
+
+Comments are threaded and `offset`-paginated; POST bodies take `{ text }` and `@[usrXXX]` mentions are parsed into `mentioned`. Each comment records its author identity.
+
+## Meta
+
+- `GET /v0/meta/whoami` - token identity (`id`, `email`, `scopes`)
+- `GET /v0/meta/bases` - accessible bases
+- `GET /v0/meta/bases/:baseId/tables` - base schema (tables, fields, views)
+
+## Seed Config
+
+```yaml
+airtable:
+  user:
+    email: dev@example.com
+    name: Local Developer
+  bases:
+    - id: appLocalDevExample
+      name: Product
+      tables:
+        - name: Tasks
+          fields:
+            - { name: Name, type: singleLineText }
+            - name: Status
+              type: singleSelect
+              options:
+                choices:
+                  - { name: Todo }
+                  - { name: Doing }
+                  - { name: Done }
+            - { name: Estimate, type: number }
+          views:
+            - { name: All Tasks, type: grid }
+          records:
+            - { Name: Ship the emulator, Status: Doing, Estimate: 3 }
+```
+
+Base, table, and field ids pass through verbatim, so mirroring a real base's ids lets code that hardcodes those ids run unchanged. A table with records but no declared `fields` infers its schema from the records.
+
+## Inspector
+
+Open `GET /` in the Airtable emulator to inspect bases, tables, records, and identity.
+
+## Current Limits
+
+`filterByFormula` implements a documented function subset; computed fields are stored, not recomputed; view filters are seeded rather than discovered; webhooks, attachment uploads, and Meta write endpoints are not implemented.

--- a/skills/airtable/SKILL.md
+++ b/skills/airtable/SKILL.md
@@ -35,7 +35,7 @@ AIRTABLE_ENDPOINT_URL=http://localhost:4014
 Api("pat_test_token", endpoint_url="http://localhost:4014")
 ```
 
-Set `airtable.strict_tokens: true` in seed config to enforce the seeded PATs and their scopes (`data.records:read`, `data.records:write`, `schema.bases:read`).
+The seeded user's scopes (`data.records:read`, `data.records:write`, `schema.bases:read`) are returned by `whoami`.
 
 ## Records
 


### PR DESCRIPTION
## Airtable emulator

Adds a stateful Airtable Data API emulator (`@emulators/airtable`, port 4014) — a drop-in for the REST API used by the official Airtable.js and pyairtable SDKs, not a mock.

Airtable is the first schema-defined service in the project: bases, tables, fields, and views are user data, and the Data API validates records against them. The package carries a small schema registry (kept inside the package, not in `core`) and validates generic record blobs against it.

### Records

- `GET /v0/:baseId/:tableIdOrName` — list (`filterByFormula`, `sort`, `fields`, `view`, `pageSize`, `maxRecords`, `offset`, `cellFormat`, `returnFieldsByFieldId`)
- `POST /v0/:baseId/:tableIdOrName/listRecords` — body-based list for long formulas
- `GET /v0/:baseId/:tableIdOrName/:recordId` — get one
- `POST /v0/:baseId/:tableIdOrName` — create single `{fields}` or batch `{records}` (up to 10, with `typecast`)
- `PATCH /v0/:baseId/:tableIdOrName` — batch update, or upsert via `performUpsert.fieldsToMergeOn`
- `PUT /v0/:baseId/:tableIdOrName` — batch replace
- `PATCH` / `PUT /v0/:baseId/:tableIdOrName/:recordId` — update (merge) or replace one
- `DELETE /v0/:baseId/:tableIdOrName/:recordId` and `DELETE /v0/:baseId/:tableIdOrName?records[]=...` — delete one or batch

Tables and fields are addressable by id or name. `filterByFormula` is a real recursive-descent parser + evaluator over the record's cells, covering the common subset (`AND`/`OR`/`NOT`/`IF`, comparisons, `LOWER`/`FIND`/`SEARCH`, `RECORD_ID`, `BLANK`, `IS_AFTER`/`IS_SAME`/`DATEADD`/`TODAY`, `{Field}` refs) with Airtable's loose coercion. It references fields by name (a `{fldXXX}` id token errors, matching Airtable); computed fields filter on their stored value. Unsupported functions return `INVALID_FILTER_BY_FORMULA`.

### Record comments

- `GET` / `POST` / `DELETE /v0/:baseId/:tableIdOrName/:recordId/comments` — threaded, `offset`-paginated, with author identity and `@[usrXXX]` mention parsing.

### Meta and inspector

- `GET /v0/meta/whoami`, `GET /v0/meta/bases`, `GET /v0/meta/bases/:baseId/tables`
- `GET /` — tabbed inspector (bases, tables, records, identity) via the shared `ui.ts` design system.

### Auth, seeding, error envelopes

Auth is relaxed by default so any bearer token works. Seeding takes an explicit schema, or infers fields from records when none are declared; base/table/field ids pass through verbatim. Error responses match the live API, including the two shapes Airtable uses (object form `{"error":{"type","message"}}` and the bare-string `{"error":"NOT_FOUND"}` for unknown base/record).

### Testing

`vitest` conformance: a dedicated `filterByFormula` matrix plus records/comments/meta/error-envelope coverage (55 tests). Verified end to end over real HTTP via the CLI.

### Not included (deferred)

Webhooks, attachment uploads, and Meta write endpoints are not implemented; `filterByFormula` is a documented subset; computed fields are stored, not recomputed; view filters are seeded rather than discovered (the public schema API does not expose them); per-base rate limiting is not emulated.

### Notes

- Docs updated in lockstep per `AGENTS.md`: README, docs site, agent skill, and `emulate.config.example.yaml`.
- Per the release model, this PR does not bump the version or edit the changelog — left to the maintainer's release PR. `sync-versions --check` passes (the new package matches the current `0.9.0`).
- The branch is a clean series of atomic commits (scaffold, formula engine, records/meta, comments, inspector, CLI registration, tests, docs).
