### PR TITLE
docs: make service pages usable and fix config examples that silently no-op

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,25 @@
 # Agents
 
+## Build and Verify
+
+Requires Node `>=24` and pnpm `>=11 <12` (see `engines` in the root `package.json`).
+
+```bash
+pnpm install
+pnpm build        # turbo build across the workspace
+pnpm test         # vitest, per package
+pnpm lint
+pnpm type-check
+pnpm format       # prettier --write; pnpm format:check to verify only
+```
+
+`turbo.json` marks `test` with `dependsOn: ["^build"]`, but each package's own
+test script is a bare `vitest run`. Packages resolve their workspace deps through
+`dist/`, which is gitignored and has no `postinstall` step — so **run `pnpm build`
+at least once before running tests directly in a package**, or you get
+`Cannot find module '.../dist/index.js'`. The same applies before running anything
+in `examples/`.
+
 ## Package Manager
 
 Use `pnpm` for all package management commands (not npm or yarn).
@@ -43,10 +63,39 @@ If a new page type cannot be built with the existing render functions and CSS cl
 
 When a change affects how humans or agents use emulate (new/changed/removed commands, flags, behavior, routes, seed config, or SDK integration), update all of these:
 
-1. `README.md`
-2. `skills/*/SKILL.md` (agent skills for each service)
-3. `apps/web/` (docs site pages)
-4. CLI `--help` output in `packages/emulate/src/index.ts`
+1. `README.md` — also the npm page for the `emulate` package (copied on `prepack`)
+2. `packages/@emulators/<service>/README.md` — the npm page for that package
+3. `skills/*/SKILL.md` (agent skills for each service)
+4. `apps/web/app/docs/**` (docs site pages)
+5. `emulate.config.example.yaml`, if seed config changed
+6. `examples/`, if the change affects how an example is set up or run
+7. CLI `--help` output in `packages/emulate/src/index.ts`
+
+### Adding a service
+
+Registration lives in `packages/emulate/src/registry.ts`, not `index.ts` (which is
+generic). Add the name to `SERVICE_NAME_LIST` and an entry to `SERVICE_REGISTRY`
+with all five `ServiceEntry` fields (`label`, `endpoints`, `load()`,
+`defaultFallback()`, `initConfig`), plus the package to `packages/emulate/package.json`.
+
+A new service is not done until it also has:
+
+- `packages/@emulators/<service>/README.md`
+- `apps/web/app/docs/<service>/page.mdx`
+- `skills/<service>/SKILL.md`
+- entries in `apps/web/lib/docs-navigation.ts`, `apps/web/lib/page-titles.ts`,
+  `apps/web/components/docs-nav.tsx` **and** `apps/web/components/docs-mobile-nav.tsx`
+  (four separate lists — missing any one leaves the page orphaned)
+- the port table updated in `README.md`, `apps/web/app/docs/page.mdx`,
+  `skills/emulate/SKILL.md` and `apps/web/components/hero-terminal.tsx`
+
+### Which document is canonical
+
+Seed config is **not validated anywhere**, so a wrong key in the docs produces
+silently missing data rather than an error. When documenting seed config, copy the
+field names from the service's `*SeedConfig` interface in
+`packages/@emulators/<service>/src/index.ts` — that interface is the source of
+truth, and the docs must match it exactly.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,45 @@
 
 Local drop-in replacement services for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
 
+**[Documentation](https://emulate.dev/docs)** ·
+[Runnable examples](./examples) ·
+[Agent skills](./skills) ·
+[Changelog](./CHANGELOG.md)
+
+New here? [Quick Start](#quick-start) below, then
+[Connecting your app](https://emulate.dev/docs/connecting) for pointing an SDK at
+an emulator, and [Troubleshooting](https://emulate.dev/docs/troubleshooting) when
+something silently does nothing.
+
+## Contents
+
+- [Quick Start](#quick-start) — install, run, and the port table
+- [CLI](#cli) — commands, flags, env vars
+- [HTTPS with portless](#https-with-portless)
+- [Programmatic API](#programmatic-api) — `createEmulator`, seeding, test setup
+- [Configuration](#configuration) — the seed config file, per service
+- [OAuth & Integrations](#oauth--integrations)
+- [Next.js Integration](#nextjs-integration) · [Nuxt Integration](#nuxt-integration) — embedding emulators in your app
+- [Architecture](#architecture) · [Auth](#auth)
+
+Per-service API reference:
+[Vercel](#vercel-api) ·
+[GitHub](#github-api) ·
+[Google](#google-oauth--gmail-calendar-and-drive-apis) ·
+[Slack](#slack-api) ·
+[Linear](#linear-api) ·
+[Twilio](#twilio-api) ·
+[Apple](#apple-sign-in) ·
+[Microsoft](#microsoft-entra-id) ·
+[AWS](#aws)
+
+Okta, Resend, Stripe, MongoDB Atlas and Clerk are documented on the docs site:
+[Okta](https://emulate.dev/docs/okta) ·
+[Resend](https://emulate.dev/docs/resend) ·
+[Stripe](https://emulate.dev/docs/stripe) ·
+[MongoDB Atlas](https://emulate.dev/docs/mongoatlas) ·
+[Clerk](https://emulate.dev/docs/clerk)
+
 ## Quick Start
 
 ```bash
@@ -24,6 +63,23 @@ All services start with sensible defaults. No config file needed:
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
 - **Twilio** on `http://localhost:4013`
+
+### How ports are assigned
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set — not a fixed number per service. The list above is what a bare
+`npx emulate` gives you, because that enables all 14 in registry order.
+
+Enable a subset and the numbering restarts from the base port:
+
+```bash
+npx emulate --service github        # GitHub on 4000, not 4001
+npx emulate --service github,google # GitHub 4000, Google 4001
+npx emulate --service google,github # Google 4000, GitHub 4001 (your order wins)
+```
+
+To pin a service to a port no matter what else is running, set `port` on it in
+the seed config — see [Per-service options](#per-service-options).
 
 ## CLI
 
@@ -54,13 +110,20 @@ npx emulate list
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-p, --port` | `4000` | Base port (auto-increments per service) |
+| `-p, --port` | `4000` | Base port; each enabled service gets base + its index |
 | `-s, --service` | all | Comma-separated services to enable |
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
 | `--base-url` | none | Override advertised base URL (supports `{service}` template) |
 | `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+`--portless` and `--base-url` are mutually exclusive; passing both exits with an
+error.
+
+A seed config file also acts as an implicit `--service`: if it contains any
+top-level service keys, only those services start. A config with just a `stripe:`
+block starts Stripe alone, on the base port. Pass `--service` explicitly to
+override this.
 
 ## HTTPS with portless
 
@@ -113,10 +176,10 @@ Each call to `createEmulator` starts a single service:
 import { createEmulator } from 'emulate'
 
 const github = await createEmulator({ service: 'github', port: 4001 })
-const vercel = await createEmulator({ service: 'vercel', port: 4002 })
+const vercel = await createEmulator({ service: 'vercel', port: 4000 })
 
 github.url   // 'http://localhost:4001'
-vercel.url   // 'http://localhost:4002'
+vercel.url   // 'http://localhost:4000'
 
 await github.close()
 await vercel.close()
@@ -134,7 +197,7 @@ let vercel: Emulator
 beforeAll(async () => {
   ;[github, vercel] = await Promise.all([
     createEmulator({ service: 'github', port: 4001 }),
-    createEmulator({ service: 'vercel', port: 4002 }),
+    createEmulator({ service: 'vercel', port: 4000 }),
   ])
   process.env.GITHUB_EMULATOR_URL = github.url
   process.env.VERCEL_EMULATOR_URL = vercel.url
@@ -150,8 +213,64 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 |--------|---------|-------------|
 | `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
 | `port` | `4000` | Port for the HTTP server |
-| `seed` | none | Inline seed data (same shape as YAML config) |
+| `seed` | none | Inline seed data, **keyed by service name** — same shape as the YAML config file, service key included. See [Seeding data](#seeding-data). |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
+
+### Seeding data
+
+`seed` mirrors the YAML config file exactly, **including the top-level service
+key**. Even though `service` is already passed as its own option, the seed object
+must repeat it — `createEmulator` reads `seed[service]` and ignores anything else.
+
+```typescript
+const github = await createEmulator({
+  service: 'github',
+  port: 4001,
+  seed: {
+    github: {                                        // <- required service key
+      users: [{ login: 'octocat', name: 'The Octocat' }],
+      repos: [{ owner: 'octocat', name: 'hello-world', auto_init: true }],
+    },
+  },
+})
+```
+
+Passing the inner object directly is the most common mistake with this API:
+
+```typescript
+// WRONG — seeds nothing. There is no error and no warning: the emulator
+// starts with defaults and GET /users/octocat/repos returns 404.
+await createEmulator({
+  service: 'github',
+  seed: { users: [{ login: 'octocat' }] },
+})
+```
+
+Seed config is never validated, so an unrecognized shape is dropped silently. If
+a request 404s or returns an empty list right after startup, check this nesting
+first.
+
+`tokens` sits at the top level, beside the service key rather than inside it.
+When it is omitted, the emulator creates `test_token_admin` for user `admin`:
+
+```typescript
+seed: {
+  tokens: { my_token: { login: 'octocat', scopes: ['repo'] } },
+  github: { users: [{ login: 'octocat' }] },
+}
+```
+
+The [Next.js](#nextjs-integration) and Nuxt adapters take the **opposite** shape.
+In `createEmulateHandler` the service name is already the key in `services`, so
+`seed` holds the inner object directly:
+
+```typescript
+createEmulateHandler({
+  services: {
+    github: { emulator: github, seed: { users: [{ login: 'octocat' }] } },
+  },
+})
+```
 
 ### Instance methods
 
@@ -164,6 +283,32 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 ## Configuration
 
 Configuration is optional. The CLI auto-detects config files in this order: `emulate.config.yaml` / `.yml`, `emulate.config.json`, `service-emulator.config.yaml` / `.yml`, `service-emulator.config.json`. Or pass `--seed <file>` explicitly. Run `npx emulate init` to generate a starter file.
+
+Two things to know before writing one:
+
+- **A config file selects services.** Every top-level service key in the file is
+  treated as an implicit `--service`. A file containing only `stripe:` makes
+  `npx emulate` start Stripe alone, on the base port — not all 14. Pass
+  `--service` explicitly if you want a different set.
+- **Nothing here is validated.** Unknown or misspelled keys are dropped without a
+  warning, and the emulator starts anyway with that data missing. If something
+  you seeded isn't there, suspect a key name first.
+
+### Per-service options
+
+Alongside the seed collections, every service accepts two operational keys:
+
+```yaml
+github:
+  port: 4001 # pin this service's port, ignoring base + index
+  baseUrl: https://github.emulate.test # advertised URL in OAuth redirects, webhooks
+  users:
+    - login: octocat
+```
+
+`port` is the only way to give a service a stable port regardless of which other
+services are enabled. `baseUrl` has the highest priority of all base-URL sources,
+ahead of `--base-url` and `EMULATE_BASE_URL`.
 
 ```yaml
 tokens:
@@ -466,9 +611,9 @@ github:
       slug: "my-github-app"
       name: "My GitHub App"
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...your PEM key...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
       permissions:
         contents: read
         issues: write
@@ -482,6 +627,18 @@ github:
 ```
 
 JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's private key (RS256). The emulator verifies the signature and resolves the app.
+
+**The private key must be PKCS#8.** It is parsed with `importPKCS8`, so it has to
+begin with `-----BEGIN PRIVATE KEY-----`. GitHub issues App keys in PKCS#1
+(`-----BEGIN RSA PRIVATE KEY-----`), which the emulator cannot read. Convert once:
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in github-app.private-key.pem -out github-app.pkcs8.pem
+```
+
+A key in the wrong format fails silently — verification throws, the error is
+swallowed, and the request is treated as unauthenticated. If `GET /app` returns
+401 with a JWT you believe is valid, check the PEM header first.
 
 **App webhook delivery**: When events occur on repos where a GitHub App is installed, the emulator mirrors real GitHub behavior:
 - All webhook payloads (including repo and org hooks) include an `installation` field with `{ id, node_id }`.
@@ -1200,20 +1357,39 @@ packages/
     github/         # GitHub API service
     google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, Drive
     slack/          # Slack Web API, OAuth v2, incoming webhooks
-    linear/         # Linear GraphQL API, OAuth, webhooks
-    twilio/         # Twilio Messaging, Verify, Voice, webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
+    okta/           # Okta identity provider / OIDC
     aws/            # AWS S3, SQS, IAM, STS
+    resend/         # Resend email API
+    stripe/         # Stripe billing and payments API
+    mongoatlas/     # MongoDB Atlas Admin API + Data API
+    clerk/          # Clerk Backend API and OAuth
+    linear/         # Linear GraphQL API, OAuth, webhooks
+    twilio/         # Twilio Messaging, Verify, Voice, webhooks
 apps/
   web/              # Documentation site (Next.js)
 ```
+
+The service plugins are listed in registry order, which is also the port order
+for a bare `npx emulate`.
 
 The core provides a generic `Store` with typed `Collection<T>` instances supporting CRUD, indexing, filtering, and pagination. Each service plugin registers its routes with the shared internal app and uses the store for state.
 
 ## Auth
 
-Tokens are configured in the seed config and map to users. Pass them as `Authorization: Bearer <token>` or `Authorization: token <token>`.
+Tokens are configured in the seed config and map to users. Pass them as `Authorization: Bearer <token>` or `Authorization: token <token>`. When no `tokens` block is configured, `test_token_admin` is created for the user `admin`.
+
+**The token check is deliberately permissive.** A request with **no**
+`Authorization` header is unauthenticated and protected routes return 401 — but
+**any non-empty token is accepted**, and an unrecognized one resolves to the
+service's fallback user. So `Bearer totally-made-up` succeeds while sending
+nothing fails. A test asserting "an invalid token gives 401" passes against the
+real API and fails here; assert on the missing-header case instead.
+
+Every emulator also applies a rate limit of 5000 requests per hour per token,
+with all anonymous traffic in one shared bucket. Exhausting it returns **403**
+(not 429). See [Troubleshooting](https://emulate.dev/docs/troubleshooting).
 
 **Vercel**: All endpoints accept `teamId` or `slug` query params for team scoping. Pagination uses cursor-based `limit`/`since`/`until` with `pagination` response objects.
 

--- a/apps/web/app/docs/apple/page.mdx
+++ b/apps/web/app/docs/apple/page.mdx
@@ -2,6 +2,106 @@
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
 
+## Start
+
+```bash
+# Apple only
+npx emulate --service apple
+
+# Or run all 14 services; Apple is the 5th, so it lands on 4004
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service apple` puts Apple on **4000**, not 4004. Pass `--port` or set
+`apple.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your app at it
+
+This is a standards-compliant OIDC provider, so point any OIDC-aware library
+(Auth.js, `openid-client`, Passport) at the discovery document and it will find
+the authorize, token and JWKS endpoints itself:
+
+```
+http://localhost:4004/.well-known/openid-configuration
+```
+
+```bash
+APPLE_EMULATOR_URL=http://localhost:4004
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Real Apple URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://appleid.apple.com/.well-known/openid-configuration</code></td>
+      <td><code>$APPLE_EMULATOR_URL/.well-known/openid-configuration</code></td>
+    </tr>
+    <tr>
+      <td><code>https://appleid.apple.com/auth/authorize</code></td>
+      <td><code>$APPLE_EMULATOR_URL/auth/authorize</code></td>
+    </tr>
+    <tr>
+      <td><code>https://appleid.apple.com/auth/token</code></td>
+      <td><code>$APPLE_EMULATOR_URL/auth/token</code></td>
+    </tr>
+    <tr>
+      <td><code>https://appleid.apple.com/auth/keys</code></td>
+      <td><code>$APPLE_EMULATOR_URL/auth/keys</code></td>
+    </tr>
+    <tr>
+      <td><code>https://appleid.apple.com/auth/revoke</code></td>
+      <td><code>$APPLE_EMULATOR_URL/auth/revoke</code></td>
+    </tr>
+  </tbody>
+</table>
+
+```typescript
+import Apple from '@auth/core/providers/apple'
+
+Apple({
+  clientId: process.env.APPLE_CLIENT_ID,
+  clientSecret: process.env.APPLE_CLIENT_SECRET,
+  authorization: {
+    url: `${process.env.APPLE_EMULATOR_URL}/auth/authorize`,
+    params: { scope: 'openid email name', response_mode: 'form_post' },
+  },
+  token: { url: `${process.env.APPLE_EMULATOR_URL}/auth/token` },
+})
+```
+
+Unlike real Apple, the emulator does not require a signed JWT client secret — any
+non-empty value works. The authorize endpoint shows a user picker instead of a
+real Apple login, so a browser-driven flow works end to end.
+
+## Seed config
+
+```yaml
+apple:
+  users:
+    - email: testuser@icloud.com
+      name: Test User
+      given_name: Test
+      family_name: User
+  oauth_clients:
+    - client_id: com.example.app
+      team_id: TEAM123456 # required
+      name: My App # required
+      key_id: KEY123456
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/apple
+```
+
+`oauth_clients` entries require `client_id`, `team_id`, `name` and
+`redirect_uris`. Seed config is not validated, so a missing or misspelled key is
+dropped silently rather than reported. Full reference:
+[Configuration](/docs/configuration).
+
 ## Endpoints
 
 - `GET /.well-known/openid-configuration` - OIDC discovery document

--- a/apps/web/app/docs/architecture/page.mdx
+++ b/apps/web/app/docs/architecture/page.mdx
@@ -11,18 +11,22 @@ packages/
     github/         # GitHub API service
     google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, Drive
     slack/          # Slack Web API, OAuth v2, incoming webhooks
-    linear/         # Linear GraphQL API, OAuth, webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
-    aws/            # AWS S3, SQS, IAM, STS
     okta/           # Okta identity provider / OIDC
-    mongoatlas/     # MongoDB Atlas Admin API + Data API
+    aws/            # AWS S3, SQS, IAM, STS
     resend/         # Resend email API
     stripe/         # Stripe billing and payments API
+    mongoatlas/     # MongoDB Atlas Admin API + Data API
     clerk/          # Clerk Backend API and OAuth
+    linear/         # Linear GraphQL API, OAuth, webhooks
+    twilio/         # Twilio Messaging, Verify, Voice, webhooks
 apps/
   web/              # Documentation site (Next.js)
 ```
+
+The service plugins are listed in registry order, which is also the port order
+for a bare `npx emulate`.
 
 ## Core
 
@@ -37,7 +41,7 @@ Each service is a plugin that:
 3. Provides a seed function to populate initial state from config
 4. Uses shared middleware for auth, error handling, and pagination
 
-Multiple services can run simultaneously, each on its own port (auto-incremented from the base port).
+Multiple services can run simultaneously, each on its own port: the base port plus the service's index in the **enabled** set. Enabling a subset renumbers from the base port, so `--service github` puts GitHub on 4000. See [how ports are assigned](/docs).
 
 ## In-Memory State
 
@@ -45,8 +49,10 @@ All state is held in memory with no database. This makes the emulator fast, easy
 
 ## Middleware
 
-The core provides shared middleware:
+The core provides shared middleware, applied to every route of every service:
 
-- **Auth**: validates Bearer/token authorization headers against configured tokens
+- **CORS**
+- **Auth**: reads Bearer/token authorization headers. Configured tokens map to their user; **any other non-empty token is accepted** and resolves to the service's fallback user. Only a request with no `Authorization` header is unauthenticated. See [Authentication](/docs/authentication).
+- **Rate limiting**: 5000 requests per hour, bucketed per token, with all anonymous traffic sharing one bucket. Exhausting it returns **403** (not 429) with `X-RateLimit-*` headers on every response. See [Troubleshooting](/docs/troubleshooting).
 - **Error handling**: consistent error responses matching each service's format
 - **Pagination**: GitHub-style `page`/`per_page` with `Link` headers, Vercel-style cursor-based pagination

--- a/apps/web/app/docs/authentication/page.mdx
+++ b/apps/web/app/docs/authentication/page.mdx
@@ -2,6 +2,24 @@
 
 Tokens are configured in the seed config and map to users. Pass them as `Authorization: Bearer <token>` or `Authorization: token <token>`.
 
+When no `tokens` block is configured, the emulator creates `test_token_admin` for
+the user `admin`.
+
+## How permissive the check really is
+
+The emulator is deliberately lenient, in a way that can make a passing test
+misleading:
+
+- **No `Authorization` header** → unauthenticated; protected routes return 401.
+- **Any non-empty bearer token** → accepted. An unrecognized token resolves to the service's fallback user, so `Bearer totally-made-up` succeeds as though it were valid.
+
+Note the direction: a *missing* header fails, an *invalid* token does not. A test
+asserting "an invalid token is rejected with 401" passes against the real API and
+fails here. Assert on the missing-header case instead.
+
+Configure `tokens` when you need a request to authenticate as a specific user or
+carry specific scopes — not as a way to make invalid tokens fail.
+
 ## Vercel
 
 All endpoints accept `teamId` or `slug` query params for team scoping. Pagination uses cursor-based `limit`/`since`/`until` with `pagination` response objects.
@@ -99,7 +117,7 @@ Supports `Authorization: Basic` header with base64-encoded `client_id:client_sec
 Pass tokens as `Authorization: Bearer <token>`. Scoped permissions use `s3:*`, `sqs:*`, `iam:*`, `sts:*` patterns.
 
 ```bash
-curl http://localhost:4006/s3/ \
+curl http://localhost:4007/s3/ \
   -H "Authorization: Bearer test_token_admin"
 ```
 

--- a/apps/web/app/docs/aws/page.mdx
+++ b/apps/web/app/docs/aws/page.mdx
@@ -2,7 +2,93 @@
 
 S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/IAM/STS endpoints. All state is in-memory, and responses use AWS-compatible XML.
 
-## S3
+## Start
+
+```bash
+# AWS only
+npx emulate --service aws
+
+# Or run all 14 services; AWS is the 8th, so it lands on 4007
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service aws` puts AWS on **4000**, not 4007. Pass `--port` or set
+`aws.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your SDK at it
+
+The AWS SDK needs `endpoint`, and for S3 also **`forcePathStyle: true`** —
+without it the SDK builds virtual-host URLs like `my-bucket.localhost` that never
+reach the emulator. A default access key pair is always seeded:
+
+```typescript
+import { S3Client } from '@aws-sdk/client-s3'
+
+const s3 = new S3Client({
+  endpoint: process.env.AWS_EMULATOR_URL,
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  },
+  forcePathStyle: true,
+})
+```
+
+```bash
+AWS_EMULATOR_URL=http://localhost:4007
+```
+
+SQS, IAM and STS live under path prefixes, so append them to the endpoint:
+
+```typescript
+import { SQSClient } from '@aws-sdk/client-sqs'
+
+const sqs = new SQSClient({
+  endpoint: `${process.env.AWS_EMULATOR_URL}/sqs`,
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  },
+})
+```
+
+Use `/iam` and `/sts` the same way.
+
+## Default seed
+
+Always created: S3 bucket `emulate-default`, SQS queue `emulate-default-queue`,
+and IAM user `admin` with the access key pair shown above.
+
+## Seed config
+
+```yaml
+aws:
+  region: us-east-1
+  s3:
+    buckets:
+      - name: my-app-bucket
+  sqs:
+    queues:
+      - name: my-app-events
+      - name: my-app-orders.fifo
+        fifo: true
+  iam:
+    users:
+      - user_name: developer
+        create_access_key: true
+    roles:
+      - role_name: lambda-execution-role
+```
+
+Seed config is not validated, so an unknown key is dropped silently. Full
+reference: [Configuration](/docs/configuration).
+
+## Endpoints
+
+### S3
 
 S3 routes use root paths matching the real AWS S3 wire format, so the official AWS SDK works out of the box with `forcePathStyle: true`. Legacy `/s3/` prefixed paths are also supported for backward compatibility.
 
@@ -18,7 +104,7 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 - `DELETE /:bucket/:key` - delete object
 - `PUT /:bucket/:key` with `x-amz-copy-source` - copy object
 
-## SQS
+### SQS
 
 All SQS operations use `POST /sqs/` with an `Action` form parameter.
 
@@ -32,7 +118,7 @@ All SQS operations use `POST /sqs/` with an `Action` form parameter.
 - `PurgeQueue` - purge all messages
 - `DeleteQueue` - delete queue
 
-## IAM
+### IAM
 
 All IAM operations use `POST /iam/` with an `Action` form parameter.
 
@@ -40,7 +126,7 @@ All IAM operations use `POST /iam/` with an `Action` form parameter.
 - `CreateAccessKey` / `ListAccessKeys` / `DeleteAccessKey` - access key management
 - `CreateRole` / `GetRole` / `ListRoles` / `DeleteRole` - role management
 
-## STS
+### STS
 
 All STS operations use `POST /sts/` with an `Action` form parameter.
 

--- a/apps/web/app/docs/clerk/page.mdx
+++ b/apps/web/app/docs/clerk/page.mdx
@@ -1,0 +1,177 @@
+# Clerk
+
+Clerk user management and OAuth 2.0 / OIDC emulation: users, email addresses,
+sessions and session tokens, organizations, memberships, and invitations. State
+is in-memory and resets when the process restarts.
+
+## Start
+
+```bash
+# Clerk only
+npx emulate --service clerk
+
+# Or run all 14 services; Clerk is the 12th, so it lands on 4011
+npx emulate
+```
+
+Ports are `--port` (default `4000`) plus the service's index in the enabled set,
+so `--service clerk` puts Clerk on 4000, not 4011. To pin it, pass `--port` or
+set `clerk.port` in the [seed config](/docs/configuration).
+
+## Default seed
+
+With no configuration, the emulator creates one user:
+
+- `first_name: Test`, `last_name: User`
+- primary email `test@example.com`, verified
+- password `test_password`
+
+## Point your SDK at it
+
+Clerk's backend SDK reads its API base URL from `CLERK_API_URL`. Point it at the
+emulator and use any non-empty secret key:
+
+```bash
+CLERK_API_URL=http://localhost:4011
+CLERK_SECRET_KEY=sk_test_anything
+```
+
+```typescript
+import { createClerkClient } from '@clerk/backend'
+
+const clerk = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+  apiUrl: process.env.CLERK_API_URL,
+})
+
+const users = await clerk.users.getUserList()
+```
+
+For OIDC flows, discovery is served at
+`http://localhost:4011/.well-known/openid-configuration` and the signing keys at
+`/v1/jwks`.
+
+## Seed config
+
+```yaml
+clerk:
+  users:
+    - email_addresses: ["test@example.com"] # required, an array
+      first_name: Test
+      last_name: User
+      username: testuser
+      password: clerk_test_password
+      public_metadata:
+        plan: pro
+  organizations:
+    - name: My Company
+      slug: my-company
+      members:
+        - email: test@example.com
+          role: admin
+  oauth_applications:
+    - client_id: clerk_emulate_client
+      client_secret: clerk_emulate_secret
+      name: Emulate App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/clerk
+```
+
+Seed config is not validated, so two mistakes fail silently:
+
+- `email_addresses` is an **array of strings** and is required. A user seeded
+  with `email:` instead gets no email address at all.
+- There is no `name` field. Use `first_name` and `last_name`.
+
+`organizations[].members[].email` must match a seeded user's email, otherwise the
+membership is skipped.
+
+## Endpoints
+
+### Users
+
+- `GET /v1/users` — list users
+- `GET /v1/users/count` — count users
+- `GET /v1/users/:userId` — retrieve user
+- `POST /v1/users` — create user
+- `PATCH /v1/users/:userId` — update user
+- `DELETE /v1/users/:userId` — delete user
+- `POST /v1/users/:userId/ban` — ban user
+- `POST /v1/users/:userId/unban` — unban user
+- `POST /v1/users/:userId/lock` — lock user
+- `POST /v1/users/:userId/unlock` — unlock user
+- `PATCH /v1/users/:userId/metadata` — merge user metadata
+- `POST /v1/users/:userId/verify_password` — verify a password
+
+### Email Addresses
+
+- `GET /v1/email_addresses/:emailId` — retrieve
+- `POST /v1/email_addresses` — create
+- `PATCH /v1/email_addresses/:emailId` — update
+- `DELETE /v1/email_addresses/:emailId` — delete
+
+### Sessions
+
+- `GET /v1/sessions` — list sessions
+- `GET /v1/sessions/:sessionId` — retrieve session
+- `POST /v1/sessions` — create session
+- `POST /v1/sessions/:sessionId/revoke` — revoke session
+- `POST /v1/sessions/:sessionId/tokens` — mint a session token
+- `POST /v1/sessions/:sessionId/tokens/:template` — mint a token from a JWT template
+
+### Organizations
+
+- `GET /v1/organizations` — list organizations
+- `GET /v1/organizations/:orgId` — retrieve organization
+- `POST /v1/organizations` — create organization
+- `PATCH /v1/organizations/:orgId` — update organization
+- `DELETE /v1/organizations/:orgId` — delete organization
+- `PATCH /v1/organizations/:orgId/metadata` — merge organization metadata
+
+### Memberships
+
+- `GET /v1/organizations/:orgId/memberships` — list members
+- `POST /v1/organizations/:orgId/memberships` — add member
+- `PATCH /v1/organizations/:orgId/memberships/:userId` — update role
+- `DELETE /v1/organizations/:orgId/memberships/:userId` — remove member
+- `PATCH /v1/organizations/:orgId/memberships/:userId/metadata` — merge membership metadata
+
+### Invitations
+
+- `GET /v1/organizations/:orgId/invitations` — list invitations
+- `GET /v1/organizations/:orgId/invitations/:invitationId` — retrieve invitation
+- `POST /v1/organizations/:orgId/invitations` — create invitation
+- `POST /v1/organizations/:orgId/invitations/bulk` — create invitations in bulk
+- `POST /v1/organizations/:orgId/invitations/:invitationId/revoke` — revoke invitation
+
+### OAuth / OIDC
+
+- `GET /.well-known/openid-configuration` — discovery document
+- `GET /v1/jwks` — signing keys
+- `GET /oauth/authorize` — authorization endpoint
+- `POST /oauth/authorize/callback` — authorization callback
+- `POST /oauth/token` — token exchange
+- `GET /oauth/userinfo` — userinfo
+
+## Examples
+
+```bash
+# List users
+curl http://localhost:4011/v1/users \
+  -H "Authorization: Bearer test_token_admin"
+
+# Create a user
+curl -X POST http://localhost:4011/v1/users \
+  -H "Authorization: Bearer test_token_admin" \
+  -H "Content-Type: application/json" \
+  -d '{"email_address":["new@example.com"],"first_name":"New","last_name":"User"}'
+
+# Create an organization
+curl -X POST http://localhost:4011/v1/organizations \
+  -H "Authorization: Bearer test_token_admin" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme","slug":"acme"}'
+```
+
+Any non-empty bearer token is accepted — see
+[Authentication](/docs/authentication).

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -1,6 +1,38 @@
 # Configuration
 
-Configuration is optional. All services start with sensible defaults. To customize seed data, create `emulate.config.yaml` in your project root (or pass `--seed`):
+Configuration is optional. All services start with sensible defaults. To customize seed data, create `emulate.config.yaml` in your project root (or pass `--seed`).
+
+The CLI auto-detects, in order: `emulate.config.yaml` / `.yml`,
+`emulate.config.json`, `service-emulator.config.yaml` / `.yml`,
+`service-emulator.config.json`. Run `npx emulate init` to generate a starter file.
+
+Two things to know before writing one:
+
+- **A config file selects services.** Every top-level service key is treated as
+  an implicit `--service`. A file containing only `stripe:` makes `npx emulate`
+  start Stripe alone, on the base port — not all 14. Pass `--service` explicitly
+  to override.
+- **Nothing here is validated.** Unknown or misspelled keys are dropped without a
+  warning and the emulator starts anyway with that data missing. If something you
+  seeded isn't there, suspect a key name first.
+
+## Per-service options
+
+Alongside the seed collections, every service accepts two operational keys:
+
+```yaml
+github:
+  port: 4001 # pin this service's port, ignoring base + index
+  baseUrl: https://github.emulate.test # advertised URL in OAuth redirects, webhooks
+  users:
+    - login: octocat
+```
+
+`port` is the only way to give a service a stable port regardless of which other
+services are enabled. `baseUrl` has the highest priority of all base-URL sources,
+ahead of `--base-url` and the `EMULATE_BASE_URL` env var.
+
+## Tokens
 
 ```yaml
 tokens:
@@ -111,9 +143,9 @@ github:
       slug: "my-github-app"
       name: "My GitHub App"
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...your PEM key...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
       permissions:
         contents: read
         issues: write
@@ -136,6 +168,21 @@ github:
 - `GET /users/:username/installation` - find user installation
 
 JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's private key (RS256). The emulator verifies the signature and resolves the app.
+
+### The private key must be PKCS#8
+
+`private_key` is parsed with `importPKCS8`, so it has to begin with
+`-----BEGIN PRIVATE KEY-----`. GitHub hands out App keys in PKCS#1 format
+(`-----BEGIN RSA PRIVATE KEY-----`), which this emulator cannot read. Convert it
+once:
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in github-app.private-key.pem -out github-app.pkcs8.pem
+```
+
+A key in the wrong format fails silently: JWT verification throws, the error is
+swallowed, and the request is simply treated as unauthenticated. If `GET /app`
+returns 401 with a JWT you believe is valid, check the PEM header first.
 
 ## Google Seed Config
 
@@ -327,8 +374,8 @@ okta:
   users:
     - login: testuser@example.com
       email: testuser@example.com
-      firstName: Test
-      lastName: User
+      first_name: Test # snake_case, not firstName
+      last_name: User
   groups:
     - name: Everyone
       description: All users
@@ -336,9 +383,15 @@ okta:
     - name: My App
       label: My App
   authorization_servers:
-    - name: default
+    - id: default # required — primary key used in /oauth2/:id/... paths
+      name: default
       audiences: ["api://default"]
 ```
+
+User fields are snake_case (`first_name`, `last_name`). A camelCase key is
+ignored and the user gets the default name `Test User`.
+`authorization_servers[].id` is required — it becomes the `server_id` that the
+OAuth routes look up, so a server seeded without it is unreachable.
 
 ## MongoDB Atlas Seed Config
 
@@ -360,9 +413,17 @@ mongoatlas:
 resend:
   domains:
     - name: example.com
-  api_keys:
-    - name: default
+      region: us-east-1 # optional, defaults to us-east-1
+  contacts:
+    - email: subscriber@example.com
+      first_name: Sub
+      last_name: Scriber
+      audience: newsletter
 ```
+
+`domains` and `contacts` are the only seedable collections. API keys cannot be
+seeded — create them with `POST /api-keys`, or just send any non-empty bearer
+token, which the emulator accepts.
 
 ## Stripe Seed Config
 
@@ -374,9 +435,19 @@ stripe:
   products:
     - name: Pro Plan
   prices:
-    - product: Pro Plan
+    - product_name: Pro Plan # must match a products[].name above
       unit_amount: 2000
       currency: usd
-      recurring:
-        interval: month
+  webhooks:
+    - url: http://localhost:3000/api/stripe/webhook
+      events: ["checkout.session.completed"]
 ```
+
+Prices are seeded through their product: an entry is only created if its
+`product_name` matches the `name` of an entry in `products`. Spell the key
+`product`, or reference a product that isn't seeded, and the price is dropped —
+`GET /v1/prices` then returns `{"data":[]}` and checkout fails with
+`No such price`.
+
+Seeded prices are always `type: "one_time"`; there is no `recurring` key. Create
+subscription-style prices at runtime with `POST /v1/prices`.

--- a/apps/web/app/docs/connecting/page.mdx
+++ b/apps/web/app/docs/connecting/page.mdx
@@ -1,0 +1,235 @@
+# Connecting your app
+
+There is no proxy, no DNS trick, and no traffic interception. Each emulator is an
+ordinary HTTP server on localhost that speaks the same wire protocol as the real
+service. Connecting your app means one thing: **point the SDK at a different base
+URL**, and give it any non-empty credential.
+
+```typescript
+// before
+const client = new Client({ apiKey: process.env.API_KEY })
+
+// with emulate
+const client = new Client({
+  apiKey: 'anything',
+  baseUrl: process.env.SERVICE_EMULATOR_URL,
+})
+```
+
+Most SDKs expose that knob under a slightly different name. The table below gives
+the one you need per service. Substitute your own port — see
+[how ports are assigned](/docs).
+
+## Where the base URL goes, per SDK
+
+<table>
+  <thead>
+    <tr>
+      <th>Service</th>
+      <th>SDK</th>
+      <th>The knob</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Vercel</td>
+      <td><code>fetch</code> / custom</td>
+      <td>Replace <code>https://api.vercel.com</code> with the emulator URL</td>
+    </tr>
+    <tr>
+      <td>GitHub</td>
+      <td><code>@octokit/rest</code></td>
+      <td><code>{'new Octokit({ baseUrl })'}</code></td>
+    </tr>
+    <tr>
+      <td>Google</td>
+      <td><code>google-auth-library</code></td>
+      <td>Per-endpoint URLs — see <a href="/docs/google">Google</a></td>
+    </tr>
+    <tr>
+      <td>Slack</td>
+      <td><code>@slack/web-api</code></td>
+      <td><code>{'new WebClient(token, { slackApiUrl: \'<url>/api/\' })'}</code> — note the trailing <code>/api/</code></td>
+    </tr>
+    <tr>
+      <td>Apple</td>
+      <td>Auth.js / OIDC</td>
+      <td>Discovery at <code>{'<url>/.well-known/openid-configuration'}</code></td>
+    </tr>
+    <tr>
+      <td>Microsoft</td>
+      <td>Auth.js / MSAL</td>
+      <td>Discovery at <code>{'<url>/.well-known/openid-configuration'}</code></td>
+    </tr>
+    <tr>
+      <td>Okta</td>
+      <td><code>@okta/okta-sdk-nodejs</code></td>
+      <td><code>orgUrl</code> = the emulator URL; issuer is <code>{'<url>/oauth2/default'}</code></td>
+    </tr>
+    <tr>
+      <td>AWS</td>
+      <td>AWS SDK v3</td>
+      <td><code>endpoint</code> <strong>and</strong> <code>forcePathStyle: true</code> for S3</td>
+    </tr>
+    <tr>
+      <td>Resend</td>
+      <td><code>resend</code></td>
+      <td><code>RESEND_BASE_URL</code> env var — no code change needed</td>
+    </tr>
+    <tr>
+      <td>Stripe</td>
+      <td><code>stripe</code></td>
+      <td><code>{'new Stripe(key, { host: \'localhost\', port, protocol: \'http\' })'}</code></td>
+    </tr>
+    <tr>
+      <td>MongoDB Atlas</td>
+      <td>Admin API over <code>fetch</code></td>
+      <td>Replace <code>https://cloud.mongodb.com/api/atlas/v2</code> with the emulator URL</td>
+    </tr>
+    <tr>
+      <td>Clerk</td>
+      <td><code>@clerk/backend</code></td>
+      <td><code>{'createClerkClient({ apiUrl })'}</code></td>
+    </tr>
+    <tr>
+      <td>Linear</td>
+      <td><code>fetch</code> / GraphQL</td>
+      <td>POST to <code>{'<url>/graphql'}</code></td>
+    </tr>
+    <tr>
+      <td>Twilio</td>
+      <td><code>twilio</code></td>
+      <td>Product hosts map to path prefixes — see <a href="/docs/twilio">Twilio</a></td>
+    </tr>
+  </tbody>
+</table>
+
+Credentials are not checked for validity: any non-empty bearer token is accepted.
+A request with **no** `Authorization` header is still rejected with 401. See
+[Authentication](/docs/authentication).
+
+## Examples
+
+### AWS
+
+The AWS SDK needs both `endpoint` and, for S3, path-style addressing — without
+`forcePathStyle` it builds virtual-host URLs like `my-bucket.localhost` that never
+reach the emulator.
+
+```typescript
+import { S3Client } from '@aws-sdk/client-s3'
+
+const s3 = new S3Client({
+  endpoint: process.env.AWS_EMULATOR_URL,
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  },
+  forcePathStyle: true,
+})
+```
+
+SQS and IAM live under path prefixes, so append them to the endpoint:
+`${AWS_EMULATOR_URL}/sqs`, `${AWS_EMULATOR_URL}/iam`.
+
+### Stripe
+
+```typescript
+import Stripe from 'stripe'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-12-18.acacia',
+  host: 'localhost',
+  port: 4009,
+  protocol: 'http',
+})
+```
+
+### Resend
+
+The official Node SDK reads `RESEND_BASE_URL` at module load time, so no code
+change is needed at all:
+
+```bash
+RESEND_BASE_URL=http://localhost:4008
+```
+
+### Slack
+
+```typescript
+import { WebClient } from '@slack/web-api'
+
+const client = new WebClient(token, {
+  slackApiUrl: `${process.env.SLACK_EMULATOR_URL}/api/`,
+})
+```
+
+### Clerk
+
+```typescript
+import { createClerkClient } from '@clerk/backend'
+
+const clerk = createClerkClient({
+  secretKey: 'sk_test_anything',
+  apiUrl: process.env.CLERK_EMULATOR_URL,
+})
+```
+
+### Okta
+
+```typescript
+import { Client } from '@okta/okta-sdk-nodejs'
+
+const client = new Client({
+  orgUrl: process.env.OKTA_EMULATOR_URL,
+  token: 'anything',
+})
+```
+
+The OAuth issuer is `${OKTA_EMULATOR_URL}/oauth2/default`, matching the
+authorization server seeded with `id: default`.
+
+## OIDC providers
+
+Apple, Microsoft, Google, Okta and Clerk all serve a standards-compliant
+discovery document. Any OIDC-aware library — Auth.js, `openid-client`, Passport —
+can be pointed at it and will find the authorize, token, userinfo and JWKS
+endpoints on its own:
+
+```
+http://localhost:<port>/.well-known/openid-configuration
+```
+
+Microsoft additionally serves a tenant-scoped variant at
+`/{tenant}/v2.0/.well-known/openid-configuration`.
+
+## Env-var-only setups
+
+There is no single env var that redirects every SDK — each library has its own.
+The `<SERVICE>_EMULATOR_URL` names used across these docs are a convention for
+*your* application code to read; the emulator does not read them itself.
+
+Two genuine exceptions, where no code change is required:
+
+- **Resend** reads `RESEND_BASE_URL` natively.
+- **Any service**, if your code already reads its base URL from an env var — then
+  you only need to change that variable's value.
+
+For everything else, plan on a one-line code change guarded by an env var, as in
+the examples above.
+
+## Which URL the emulator advertises
+
+Some responses embed absolute URLs — OAuth redirects, webhook payloads, blob
+URLs. That advertised base URL is resolved in this order:
+
+1. Per-service `baseUrl` in the seed config
+2. The `--base-url` flag or the `baseUrl` option of `createEmulator`
+3. The `EMULATE_BASE_URL` env var (supports the `{service}` template)
+4. `PORTLESS_URL`, set automatically by the `portless` wrapper
+5. `http://localhost:<port>`
+
+If your app receives callbacks on a hostname other than `localhost` — a container,
+a preview deployment, a reverse proxy — set one of the first three so the
+emulator advertises a URL your app can actually reach.

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -2,7 +2,111 @@
 
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.
 
-## Users
+## Start
+
+```bash
+# GitHub only
+npx emulate --service github
+
+# Or run all 14 services; GitHub is the 2nd, so it lands on 4001
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service github` puts GitHub on **4000**, not 4001. Pass `--port` or set
+`github.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your SDK at it
+
+Octokit takes a `baseUrl`. The token is not validated, so any non-empty value
+works:
+
+```typescript
+import { Octokit } from '@octokit/rest'
+
+const octokit = new Octokit({
+  baseUrl: process.env.GITHUB_EMULATOR_URL ?? 'https://api.github.com',
+  auth: 'test_token_admin',
+})
+
+const { data } = await octokit.repos.listForUser({ username: 'octocat' })
+```
+
+Or over plain HTTP:
+
+```bash
+curl http://localhost:4001/user \
+  -H "Authorization: Bearer test_token_admin"
+```
+
+For OAuth sign-in flows:
+
+<table>
+  <thead>
+    <tr>
+      <th>Real GitHub URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://github.com/login/oauth/authorize</code></td>
+      <td><code>$GITHUB_EMULATOR_URL/login/oauth/authorize</code></td>
+    </tr>
+    <tr>
+      <td><code>https://github.com/login/oauth/access_token</code></td>
+      <td><code>$GITHUB_EMULATOR_URL/login/oauth/access_token</code></td>
+    </tr>
+    <tr>
+      <td><code>https://api.github.com/user</code></td>
+      <td><code>$GITHUB_EMULATOR_URL/user</code></td>
+    </tr>
+  </tbody>
+</table>
+
+The authorize endpoint renders a user-picker page instead of a real login, so a
+browser-driven OAuth flow works end to end. See the
+[oauth example](https://github.com/vercel-labs/emulate/tree/main/examples/oauth).
+
+## Seed config
+
+```yaml
+github:
+  users:
+    - login: octocat
+      name: The Octocat
+      email: octocat@github.com
+  orgs:
+    - login: my-org
+      name: My Organization
+  repos:
+    - owner: octocat
+      name: hello-world
+      language: JavaScript
+      auto_init: true
+```
+
+Repos are auto-initialized with a commit, branch, and README unless
+`auto_init: false`. Seed config is not validated, so an unknown key is dropped
+silently. Full reference, including OAuth apps and GitHub Apps:
+[Configuration](/docs/configuration).
+
+## Authentication
+
+Public repo endpoints work without auth; private repos and writes require an
+`Authorization` header. The check is deliberately permissive: **any non-empty
+token is accepted**, and an unrecognized one resolves to the fallback user. Only a
+request with **no** header is rejected with 401. See
+[Authentication](/docs/authentication).
+
+GitHub App JWTs are verified for real, and the private key must be **PKCS#8**
+(`-----BEGIN PRIVATE KEY-----`). GitHub issues App keys in PKCS#1, which fails
+silently here — convert with
+`openssl pkcs8 -topk8 -nocrypt -in key.pem -out key.pkcs8.pem`.
+
+## Endpoints
+
+### Users
 
 - `GET /user` - authenticated user
 - `PATCH /user` - update profile
@@ -13,7 +117,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /users/:username/followers` - list followers
 - `GET /users/:username/following` - list following
 
-## Repositories
+### Repositories
 
 - `GET /repos/:owner/:repo` - get repo
 - `POST /user/repos` - create user repo
@@ -30,7 +134,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `POST /repos/:owner/:repo/transfer` - transfer repo
 - `GET /repos/:owner/:repo/tags` - list tags
 
-## Issues
+### Issues
 
 - `GET /repos/:owner/:repo/issues` - list (filter by state, labels, assignee, milestone, creator, since)
 - `POST /repos/:owner/:repo/issues` - create
@@ -41,7 +145,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /repos/:owner/:repo/issues/:number/events` - events
 - `POST/DELETE /repos/:owner/:repo/issues/:number/assignees` - manage assignees
 
-## Pull Requests
+### Pull Requests
 
 - `GET /repos/:owner/:repo/pulls` - list (filter by state, head, base)
 - `POST /repos/:owner/:repo/pulls` - create
@@ -53,14 +157,14 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `POST/DELETE /repos/:owner/:repo/pulls/:number/requested_reviewers` - manage reviewers
 - `PUT /repos/:owner/:repo/pulls/:number/update-branch` - update branch
 
-## Comments
+### Comments
 
 - Issue comments: full CRUD on `/repos/:owner/:repo/issues/:number/comments`
 - Review comments: full CRUD on `/repos/:owner/:repo/pulls/:number/comments`
 - Commit comments: full CRUD on `/repos/:owner/:repo/commits/:sha/comments`
 - Repo-wide listings for each type
 
-## Reviews
+### Reviews
 
 - `GET /repos/:owner/:repo/pulls/:number/reviews` - list
 - `POST /repos/:owner/:repo/pulls/:number/reviews` - create (with inline comments)
@@ -68,12 +172,12 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `POST /repos/:owner/:repo/pulls/:number/reviews/:id/events` - submit
 - `PUT /repos/:owner/:repo/pulls/:number/reviews/:id/dismissals` - dismiss
 
-## Labels & Milestones
+### Labels & Milestones
 
 - Labels: full CRUD, add/remove from issues, replace all
 - Milestones: full CRUD, state transitions, issue counts
 
-## Branches & Git Data
+### Branches & Git Data
 
 - Branches: list, get, protection CRUD (status checks, PR reviews, enforce admins)
 - Refs: get, match, create, update, delete
@@ -82,25 +186,25 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - Blobs: get, create
 - Tags: get, create
 
-## Organizations & Teams
+### Organizations & Teams
 
 - Orgs: get, update, list
 - Org members: list, check, remove, get/set membership
 - Teams: full CRUD, members, repos
 
-## Releases
+### Releases
 
 - Releases: full CRUD, latest, by tag
 - Release assets: full CRUD, upload
 - Generate release notes
 
-## Webhooks
+### Webhooks
 
 - Repo webhooks: full CRUD, ping, test, deliveries
 - Org webhooks: full CRUD, ping
 - Real HTTP delivery to registered URLs on all state changes
 
-## Search
+### Search
 
 - `GET /search/repositories` - full query syntax (user, org, language, topic, stars, forks, etc.)
 - `GET /search/issues` - issues + PRs (repo, is, author, label, milestone, state, etc.)
@@ -110,7 +214,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /search/topics` - topic search
 - `GET /search/labels` - label search
 
-## Actions
+### Actions
 
 - Workflows: list, get, enable/disable, dispatch
 - Workflow runs: list, get, cancel, rerun, delete, logs
@@ -118,15 +222,15 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - Artifacts: list, get, delete
 - Secrets: repo + org CRUD
 
-## Checks
+### Checks
 
 - Check runs: create, update, get, annotations, rerequest, list by ref/suite
 - Check suites: create, get, preferences, rerequest, list by ref
 - Automatic suite status rollup from check run results
 
-## Misc
+### Misc
 
-- `GET /rate_limit` - rate limit status
+- `GET /rate_limit` - rate limit status (static values; it does **not** report the emulator's own 5000/hr limiter — see [Troubleshooting](/docs/troubleshooting))
 - `GET /meta` - server metadata
 - `GET /octocat` - ASCII art
 - `GET /emojis` - emoji URLs

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -2,7 +2,123 @@
 
 OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local inbox, calendar, and drive flows.
 
-## OAuth & OpenID Connect
+## Start
+
+```bash
+# Google only
+npx emulate --service google
+
+# Or run all 14 services; Google is the 3rd, so it lands on 4002
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service google` puts Google on **4000**, not 4002. Pass `--port` or set
+`google.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your app at it
+
+Google's client libraries do not share a single base-URL switch, so redirect them
+per endpoint. Any OIDC-aware library (Auth.js, `openid-client`, Passport) can
+instead be pointed at the discovery document and will find the rest itself:
+
+```
+http://localhost:4002/.well-known/openid-configuration
+```
+
+```bash
+GOOGLE_EMULATOR_URL=http://localhost:4002
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Real Google URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://accounts.google.com/o/oauth2/v2/auth</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/o/oauth2/v2/auth</code></td>
+    </tr>
+    <tr>
+      <td><code>https://oauth2.googleapis.com/token</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/oauth2/token</code></td>
+    </tr>
+    <tr>
+      <td><code>https://www.googleapis.com/oauth2/v2/userinfo</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/oauth2/v2/userinfo</code></td>
+    </tr>
+    <tr>
+      <td><code>https://accounts.google.com/.well-known/openid-configuration</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/.well-known/openid-configuration</code></td>
+    </tr>
+    <tr>
+      <td><code>https://www.googleapis.com/oauth2/v3/certs</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/oauth2/v3/certs</code></td>
+    </tr>
+    <tr>
+      <td><code>https://gmail.googleapis.com/gmail/v1/...</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/gmail/v1/...</code></td>
+    </tr>
+    <tr>
+      <td><code>https://www.googleapis.com/calendar/v3/...</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/calendar/v3/...</code></td>
+    </tr>
+    <tr>
+      <td><code>https://www.googleapis.com/drive/v3/...</code></td>
+      <td><code>$GOOGLE_EMULATOR_URL/drive/v3/...</code></td>
+    </tr>
+  </tbody>
+</table>
+
+```typescript
+import { OAuth2Client } from 'google-auth-library'
+
+const GOOGLE_URL = process.env.GOOGLE_EMULATOR_URL ?? 'https://accounts.google.com'
+
+const client = new OAuth2Client({
+  clientId: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  redirectUri: 'http://localhost:3000/api/auth/callback/google',
+})
+```
+
+The authorize endpoint renders a user-picker page instead of a real Google login,
+so a browser-driven flow works end to end. See the
+[oauth example](https://github.com/vercel-labs/emulate/tree/main/examples/oauth).
+
+## Seed config
+
+```yaml
+google:
+  users:
+    - email: testuser@example.com
+      name: Test User
+  oauth_clients:
+    - client_id: my-client-id.apps.googleusercontent.com
+      client_secret: GOCSPX-secret
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/google
+  messages:
+    - id: msg_welcome
+      user_email: testuser@example.com
+      from: welcome@example.com
+      to: testuser@example.com
+      subject: Welcome
+      body_text: Hello from the Gmail emulator
+      label_ids: [INBOX, UNREAD]
+```
+
+Gmail, Calendar and Drive entities are attached to a user through `user_email`,
+which must match a seeded user. Seed config is not validated, so an unknown key is
+dropped silently. Full reference, including calendars, events and drive items:
+[Configuration](/docs/configuration).
+
+## Endpoints
+
+### OAuth & OpenID Connect
 
 - `GET /o/oauth2/v2/auth` - authorization endpoint
 - `POST /oauth2/token` - token exchange
@@ -10,7 +126,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `GET /.well-known/openid-configuration` - OIDC discovery document
 - `GET /oauth2/v3/certs` - JSON Web Key Set (JWKS)
 
-## Gmail
+### Gmail
 
 - `GET /gmail/v1/users/:userId/messages` - list messages (`q`, `labelIds`, `maxResults`, `pageToken`)
 - `GET /gmail/v1/users/:userId/messages/:id` - get message (`full`, `metadata`, `minimal`, `raw` formats)
@@ -23,7 +139,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `POST /gmail/v1/users/:userId/messages/:id/trash` - trash message
 - `POST /gmail/v1/users/:userId/messages/:id/untrash` - untrash message
 
-## Gmail Drafts
+### Gmail Drafts
 
 - `GET /gmail/v1/users/:userId/drafts` - list drafts
 - `POST /gmail/v1/users/:userId/drafts` - create draft
@@ -32,26 +148,26 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `POST /gmail/v1/users/:userId/drafts/:id/send` - send draft
 - `DELETE /gmail/v1/users/:userId/drafts/:id` - delete draft
 
-## Gmail Threads
+### Gmail Threads
 
 - `GET /gmail/v1/users/:userId/threads` - list threads
 - `GET /gmail/v1/users/:userId/threads/:id` - get thread
 - `POST /gmail/v1/users/:userId/threads/:id/modify` - add/remove labels across a thread
 
-## Gmail Labels
+### Gmail Labels
 
 - `GET /gmail/v1/users/:userId/labels` - list labels
 - `POST /gmail/v1/users/:userId/labels` - create label
 - `PATCH /gmail/v1/users/:userId/labels/:id` - update label
 - `DELETE /gmail/v1/users/:userId/labels/:id` - delete label
 
-## Gmail History & Push
+### Gmail History & Push
 
 - `GET /gmail/v1/users/:userId/history` - list history changes
 - `POST /gmail/v1/users/:userId/watch` - set up push notifications
 - `POST /gmail/v1/users/:userId/stop` - stop push notifications
 
-## Gmail Settings
+### Gmail Settings
 
 - `GET /gmail/v1/users/:userId/settings/filters` - list filters
 - `POST /gmail/v1/users/:userId/settings/filters` - create filter
@@ -59,7 +175,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `GET /gmail/v1/users/:userId/settings/forwardingAddresses` - list forwarding addresses
 - `GET /gmail/v1/users/:userId/settings/sendAs` - list send-as aliases
 
-## Calendar
+### Calendar
 
 - `GET /calendar/v3/users/:userId/calendarList` - list calendars
 - `GET /calendar/v3/calendars/:calendarId/events` - list events
@@ -67,7 +183,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `DELETE /calendar/v3/calendars/:calendarId/events/:eventId` - delete event
 - `POST /calendar/v3/freeBusy` - query free/busy
 
-## Drive
+### Drive
 
 - `GET /drive/v3/files` - list files
 - `GET /drive/v3/files/:fileId` - get file metadata

--- a/apps/web/app/docs/linear/page.mdx
+++ b/apps/web/app/docs/linear/page.mdx
@@ -12,12 +12,32 @@ When Linear is the only enabled service, it starts on `http://localhost:4000`. W
 
 ## URL Mapping
 
-| Real Linear URL | Emulator URL |
-|-----------------|--------------|
-| `https://api.linear.app/graphql` | `$LINEAR_EMULATOR_URL/graphql` |
-| `https://linear.app/oauth/authorize` | `$LINEAR_EMULATOR_URL/oauth/authorize` |
-| `https://api.linear.app/oauth/token` | `$LINEAR_EMULATOR_URL/oauth/token` |
-| `https://api.linear.app/oauth/revoke` | `$LINEAR_EMULATOR_URL/oauth/revoke` |
+<table>
+  <thead>
+    <tr>
+      <th>Real Linear URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://api.linear.app/graphql</code></td>
+      <td><code>$LINEAR_EMULATOR_URL/graphql</code></td>
+    </tr>
+    <tr>
+      <td><code>https://linear.app/oauth/authorize</code></td>
+      <td><code>$LINEAR_EMULATOR_URL/oauth/authorize</code></td>
+    </tr>
+    <tr>
+      <td><code>https://api.linear.app/oauth/token</code></td>
+      <td><code>$LINEAR_EMULATOR_URL/oauth/token</code></td>
+    </tr>
+    <tr>
+      <td><code>https://api.linear.app/oauth/revoke</code></td>
+      <td><code>$LINEAR_EMULATOR_URL/oauth/revoke</code></td>
+    </tr>
+  </tbody>
+</table>
 
 ## GraphQL
 

--- a/apps/web/app/docs/microsoft/page.mdx
+++ b/apps/web/app/docs/microsoft/page.mdx
@@ -2,6 +2,108 @@
 
 Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with authorization code flow, PKCE, client credentials, RS256 ID tokens, OIDC discovery, and a Microsoft Graph `/v1.0/me` endpoint.
 
+## Start
+
+```bash
+# Microsoft only
+npx emulate --service microsoft
+
+# Or run all 14 services; Microsoft is the 6th, so it lands on 4005
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service microsoft` puts it on **4000**, not 4005. Pass `--port` or set
+`microsoft.port` in the seed config to pin it. See
+[how ports are assigned](/docs).
+
+## Point your app at it
+
+This is a standards-compliant OIDC provider, so point any OIDC-aware library
+(Auth.js, MSAL, `openid-client`) at the discovery document and it will find the
+rest itself. Both the org-wide and tenant-scoped forms are served:
+
+```
+http://localhost:4005/.well-known/openid-configuration
+http://localhost:4005/{tenant}/v2.0/.well-known/openid-configuration
+```
+
+```bash
+MICROSOFT_EMULATOR_URL=http://localhost:4005
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Real Microsoft URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://login.microsoftonline.com/common/oauth2/v2.0/authorize</code></td>
+      <td><code>$MICROSOFT_EMULATOR_URL/oauth2/v2.0/authorize</code></td>
+    </tr>
+    <tr>
+      <td><code>https://login.microsoftonline.com/common/oauth2/v2.0/token</code></td>
+      <td><code>$MICROSOFT_EMULATOR_URL/oauth2/v2.0/token</code></td>
+    </tr>
+    <tr>
+      <td><code>https://login.microsoftonline.com/common/discovery/v2.0/keys</code></td>
+      <td><code>$MICROSOFT_EMULATOR_URL/discovery/v2.0/keys</code></td>
+    </tr>
+    <tr>
+      <td><code>https://graph.microsoft.com/oidc/userinfo</code></td>
+      <td><code>$MICROSOFT_EMULATOR_URL/oidc/userinfo</code></td>
+    </tr>
+    <tr>
+      <td><code>https://graph.microsoft.com/v1.0/me</code></td>
+      <td><code>$MICROSOFT_EMULATOR_URL/v1.0/me</code></td>
+    </tr>
+  </tbody>
+</table>
+
+```typescript
+import MicrosoftEntraId from '@auth/core/providers/microsoft-entra-id'
+
+MicrosoftEntraId({
+  clientId: process.env.MICROSOFT_CLIENT_ID,
+  clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+  authorization: {
+    url: `${process.env.MICROSOFT_EMULATOR_URL}/oauth2/v2.0/authorize`,
+    params: { scope: 'openid email profile User.Read' },
+  },
+  token: { url: `${process.env.MICROSOFT_EMULATOR_URL}/oauth2/v2.0/token` },
+})
+```
+
+The authorize endpoint shows a user picker instead of a real Microsoft login, so
+a browser-driven flow works end to end.
+
+## Seed config
+
+```yaml
+microsoft:
+  users:
+    - email: testuser@example.com
+      name: Test User
+      given_name: Test
+      family_name: User
+      tenant_id: common
+  oauth_clients:
+    - client_id: example-client-id
+      client_secret: example_secret # required
+      name: My App # required
+      tenant_id: common
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/microsoft-entra-id
+```
+
+`oauth_clients` entries require `client_id`, `client_secret`, `name` and
+`redirect_uris`. Seed config is not validated, so a missing or misspelled key is
+dropped silently rather than reported. Full reference:
+[Configuration](/docs/configuration).
+
 ## Endpoints
 
 - `GET /.well-known/openid-configuration` - OIDC discovery document

--- a/apps/web/app/docs/mongoatlas/page.mdx
+++ b/apps/web/app/docs/mongoatlas/page.mdx
@@ -2,16 +2,126 @@
 
 MongoDB Atlas emulation with Atlas Admin API v2 and Atlas Data API v1. In-memory document storage with CRUD, filtering, and aggregation.
 
-## Admin API
+This emulates the Atlas **HTTP APIs**, not the MongoDB wire protocol. Cluster
+responses do contain a `connectionStrings.standard` value such as
+`mongodb://Cluster0.emulate.mongodb.net:27017`, but that is a realistic-looking
+string only — nothing listens on it, and a `mongodb://` driver cannot connect.
+Use this emulator for control-plane code (projects, clusters, database users) and
+for document access through the Data API.
 
-### Projects
+## Start
+
+```bash
+# MongoDB Atlas only
+npx emulate --service mongoatlas
+
+# Or run all 14 services; Atlas is the 11th, so it lands on 4010
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service mongoatlas` puts it on **4000**, not 4010. Pass `--port` or set
+`mongoatlas.port` in the seed config to pin it. See
+[how ports are assigned](/docs).
+
+## Point your app at it
+
+There is no SDK switch to flip — replace the Atlas host in your own base URL. Any
+non-empty bearer token is accepted:
+
+```bash
+MONGOATLAS_EMULATOR_URL=http://localhost:4000
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Real Atlas URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://cloud.mongodb.com/api/atlas/v2/...</code></td>
+      <td><code>$MONGOATLAS_EMULATOR_URL/api/atlas/v2/...</code></td>
+    </tr>
+    <tr>
+      <td><code>{'https://data.mongodb-api.com/app/<id>/endpoint/data/v1/action/...'}</code></td>
+      <td><code>$MONGOATLAS_EMULATOR_URL/app/data-api/v1/action/...</code></td>
+    </tr>
+  </tbody>
+</table>
+
+```typescript
+const ATLAS = process.env.MONGOATLAS_EMULATOR_URL ?? 'https://cloud.mongodb.com'
+
+const res = await fetch(`${ATLAS}/api/atlas/v2/groups`, {
+  headers: { Authorization: 'Bearer test_token_admin' },
+})
+```
+
+Insert and read a document through the Data API:
+
+```bash
+curl -X POST http://localhost:4000/app/data-api/v1/action/insertOne \
+  -H "Authorization: Bearer test_token_admin" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","document":{"name":"Ada"}}'
+
+curl -X POST http://localhost:4000/app/data-api/v1/action/find \
+  -H "Authorization: Bearer test_token_admin" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","filter":{}}'
+```
+
+Every Data API action is a `POST` whose body names `dataSource`, `database` and
+`collection`.
+
+## Default seed
+
+With no configuration: one project `Project0` containing one cluster.
+
+## Seed config
+
+```yaml
+mongoatlas:
+  projects:
+    - name: my-project
+  clusters:
+    - name: my-cluster
+      project: my-project # must match a projects[].name
+      provider: AWS
+      instance_size: M10
+      region: US_EAST_1
+  database_users:
+    - username: app-user
+      project: my-project # must match a projects[].name
+      roles:
+        - database_name: appdb
+          role_name: readWrite
+  databases:
+    - cluster: my-cluster # must match a clusters[].name
+      name: appdb
+      collections: [users, orders]
+```
+
+Seed config is not validated. The cross-references above matter:
+`clusters[].project` and `database_users[].project` must name a seeded project,
+and `databases[].cluster` must name a seeded cluster, or the entry is skipped
+with no warning.
+
+## Endpoints
+
+### Admin API
+
+#### Projects
 
 - `GET /api/atlas/v2/groups` — list projects
 - `GET /api/atlas/v2/groups/:groupId` — get project
 - `POST /api/atlas/v2/groups` — create project
 - `DELETE /api/atlas/v2/groups/:groupId` — delete project (cascades clusters and data)
 
-### Clusters
+#### Clusters
 
 - `GET /api/atlas/v2/groups/:groupId/clusters` — list clusters
 - `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName` — get cluster
@@ -19,19 +129,19 @@ MongoDB Atlas emulation with Atlas Admin API v2 and Atlas Data API v1. In-memory
 - `PATCH /api/atlas/v2/groups/:groupId/clusters/:clusterName` — update cluster
 - `DELETE /api/atlas/v2/groups/:groupId/clusters/:clusterName` — delete cluster
 
-### Database Users
+#### Database Users
 
 - `GET /api/atlas/v2/groups/:groupId/databaseUsers` — list database users
 - `GET /api/atlas/v2/groups/:groupId/databaseUsers/admin/:username` — get database user
 - `POST /api/atlas/v2/groups/:groupId/databaseUsers` — create database user
 - `DELETE /api/atlas/v2/groups/:groupId/databaseUsers/admin/:username` — delete database user
 
-### Data Explorer
+#### Data Explorer
 
 - `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName/databases` — list databases
 - `GET /api/atlas/v2/groups/:groupId/clusters/:clusterName/databases/:databaseName/collections` — list collections
 
-## Data API
+### Data API
 
 All operations via `POST` with JSON body specifying `dataSource`, `database`, and `collection`:
 

--- a/apps/web/app/docs/okta/page.mdx
+++ b/apps/web/app/docs/okta/page.mdx
@@ -2,7 +2,111 @@
 
 Okta identity provider emulation with OAuth 2.0 / OIDC, user management, groups, apps, and authorization servers. Supports both default org server and custom authorization server paths.
 
-## OAuth / OIDC
+## Start
+
+```bash
+# Okta only
+npx emulate --service okta
+
+# Or run all 14 services; Okta is the 7th, so it lands on 4006
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service okta` puts Okta on **4000**, not 4006. Pass `--port` or set
+`okta.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your SDK at it
+
+The Okta SDK takes an `orgUrl`. The token is not validated, so any non-empty
+value works:
+
+```typescript
+import { Client } from '@okta/okta-sdk-nodejs'
+
+const client = new Client({
+  orgUrl: process.env.OKTA_EMULATOR_URL,
+  token: 'anything',
+})
+```
+
+```bash
+OKTA_EMULATOR_URL=http://localhost:4006
+```
+
+For sign-in, the OIDC issuer is `${OKTA_EMULATOR_URL}/oauth2/default`. Point any
+OIDC-aware library (Auth.js, `openid-client`, Passport) at the discovery document
+and it will find the rest itself:
+
+```
+http://localhost:4006/oauth2/default/.well-known/openid-configuration
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Real Okta URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>{'https://<org>.okta.com/oauth2/default/v1/authorize'}</code></td>
+      <td><code>$OKTA_EMULATOR_URL/oauth2/default/v1/authorize</code></td>
+    </tr>
+    <tr>
+      <td><code>{'https://<org>.okta.com/oauth2/default/v1/token'}</code></td>
+      <td><code>$OKTA_EMULATOR_URL/oauth2/default/v1/token</code></td>
+    </tr>
+    <tr>
+      <td><code>{'https://<org>.okta.com/api/v1/users'}</code></td>
+      <td><code>$OKTA_EMULATOR_URL/api/v1/users</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Every `/oauth2/...` route exists both with and without the `:authServerId`
+segment, so `/oauth2/v1/token` and `/oauth2/default/v1/token` both work.
+
+## Default seed
+
+Always created on startup: an authorization server with id `default`, an
+`Everyone` group, a default app, and a default user.
+
+## Seed config
+
+```yaml
+okta:
+  users:
+    - login: testuser@example.com
+      email: testuser@example.com
+      first_name: Test # snake_case, not firstName
+      last_name: User
+  groups:
+    - name: Everyone
+  oauth_clients:
+    - client_id: okta_example_client
+      client_secret: okta_example_secret
+      name: My App
+      redirect_uris: ["http://localhost:3000/api/auth/callback/okta"]
+  authorization_servers:
+    - id: default # required — the primary key used in /oauth2/:id/... paths
+      name: default
+      audiences: ["api://default"]
+```
+
+Seed config is not validated, so two mistakes here fail silently:
+
+- **User name fields are snake_case** (`first_name`, `last_name`). A camelCase key
+  is ignored and the user gets the default name `Test User`.
+- **`authorization_servers[].id` is required.** It becomes the `server_id` the
+  OAuth routes look up, so a server seeded without it is created but unreachable.
+
+Full reference: [Configuration](/docs/configuration).
+
+## Endpoints
+
+### OAuth / OIDC
 
 Default org server and custom authorization server paths (`/oauth2/:authServerId/...`):
 
@@ -16,7 +120,7 @@ Default org server and custom authorization server paths (`/oauth2/:authServerId
 - `POST /oauth2/v1/introspect` — token introspection
 - `GET /oauth2/v1/logout` — end session
 
-## Users
+### Users
 
 - `GET /api/v1/users` — list users
 - `POST /api/v1/users` — create user
@@ -32,7 +136,7 @@ Default org server and custom authorization server paths (`/oauth2/:authServerId
 - `POST /api/v1/users/:userId/lifecycle/unsuspend` — unsuspend
 - `POST /api/v1/users/:userId/lifecycle/reactivate` — reactivate
 
-## Groups
+### Groups
 
 - `GET /api/v1/groups` — list groups
 - `POST /api/v1/groups` — create group
@@ -43,7 +147,7 @@ Default org server and custom authorization server paths (`/oauth2/:authServerId
 - `PUT /api/v1/groups/:groupId/users/:userId` — add user to group
 - `DELETE /api/v1/groups/:groupId/users/:userId` — remove user from group
 
-## Apps
+### Apps
 
 - `GET /api/v1/apps` — list apps
 - `POST /api/v1/apps` — create app
@@ -56,7 +160,7 @@ Default org server and custom authorization server paths (`/oauth2/:authServerId
 - `POST /api/v1/apps/:appId/lifecycle/activate` — activate app
 - `POST /api/v1/apps/:appId/lifecycle/deactivate` — deactivate app
 
-## Authorization Servers
+### Authorization Servers
 
 - `GET /api/v1/authorizationServers` — list
 - `POST /api/v1/authorizationServers` — create

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -1,6 +1,6 @@
 # Getting Started
 
-Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, and Linear APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
+Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, Linear, and Twilio APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
 
 ## Quick Start
 
@@ -23,6 +23,24 @@ All services start with sensible defaults. No config file needed:
 - **MongoDB Atlas** on `http://localhost:4010`
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
+- **Twilio** on `http://localhost:4013`
+
+### How ports are assigned
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set — not a fixed number per service. The list above is what a bare `npx emulate`
+gives you, because that enables all 14 in registry order.
+
+Enable a subset and the numbering restarts from the base port:
+
+```bash
+npx emulate --service github        # GitHub on 4000, not 4001
+npx emulate --service github,google # GitHub 4000, Google 4001
+npx emulate --service google,github # Google 4000, GitHub 4001 (your order wins)
+```
+
+To pin a service to a port no matter what else is running, set `port` on it in
+the [seed config](/docs/configuration).
 
 ## CLI
 
@@ -63,7 +81,7 @@ npx emulate list
     <tr>
       <td><code>-p, --port</code></td>
       <td><code>4000</code></td>
-      <td>Base port (auto-increments per service)</td>
+      <td>Base port; each enabled service gets base + its index</td>
     </tr>
     <tr>
       <td><code>-s, --service</code></td>
@@ -75,10 +93,26 @@ npx emulate list
       <td>auto-detect</td>
       <td>Path to seed config (YAML or JSON)</td>
     </tr>
+    <tr>
+      <td><code>--base-url</code></td>
+      <td>none</td>
+      <td>Override the advertised base URL (supports the <code>{'{service}'}</code> template)</td>
+    </tr>
+    <tr>
+      <td><code>--portless</code></td>
+      <td>off</td>
+      <td>Serve over HTTPS via portless, auto-registering aliases</td>
+    </tr>
   </tbody>
 </table>
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+`--portless` and `--base-url` are mutually exclusive; passing both exits with an
+error.
+
+A seed config file also acts as an implicit `--service`: if it contains any
+top-level service keys, only those services start. See
+[Configuration](/docs/configuration).
 
 ## Programmatic API
 

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -59,7 +59,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>service</code></td>
       <td><em>(required)</em></td>
-      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, <code>'clerk'</code>, or <code>'linear'</code></td>
+      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, <code>'clerk'</code>, <code>'linear'</code>, or <code>'twilio'</code></td>
     </tr>
     <tr>
       <td><code>port</code></td>
@@ -69,7 +69,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>seed</code></td>
       <td>none</td>
-      <td>Inline seed data (same shape as YAML config)</td>
+      <td>Inline seed data, keyed by service name — the same shape as the YAML config file, including the top-level service key. See <strong>Seeding data</strong> below.</td>
     </tr>
     <tr>
       <td><code>baseUrl</code></td>
@@ -78,6 +78,70 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     </tr>
   </tbody>
 </table>
+
+### Seeding data
+
+`seed` mirrors the YAML config file exactly, **including the top-level service
+key**. Even though you already passed `service`, the seed object must repeat it —
+`createEmulator` looks up `seed[service]` and ignores everything else.
+
+```typescript
+const github = await createEmulator({
+  service: 'github',
+  port: 4001,
+  seed: {
+    github: {
+      // <- the service key is required
+      users: [{ login: 'octocat', name: 'The Octocat' }],
+      repos: [{ owner: 'octocat', name: 'hello-world', auto_init: true }],
+    },
+  },
+})
+
+const res = await fetch(`${github.url}/users/octocat/repos`, {
+  headers: { Authorization: 'Bearer test_token_admin' },
+})
+```
+
+Passing the inner object directly is the single most common mistake:
+
+```typescript
+// WRONG — silently seeds nothing, no error, no warning.
+// The emulator starts with defaults and /users/octocat/repos returns 404.
+await createEmulator({
+  service: 'github',
+  seed: { users: [{ login: 'octocat' }] },
+})
+```
+
+Seed config is not validated, so an unrecognized shape is dropped without a
+message. If a request returns 404 or an empty list right after startup, check
+this nesting first.
+
+The `tokens` key sits at the top level, next to the service key, not inside it:
+
+```typescript
+seed: {
+  tokens: { my_token: { login: 'octocat', scopes: ['repo'] } },
+  github: { users: [{ login: 'octocat' }] },
+}
+```
+
+When no `tokens` are given, the emulator creates `test_token_admin` for user
+`admin`.
+
+> The Next.js and Nuxt adapters use the **opposite** shape. In
+> `createEmulateHandler` the service name is already the key in `services`, so
+> `seed` holds the inner object directly, with no service key repeated inside
+> it — see [Next.js Integration](/docs/nextjs):
+>
+> ```typescript
+> createEmulateHandler({
+>   services: {
+>     github: { emulator: github, seed: { users: [{ login: 'octocat' }] } },
+>   },
+> })
+> ```
 
 ### Instance methods
 

--- a/apps/web/app/docs/resend/page.mdx
+++ b/apps/web/app/docs/resend/page.mdx
@@ -2,7 +2,87 @@
 
 Resend email API emulation with email sending, domain management, API keys, audiences, contacts, and a local inbox for captured messages.
 
-## Emails
+## Start
+
+```bash
+# Resend only
+npx emulate --service resend
+
+# Or run all 14 services; Resend is the 9th, so it lands on 4008
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service resend` puts Resend on **4000**, not 4008. Pass `--port` or set
+`resend.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your SDK at it
+
+Resend is the easiest service to redirect: the official Node SDK reads
+`RESEND_BASE_URL` at module load time, so **no code change is needed at all**.
+
+```bash
+RESEND_BASE_URL=http://localhost:4000
+```
+
+```typescript
+import { Resend } from 'resend'
+
+// No baseUrl argument; the SDK picks up RESEND_BASE_URL itself.
+// The API key is not validated — any non-empty value works.
+const resend = new Resend('re_test_key')
+
+await resend.emails.send({
+  from: 'hello@example.com',
+  to: 'user@example.com',
+  subject: 'Hello',
+  html: '<p>It works!</p>',
+})
+```
+
+Because the variable is read at import time, set it before the process starts —
+in `.env`, your test runner's env config, or the shell. Setting
+`process.env.RESEND_BASE_URL` after importing the SDK has no effect.
+
+## Reading the mail back
+
+Nothing is actually delivered. Every message is captured and can be inspected,
+which is what makes this useful in tests:
+
+```bash
+# Browse captured mail in the browser
+open http://localhost:4000/inbox
+
+# Or read it over HTTP
+curl http://localhost:4000/emails -H "Authorization: Bearer re_test_key"
+```
+
+To assert on a magic link or verification code in a test, list `/emails`, take
+the newest id, then fetch `/emails/:id` and match against its `html`. See the
+[resend-magic-link example](https://github.com/vercel-labs/emulate/tree/main/examples/resend-magic-link).
+
+## Seed config
+
+```yaml
+resend:
+  domains:
+    - name: example.com
+      region: us-east-1 # optional, defaults to us-east-1
+  contacts:
+    - email: subscriber@example.com
+      first_name: Sub
+      last_name: Scriber
+      audience: newsletter
+```
+
+`domains` and `contacts` are the only seedable collections. API keys cannot be
+seeded — create them with `POST /api-keys`, or just send any non-empty bearer
+token, which the emulator accepts. Seed config is not validated, so an unknown
+key is dropped silently.
+
+## Endpoints
+
+### Emails
 
 - `POST /emails` — send single email
 - `POST /emails/batch` — send up to 100 emails
@@ -10,7 +90,7 @@ Resend email API emulation with email sending, domain management, API keys, audi
 - `GET /emails/:id` — get email
 - `POST /emails/:id/cancel` — cancel scheduled email
 
-## Domains
+### Domains
 
 - `POST /domains` — create domain
 - `GET /domains` — list domains
@@ -18,13 +98,13 @@ Resend email API emulation with email sending, domain management, API keys, audi
 - `DELETE /domains/:id` — remove domain
 - `POST /domains/:id/verify` — trigger domain verification
 
-## API Keys
+### API Keys
 
 - `POST /api-keys` — create API key
 - `GET /api-keys` — list API keys
 - `DELETE /api-keys/:id` — delete API key
 
-## Audiences & Contacts
+### Audiences & Contacts
 
 - `POST /audiences` — create audience
 - `GET /audiences` — list audiences
@@ -33,7 +113,7 @@ Resend email API emulation with email sending, domain management, API keys, audi
 - `GET /audiences/:audience_id/contacts` — list contacts
 - `DELETE /audiences/:audience_id/contacts/:id` — delete contact
 
-## Inbox
+### Inbox
 
 - `GET /inbox` — list captured emails
 - `GET /inbox/:id` — view captured email

--- a/apps/web/app/docs/slack/page.mdx
+++ b/apps/web/app/docs/slack/page.mdx
@@ -2,13 +2,107 @@
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, user profiles, presence, modern file uploads, pins, bookmarks, views, OAuth v2, and incoming webhooks. Chat writes preserve common rich message fields such as `blocks`, `attachments`, `metadata`, formatting flags, unfurl flags, and client message ids. Conversation writes update archive state, names, topics, purposes, membership, DMs, MPIMs, and read cursors. User writes update profile fields, status, custom fields, and deterministic active or away presence. File writes support the current external upload flow with local upload URLs, file share messages, reads, lists, downloads, and deletes. Pin and bookmark writes support channel message pins and link bookmarks. View writes support App Home publishing and modal stacks. Seeded OAuth apps and OAuth installs create bot users and installation records. OAuth exchanges and explicit token seeds create scoped token records. State changes dispatch `event_callback` payloads to configured webhook URLs.
 
-## Auth
+## Start
+
+```bash
+# Slack only
+npx emulate --service slack
+
+# Or run all 14 services; Slack is the 4th, so it lands on 4003
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service slack` puts Slack on **4000**, not 4003. Pass `--port` or set
+`slack.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your SDK at it
+
+The Slack SDK takes a `slackApiUrl`. Note the **trailing `/api/`** — without it
+every method call 404s:
+
+```typescript
+import { WebClient } from '@slack/web-api'
+
+const client = new WebClient('xoxb-local-test', {
+  slackApiUrl: `${process.env.SLACK_EMULATOR_URL}/api/`,
+})
+
+await client.chat.postMessage({ channel: '#general', text: 'Hello' })
+```
+
+```bash
+SLACK_EMULATOR_URL=http://localhost:4003
+```
+
+Or over plain HTTP:
+
+```bash
+curl -X POST http://localhost:4003/api/chat.postMessage \
+  -H "Authorization: Bearer xoxb-local-test" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"#general","text":"Hello"}'
+```
+
+For OAuth v2 install flows:
+
+<table>
+  <thead>
+    <tr>
+      <th>Real Slack URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://slack.com/oauth/v2/authorize</code></td>
+      <td><code>$SLACK_EMULATOR_URL/oauth/v2/authorize</code></td>
+    </tr>
+    <tr>
+      <td><code>https://slack.com/api/oauth.v2.access</code></td>
+      <td><code>$SLACK_EMULATOR_URL/api/oauth.v2.access</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Requests without a token return `not_authed`. Any non-empty unknown bearer token
+maps to the first seeded user unless strict scope mode is enabled.
+
+## Seed config
+
+```yaml
+slack:
+  team:
+    name: My Workspace
+    domain: my-workspace
+  users:
+    - name: developer
+      real_name: Developer
+      email: dev@example.com
+      is_admin: true
+  channels:
+    - name: general
+      topic: General discussion
+    - name: engineering
+      is_private: true
+  tokens:
+    - token: xoxb-local-test
+      user: developer
+```
+
+Seed config is not validated, so an unknown key is dropped silently. Full
+reference, including OAuth apps, bots and scopes:
+[Configuration](/docs/configuration).
+
+## Endpoints
+
+### Auth
 
 - `POST /api/auth.test` - test authentication
 
 Scope checks are relaxed by default for local development. Set `slack.strict_scopes: true` in seed config to make supported Web API methods return Slack-style `missing_scope` errors with `needed` and `provided` fields. Strict mode checks `chat:write`, `channels:read`, `channels:history`, `channels:join`, `channels:manage`, `channels:write`, `groups:read`, `groups:history`, `groups:write`, `im:read`, `im:history`, `im:write`, `mpim:read`, `mpim:history`, `mpim:write`, `users:read`, `users:read.email`, `users.profile:read`, `users.profile:write`, `users:write`, `files:read`, `files:write`, `pins:read`, `pins:write`, `bookmarks:read`, `bookmarks:write`, `reactions:read`, `reactions:write`, and `team:read`. Slack lists no method-specific scopes for `views.publish`, `views.open`, `views.update`, or `views.push`, so the emulator requires auth but does not add strict-scope checks for those methods.
 
-## Chat
+### Chat
 
 - `POST /api/chat.postMessage` - post message with text or rich payload fields (supports threads via `thread_ts` and DM user IDs)
 - `POST /api/chat.postEphemeral` - post ephemeral message outside channel history
@@ -20,7 +114,7 @@ Scope checks are relaxed by default for local development. Set `slack.strict_sco
 - `POST /api/chat.scheduledMessages.list` - list pending scheduled messages
 - `POST /api/chat.meMessage` - /me message
 
-## Conversations
+### Conversations
 
 - `POST /api/conversations.list` - list conversations (cursor pagination, `types`, `exclude_archived`)
 - `POST /api/conversations.info` - get channel info
@@ -41,7 +135,7 @@ Scope checks are relaxed by default for local development. Set `slack.strict_sco
 - `POST /api/conversations.mark` - set read cursor
 - `POST /api/conversations.members` - list members
 
-## Users
+### Users
 
 - `POST /api/users.list` - list users (cursor pagination)
 - `POST /api/users.info` - get user info
@@ -51,13 +145,13 @@ Scope checks are relaxed by default for local development. Set `slack.strict_sco
 - `GET /api/users.getPresence` / `POST /api/users.getPresence` - get active or away presence
 - `POST /api/users.setPresence` - set the authed user to away or automatic presence
 
-## Reactions
+### Reactions
 
 - `POST /api/reactions.add` - add reaction
 - `POST /api/reactions.remove` - remove reaction
 - `POST /api/reactions.get` - get reactions for a message
 
-## Files
+### Files
 
 - `POST /api/files.getUploadURLExternal` - create a local external upload session
 - `POST /upload/v1/:fileId` - receive raw uploaded file bytes
@@ -67,7 +161,7 @@ Scope checks are relaxed by default for local development. Set `slack.strict_sco
 - `GET /files-pri/:fileId/:filename` - download file bytes with a bearer token that can access the file
 - `POST /api/files.delete` - delete a completed file
 
-## Pins And Bookmarks
+### Pins And Bookmarks
 
 - `POST /api/pins.add` - pin a message to a channel
 - `GET /api/pins.list` / `POST /api/pins.list` - list pinned message items for a channel
@@ -77,7 +171,7 @@ Scope checks are relaxed by default for local development. Set `slack.strict_sco
 - `POST /api/bookmarks.list` - list channel bookmarks
 - `POST /api/bookmarks.remove` - remove a bookmark from a channel
 
-## Views
+### Views
 
 - `POST /api/views.publish` - publish or update an App Home view for a user
 - `POST /api/views.open` - open a modal view
@@ -87,25 +181,25 @@ Scope checks are relaxed by default for local development. Set `slack.strict_sco
 
 Modal opens and pushes require values from `/api/views.generateTriggerId`. Pass the returned value as `trigger_id` or `interactivity_pointer`; generate push values with an existing `view_id` and use them within 3 seconds.
 
-## Team
+### Team
 
 - `POST /api/team.info` - get workspace info
 
-## Bots
+### Bots
 
 - `POST /api/bots.info` - get bot info
 
-## Incoming Webhooks
+### Incoming Webhooks
 
 - `POST /services/:teamId/:botId/:webhookId` - post text or rich payload fields via incoming webhook (supports `channel` override and `thread_ts`)
 
-## OAuth
+### OAuth
 
 - `GET /oauth/v2/authorize` - authorization endpoint (shows user picker)
 - `POST /oauth/v2/authorize/callback` - local user picker callback that creates the auth code
 - `POST /api/oauth.v2.access` - token exchange
 
-## Inspector
+### Inspector
 
 - `GET /` - tabbed local inspector for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries
 

--- a/apps/web/app/docs/stripe/page.mdx
+++ b/apps/web/app/docs/stripe/page.mdx
@@ -2,7 +2,90 @@
 
 Stripe API emulation with customers, payment methods, customer sessions, payment intents, charges, products, prices, and checkout sessions. Includes a hosted checkout page and webhook delivery.
 
-## Customers
+## Start
+
+```bash
+# Stripe only
+npx emulate --service stripe
+
+# Or run all 14 services; Stripe is the 10th, so it lands on 4009
+npx emulate
+```
+
+A service's port is `--port` (default `4000`) plus its index in the **enabled**
+set, so `--service stripe` puts Stripe on **4000**, not 4009. Pass `--port` or set
+`stripe.port` in the seed config to pin it. See [how ports are assigned](/docs).
+
+## Point your SDK at it
+
+The Stripe Node SDK has no env var for the base URL — pass the host explicitly.
+The secret key is not validated, so any non-empty value works:
+
+```typescript
+import Stripe from 'stripe'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? 'sk_test_emulated', {
+  apiVersion: '2024-12-18.acacia',
+  host: 'localhost',
+  port: 4000,
+  protocol: 'http',
+})
+
+const session = await stripe.checkout.sessions.create({
+  mode: 'payment',
+  line_items: [{ price: 'price_tshirt', quantity: 1 }],
+  success_url: 'http://localhost:3000/success?session_id={CHECKOUT_SESSION_ID}',
+  cancel_url: 'http://localhost:3000/cart',
+})
+```
+
+Or over plain HTTP:
+
+```bash
+curl http://localhost:4000/v1/customers \
+  -H "Authorization: Bearer sk_test_emulated"
+```
+
+The session's `url` points at a hosted checkout page served by the emulator.
+Clicking **Pay** there completes the session, fires
+`checkout.session.completed`, and redirects to your `success_url`.
+
+For a full working app, see the
+[stripe-checkout example](https://github.com/vercel-labs/emulate/tree/main/examples/stripe-checkout).
+
+## Seed config
+
+```yaml
+stripe:
+  customers:
+    - name: Test Customer
+      email: test@example.com
+  products:
+    - name: Pro Plan
+  prices:
+    - product_name: Pro Plan # must match a products[].name above
+      unit_amount: 2000
+      currency: usd
+  webhooks:
+    - url: http://localhost:3000/api/stripe/webhook
+      events: ["checkout.session.completed"]
+```
+
+Seed config is not validated, so two mistakes here fail silently and leave you
+with an empty store:
+
+- **Prices are seeded through their product.** A price is only created if its
+  `product_name` matches the `name` of a seeded product. Spell the key `product`,
+  or reference a product that isn't seeded, and `GET /v1/prices` returns
+  `{"data":[]}` and checkout fails with `No such price`.
+- **Seeded prices are always one-time.** There is no `recurring` key. Create
+  subscription-style prices at runtime with `POST /v1/prices`.
+
+Full reference: [Configuration](/docs/configuration).
+
+## Endpoints
+
+### Customers
 
 - `POST /v1/customers` — create customer
 - `GET /v1/customers/:id` — retrieve customer
@@ -10,15 +93,15 @@ Stripe API emulation with customers, payment methods, customer sessions, payment
 - `DELETE /v1/customers/:id` — delete customer
 - `GET /v1/customers` — list customers
 
-## Payment Methods
+### Payment Methods
 
 - `GET /v1/payment_methods` — list payment methods
 
-## Customer Sessions
+### Customer Sessions
 
 - `POST /v1/customer_sessions` — create customer session
 
-## Payment Intents
+### Payment Intents
 
 - `POST /v1/payment_intents` — create payment intent
 - `GET /v1/payment_intents/:id` — retrieve payment intent
@@ -27,24 +110,24 @@ Stripe API emulation with customers, payment methods, customer sessions, payment
 - `POST /v1/payment_intents/:id/cancel` — cancel payment intent
 - `GET /v1/payment_intents` — list payment intents
 
-## Charges
+### Charges
 
 - `GET /v1/charges/:id` — retrieve charge
 - `GET /v1/charges` — list charges
 
-## Products
+### Products
 
 - `POST /v1/products` — create product
 - `GET /v1/products/:id` — retrieve product
 - `GET /v1/products` — list products
 
-## Prices
+### Prices
 
 - `POST /v1/prices` — create price
 - `GET /v1/prices/:id` — retrieve price
 - `GET /v1/prices` — list prices
 
-## Checkout Sessions
+### Checkout Sessions
 
 - `POST /v1/checkout/sessions` — create checkout session
 - `GET /v1/checkout/sessions/:id` — retrieve session

--- a/apps/web/app/docs/troubleshooting/page.mdx
+++ b/apps/web/app/docs/troubleshooting/page.mdx
@@ -1,0 +1,133 @@
+# Troubleshooting
+
+Runtime behaviour that surprises people, and how to diagnose it. Most confusion
+here comes from one design choice: **seed config is never validated**, so a bad
+key produces missing data rather than an error.
+
+## Turn on debug logging
+
+```bash
+DEBUG=1 npx emulate
+# or
+EMULATE_DEBUG=1 npx emulate
+```
+
+Accepted values are `DEBUG=1`, `DEBUG=true`, or `EMULATE_DEBUG=1`. The flag is
+read once when the module is first imported, so setting `process.env.DEBUG` from
+inside a test after importing the emulator has no effect — set it in the shell or
+in your test runner's env config.
+
+## I seeded data but the API returns 404 or an empty list
+
+This is almost always a config-shape problem, and it never produces an error
+message. Check, in order:
+
+1. **Using `createEmulator`?** `seed` must be keyed by service name — `seed: { github: { users: [...] } }`, not `seed: { users: [...] }`. See [Programmatic API](/docs/programmatic-api).
+2. **Key spelling.** Unknown keys are dropped silently. The known traps: Stripe wants `product_name` (not `product`), Okta wants `first_name` / `last_name` (not camelCase), Clerk wants `email_addresses` as an array. See [Configuration](/docs/configuration).
+3. **Cross-references.** Some collections are seeded through a parent: a Stripe price is only created if its `product_name` matches a seeded product; a Clerk org member is only added if its `email` matches a seeded user.
+
+The startup banner prints which config file was actually loaded. If it says no
+config, your file wasn't found under any of the auto-detected names.
+
+## Only one service started, not all 14
+
+A seed config file doubles as an implicit `--service`. If the file contains any
+top-level service keys, only those services start — and they are numbered from
+the base port, so the first one lands on 4000.
+
+```bash
+npx emulate init --service stripe # writes a config with only a `stripe:` block
+npx emulate                       # starts Stripe alone, on 4000 — not 4009
+```
+
+Pass `--service` explicitly to override, or delete the config file.
+
+## A request goes to the wrong service
+
+Ports are `--port` (default `4000`) plus each service's index in the **enabled**
+set, not a fixed number per service. `npx emulate --service aws` puts AWS on
+4000; a script pointing at 4007 will either get connection refused or, if you
+also have a full fleet running, silently hit a different emulator.
+
+Set `port` on the service in the seed config to pin it:
+
+```yaml
+aws:
+  port: 4007
+```
+
+## Port already in use
+
+The server does not install an error handler on `listen`, so a busy port surfaces
+as a raw `EADDRINUSE` from Node rather than a friendly message. Pick a different
+base port with `--port`, or stop whatever is holding it:
+
+```bash
+lsof -i :4000
+```
+
+## `--portless` and `--base-url` together
+
+These are mutually exclusive. Passing both prints
+`--portless and --base-url are mutually exclusive.` and exits with code 1.
+
+## `emulate init` won't overwrite my config
+
+By design — it refuses rather than clobbering an existing file. Delete or rename
+the file first.
+
+## Everything returns 403 "API rate limit exceeded"
+
+Every emulator applies a rate limit of **5000 requests per hour**, bucketed by
+bearer token. All unauthenticated traffic shares a single `__anonymous__` bucket,
+so a test suite that sends no `Authorization` header can exhaust the shared quota
+faster than expected.
+
+Two things to know:
+
+- The response status is **403**, not 429. SDK retry logic keyed on 429 will not
+  recognise it.
+- Every response carries `X-RateLimit-Limit`, `X-RateLimit-Remaining`,
+  `X-RateLimit-Reset` and `X-RateLimit-Resource`. Read `X-RateLimit-Remaining` to
+  see how close you are.
+
+The counter resets an hour after the first request in the window, and restarting
+the emulator clears it. Note that GitHub's own `GET /rate_limit` endpoint is
+emulated with static values and does **not** report this limiter's state.
+
+## Auth behaves differently from production
+
+The emulator is deliberately permissive, in a way that can make a passing test
+misleading:
+
+- **No `Authorization` header** → the request is unauthenticated, and protected routes return 401.
+- **Any non-empty bearer token** → accepted. Unknown tokens resolve to the service's fallback user, so `Bearer totally-made-up` succeeds as if it were valid.
+
+A test asserting "an invalid token is rejected with 401" will pass against the
+real API and fail against the emulator, because only a *missing* header is
+rejected. Assert on the missing-header case instead.
+
+Configure real tokens under the top-level `tokens` key to control which user a
+token maps to. With no `tokens` configured, `test_token_admin` is created for the
+user `admin`. See [Authentication](/docs/authentication).
+
+## GitHub App JWT authentication always fails
+
+`private_key` is parsed with `importPKCS8`, so it must be a PKCS#8 key beginning
+`-----BEGIN PRIVATE KEY-----`. GitHub issues App keys in PKCS#1
+(`-----BEGIN RSA PRIVATE KEY-----`), which the emulator cannot read. The failure
+is silent — verification throws, the error is swallowed, and the request is
+treated as unauthenticated.
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in github-app.private-key.pem -out github-app.pkcs8.pem
+```
+
+## State disappeared
+
+All emulator state is in-memory and is lost when the process exits. `reset()` on
+a programmatic emulator wipes the store and replays the seed data.
+
+Persistence across restarts is available only in the Next.js and Nuxt adapters,
+via their `persistence` option — not in the CLI or in `createEmulator`. See
+[Next.js Integration](/docs/nextjs).

--- a/apps/web/app/docs/twilio/page.mdx
+++ b/apps/web/app/docs/twilio/page.mdx
@@ -23,12 +23,32 @@ TWILIO_VERIFY_SERVICE_SID=VA00000000000000000000000000000000
 
 ## URL Mapping
 
-| Real Twilio URL | Emulator URL |
-|-----------------|--------------|
-| `https://api.twilio.com/2010-04-01/...` | `$TWILIO_EMULATOR_URL/2010-04-01/...` |
-| `https://messaging.twilio.com/v1/...` | `$TWILIO_EMULATOR_URL/messaging/v1/...` |
-| `https://verify.twilio.com/v2/...` | `$TWILIO_EMULATOR_URL/verify/v2/...` |
-| `https://conversations.twilio.com/v1/...` | `$TWILIO_EMULATOR_URL/conversations/v1/...` |
+<table>
+  <thead>
+    <tr>
+      <th>Real Twilio URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://api.twilio.com/2010-04-01/...</code></td>
+      <td><code>$TWILIO_EMULATOR_URL/2010-04-01/...</code></td>
+    </tr>
+    <tr>
+      <td><code>https://messaging.twilio.com/v1/...</code></td>
+      <td><code>$TWILIO_EMULATOR_URL/messaging/v1/...</code></td>
+    </tr>
+    <tr>
+      <td><code>https://verify.twilio.com/v2/...</code></td>
+      <td><code>$TWILIO_EMULATOR_URL/verify/v2/...</code></td>
+    </tr>
+    <tr>
+      <td><code>https://conversations.twilio.com/v1/...</code></td>
+      <td><code>$TWILIO_EMULATOR_URL/conversations/v1/...</code></td>
+    </tr>
+  </tbody>
+</table>
 
 The official Node SDK builds absolute Twilio product URLs. In SDK tests, use a custom request client that rewrites those hosts to the emulator prefixes above.
 

--- a/apps/web/app/docs/vercel/page.mdx
+++ b/apps/web/app/docs/vercel/page.mdx
@@ -2,7 +2,100 @@
 
 Every endpoint below is fully stateful with Vercel-style JSON responses and cursor-based pagination.
 
-## User & Teams
+## Start
+
+```bash
+# Vercel only
+npx emulate --service vercel
+
+# Or run all 14 services
+npx emulate
+```
+
+Vercel is the first service in the registry, so it is on `http://localhost:4000`
+in both modes. See [how ports are assigned](/docs).
+
+## Point your app at it
+
+There is no SDK option to override — replace the Vercel API host in your own base
+URL. Any non-empty bearer token is accepted:
+
+```bash
+VERCEL_EMULATOR_URL=http://localhost:4000
+```
+
+```typescript
+const VERCEL_API = process.env.VERCEL_EMULATOR_URL ?? 'https://api.vercel.com'
+
+const res = await fetch(`${VERCEL_API}/v10/projects`, {
+  headers: { Authorization: `Bearer ${token}` },
+})
+```
+
+For OAuth integrations:
+
+<table>
+  <thead>
+    <tr>
+      <th>Real Vercel URL</th>
+      <th>Emulator URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>https://vercel.com/integrations/oauth/authorize</code></td>
+      <td><code>$VERCEL_EMULATOR_URL/oauth/authorize</code></td>
+    </tr>
+    <tr>
+      <td><code>https://api.vercel.com/login/oauth/token</code></td>
+      <td><code>$VERCEL_EMULATOR_URL/login/oauth/token</code></td>
+    </tr>
+    <tr>
+      <td><code>https://api.vercel.com/login/oauth/userinfo</code></td>
+      <td><code>$VERCEL_EMULATOR_URL/login/oauth/userinfo</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Blob storage is the one part with a real SDK switch — `@vercel/blob` reads both
+variables on every call:
+
+```bash
+VERCEL_BLOB_API_URL=http://localhost:4000/api/blob
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_mystore_secret
+```
+
+See the
+[vercel-blob-sharing example](https://github.com/vercel-labs/emulate/tree/main/examples/vercel-blob-sharing)
+for a working setup.
+
+## Seed config
+
+```yaml
+vercel:
+  users:
+    - username: developer
+      name: Developer
+      email: dev@example.com
+  teams:
+    - slug: my-team
+      name: My Team
+  projects:
+    - name: my-app
+      team: my-team
+      framework: nextjs
+      envVars:
+        - key: DATABASE_URL
+          value: postgres://localhost
+          target: [production, preview]
+```
+
+Seed config is not validated, so an unknown key is dropped silently. Full
+reference, including OAuth integrations: [Configuration](/docs/configuration).
+
+## Endpoints
+
+### User & Teams
 
 - `GET /v2/user` - authenticated user
 - `PATCH /v2/user` - update user
@@ -13,7 +106,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `GET /v2/teams/:teamId/members` - list members
 - `POST /v2/teams/:teamId/members` - add member
 
-## Projects
+### Projects
 
 - `POST /v11/projects` - create project (with optional env vars and git integration)
 - `GET /v10/projects` - list projects (search, cursor pagination)
@@ -23,7 +116,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `GET /v1/projects/:projectId/promote/aliases` - promote aliases status
 - `PATCH /v1/projects/:idOrName/protection-bypass` - manage bypass secrets
 
-## Deployments
+### Deployments
 
 - `POST /v13/deployments` - create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` - get deployment (by ID or URL)
@@ -35,7 +128,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `GET /v6/deployments/:id/files` - list deployment files
 - `POST /v2/files` - upload file (by SHA digest)
 
-## Domains
+### Domains
 
 - `POST /v10/projects/:idOrName/domains` - add domain (with verification challenge)
 - `GET /v9/projects/:idOrName/domains` - list domains
@@ -44,7 +137,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `DELETE /v9/projects/:idOrName/domains/:domain` - remove domain
 - `POST /v9/projects/:idOrName/domains/:domain/verify` - verify domain
 
-## Environment Variables
+### Environment Variables
 
 - `GET /v10/projects/:idOrName/env` - list env vars (with decrypt option)
 - `POST /v10/projects/:idOrName/env` - create env vars (single, batch, upsert)
@@ -52,7 +145,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `PATCH /v9/projects/:idOrName/env/:id` - update env var
 - `DELETE /v9/projects/:idOrName/env/:id` - delete env var
 
-## Blob
+### Blob
 
 Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`).
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,7 @@ export default function LandingPage() {
           Local API emulation for dev and CI
         </h1>
         <p className="mb-8 max-w-xl text-base text-neutral-600 dark:text-neutral-400">
-          Stateful, production-fidelity replacements for Stripe, GitHub, Google, AWS, and 7 more services. No API keys.
+          Stateful, production-fidelity replacements for Stripe, GitHub, Google, AWS, and 10 more services. No API keys.
           No network. Not mocks.
         </p>
 
@@ -62,7 +62,7 @@ export default function LandingPage() {
               <h3 className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">Zero config</h3>
               <p className="text-sm text-neutral-600 dark:text-neutral-400">
                 Run <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">npx emulate</code>{" "}
-                and all 11 services start with sensible defaults. Seed data via YAML when you need it.
+                and all 14 services start with sensible defaults. Seed data via YAML when you need it.
               </p>
             </div>
             <div>
@@ -109,7 +109,7 @@ export default function LandingPage() {
 stripe.config.host = `}</span>
                     <span className="text-emerald-400">{`"localhost"`}</span>
                     {`\nstripe.config.port = `}
-                    <span className="text-emerald-400">{`4010`}</span>
+                    <span className="text-emerald-400">{`4009`}</span>
                     {`\nstripe.config.protocol = `}
                     <span className="text-emerald-400">{`"http"`}</span>
                     {`\n\n// offline, instant, stateful`}

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -35,13 +35,17 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/clerk", label: "Clerk" },
+      { href: "/docs/twilio", label: "Twilio" },
     ],
   },
   {
     title: "Reference",
     items: [
+      { href: "/docs/connecting", label: "Connecting your app" },
       { href: "/docs/authentication", label: "Authentication" },
       { href: "/docs/architecture", label: "Architecture" },
+      { href: "/docs/troubleshooting", label: "Troubleshooting" },
     ],
   },
 ];

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -33,13 +33,17 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/clerk", label: "Clerk" },
+      { href: "/docs/twilio", label: "Twilio" },
     ],
   },
   {
     title: "Reference",
     items: [
+      { href: "/docs/connecting", label: "Connecting your app" },
       { href: "/docs/authentication", label: "Authentication" },
       { href: "/docs/architecture", label: "Architecture" },
+      { href: "/docs/troubleshooting", label: "Troubleshooting" },
     ],
   },
 ];

--- a/apps/web/components/hero-terminal.tsx
+++ b/apps/web/components/hero-terminal.tsx
@@ -9,11 +9,14 @@ const services = [
   { name: "Slack", port: 4003, slug: "slack" },
   { name: "Apple", port: 4004, slug: "apple" },
   { name: "Microsoft", port: 4005, slug: "microsoft" },
-  { name: "AWS", port: 4006, slug: "aws" },
-  { name: "Okta", port: 4007, slug: "okta" },
-  { name: "MongoDB Atlas", port: 4008, slug: "mongoatlas" },
-  { name: "Resend", port: 4009, slug: "resend" },
-  { name: "Stripe", port: 4010, slug: "stripe" },
+  { name: "Okta", port: 4006, slug: "okta" },
+  { name: "AWS", port: 4007, slug: "aws" },
+  { name: "Resend", port: 4008, slug: "resend" },
+  { name: "Stripe", port: 4009, slug: "stripe" },
+  { name: "MongoDB Atlas", port: 4010, slug: "mongoatlas" },
+  { name: "Clerk", port: 4011, slug: "clerk" },
+  { name: "Linear", port: 4012, slug: "linear" },
+  { name: "Twilio", port: 4013, slug: "twilio" },
 ];
 
 export function HeroTerminal({ pixelFont }: { pixelFont: string }) {

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -22,6 +22,9 @@ export const allDocsPages: NavItem[] = [
   { name: "MongoDB Atlas", href: "/docs/mongoatlas" },
   { name: "Resend", href: "/docs/resend" },
   { name: "Stripe", href: "/docs/stripe" },
+  { name: "Clerk", href: "/docs/clerk" },
+  { name: "Connecting your app", href: "/docs/connecting" },
   { name: "Authentication", href: "/docs/authentication" },
   { name: "Architecture", href: "/docs/architecture" },
+  { name: "Troubleshooting", href: "/docs/troubleshooting" },
 ];

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -17,8 +17,11 @@ export const PAGE_TITLES: Record<string, string> = {
   mongoatlas: "MongoDB Atlas",
   resend: "Resend",
   stripe: "Stripe",
+  clerk: "Clerk",
+  connecting: "Connecting your app",
   authentication: "Authentication",
   architecture: "Architecture",
+  troubleshooting: "Troubleshooting",
 };
 
 export function getPageTitle(slug: string): string | null {

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -1,3 +1,9 @@
+# Every top-level service key below also selects that service: with this file
+# present, `npx emulate` starts only the services listed here, not all 14.
+#
+# Nothing in this file is validated. A misspelled key is dropped silently and
+# the emulator starts anyway with that data missing.
+
 tokens:
   gho_test_token_admin:
     login: admin
@@ -7,6 +13,9 @@ tokens:
     scopes: [repo, user, read:user, "user:email", workflow]
 
 github:
+  # Every service accepts these two operational keys alongside its seed data:
+  # port: 4001                            # pin the port, ignoring base + index
+  # baseUrl: https://github.emulate.test  # advertised URL for OAuth/webhooks
   users:
     - login: octocat
       name: The Octocat
@@ -37,10 +46,13 @@ github:
     - app_id: 12345
       slug: my-github-app
       name: My GitHub App
+      # Must be PKCS#8. GitHub issues App keys as PKCS#1 ("BEGIN RSA PRIVATE
+      # KEY"), which the emulator cannot read — convert once with:
+      #   openssl pkcs8 -topk8 -nocrypt -in key.pem -out key.pkcs8.pem
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...your PEM key...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
       permissions:
         contents: read
         issues: write

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,41 @@
+# Examples
+
+Runnable apps built against the emulators. Each has its own README with setup
+steps.
+
+| Example | Services | Mode | Shows |
+|---|---|---|---|
+| [oauth](./oauth) | GitHub, Google, Vercel | Standalone CLI | OAuth sign-in against a separate `npx emulate` process |
+| [nextjs-embedded](./nextjs-embedded) | GitHub, Google | Embedded (Next.js) | Emulators on the app's own origin via `@emulators/adapter-next` — survives changing preview URLs |
+| [nuxt-embedded](./nuxt-embedded) | GitHub, Google | Embedded (Nuxt) | The same, via `@emulators/adapter-nuxt` |
+| [stripe-checkout](./stripe-checkout) | Stripe | Embedded (Next.js) | Checkout session, hosted payment page, webhook handling |
+| [resend-magic-link](./resend-magic-link) | Resend | Embedded (Next.js) | Magic-link sign-in, reading sent mail back from the emulator inbox |
+| [twilio-sms-verification](./twilio-sms-verification) | Twilio | Embedded (Next.js) | SMS verification codes, and simulating the inbound code |
+| [vercel-blob-sharing](./vercel-blob-sharing) | Vercel Blob | Embedded (Next.js) | File upload and sharing against emulated Blob storage |
+
+## Before your first run
+
+All examples import `@emulators/*` packages from their `dist/` output, which is
+gitignored and has no `postinstall` step. Build the workspace once from the repo
+root:
+
+```bash
+pnpm install
+pnpm build
+```
+
+Skipping this produces `Cannot find module '.../dist/index.js'` on `pnpm dev`.
+
+Five of the seven examples serve the app through
+[portless](https://github.com/vercel-labs/portless) (`npm i -g portless`), which
+assigns a random local port and a stable HTTPS hostname — so they are **not** on
+`http://localhost:3000`. Each README states the URL to open. The two that do use
+`localhost:3000` are `resend-magic-link` and `twilio-sms-verification`.
+
+## Standalone vs embedded
+
+- **Standalone** runs `npx emulate` as a separate process; your app talks to it over `http://localhost:<port>`. Closest to how a real third-party API is reached.
+- **Embedded** mounts the emulators inside the app itself under `/emulate/**`, so they share the app's origin. Callback URLs keep working even when the deployment URL changes, which is what makes preview deployments practical.
+
+See [Next.js Integration](https://emulate.dev/docs/nextjs) and
+[Nuxt Integration](https://emulate.dev/docs/nuxt).

--- a/examples/nextjs-embedded/README.md
+++ b/examples/nextjs-embedded/README.md
@@ -4,18 +4,29 @@ A Next.js app with emulators embedded directly via `@emulators/adapter-next`. No
 
 This demonstrates the solution for **Vercel preview deployments** where OAuth callback URLs change with every deployment. Because the emulators run on the same origin as the app, callbacks always work regardless of the deployment URL.
 
+## Prerequisites
+
+The dev script runs through [portless](https://github.com/vercel-labs/portless),
+so install it once if you haven't: `npm i -g portless`.
+
 ## Setup
 
 ```bash
-# From the repo root, install dependencies
+# From the repo root: install, then build the workspace emulator packages.
+# This example imports @emulators/adapter-next from dist/, which is gitignored
+# and has no postinstall step, so the build is required before the first run.
 pnpm install
+pnpm build
 
 # Start the Next.js app (emulators are embedded, no separate process needed)
 cd examples/nextjs-embedded
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) and click any provider to sign in.
+Open [https://nextjs-embedded-demo.emulate.localhost](https://nextjs-embedded-demo.emulate.localhost)
+(or the `http://localhost:<port>` URL printed by portless) and click any provider
+to sign in. portless assigns a random local port, so this app is not served on
+`http://localhost:3000`.
 
 ## How It Works
 
@@ -35,7 +46,7 @@ The session cookie in this example is a plain base64url-encoded JSON blob with n
 | | `examples/oauth` | `examples/nextjs-embedded` |
 |---|---|---|
 | Emulator process | Separate `npx emulate` process | Embedded in the Next.js app |
-| Config | `emulate.config.yaml` + `.env.local` | Seed data in `route.ts` |
+| Config | Optional `.env.local`; emulator defaults otherwise | Seed data inline in `route.ts` |
 | OAuth URLs | `http://localhost:4001/login/oauth/...` | `/emulate/github/login/oauth/...` (same origin) |
 | Client credentials | Must match config | `"any"` (validation skipped) |
 | Preview deploys | Requires fixed callback URL | Works on any URL |

--- a/examples/nuxt-embedded/README.md
+++ b/examples/nuxt-embedded/README.md
@@ -4,18 +4,29 @@ A Nuxt app with emulators embedded directly via `@emulators/adapter-nuxt`. No se
 
 This demonstrates the solution for **preview deployments** where OAuth callback URLs change with every deployment. Because the emulators run on the same origin as the app, callbacks always work regardless of the deployment URL.
 
+## Prerequisites
+
+The dev script runs through [portless](https://github.com/vercel-labs/portless),
+so install it once if you haven't: `npm i -g portless`.
+
 ## Setup
 
 ```bash
-# From the repo root, install dependencies
+# From the repo root: install, then build the workspace emulator packages.
+# This example imports @emulators/adapter-nuxt from dist/, which is gitignored
+# and has no postinstall step, so the build is required before the first run.
 pnpm install
+pnpm build
 
 # Start the Nuxt app (emulators are embedded, no separate process needed)
 cd examples/nuxt-embedded
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) and click any provider to sign in.
+Open [https://nuxt-embedded-demo.emulate.localhost](https://nuxt-embedded-demo.emulate.localhost)
+(or the `http://localhost:<port>` URL printed by portless) and click any provider
+to sign in. portless assigns a random local port, so this app is not served on
+`http://localhost:3000`.
 
 ## How It Works
 
@@ -39,7 +50,7 @@ The session cookie in this example is a plain base64url-encoded JSON blob with n
 | | `examples/oauth` | `examples/nuxt-embedded` |
 |---|---|---|
 | Emulator process | Separate `npx emulate` process | Embedded in the Nuxt app |
-| Config | `emulate.config.yaml` + `.env.local` | Seed data in `[...path].ts` |
+| Config | Optional `.env.local`; emulator defaults otherwise | Seed data inline in `[...path].ts` |
 | OAuth URLs | `http://localhost:4001/login/oauth/...` | `/emulate/github/login/oauth/...` (same origin) |
 | Client credentials | Must match config | `"any"` (validation skipped) |
 | Preview deploys | Requires fixed callback URL | Works on any URL |

--- a/examples/oauth/README.md
+++ b/examples/oauth/README.md
@@ -1,25 +1,80 @@
 # OAuth Example
 
-A Next.js app demonstrating OAuth sign-in with all three emulated providers: **GitHub**, **Google**, and **Vercel**.
+A Next.js app demonstrating OAuth sign-in with three emulated providers:
+**GitHub**, **Google**, and **Vercel**.
 
 No real accounts or API keys needed — everything runs against the local emulator.
+
+## Prerequisites
+
+This example is served through [portless](https://github.com/vercel-labs/portless),
+which gives it a stable HTTPS hostname:
+
+```bash
+npm i -g portless
+portless proxy start
+```
 
 ## Setup
 
 ```bash
-# From the repo root, install dependencies
+# From the repo root: install, then build the workspace emulator packages.
+# The examples import @emulators/* from dist/, which is gitignored and has no
+# postinstall step, so this build is required before the first run.
 pnpm install
+pnpm build
 
-# Start the emulator with the example config
-cd examples/oauth
-npx emulate --seed emulate.config.yaml
+# Start the emulators. A bare `npx emulate` runs all 14 services, which puts
+# Vercel on 4000, GitHub on 4001 and Google on 4002 — exactly the ports this
+# example falls back to.
+npx emulate
+```
 
-# In a separate terminal, start the Next.js app
+In a separate terminal:
+
+```bash
 cd examples/oauth
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) and click any provider to sign in.
+Open **https://oauth-demo.emulate.localhost** and click any provider to sign in.
+portless prints the URL on startup; it also assigns a random local port, so
+`http://localhost:3000` is *not* where this app is served.
+
+## Configuration
+
+The app runs with no configuration at all: every value below has a working
+fallback, and with no seed config the emulator accepts any `client_id`.
+
+Create `examples/oauth/.env.local` only if you need to override something —
+most importantly `NEXT_PUBLIC_APP_URL`, which must match the URL your browser
+actually uses, because it is what the OAuth `redirect_uri` is built from.
+
+```bash
+# The app's own public URL. Must match where the browser reaches the app,
+# or the OAuth callback will redirect to the wrong host.
+NEXT_PUBLIC_APP_URL=https://oauth-demo.emulate.localhost
+
+# Emulator base URLs (defaults shown; correct for a bare `npx emulate`)
+VERCEL_EMULATOR_URL=http://localhost:4000
+GITHUB_EMULATOR_URL=http://localhost:4001
+GOOGLE_EMULATOR_URL=http://localhost:4002
+
+# OAuth client credentials (defaults shown). Any value works unless you seed
+# `oauth_apps` / `integrations`, which switches the emulator to strict validation.
+GITHUB_CLIENT_ID=emu_github_client_id
+GITHUB_CLIENT_SECRET=emu_github_client_secret
+GOOGLE_CLIENT_ID=emu_google_client_id
+GOOGLE_CLIENT_SECRET=emu_google_client_secret
+VERCEL_CLIENT_ID=emu_vercel_client_id
+VERCEL_CLIENT_SECRET=emu_vercel_client_secret
+```
+
+If you do seed OAuth apps in a config file, the `client_id` and `redirect_uris`
+there must match these values exactly — otherwise the authorize request is
+rejected. Note also that a config file containing only some service keys acts as
+an implicit `--service`, so it would start fewer services and shift the ports
+above.
 
 ## How It Works
 
@@ -29,8 +84,8 @@ Open [http://localhost:3000](http://localhost:3000) and click any provider to si
 4. The callback route exchanges the code for an access token, fetches user info, and stores the session in an HTTP-only cookie.
 5. The dashboard displays the authenticated user's profile and access token.
 
-## Configuration
+## Links
 
-The `emulate.config.yaml` seeds users and OAuth apps for all three providers. The `.env.local` connects the Next.js app to the emulator's ports and provides matching client credentials.
-
-See the root [README](../../README.md) for full emulator configuration options.
+- [Emulator configuration](https://emulate.dev/docs/configuration)
+- [Connecting your app](https://emulate.dev/docs/connecting)
+- [Troubleshooting](https://emulate.dev/docs/troubleshooting)

--- a/examples/resend-magic-link/README.md
+++ b/examples/resend-magic-link/README.md
@@ -20,6 +20,7 @@ From the repository root:
 
 ```bash
 pnpm install
+pnpm build   # builds the workspace emulator packages once; required before first run
 pnpm --filter resend-magic-link dev
 ```
 
@@ -49,13 +50,18 @@ curl http://localhost:3000/emulate/resend/emails/<id> \
 
 ### Extracting the sign-in code programmatically
 
-This is useful in tests or agent workflows where you need to complete the magic link flow without a human reading the email:
+Useful in tests or agent workflows where you need the code without a human
+reading the email.
+
+**Trigger the send from the app first.** In this example the email is sent by a
+Next.js Server Action (`src/app/actions.ts`), not by an HTTP route, so it cannot
+be invoked with a plain `curl -X POST`. Submit the form in the browser, or drive
+it from a browser-automation test. The action is also what sets the
+`pending_signin` cookie the verification step needs.
+
+Once the email has been sent, read it back over the emulator's REST API:
 
 ```bash
-# Send a sign-in request (sets the pending_signin cookie)
-curl -s -c cookies.txt -L -X POST http://localhost:3000 \
-  -d "email=test@example.com"
-
 # List emails and grab the latest one
 EMAIL_ID=$(curl -s http://localhost:3000/emulate/resend/emails \
   -H "Authorization: Bearer re_emulated_key" | jq -r '.data[0].id')

--- a/examples/stripe-checkout/README.md
+++ b/examples/stripe-checkout/README.md
@@ -18,14 +18,20 @@ The Stripe SDK is configured with `host: localhost` and `protocol: http` so all 
 
 ## Getting started
 
+The dev script runs through [portless](https://github.com/vercel-labs/portless),
+so install it once if you haven't: `npm i -g portless`.
+
 From the repository root:
 
 ```bash
 pnpm install
+pnpm build   # builds the workspace emulator packages once; required before first run
 pnpm --filter stripe-checkout dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000).
+Open [https://stripe-checkout.emulate.localhost](https://stripe-checkout.emulate.localhost)
+(or the `http://localhost:<port>` URL printed by portless). portless assigns a
+random local port, so this app is not served on `http://localhost:3000`.
 
 ## Seeded data
 

--- a/examples/twilio-sms-verification/README.md
+++ b/examples/twilio-sms-verification/README.md
@@ -32,6 +32,7 @@ From the repository root:
 
 ```bash
 pnpm install
+pnpm build   # builds the workspace emulator packages once; required before first run
 pnpm --filter twilio-sms-verification dev
 ```
 

--- a/packages/@emulators/clerk/README.md
+++ b/packages/@emulators/clerk/README.md
@@ -1,0 +1,116 @@
+# @emulators/clerk
+
+Clerk emulation with users, email addresses, sessions and session tokens,
+organizations, memberships, invitations, and an OAuth 2.0 / OIDC provider.
+
+Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
+
+## Install
+
+```bash
+npm install @emulators/clerk
+```
+
+## Endpoints
+
+### Users
+- `GET /v1/users` — list users
+- `GET /v1/users/count` — count users
+- `GET /v1/users/:userId` — retrieve user
+- `POST /v1/users` — create user
+- `PATCH /v1/users/:userId` — update user
+- `DELETE /v1/users/:userId` — delete user
+- `POST /v1/users/:userId/ban` — ban user
+- `POST /v1/users/:userId/unban` — unban user
+- `POST /v1/users/:userId/lock` — lock user
+- `POST /v1/users/:userId/unlock` — unlock user
+- `PATCH /v1/users/:userId/metadata` — merge user metadata
+- `POST /v1/users/:userId/verify_password` — verify a password
+
+### Email Addresses
+- `GET /v1/email_addresses/:emailId` — retrieve
+- `POST /v1/email_addresses` — create
+- `PATCH /v1/email_addresses/:emailId` — update
+- `DELETE /v1/email_addresses/:emailId` — delete
+
+### Sessions
+- `GET /v1/sessions` — list sessions
+- `GET /v1/sessions/:sessionId` — retrieve session
+- `POST /v1/sessions` — create session
+- `POST /v1/sessions/:sessionId/revoke` — revoke session
+- `POST /v1/sessions/:sessionId/tokens` — mint a session token
+- `POST /v1/sessions/:sessionId/tokens/:template` — mint a token from a JWT template
+
+### Organizations
+- `GET /v1/organizations` — list organizations
+- `GET /v1/organizations/:orgId` — retrieve organization
+- `POST /v1/organizations` — create organization
+- `PATCH /v1/organizations/:orgId` — update organization
+- `DELETE /v1/organizations/:orgId` — delete organization
+- `PATCH /v1/organizations/:orgId/metadata` — merge organization metadata
+
+### Memberships
+- `GET /v1/organizations/:orgId/memberships` — list members
+- `POST /v1/organizations/:orgId/memberships` — add member
+- `PATCH /v1/organizations/:orgId/memberships/:userId` — update role
+- `DELETE /v1/organizations/:orgId/memberships/:userId` — remove member
+- `PATCH /v1/organizations/:orgId/memberships/:userId/metadata` — merge membership metadata
+
+### Invitations
+- `GET /v1/organizations/:orgId/invitations` — list invitations
+- `GET /v1/organizations/:orgId/invitations/:invitationId` — retrieve invitation
+- `POST /v1/organizations/:orgId/invitations` — create invitation
+- `POST /v1/organizations/:orgId/invitations/bulk` — create invitations in bulk
+- `POST /v1/organizations/:orgId/invitations/:invitationId/revoke` — revoke invitation
+
+### OAuth / OIDC
+- `GET /.well-known/openid-configuration` — discovery document
+- `GET /v1/jwks` — signing keys
+- `GET /oauth/authorize` — authorization endpoint
+- `POST /oauth/authorize/callback` — authorization callback
+- `POST /oauth/token` — token exchange
+- `GET /oauth/userinfo` — userinfo
+
+## Default seed
+
+With no configuration, one user is created: `Test User`, primary email
+`test@example.com` (verified), password `test_password`.
+
+## Seed Configuration
+
+```yaml
+clerk:
+  users:
+    - email_addresses: ["test@example.com"] # required, an array of strings
+      first_name: Test
+      last_name: User
+      username: testuser
+      password: clerk_test_password
+      public_metadata:
+        plan: pro
+  organizations:
+    - name: My Company
+      slug: my-company
+      members:
+        - email: test@example.com
+          role: admin
+  oauth_applications:
+    - client_id: clerk_emulate_client
+      client_secret: clerk_emulate_secret
+      name: Emulate App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/clerk
+```
+
+Seed config is not validated, so these fail silently:
+
+- `email_addresses` is a required **array of strings**. A user seeded with
+  `email:` instead ends up with no email address.
+- There is no `name` field — use `first_name` and `last_name`.
+- `organizations[].members[].email` must match a seeded user's email, or the
+  membership is skipped.
+
+## Links
+
+- [Full documentation](https://emulate.dev/docs/clerk)
+- [GitHub](https://github.com/vercel-labs/emulate)

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -159,9 +159,9 @@ github:
       slug: "my-github-app"
       name: "My GitHub App"
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...your PEM key...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
       permissions:
         contents: read
         issues: write
@@ -172,7 +172,18 @@ github:
           repository_selection: all
 ```
 
+`private_key` must be **PKCS#8** — it is parsed with `importPKCS8`, so it has to
+begin with `-----BEGIN PRIVATE KEY-----`. GitHub issues App keys in PKCS#1
+(`-----BEGIN RSA PRIVATE KEY-----`), which the emulator cannot read. Convert once:
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in github-app.private-key.pem -out github-app.pkcs8.pem
+```
+
+A key in the wrong format fails silently: JWT verification throws, the error is
+swallowed, and the request is treated as unauthenticated.
+
 ## Links
 
-- [Full documentation](https://emulate.dev/github)
+- [Full documentation](https://emulate.dev/docs/github)
 - [GitHub](https://github.com/vercel-labs/emulate)

--- a/packages/@emulators/okta/README.md
+++ b/packages/@emulators/okta/README.md
@@ -79,20 +79,37 @@ okta:
   users:
     - login: testuser@example.com
       email: testuser@example.com
-      firstName: Test
-      lastName: User
+      first_name: Test # snake_case, not firstName
+      last_name: User
   groups:
     - name: Everyone
       description: All users
   apps:
     - name: My App
       label: My App
+  oauth_clients:
+    - client_id: okta_example_client
+      client_secret: okta_example_secret
+      name: My App
+      redirect_uris: ["http://localhost:3000/api/auth/callback/okta"]
   authorization_servers:
-    - name: default
+    - id: default # required — this is the primary key used in /oauth2/:id/... paths
+      name: default
       audiences: ["api://default"]
 ```
 
+Seed config is not validated, so both of these fail silently:
+
+- **User fields are snake_case.** `first_name` / `last_name`, not `firstName` /
+  `lastName`. A camelCase key is ignored and the user is seeded with the default
+  name `Test User`.
+- **`authorization_servers[].id` is required.** It becomes the server's
+  `server_id`, which is what `/oauth2/:authServerId/v1/token` and the other OAuth
+  routes look up. Omit it and the server is created but unreachable. The
+  emulator always creates a server with `id: default` on startup, so you only
+  need this block to add more.
+
 ## Links
 
-- [Full documentation](https://emulate.dev)
+- [Full documentation](https://emulate.dev/docs/okta)
 - [GitHub](https://github.com/vercel-labs/emulate)

--- a/packages/@emulators/resend/README.md
+++ b/packages/@emulators/resend/README.md
@@ -49,11 +49,19 @@ npm install @emulators/resend
 resend:
   domains:
     - name: example.com
-  api_keys:
-    - name: default
+      region: us-east-1 # optional, defaults to us-east-1
+  contacts:
+    - email: subscriber@example.com
+      first_name: Sub
+      last_name: Scriber
+      audience: newsletter
 ```
+
+`domains` and `contacts` are the only seedable collections. API keys cannot be
+seeded — create them at runtime with `POST /api-keys`, or send any non-empty
+bearer token, which the emulator accepts.
 
 ## Links
 
-- [Full documentation](https://emulate.dev)
+- [Full documentation](https://emulate.dev/docs/resend)
 - [GitHub](https://github.com/vercel-labs/emulate)

--- a/packages/@emulators/stripe/README.md
+++ b/packages/@emulators/stripe/README.md
@@ -71,14 +71,26 @@ stripe:
   products:
     - name: Pro Plan
   prices:
-    - product: Pro Plan
+    - product_name: Pro Plan # must match a `products[].name` above
       unit_amount: 2000
       currency: usd
-      recurring:
-        interval: month
+  webhooks:
+    - url: http://localhost:3000/api/stripe/webhook
+      events: ["checkout.session.completed"]
 ```
+
+Two rules the emulator enforces silently — seed config is not validated, so a
+mistake produces an empty store rather than an error:
+
+- **Prices are seeded through their product.** A `prices[]` entry is only created
+  if its `product_name` matches the `name` of an entry in `products[]`. A `prices`
+  block with no matching product — or with the key spelled `product` — is dropped,
+  and `GET /v1/prices` returns `{"data":[]}`.
+- **All seeded prices are one-time.** The emulator sets `type: "one_time"`;
+  there is no `recurring` key. Create subscription-style prices through
+  `POST /v1/prices` at runtime instead.
 
 ## Links
 
-- [Full documentation](https://emulate.dev)
+- [Full documentation](https://emulate.dev/docs/stripe)
 - [GitHub](https://github.com/vercel-labs/emulate)

--- a/skills/apple/SKILL.md
+++ b/skills/apple/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: apple
 description: Emulated Sign in with Apple / Apple OIDC for local development and testing. Use when the user needs to test Apple sign-in locally, emulate Apple OIDC discovery, handle Apple token exchange, configure Apple OAuth clients, or work with Apple userinfo without hitting real Apple APIs. Triggers include "Apple OAuth", "emulate Apple", "mock Apple login", "test Apple sign-in", "Sign in with Apple", "Apple OIDC", "local Apple auth", or any task requiring a local Apple OAuth/OIDC provider.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Apple Sign In Emulator
@@ -11,12 +11,17 @@ Sign in with Apple emulation with authorization code flow, PKCE support, RS256 I
 ## Start
 
 ```bash
-# Apple only
-npx emulate --service apple
+# Apple only, pinned to the port used throughout this guide
+npx emulate --service apple --port 4004
 
-# Default port (when run alone)
-# http://localhost:4000
+# Or run all 14 services; Apple is the 5th, so it also lands on 4004
+npx emulate
 ```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service apple` puts Apple on 4000, not 4004. The
+`--port 4004` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `apple.port` in the seed config.
 
 Or programmatically:
 

--- a/skills/aws/SKILL.md
+++ b/skills/aws/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aws
 description: Emulated AWS cloud services (S3, SQS, IAM, STS) for local development and testing. Use when the user needs to interact with AWS API endpoints locally, test S3 bucket and object operations, emulate SQS queues and messages, manage IAM users/roles/access keys, test STS assume role, or work without hitting real AWS APIs. Triggers include "AWS emulator", "emulate AWS", "mock S3", "local SQS", "test IAM", "emulate S3", "AWS locally", "STS assume role", or any task requiring local AWS service emulation.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # AWS Emulator
@@ -11,20 +11,25 @@ S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style
 ## Start
 
 ```bash
-# AWS only
-npx emulate --service aws
+# AWS only, pinned to the port used throughout this guide
+npx emulate --service aws --port 4007
 
-# Default port (when run alone)
-# http://localhost:4000
+# Or run all 14 services; AWS is the 8th, so it also lands on 4007
+npx emulate
 ```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service aws` puts AWS on 4000, not 4007. The
+`--port 4007` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `aws.port` in the seed config.
 
 Or programmatically:
 
 ```typescript
 import { createEmulator } from 'emulate'
 
-const aws = await createEmulator({ service: 'aws', port: 4006 })
-// aws.url === 'http://localhost:4006'
+const aws = await createEmulator({ service: 'aws', port: 4007 })
+// aws.url === 'http://localhost:4007'
 ```
 
 ## Auth
@@ -32,7 +37,7 @@ const aws = await createEmulator({ service: 'aws', port: 4006 })
 Pass tokens as `Authorization: Bearer <token>`. Scoped permissions use `s3:*`, `sqs:*`, `iam:*`, `sts:*` patterns.
 
 ```bash
-curl http://localhost:4006/ \
+curl http://localhost:4007/ \
   -H "Authorization: Bearer test_token_admin"
 ```
 
@@ -41,7 +46,7 @@ curl http://localhost:4006/ \
 ### Environment Variable
 
 ```bash
-AWS_EMULATOR_URL=http://localhost:4006
+AWS_EMULATOR_URL=http://localhost:4007
 ```
 
 ### AWS SDK v3
@@ -124,46 +129,46 @@ S3 routes use root paths matching the real AWS S3 wire format. Legacy `/s3/` pre
 
 ```bash
 # List all buckets
-curl http://localhost:4006/ \
+curl http://localhost:4007/ \
   -H "Authorization: Bearer $TOKEN"
 
 # Create bucket
-curl -X PUT http://localhost:4006/my-bucket \
+curl -X PUT http://localhost:4007/my-bucket \
   -H "Authorization: Bearer $TOKEN"
 
 # Delete bucket (must be empty)
-curl -X DELETE http://localhost:4006/my-bucket \
+curl -X DELETE http://localhost:4007/my-bucket \
   -H "Authorization: Bearer $TOKEN"
 
 # Head bucket (check existence, get region)
-curl -I http://localhost:4006/my-bucket \
+curl -I http://localhost:4007/my-bucket \
   -H "Authorization: Bearer $TOKEN"
 
 # List objects (with prefix, delimiter, pagination)
-curl "http://localhost:4006/my-bucket?prefix=uploads/&delimiter=/&max-keys=100" \
+curl "http://localhost:4007/my-bucket?prefix=uploads/&delimiter=/&max-keys=100" \
   -H "Authorization: Bearer $TOKEN"
 
 # Put object
-curl -X PUT http://localhost:4006/my-bucket/path/to/file.txt \
+curl -X PUT http://localhost:4007/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: text/plain" \
   -H "x-amz-meta-author: test" \
   --data-binary "file contents"
 
 # Get object
-curl http://localhost:4006/my-bucket/path/to/file.txt \
+curl http://localhost:4007/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN"
 
 # Head object (metadata only)
-curl -I http://localhost:4006/my-bucket/path/to/file.txt \
+curl -I http://localhost:4007/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN"
 
 # Delete object
-curl -X DELETE http://localhost:4006/my-bucket/path/to/file.txt \
+curl -X DELETE http://localhost:4007/my-bucket/path/to/file.txt \
   -H "Authorization: Bearer $TOKEN"
 
 # Copy object
-curl -X PUT http://localhost:4006/dest-bucket/copy.txt \
+curl -X PUT http://localhost:4007/dest-bucket/copy.txt \
   -H "Authorization: Bearer $TOKEN" \
   -H "x-amz-copy-source: /source-bucket/original.txt"
 ```
@@ -174,64 +179,64 @@ All SQS operations use `POST /sqs/` with `Action` as a form-urlencoded parameter
 
 ```bash
 # Create queue
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "Action=CreateQueue&QueueName=my-queue"
 
 # Create queue with attributes
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "Action=CreateQueue&QueueName=my-queue&Attribute.1.Name=VisibilityTimeout&Attribute.1.Value=30"
 
 # List queues
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListQueues"
 
 # List queues with prefix filter
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListQueues&QueueNamePrefix=my-"
 
 # Get queue URL
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetQueueUrl&QueueName=my-queue"
 
 # Get queue attributes
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetQueueAttributes&QueueUrl=<queue_url>"
 
 # Send message
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=SendMessage&QueueUrl=<queue_url>&MessageBody=Hello+World"
 
 # Send message with attributes
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=SendMessage&QueueUrl=<queue_url>&MessageBody=Hello&MessageAttribute.1.Name=type&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=greeting"
 
 # Receive messages
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ReceiveMessage&QueueUrl=<queue_url>&MaxNumberOfMessages=5"
 
 # Delete message
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteMessage&QueueUrl=<queue_url>&ReceiptHandle=<receipt_handle>"
 
 # Purge queue
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=PurgeQueue&QueueUrl=<queue_url>"
 
 # Delete queue
-curl -X POST http://localhost:4006/sqs/ \
+curl -X POST http://localhost:4007/sqs/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteQueue&QueueUrl=<queue_url>"
 ```
@@ -242,57 +247,57 @@ All IAM operations use `POST /iam/` with `Action` as a form-urlencoded parameter
 
 ```bash
 # Create user
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=CreateUser&UserName=new-user"
 
 # Get user
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetUser&UserName=new-user"
 
 # List users
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListUsers"
 
 # Delete user
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteUser&UserName=new-user"
 
 # Create access key
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=CreateAccessKey&UserName=developer"
 
 # List access keys
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListAccessKeys&UserName=developer"
 
 # Delete access key
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteAccessKey&UserName=developer&AccessKeyId=AKIA..."
 
 # Create role
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=CreateRole&RoleName=my-role&AssumeRolePolicyDocument={}"
 
 # Get role
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetRole&RoleName=my-role"
 
 # List roles
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=ListRoles"
 
 # Delete role
-curl -X POST http://localhost:4006/iam/ \
+curl -X POST http://localhost:4007/iam/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=DeleteRole&RoleName=my-role"
 ```
@@ -303,12 +308,12 @@ All STS operations use `POST /sts/` with `Action` as a form-urlencoded parameter
 
 ```bash
 # Get caller identity
-curl -X POST http://localhost:4006/sts/ \
+curl -X POST http://localhost:4007/sts/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=GetCallerIdentity"
 
 # Assume role
-curl -X POST http://localhost:4006/sts/ \
+curl -X POST http://localhost:4007/sts/ \
   -H "Authorization: Bearer $TOKEN" \
   -d "Action=AssumeRole&RoleArn=arn:aws:iam::123456789012:role/my-role&RoleSessionName=my-session"
 ```
@@ -317,9 +322,9 @@ curl -X POST http://localhost:4006/sts/ \
 
 ```bash
 # HTML dashboard (shows S3, SQS, IAM state)
-curl http://localhost:4006/_inspector?tab=s3
-curl http://localhost:4006/_inspector?tab=sqs
-curl http://localhost:4006/_inspector?tab=iam
+curl http://localhost:4007/_inspector?tab=s3
+curl http://localhost:4007/_inspector?tab=sqs
+curl http://localhost:4007/_inspector?tab=iam
 ```
 
 ## Common Patterns
@@ -328,7 +333,7 @@ curl http://localhost:4006/_inspector?tab=iam
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4006"
+BASE="http://localhost:4007"
 
 # Create bucket
 curl -X PUT $BASE/my-data \
@@ -349,7 +354,7 @@ curl $BASE/my-data/config.json \
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4006"
+BASE="http://localhost:4007"
 
 # Get queue URL
 QUEUE_URL=$(curl -s -X POST $BASE/sqs/ \
@@ -371,7 +376,7 @@ curl -X POST $BASE/sqs/ \
 
 ```bash
 TOKEN="test_token_admin"
-BASE="http://localhost:4006"
+BASE="http://localhost:4007"
 
 # Create user
 curl -X POST $BASE/iam/ \

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: clerk
+description: Emulated Clerk user management and OAuth 2.0 / OIDC API for local development and testing. Use when the user needs to test Clerk integrations locally, emulate Clerk users, email addresses, sessions and session tokens, organizations, memberships, invitations, or Clerk OAuth/OIDC flows without hitting the real Clerk service. Triggers include "Clerk API", "emulate Clerk", "mock Clerk", "test Clerk auth", "Clerk organizations", "Clerk sessions", "local Clerk", or any task requiring a local Clerk API.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
+---
+
+# Clerk Emulator
+
+Clerk user management and OAuth 2.0 / OIDC emulation: users, email addresses,
+sessions and session tokens, organizations, memberships, and invitations. All
+state is in-memory and resets when the process restarts.
+
+## Start
+
+```bash
+# Clerk only, pinned to the port used throughout this guide
+npx emulate --service clerk --port 4011
+
+# Or run all 14 services; Clerk is the 12th, so it also lands on 4011
+npx emulate
+```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service clerk` puts Clerk on 4000, not 4011. The
+`--port 4011` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `clerk.port` in the seed config.
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const clerk = await createEmulator({ service: 'clerk', port: 4011 })
+// clerk.url === 'http://localhost:4011'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>`. Any non-empty token is accepted
+and resolves to the fallback user; a request with **no** `Authorization` header
+is rejected with 401.
+
+```bash
+curl http://localhost:4011/v1/users \
+  -H "Authorization: Bearer test_token_admin"
+```
+
+## Default Seed
+
+With no configuration, one user is created: `Test User`, primary email
+`test@example.com` (verified), password `test_password`.
+
+## Pointing Your App at the Emulator
+
+Clerk's backend SDK takes an API base URL. Point it at the emulator and use any
+non-empty secret key:
+
+```bash
+CLERK_API_URL=http://localhost:4011
+CLERK_SECRET_KEY=sk_test_anything
+```
+
+```typescript
+import { createClerkClient } from '@clerk/backend'
+
+const clerk = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+  apiUrl: process.env.CLERK_API_URL,
+})
+
+const users = await clerk.users.getUserList()
+```
+
+For OIDC, discovery is at `/.well-known/openid-configuration` and signing keys at
+`/v1/jwks`.
+
+## Seed Config
+
+```yaml
+clerk:
+  users:
+    - email_addresses: ["test@example.com"] # required, an array of strings
+      first_name: Test
+      last_name: User
+      username: testuser
+      password: clerk_test_password
+      public_metadata:
+        plan: pro
+  organizations:
+    - name: My Company
+      slug: my-company
+      members:
+        - email: test@example.com
+          role: admin
+  oauth_applications:
+    - client_id: clerk_emulate_client
+      client_secret: clerk_emulate_secret
+      name: Emulate App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/clerk
+```
+
+Seed config is never validated, so these fail silently:
+
+- `email_addresses` is a required **array of strings**. A user seeded with
+  `email:` instead ends up with no email address.
+- There is no `name` field — use `first_name` and `last_name`.
+- `organizations[].members[].email` must match a seeded user's email, or the
+  membership is skipped.
+
+## API Endpoints
+
+### Users
+
+```bash
+# List users (filter by email_address, query params repeatable)
+curl http://localhost:4011/v1/users \
+  -H "Authorization: Bearer $TOKEN"
+
+# Count users
+curl http://localhost:4011/v1/users/count \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get user
+curl http://localhost:4011/v1/users/$USER_ID \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create user
+curl -X POST http://localhost:4011/v1/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email_address":["new@example.com"],"first_name":"New","last_name":"User"}'
+
+# Update user
+curl -X PATCH http://localhost:4011/v1/users/$USER_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"first_name":"Renamed"}'
+
+# Delete user
+curl -X DELETE http://localhost:4011/v1/users/$USER_ID \
+  -H "Authorization: Bearer $TOKEN"
+
+# Ban / unban / lock / unlock
+curl -X POST http://localhost:4011/v1/users/$USER_ID/ban \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4011/v1/users/$USER_ID/unban \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4011/v1/users/$USER_ID/lock \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4011/v1/users/$USER_ID/unlock \
+  -H "Authorization: Bearer $TOKEN"
+
+# Merge metadata
+curl -X PATCH http://localhost:4011/v1/users/$USER_ID/metadata \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"public_metadata":{"plan":"pro"}}'
+
+# Verify password
+curl -X POST http://localhost:4011/v1/users/$USER_ID/verify_password \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"password":"test_password"}'
+```
+
+### Email Addresses
+
+```bash
+# Create
+curl -X POST http://localhost:4011/v1/email_addresses \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id":"'$USER_ID'","email_address":"second@example.com"}'
+
+# Retrieve / update / delete
+curl http://localhost:4011/v1/email_addresses/$EMAIL_ID \
+  -H "Authorization: Bearer $TOKEN"
+curl -X PATCH http://localhost:4011/v1/email_addresses/$EMAIL_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"verified":true}'
+curl -X DELETE http://localhost:4011/v1/email_addresses/$EMAIL_ID \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Sessions
+
+```bash
+# List / retrieve
+curl http://localhost:4011/v1/sessions \
+  -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4011/v1/sessions/$SESSION_ID \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create session
+curl -X POST http://localhost:4011/v1/sessions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id":"'$USER_ID'"}'
+
+# Revoke
+curl -X POST http://localhost:4011/v1/sessions/$SESSION_ID/revoke \
+  -H "Authorization: Bearer $TOKEN"
+
+# Mint a session token, optionally from a JWT template
+curl -X POST http://localhost:4011/v1/sessions/$SESSION_ID/tokens \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4011/v1/sessions/$SESSION_ID/tokens/my-template \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Organizations
+
+```bash
+# List / retrieve
+curl http://localhost:4011/v1/organizations \
+  -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4011/v1/organizations/$ORG_ID \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create
+curl -X POST http://localhost:4011/v1/organizations \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme","slug":"acme"}'
+
+# Update / delete / merge metadata
+curl -X PATCH http://localhost:4011/v1/organizations/$ORG_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme Inc"}'
+curl -X DELETE http://localhost:4011/v1/organizations/$ORG_ID \
+  -H "Authorization: Bearer $TOKEN"
+curl -X PATCH http://localhost:4011/v1/organizations/$ORG_ID/metadata \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"public_metadata":{"tier":"enterprise"}}'
+```
+
+### Memberships
+
+```bash
+# List members
+curl http://localhost:4011/v1/organizations/$ORG_ID/memberships \
+  -H "Authorization: Bearer $TOKEN"
+
+# Add member
+curl -X POST http://localhost:4011/v1/organizations/$ORG_ID/memberships \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id":"'$USER_ID'","role":"admin"}'
+
+# Update role / remove / merge metadata
+curl -X PATCH http://localhost:4011/v1/organizations/$ORG_ID/memberships/$USER_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role":"basic_member"}'
+curl -X DELETE http://localhost:4011/v1/organizations/$ORG_ID/memberships/$USER_ID \
+  -H "Authorization: Bearer $TOKEN"
+curl -X PATCH http://localhost:4011/v1/organizations/$ORG_ID/memberships/$USER_ID/metadata \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"public_metadata":{"seat":"paid"}}'
+```
+
+### Invitations
+
+```bash
+# List / retrieve
+curl http://localhost:4011/v1/organizations/$ORG_ID/invitations \
+  -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4011/v1/organizations/$ORG_ID/invitations/$INVITATION_ID \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create one, or many at once
+curl -X POST http://localhost:4011/v1/organizations/$ORG_ID/invitations \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email_address":"invitee@example.com","role":"basic_member"}'
+curl -X POST http://localhost:4011/v1/organizations/$ORG_ID/invitations/bulk \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '[{"email_address":"a@example.com","role":"basic_member"}]'
+
+# Revoke
+curl -X POST http://localhost:4011/v1/organizations/$ORG_ID/invitations/$INVITATION_ID/revoke \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### OAuth / OIDC
+
+```bash
+# Discovery and signing keys
+curl http://localhost:4011/.well-known/openid-configuration
+curl http://localhost:4011/v1/jwks
+
+# Authorization endpoint (browser redirect in a real flow)
+curl "http://localhost:4011/oauth/authorize?client_id=clerk_emulate_client&redirect_uri=http://localhost:3000/api/auth/callback/clerk&response_type=code&scope=openid+email"
+
+# Token exchange
+curl -X POST http://localhost:4011/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=authorization_code&code=$CODE&client_id=clerk_emulate_client&client_secret=clerk_emulate_secret&redirect_uri=http://localhost:3000/api/auth/callback/clerk"
+
+# Userinfo
+curl http://localhost:4011/oauth/userinfo \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: emulate
-description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, and other developer APIs. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation.
+description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, Linear, and Twilio. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation. For deep per-service API detail, prefer the matching service skill (github, google, slack, stripe, clerk, ...) if one exists.
 allowed-tools: Bash(npx emulate:*)
 ---
 
@@ -14,9 +14,10 @@ Local drop-in replacement services for CI and no-network sandboxes. Fully statef
 npx emulate
 ```
 
-All services start with sensible defaults:
+All services start with sensible defaults. These are the ports for a bare
+`npx emulate`, which enables all 14 in this order:
 
-| Service   | Default Port |
+| Service   | Port (all services) |
 |-----------|-------------|
 | Vercel    | 4000        |
 | GitHub    | 4001        |
@@ -32,6 +33,12 @@ All services start with sensible defaults:
 | Clerk     | 4011        |
 | Linear    | 4012        |
 | Twilio    | 4013        |
+
+**A port is `--port` (default 4000) plus the service's index in the *enabled*
+set** — not a fixed number per service. `npx emulate --service github` puts
+GitHub on **4000**, not 4001; `--service google,github` puts Google on 4000 and
+GitHub on 4001 (the order you pass wins). The table above holds only when all 14
+run. To pin a service regardless, set `port` on it in the seed config.
 
 ## CLI
 
@@ -84,10 +91,10 @@ Each call to `createEmulator` starts a single service:
 import { createEmulator } from 'emulate'
 
 const github = await createEmulator({ service: 'github', port: 4001 })
-const vercel = await createEmulator({ service: 'vercel', port: 4002 })
+const vercel = await createEmulator({ service: 'vercel', port: 4000 })
 
 github.url   // 'http://localhost:4001'
-vercel.url   // 'http://localhost:4002'
+vercel.url   // 'http://localhost:4000'
 
 await github.close()
 await vercel.close()
@@ -99,8 +106,54 @@ await vercel.close()
 |--------|---------|-------------|
 | `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
 | `port` | `4000` | Port for the HTTP server |
-| `seed` | none | Inline seed data (same shape as YAML config) |
+| `seed` | none | Inline seed data, **keyed by service name** — same shape as the YAML config file, service key included. See "Seeding data" below. |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
+
+### Seeding Data
+
+`seed` mirrors the YAML config file exactly, **including the top-level service
+key**. Even though `service` is already passed, the seed object must repeat it —
+`createEmulator` reads `seed[service]` and ignores everything else.
+
+```typescript
+const github = await createEmulator({
+  service: 'github',
+  port: 4001,
+  seed: {
+    github: {                                        // <- required service key
+      users: [{ login: 'octocat', name: 'The Octocat' }],
+      repos: [{ owner: 'octocat', name: 'hello-world', auto_init: true }],
+    },
+  },
+})
+```
+
+```typescript
+// WRONG — seeds nothing. No error, no warning: the emulator starts with
+// defaults and GET /users/octocat/repos returns 404.
+await createEmulator({
+  service: 'github',
+  seed: { users: [{ login: 'octocat' }] },
+})
+```
+
+Seed config is never validated, so an unrecognized shape is dropped silently. If
+a request 404s or returns an empty list right after startup, check this nesting
+first.
+
+`tokens` sits at the top level, beside the service key, not inside it:
+
+```typescript
+seed: {
+  tokens: { my_token: { login: 'octocat', scopes: ['repo'] } },
+  github: { users: [{ login: 'octocat' }] },
+}
+```
+
+The Next.js and Nuxt adapters take the **opposite** shape: in
+`createEmulateHandler` the service name is already the key in `services`, so
+`seed` holds the inner object directly, with no service key inside it. See the
+`next` and `nuxt` skills.
 
 ### Instance Methods
 
@@ -121,7 +174,7 @@ let vercel: Emulator
 beforeAll(async () => {
   ;[github, vercel] = await Promise.all([
     createEmulator({ service: 'github', port: 4001 }),
-    createEmulator({ service: 'vercel', port: 4002 }),
+    createEmulator({ service: 'vercel', port: 4000 }),
   ])
   process.env.GITHUB_EMULATOR_URL = github.url
   process.env.VERCEL_EMULATOR_URL = vercel.url
@@ -291,7 +344,9 @@ aws:
 
 Tokens map to users. Pass them as `Authorization: Bearer <token>` or `Authorization: token <token>`. When no tokens are configured, a default `test_token_admin` is created for the `admin` user.
 
-Each service also has a fallback user. If no token is provided, requests authenticate as the first seeded user.
+Each service also has a fallback user, but it applies the other way round from what you might expect: **any non-empty bearer token is accepted**, and an unrecognized one resolves to that fallback user. A request with **no** `Authorization` header is not authenticated at all, so protected routes return 401.
+
+So `Bearer totally-made-up` succeeds, while sending nothing fails. A test asserting "an invalid token is rejected with 401" passes against the real API and fails here — assert on the missing-header case instead.
 
 ## HTTPS with portless
 
@@ -335,7 +390,13 @@ google:
 
 ## Pointing Your App at the Emulator
 
-Set environment variables to override real service URLs:
+There is no proxy and no traffic interception: each emulator is a plain HTTP
+server on localhost. Connecting an app means pointing its SDK at a different base
+URL and giving it any non-empty credential.
+
+These variable names are a **convention for your own application code to read** —
+the emulator does not read them itself. Values shown are for a bare
+`npx emulate`:
 
 ```bash
 VERCEL_EMULATOR_URL=http://localhost:4000
@@ -344,11 +405,32 @@ GOOGLE_EMULATOR_URL=http://localhost:4002
 SLACK_EMULATOR_URL=http://localhost:4003
 APPLE_EMULATOR_URL=http://localhost:4004
 MICROSOFT_EMULATOR_URL=http://localhost:4005
+OKTA_EMULATOR_URL=http://localhost:4006
 AWS_EMULATOR_URL=http://localhost:4007
+RESEND_EMULATOR_URL=http://localhost:4008
+STRIPE_EMULATOR_URL=http://localhost:4009
+MONGOATLAS_EMULATOR_URL=http://localhost:4010
+CLERK_EMULATOR_URL=http://localhost:4011
 LINEAR_EMULATOR_URL=http://localhost:4012
+TWILIO_EMULATOR_URL=http://localhost:4013
 ```
 
-Then use these in your app to construct API and OAuth URLs. See each service's skill for SDK-specific override instructions.
+Where that URL goes depends on the SDK:
+
+| Service | The knob |
+|---|---|
+| GitHub | `new Octokit({ baseUrl })` |
+| Slack | `new WebClient(token, { slackApiUrl: '<url>/api/' })` — trailing `/api/` |
+| AWS | `endpoint` **and** `forcePathStyle: true` for S3 |
+| Stripe | `new Stripe(key, { host: 'localhost', port, protocol: 'http' })` |
+| Resend | `RESEND_BASE_URL` — read natively by the SDK, no code change |
+| Clerk | `createClerkClient({ apiUrl })` |
+| Okta | `new Client({ orgUrl })`; issuer is `<url>/oauth2/default` |
+| Linear | POST to `<url>/graphql` |
+| Apple, Microsoft, Google | OIDC discovery at `<url>/.well-known/openid-configuration` |
+| Vercel, MongoDB Atlas | Replace the API host in your `fetch` base URL |
+
+See each service's skill for full SDK and OAuth URL mappings.
 
 ## Framework Integration (Embedded Mode)
 
@@ -358,15 +440,25 @@ The `@emulators/adapter-nuxt` package embeds emulators directly into a Nuxt app 
 
 ## Persistence
 
-By default, all emulator state is in-memory. For persistence across process restarts and serverless cold starts, use a `PersistenceAdapter`.
+All emulator state is in-memory and is lost when the process exits.
 
-### Built-in file persistence
+**Persistence is available only in the Next.js and Nuxt adapters**, through the
+`persistence` option of `createEmulateHandler`. Neither the CLI nor
+`createEmulator` supports it — the CLI has no persistence flag, and
+`EmulatorOptions` is `{ service, port?, seed?, baseUrl? }`. For the CLI, replay
+your seed config instead; for tests, use `reset()`, which wipes the store and
+replays the seed data.
+
+See the `next` and `nuxt` skills for the full setup. The adapter is wired like this:
 
 ```typescript
+import { createEmulateHandler } from '@emulators/adapter-next'
 import { filePersistence } from '@emulators/core'
 
-// CLI or local dev: persists to a JSON file
-const adapter = filePersistence('.emulate/state.json')
+export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
+  services: { github: { emulator: github } },
+  persistence: filePersistence('.emulate/state.json'),
+})
 ```
 
 ### Custom adapters
@@ -395,11 +487,19 @@ packages/
     github/          # GitHub API service plugin
     google/          # Google OAuth 2.0 / OIDC plugin
     slack/           # Slack Web API, OAuth, incoming webhooks plugin
-    linear/          # Linear GraphQL API, OAuth, webhooks plugin
-    twilio/          # Twilio Messaging, Verify, Voice, webhooks plugin
     apple/           # Sign in with Apple / OIDC plugin
     microsoft/       # Microsoft Entra ID OAuth 2.0 / OIDC plugin
+    okta/            # Okta users, groups, apps, OAuth plugin
     aws/             # AWS S3, SQS, IAM, STS plugin
+    resend/          # Resend email, domains, contacts, inbox plugin
+    stripe/          # Stripe customers, products, checkout, webhooks plugin
+    mongoatlas/      # MongoDB Atlas projects, clusters, database users plugin
+    clerk/           # Clerk users, sessions, organizations, OAuth plugin
+    linear/          # Linear GraphQL API, OAuth, webhooks plugin
+    twilio/          # Twilio Messaging, Verify, Voice, webhooks plugin
 ```
+
+The plugin order above is the registry order, which is also the port order for a
+bare `npx emulate`.
 
 The core provides a generic `Store` with typed `Collection<T>` instances supporting CRUD, indexing, filtering, and pagination. Each service plugin registers routes with the shared internal app and uses the store for state.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github
 description: Emulated GitHub REST API for local development and testing. Use when the user needs to interact with GitHub API endpoints locally, test GitHub integrations, emulate repos/issues/PRs, set up GitHub OAuth flows, configure GitHub Apps, test webhooks, or work with actions/checks without hitting the real GitHub API. Triggers include "GitHub API", "emulate GitHub", "mock GitHub", "test GitHub OAuth", "GitHub App JWT", "local GitHub", or any task requiring a local GitHub API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # GitHub API Emulator
@@ -11,12 +11,17 @@ Fully stateful GitHub REST API emulation. Creates, updates, and deletes persist 
 ## Start
 
 ```bash
-# GitHub only
-npx emulate --service github
+# GitHub only, pinned to the port used throughout this guide
+npx emulate --service github --port 4001
 
-# Default port
-# http://localhost:4001
+# Or run all 14 services; GitHub is the 2nd, so it also lands on 4001
+npx emulate
 ```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service github` puts GitHub on 4000, not 4001. The
+`--port 4001` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `github.port` in the seed config.
 
 Or programmatically:
 
@@ -36,7 +41,9 @@ curl http://localhost:4001/user \
   -H "Authorization: Bearer test_token_admin"
 ```
 
-Public repo endpoints work without auth. Private repos and write operations require a valid token. When no token is provided, requests fall back to the first seeded user.
+Public repo endpoints work without auth. Private repos and write operations require an `Authorization` header.
+
+Token checking is deliberately permissive: **any non-empty token is accepted**, and an unrecognized one resolves to the fallback user. A request with **no** `Authorization` header is not authenticated at all, so protected routes return 401. Do not write a test asserting that an *invalid* token gives 401 — it will pass against real GitHub and fail here. Assert on the missing-header case instead.
 
 ### GitHub App JWT
 
@@ -49,9 +56,9 @@ github:
       slug: my-github-app
       name: My GitHub App
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
       permissions:
         contents: read
         issues: write
@@ -68,6 +75,13 @@ github:
           events: [push]
           repositories: [my-org/org-repo]
 ```
+
+`private_key` must be **PKCS#8** (`-----BEGIN PRIVATE KEY-----`). It is parsed
+with `importPKCS8`; GitHub issues App keys in PKCS#1
+(`-----BEGIN RSA PRIVATE KEY-----`), which this emulator cannot read. Convert with
+`openssl pkcs8 -topk8 -nocrypt -in key.pem -out key.pkcs8.pem`. A wrong-format key
+fails silently — verification throws, the error is swallowed, and the request is
+treated as unauthenticated.
 
 ## Pointing Your App at the Emulator
 

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google
 description: Emulated Google OAuth 2.0, OpenID Connect, Gmail, Calendar, and Drive for local development and testing. Use when the user needs to test Google sign-in locally, emulate OIDC discovery, handle Google token exchange, configure Google OAuth clients, work with Gmail messages/drafts/threads/labels, manage Calendar events, upload or list Drive files, or work with Google userinfo without hitting real Google APIs. Triggers include "Google OAuth", "emulate Google", "mock Google login", "test Google sign-in", "OIDC emulator", "Google OIDC", "Gmail API", "Google Calendar", "Google Drive", "local Google auth", or any task requiring a local Google API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Google OAuth 2.0 / OIDC + Gmail, Calendar & Drive Emulator
@@ -11,12 +11,17 @@ OAuth 2.0 and OpenID Connect emulation with authorization code flow, PKCE suppor
 ## Start
 
 ```bash
-# Google only
-npx emulate --service google
+# Google only, pinned to the port used throughout this guide
+npx emulate --service google --port 4002
 
-# Default port
-# http://localhost:4002
+# Or run all 14 services; Google is the 3rd, so it also lands on 4002
+npx emulate
 ```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service google` puts Google on 4000, not 4002. The
+`--port 4002` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `google.port` in the seed config.
 
 Or programmatically:
 

--- a/skills/microsoft/SKILL.md
+++ b/skills/microsoft/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: microsoft
 description: Emulated Microsoft Entra ID (Azure AD) OAuth 2.0 / OpenID Connect for local development and testing. Use when the user needs to test Microsoft sign-in locally, emulate Entra ID OIDC discovery, handle Microsoft token exchange, configure Azure AD OAuth clients, work with Microsoft Graph /me, or test PKCE/client credentials flows without hitting real Microsoft APIs. Triggers include "Microsoft OAuth", "Entra ID", "Azure AD", "emulate Microsoft", "mock Microsoft login", "test Microsoft sign-in", "Microsoft OIDC", "local Microsoft auth", or any task requiring a local Microsoft OAuth/OIDC provider.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Microsoft Entra ID Emulator
@@ -11,12 +11,17 @@ Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with a
 ## Start
 
 ```bash
-# Microsoft only
-npx emulate --service microsoft
+# Microsoft only, pinned to the port used throughout this guide
+npx emulate --service microsoft --port 4005
 
-# Default port (when run alone)
-# http://localhost:4000
+# Or run all 14 services; Microsoft is the 6th, so it also lands on 4005
+npx emulate
 ```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service microsoft` puts it on 4000, not 4005. The
+`--port 4005` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `microsoft.port` in the seed config.
 
 Or programmatically:
 

--- a/skills/mongoatlas/SKILL.md
+++ b/skills/mongoatlas/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: mongoatlas
+description: Emulated MongoDB Atlas Admin API v2 and Data API v1 for local development and testing. Use when the user needs to manage Atlas projects, clusters or database users locally, run document CRUD and aggregations through the Data API, or work with MongoDB Atlas without hitting the real service. Triggers include "MongoDB Atlas", "Atlas Admin API", "Atlas Data API", "emulate Atlas", "mock MongoDB", "local Atlas cluster", or any task requiring a local MongoDB Atlas API.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
+---
+
+# MongoDB Atlas Emulator
+
+Atlas Admin API v2 and Atlas Data API v1 emulation with in-memory document
+storage supporting CRUD, filtering, and aggregation. State resets when the
+process restarts.
+
+## Start
+
+```bash
+# MongoDB Atlas only, pinned to the port used throughout this guide
+npx emulate --service mongoatlas --port 4010
+
+# Or run all 14 services; MongoDB Atlas is the 11th, so it also lands on 4010
+npx emulate
+```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service mongoatlas` puts it on 4000, not 4010. The
+`--port 4010` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `mongoatlas.port` in the seed config.
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const atlas = await createEmulator({ service: 'mongoatlas', port: 4010 })
+// atlas.url === 'http://localhost:4010'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>`. Any non-empty token is accepted
+and unrecognized ones resolve to the fallback user; a request with **no**
+`Authorization` header is unauthenticated and protected routes return 401.
+
+## Pointing Your App at the Emulator
+
+There is no SDK option to override — replace the Atlas API host in your own base
+URL:
+
+```bash
+MONGOATLAS_EMULATOR_URL=http://localhost:4010
+```
+
+| Real Atlas URL | Emulator URL |
+|---|---|
+| `https://cloud.mongodb.com/api/atlas/v2/...` | `$MONGOATLAS_EMULATOR_URL/api/atlas/v2/...` |
+| `https://data.mongodb-api.com/app/<id>/endpoint/data/v1/action/...` | `$MONGOATLAS_EMULATOR_URL/app/data-api/v1/action/...` |
+
+## Default Seed
+
+With no configuration: one project `Project0` with a default org, and one
+cluster inside it.
+
+## Seed Config
+
+```yaml
+mongoatlas:
+  projects:
+    - name: my-project
+      org_id: my-org # optional
+  clusters:
+    - name: my-cluster
+      project: my-project # must match a projects[].name
+      provider: AWS
+      instance_size: M10
+      region: US_EAST_1
+      disk_size_gb: 10
+      mongodb_version: "7.0"
+  database_users:
+    - username: app-user
+      project: my-project # must match a projects[].name
+      roles:
+        - database_name: appdb
+          role_name: readWrite
+  databases:
+    - cluster: my-cluster # must match a clusters[].name
+      name: appdb
+      collections: [users, orders]
+```
+
+Seed config is never validated, so an unknown key is dropped silently. The
+cross-references matter: `clusters[].project` and `database_users[].project` must
+match a seeded project name, and `databases[].cluster` must match a seeded
+cluster name, or the entry is skipped without a warning.
+
+## Admin API
+
+```bash
+# Projects
+curl http://localhost:4010/api/atlas/v2/groups \
+  -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4010/api/atlas/v2/groups/$GROUP_ID \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4010/api/atlas/v2/groups \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-project"}'
+# Deleting a project cascades to its clusters and data
+curl -X DELETE http://localhost:4010/api/atlas/v2/groups/$GROUP_ID \
+  -H "Authorization: Bearer $TOKEN"
+
+# Clusters
+curl http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/clusters \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/clusters \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-cluster"}'
+curl -X PATCH http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/clusters/my-cluster \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"diskSizeGB":20}'
+curl -X DELETE http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/clusters/my-cluster \
+  -H "Authorization: Bearer $TOKEN"
+
+# Database users (note the /admin/ segment on get and delete)
+curl http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/databaseUsers \
+  -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/databaseUsers/admin/app-user \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/databaseUsers \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"app-user","roles":[{"databaseName":"appdb","roleName":"readWrite"}]}'
+curl -X DELETE http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/databaseUsers/admin/app-user \
+  -H "Authorization: Bearer $TOKEN"
+
+# Data explorer
+curl http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/clusters/my-cluster/databases \
+  -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4010/api/atlas/v2/groups/$GROUP_ID/clusters/my-cluster/databases/appdb/collections \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Data API
+
+Every action is a `POST` whose JSON body names `dataSource`, `database` and
+`collection`:
+
+```bash
+BASE=http://localhost:4010/app/data-api/v1/action
+
+# Insert
+curl -X POST $BASE/insertOne \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","document":{"name":"Ada"}}'
+
+curl -X POST $BASE/insertMany \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","documents":[{"name":"Grace"},{"name":"Alan"}]}'
+
+# Read
+curl -X POST $BASE/findOne \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","filter":{"name":"Ada"}}'
+
+curl -X POST $BASE/find \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","filter":{},"sort":{"name":1},"limit":10,"skip":0}'
+
+# Update (supports $set and upsert)
+curl -X POST $BASE/updateOne \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","filter":{"name":"Ada"},"update":{"$set":{"role":"admin"}},"upsert":true}'
+
+curl -X POST $BASE/updateMany \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","filter":{},"update":{"$set":{"active":true}}}'
+
+# Delete
+curl -X POST $BASE/deleteOne \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","filter":{"name":"Alan"}}'
+
+curl -X POST $BASE/deleteMany \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","filter":{}}'
+
+# Aggregate — supports $match, $limit, $skip, $sort, $project, $count
+curl -X POST $BASE/aggregate \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dataSource":"my-cluster","database":"appdb","collection":"users","pipeline":[{"$match":{"active":true}},{"$sort":{"name":1}},{"$limit":5}]}'
+```
+
+Only the aggregation stages listed above are implemented; other stages are not
+supported.

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: next
 description: Next.js adapter for embedding emulators directly in a Next.js app via @emulators/adapter-next. Use when the user needs to embed emulators in Next.js, set up same-origin OAuth for Vercel preview deployments, create an emulate catch-all route handler, configure Auth.js/NextAuth with embedded emulators, add persistence to embedded emulators, or wrap next.config with withEmulate. Triggers include "Next.js emulator", "adapter-next", "embedded emulator", "same-origin OAuth", "Vercel preview", "createEmulateHandler", "withEmulate", or any task requiring emulators inside a Next.js app.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*)
+allowed-tools: Bash(npx emulate:*)
 ---
 
 # Next.js Integration

--- a/skills/okta/SKILL.md
+++ b/skills/okta/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: okta
+description: Emulated Okta identity provider with the Users, Groups, Apps and Authorization Servers Management APIs plus OAuth 2.0 / OIDC endpoints. Use when the user needs to test Okta integrations locally, emulate Okta users, groups, app assignments, lifecycle transitions, or run Okta OIDC sign-in flows without hitting a real Okta org. Triggers include "Okta API", "emulate Okta", "mock Okta", "test Okta OIDC", "Okta authorization server", "Okta groups", "local Okta", or any task requiring a local Okta API.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
+---
+
+# Okta Emulator
+
+Okta Management API emulation (users, groups, apps, authorization servers) plus a
+full OAuth 2.0 / OIDC provider. All state is in-memory and resets when the
+process restarts.
+
+## Start
+
+```bash
+# Okta only, pinned to the port used throughout this guide
+npx emulate --service okta --port 4006
+
+# Or run all 14 services; Okta is the 7th, so it also lands on 4006
+npx emulate
+```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service okta` puts Okta on 4000, not 4006. The
+`--port 4006` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `okta.port` in the seed config.
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const okta = await createEmulator({ service: 'okta', port: 4006 })
+// okta.url === 'http://localhost:4006'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>`. Any non-empty token is accepted
+and unrecognized ones resolve to the fallback user; a request with **no**
+`Authorization` header is unauthenticated and protected routes return 401.
+
+```bash
+curl http://localhost:4006/api/v1/users \
+  -H "Authorization: Bearer test_token_admin"
+```
+
+## Default Seed
+
+Always created on startup: an authorization server with id `default`, an
+`Everyone` group, a default app, and a default user.
+
+## Pointing Your App at the Emulator
+
+```bash
+OKTA_EMULATOR_URL=http://localhost:4006
+```
+
+```typescript
+import { Client } from '@okta/okta-sdk-nodejs'
+
+const client = new Client({
+  orgUrl: process.env.OKTA_EMULATOR_URL,
+  token: 'anything',
+})
+```
+
+The OIDC issuer is `${OKTA_EMULATOR_URL}/oauth2/default`. Any OIDC-aware library
+(Auth.js, `openid-client`, Passport) can be pointed at the discovery document and
+will find the rest on its own:
+
+| Real Okta URL | Emulator URL |
+|---|---|
+| `https://<org>.okta.com/.well-known/openid-configuration` | `$OKTA_EMULATOR_URL/.well-known/openid-configuration` |
+| `https://<org>.okta.com/oauth2/default/.well-known/openid-configuration` | `$OKTA_EMULATOR_URL/oauth2/default/.well-known/openid-configuration` |
+| `https://<org>.okta.com/oauth2/default/v1/authorize` | `$OKTA_EMULATOR_URL/oauth2/default/v1/authorize` |
+| `https://<org>.okta.com/oauth2/default/v1/token` | `$OKTA_EMULATOR_URL/oauth2/default/v1/token` |
+| `https://<org>.okta.com/api/v1/users` | `$OKTA_EMULATOR_URL/api/v1/users` |
+
+Every `/oauth2/...` route exists both with and without an `:authServerId`
+segment, so `/oauth2/v1/token` and `/oauth2/default/v1/token` both work.
+
+## Seed Config
+
+```yaml
+okta:
+  users:
+    - login: testuser@example.com
+      email: testuser@example.com
+      first_name: Test # snake_case, not firstName
+      last_name: User
+      status: ACTIVE
+  groups:
+    - name: Everyone
+      description: All users
+  apps:
+    - name: My App
+      label: My App
+  oauth_clients:
+    - client_id: okta_example_client
+      client_secret: okta_example_secret
+      name: My App
+      redirect_uris: ["http://localhost:3000/api/auth/callback/okta"]
+  authorization_servers:
+    - id: default # required — the primary key used in /oauth2/:id/... paths
+      name: default
+      audiences: ["api://default"]
+```
+
+Seed config is never validated, so both of these fail silently:
+
+- **User name fields are snake_case.** `first_name` / `last_name`, not
+  `firstName` / `lastName`. A camelCase key is ignored and the user is seeded
+  with the default name `Test User`.
+- **`authorization_servers[].id` is required.** It becomes the `server_id` that
+  the OAuth routes look up, so a server seeded without it is created but
+  unreachable.
+
+`group_memberships` and `app_assignments` link by Okta id
+(`group_okta_id` + `user_okta_id`, `app_okta_id` + `user_okta_id`).
+
+## Management API
+
+```bash
+BASE=http://localhost:4006/api/v1
+
+# Users
+curl $BASE/users -H "Authorization: Bearer $TOKEN"
+curl $BASE/users/me -H "Authorization: Bearer $TOKEN"
+curl $BASE/users/$USER_ID -H "Authorization: Bearer $TOKEN"
+curl $BASE/users/$USER_ID/groups -H "Authorization: Bearer $TOKEN"
+
+curl -X POST $BASE/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"profile":{"login":"new@example.com","email":"new@example.com","firstName":"New","lastName":"User"}}'
+
+# Full replace with PUT, partial update with POST
+curl -X PUT $BASE/users/$USER_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"profile":{"firstName":"Renamed"}}'
+curl -X DELETE $BASE/users/$USER_ID -H "Authorization: Bearer $TOKEN"
+
+# User lifecycle
+curl -X POST $BASE/users/$USER_ID/lifecycle/activate -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/users/$USER_ID/lifecycle/deactivate -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/users/$USER_ID/lifecycle/suspend -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/users/$USER_ID/lifecycle/unsuspend -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/users/$USER_ID/lifecycle/reactivate -H "Authorization: Bearer $TOKEN"
+
+# Groups, and group membership
+curl $BASE/groups -H "Authorization: Bearer $TOKEN"
+curl $BASE/groups/$GROUP_ID -H "Authorization: Bearer $TOKEN"
+curl $BASE/groups/$GROUP_ID/users -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/groups \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"profile":{"name":"Engineers","description":"Eng team"}}'
+curl -X PUT $BASE/groups/$GROUP_ID/users/$USER_ID -H "Authorization: Bearer $TOKEN"
+curl -X DELETE $BASE/groups/$GROUP_ID/users/$USER_ID -H "Authorization: Bearer $TOKEN"
+
+# Apps, and app assignment
+curl $BASE/apps -H "Authorization: Bearer $TOKEN"
+curl $BASE/apps/$APP_ID -H "Authorization: Bearer $TOKEN"
+curl $BASE/apps/$APP_ID/users -H "Authorization: Bearer $TOKEN"
+curl -X PUT $BASE/apps/$APP_ID/users/$USER_ID -H "Authorization: Bearer $TOKEN"
+curl -X DELETE $BASE/apps/$APP_ID/users/$USER_ID -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/apps/$APP_ID/lifecycle/activate -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/apps/$APP_ID/lifecycle/deactivate -H "Authorization: Bearer $TOKEN"
+
+# Authorization servers
+curl $BASE/authorizationServers -H "Authorization: Bearer $TOKEN"
+curl $BASE/authorizationServers/default -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/authorizationServers \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"custom","audiences":["api://custom"]}'
+curl -X POST $BASE/authorizationServers/default/lifecycle/deactivate -H "Authorization: Bearer $TOKEN"
+curl -X POST $BASE/authorizationServers/default/lifecycle/activate -H "Authorization: Bearer $TOKEN"
+```
+
+## OAuth 2.0 / OIDC
+
+```bash
+BASE=http://localhost:4006
+
+# Discovery and keys
+curl $BASE/.well-known/openid-configuration
+curl $BASE/oauth2/default/.well-known/openid-configuration
+curl $BASE/oauth2/default/v1/keys
+
+# Authorize (browser redirect in a real flow; shows a user picker)
+curl "$BASE/oauth2/default/v1/authorize?client_id=okta_example_client&redirect_uri=http://localhost:3000/api/auth/callback/okta&response_type=code&scope=openid+email+profile&state=xyz"
+
+# Token exchange
+curl -X POST $BASE/oauth2/default/v1/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=authorization_code&code=$CODE&client_id=okta_example_client&client_secret=okta_example_secret&redirect_uri=http://localhost:3000/api/auth/callback/okta"
+
+# Userinfo, introspect, revoke, logout
+curl $BASE/oauth2/default/v1/userinfo -H "Authorization: Bearer $ACCESS_TOKEN"
+curl -X POST $BASE/oauth2/default/v1/introspect -d "token=$ACCESS_TOKEN"
+curl -X POST $BASE/oauth2/default/v1/revoke -d "token=$ACCESS_TOKEN"
+curl "$BASE/oauth2/default/v1/logout?id_token_hint=$ID_TOKEN"
+```

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resend
 description: Emulated Resend email API for local development and testing. Use when the user needs to send emails locally, test transactional email flows, implement magic link or verification code auth, inspect sent emails, manage domains/contacts/API keys, or work with the Resend API without sending real emails. Triggers include "Resend API", "emulate Resend", "send email locally", "test email", "magic link", "verification email", "email inbox", "RESEND_BASE_URL", or any task requiring a local email API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Resend Email API Emulator
@@ -19,6 +19,12 @@ npx emulate --service resend
 # Default port (when run alone)
 # http://localhost:4000
 ```
+
+Every example on this page uses port 4000, which is what the command above
+gives. Ports are `--port` (default 4000) plus the service's index in the
+**enabled** set, so under a bare `npx emulate` Resend is the 9th service and
+moves to 4008. To pin it regardless, pass `--port` or set `resend.port` in the
+seed config.
 
 Or programmatically:
 
@@ -38,7 +44,7 @@ curl http://localhost:4000/emails \
   -H "Authorization: Bearer re_test_key"
 ```
 
-When no token is provided, requests fall back to the default user.
+Any non-empty token is accepted and unrecognized ones resolve to the default user; a request with no `Authorization` header is unauthenticated and protected routes return 401.
 
 ## Pointing Your App at the Emulator
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -11,12 +11,17 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 ## Start
 
 ```bash
-# Slack only
-npx emulate --service slack
+# Slack only, pinned to the port used throughout this guide
+npx emulate --service slack --port 4003
 
-# Default port (when run alone)
-# http://localhost:4000
+# Or run all 14 services; Slack is the 4th, so it also lands on 4003
+npx emulate
 ```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set, so a bare `npx emulate --service slack` puts Slack on 4000, not 4003. The
+`--port 4003` above makes every example on this page valid in both modes. To pin
+the port no matter what else runs, set `slack.port` in the seed config.
 
 Or programmatically:
 

--- a/skills/stripe/SKILL.md
+++ b/skills/stripe/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: stripe
 description: Emulated Stripe API for local development and testing. Use when the user needs to process payments locally, test checkout flows, create customers, manage products and prices, handle payment intents, work with webhooks, or use the Stripe SDK without hitting real Stripe servers. Triggers include "Stripe API", "emulate Stripe", "test payments locally", "checkout flow", "payment intent", "Stripe webhook", "Stripe SDK", "STRIPE_API_KEY", or any task requiring a local Stripe API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Stripe API Emulator
@@ -19,6 +19,12 @@ npx emulate --service stripe
 # Default port (when run alone)
 # http://localhost:4000
 ```
+
+Every example on this page uses port 4000, which is what the command above
+gives. Ports are `--port` (default 4000) plus the service's index in the
+**enabled** set, so under a bare `npx emulate` Stripe is the 10th service and
+moves to 4009. To pin it regardless, pass `--port` or set `stripe.port` in the
+seed config.
 
 Or programmatically:
 

--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vercel
 description: Emulated Vercel REST API for local development and testing. Use when the user needs to interact with Vercel API endpoints locally, test Vercel integrations, emulate projects/deployments/domains, set up Vercel OAuth flows, manage environment variables, create API keys, configure protection bypass, emulate Vercel Blob storage, or test without hitting the real Vercel API. Triggers include "Vercel API", "emulate Vercel", "mock Vercel", "test Vercel OAuth", "Vercel integration", "Vercel Blob", "local Vercel", or any task requiring a local Vercel API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Vercel API Emulator
@@ -17,6 +17,10 @@ npx emulate --service vercel
 # Default port
 # http://localhost:4000
 ```
+
+Ports are `--port` (default 4000) plus the service's index in the **enabled**
+set. Vercel is always first, so it stays on 4000 both alone and under a bare
+`npx emulate`. Every example on this page is valid in either mode.
 
 Or programmatically:
 


### PR DESCRIPTION
## Why

I tried to use emulate from the docs and kept getting stuck. Two things kept happening:

**Service pages tell you nothing about how to use the service.** You click Stripe in the sidebar and get a list of endpoints. No start command, no port, nothing about how to point the Stripe SDK at it. I checked all 14 pages: **12 had no start command at all**, and Stripe, Resend and MongoDB Atlas had no connection information of any kind.

**Copying a config example from the docs can leave you with an empty store and no error.** Seed config is never validated (`start.ts` passes the parsed YAML straight to `seedFromConfig`), so a key that doesn't exist in the schema is dropped silently. Several documented keys don't exist.

The clearest example: the Stripe seed block in `docs/configuration` and in the Stripe package README both say

```yaml
prices:
  - product: Pro Plan
```

but `StripeSeedConfig` declares `product_name`, and the matcher at `packages/@emulators/stripe/src/index.ts:89` filters on `pr.product_name === p.name`. Copy the documented example and you get zero seeded prices, no warning, and checkout fails later with `No such price`. The correct key is already used in `skills/stripe/SKILL.md` and in the `emulate init` template in `registry.ts` — so `emulate init` generates a config that contradicts the docs, on the same "Pro Plan" example.

I verified every claim in this PR against the source rather than against other docs.

## What changed

### Service pages are now usable

Every service page opens with the same three sections before the endpoint list:

- **Start** — the command, and which port the service actually lands on
- **Point your SDK at it** — a real snippet for that SDK: `new Octokit({ baseUrl })`, Slack's `slackApiUrl` with its required trailing `/api/`, AWS needing `endpoint` **and** `forcePathStyle: true`, Stripe's `host`/`port`/`protocol`, Resend's `RESEND_BASE_URL`, Okta's `orgUrl`, OIDC discovery for Apple/Microsoft/Google
- **Seed config** — a correct YAML block, with the traps for that service noted inline

Linear and Twilio already had this shape, so they are largely unchanged — the other 12 were brought up to match them.

### Config keys corrected

All of these silently seed nothing today:

| Where | Was | Is |
|---|---|---|
| Stripe | `product:`, `recurring:` | `product_name:`; `recurring` removed (the emulator hardcodes `type: "one_time"`) |
| Okta | `firstName`, `lastName` | `first_name`, `last_name` |
| Okta | `authorization_servers` without `id` | `id` documented as required — it becomes `server_id`, which the OAuth routes look up |
| Resend | `api_keys:` | `contacts:` (`api_keys` is not in `ResendSeedConfig`) |
| GitHub App | `-----BEGIN RSA PRIVATE KEY-----` | `-----BEGIN PRIVATE KEY-----` + the `openssl pkcs8 -topk8` command |

The PKCS#1 one is worth calling out: `auth.ts:85` uses `importPKCS8`, which cannot read PKCS#1, and the exception is swallowed by an empty `catch`. GitHub hands out App keys in PKCS#1, so following the docs gives you a JWT that is silently treated as unauthenticated. This was documented in five places.

### The port rule is now written down

A port is `--port` (default 4000) plus the service's index in the **enabled** set — not a fixed number per service. `--service github` binds 4000, not 4001. This was not stated anywhere, and it had broken several skills, which showed a start command producing one port and then used a different one throughout:

- `skills/aws` used `localhost:4006` in 45 places, which is Okta — with a full fleet running, those requests silently hit the wrong emulator instead of failing
- `skills/apple`, `skills/microsoft`, `skills/slack`, `skills/github`, `skills/google` had the same mismatch
- `hero-terminal.tsx` had AWS and Okta swapped and was missing three services; the landing page said "11 services" and used the wrong Stripe port

Fixed by pinning `--port` in each skill's start command, so the examples are valid both standalone and under a bare `npx emulate`. Also documents the `<service>.port` seed key, which is the only way to pin a port and was not mentioned anywhere.

### Undocumented runtime behaviour

- **`createEmulator` seed nesting.** `api.ts:45` reads `seed[service]`, so the seed object must repeat the service name even though `service` is passed separately. The adapters take the opposite shape. Both had one line of docs — "same shape as YAML config" — and no example. Now both are shown, with the wrong version marked.
- **Rate limiting.** Every service applies 5000 req/hr per token and returns **403**, not 429, with all anonymous traffic in one bucket. This was not mentioned in any doc, and GitHub's emulated `/rate_limit` reports static values that don't reflect it.
- **Token checking.** Any non-empty bearer token is accepted; only a *missing* `Authorization` header gives 401. Two skills stated this backwards. A test asserting "invalid token → 401" passes against the real API and fails here.
- **A config file acts as an implicit `--service`.** `npx emulate init --service stripe` then `npx emulate` starts Stripe alone on 4000, not all 14.

### Missing docs added

- **Clerk** — page, package README, skill. It was the only one of 14 services with no documentation at all, while being listed as supported in six places, including the docs-site AI assistant's system prompt (which has no Clerk content in its corpus).
- **Okta and MongoDB Atlas skills** — both had pages but no skill, so an agent asked to "emulate Okta locally" had nothing to match on.
- **Troubleshooting page** — the silent-failure modes above, plus `DEBUG=1`/`EMULATE_DEBUG=1`, `EADDRINUSE`, and `--portless`/`--base-url` being mutually exclusive.
- **Connecting page** — the general "point your SDK at a different base URL" pattern in one place.
- **`examples/README.md`** — the seven examples weren't linked from any human-facing doc.

### Examples

Six of seven examples don't start by following their README. They import `@emulators/*` from `dist/`, which is gitignored with no `postinstall`, so `pnpm build` is required first — documented in only one of them. Also: `examples/oauth` told you to run `npx emulate --seed emulate.config.yaml`, but that file has never existed in the repo history (`git log --all`), and the CLI exits 1 when a seed file is missing. The app works fine with a bare `npx emulate`, which is what the README now says. Four READMEs pointed at `http://localhost:3000` for apps served through portless on a random port.

### Docs contributor notes

`AGENTS.md` had no build, test, lint or type-check commands, and its "adding a service" checklist pointed at `packages/emulate/src/index.ts`, which has no service list — registration is in `registry.ts`. The checklist also omitted the four separate navigation files, which is why `/docs/twilio` shipped with no nav entry and Clerk shipped with nothing.

## Note on tables

This MDX setup calls `createMDX()` with no plugins, so there's no `remark-gfm` and pipe tables render as a paragraph of run-together text. All tables here are HTML, matching the existing pages. The tables on the **Linear and Twilio pages were already broken this way** and are fixed in this PR.

The root cause is still there — the next markdown table will fail the same way, and the build won't complain. A one-line `createMDX({ options: { remarkPlugins: [remarkGfm] } })` plus the dependency would fix it, but that's a build change rather than a docs change, so I left it out. Happy to add it if you want.

## Testing

- `pnpm --filter web build` passes; all 30 routes generate, including the three new pages
- `pnpm --filter web lint` clean
- Checked every service skill's port references against `registry.ts` with a script
- Verified all 21 internal README anchors resolve

One pre-existing failure is unrelated and untouched: `pnpm lint` fails on `examples/nuxt-embedded`, which reproduces on a clean checkout of `main`.

## Not included

No source or build changes — this is documentation only. Two structural fixes from the same investigation are deliberately left out, and without them this class of drift will come back:

1. **Validate seed config.** Every silent failure above exists because nothing checks unknown keys. Warning on unrecognized top-level keys in `start.ts` and `api.ts` would turn the whole class into a loud error.
2. **One source of navigation.** The docs nav is duplicated across `docs-nav.tsx`, `docs-mobile-nav.tsx` and `lib/docs-navigation.ts`. Twilio was in one of the three, which is why its page was reachable by search but not by the sidebar.

Happy to follow up with either.
