### PR TITLE
Add Creem and expanded Stripe billing emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ All services start with sensible defaults. No config file needed:
 - **Okta** on `http://localhost:4006`
 - **AWS** on `http://localhost:4007`
 - **Resend** on `http://localhost:4008`
-- **Stripe** on `http://localhost:4009`
-- **MongoDB Atlas** on `http://localhost:4010`
-- **Clerk** on `http://localhost:4011`
-- **Linear** on `http://localhost:4012`
-- **Twilio** on `http://localhost:4013`
+- **Creem** on `http://localhost:4009`
+- **Stripe** on `http://localhost:4010`
+- **MongoDB Atlas** on `http://localhost:4011`
+- **Clerk** on `http://localhost:4012`
+- **Linear** on `http://localhost:4013`
+- **Twilio** on `http://localhost:4014`
 
 ## CLI
 
@@ -148,7 +149,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'creem'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |

--- a/apps/web/app/docs/creem/layout.tsx
+++ b/apps/web/app/docs/creem/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("creem");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/creem/page.mdx
+++ b/apps/web/app/docs/creem/page.mdx
@@ -1,0 +1,32 @@
+# Creem
+
+Creem Test Mode emulation with hosted checkout, signed webhooks, subscriptions, cancellation, and an inspector.
+
+## Hosted checkout
+
+- `GET /test/payment/:productId` — open a Test Mode checkout
+- `GET /payment/:productId` — open a checkout
+- `POST /checkout/:checkoutId/complete` — complete checkout and emit `checkout.completed`
+
+## Lifecycle
+
+- `POST /_creem/subscriptions/:subscriptionId/cancel` — cancel a subscription and emit `subscription.canceled`
+- `GET /` — inspect checkouts and subscriptions
+
+## Seed configuration
+
+```yaml
+creem:
+  products:
+    - id: prod_console_dev
+      name: YapHaus managed relay
+      amount: 6900
+      currency: USD
+      return_url: http://127.0.0.1:4322/welcome
+  webhooks:
+    - url: http://127.0.0.1:8787/webhooks/creem
+      events: ["*"]
+      secret: local-webhook-secret
+```
+
+Webhook bodies are signed with HMAC SHA-256 in the `Creem-Signature` header.

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -34,6 +34,7 @@ const sections: NavSection[] = [
       { href: "/docs/okta", label: "Okta" },
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
+      { href: "/docs/creem", label: "Creem" },
       { href: "/docs/stripe", label: "Stripe" },
     ],
   },

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -32,6 +32,7 @@ const sections: NavSection[] = [
       { href: "/docs/okta", label: "Okta" },
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
+      { href: "/docs/creem", label: "Creem" },
       { href: "/docs/stripe", label: "Stripe" },
     ],
   },

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -21,6 +21,7 @@ export const allDocsPages: NavItem[] = [
   { name: "Okta", href: "/docs/okta" },
   { name: "MongoDB Atlas", href: "/docs/mongoatlas" },
   { name: "Resend", href: "/docs/resend" },
+  { name: "Creem", href: "/docs/creem" },
   { name: "Stripe", href: "/docs/stripe" },
   { name: "Authentication", href: "/docs/authentication" },
   { name: "Architecture", href: "/docs/architecture" },

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -17,6 +17,7 @@ export const PAGE_TITLES: Record<string, string> = {
   mongoatlas: "MongoDB Atlas",
   resend: "Resend",
   stripe: "Stripe",
+  creem: "Creem",
   authentication: "Authentication",
   architecture: "Architecture",
 };

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -18,6 +18,7 @@ const oldDocsSlugs = [
   "mongoatlas",
   "resend",
   "stripe",
+  "creem",
   "authentication",
   "architecture",
 ];

--- a/packages/@emulators/core/src/ui.ts
+++ b/packages/@emulators/core/src/ui.ts
@@ -475,8 +475,8 @@ ${emuBar(service)}
   <div class="checkout-form-side">
     <form method="post" action="/checkout/${escapeAttr(opts.sessionId)}/complete">
       <div class="checkout-form-section">
-        <label class="checkout-form-label">Email</label>
-        <input type="email" name="email" class="checkout-input" placeholder="you@example.com"/>
+        <label class="checkout-form-label" for="checkout-email">Email</label>
+        <input id="checkout-email" type="email" name="email" class="checkout-input" placeholder="you@example.com" autocomplete="email" required/>
       </div>
       <div class="checkout-form-section">
         <label class="checkout-form-label">Card information</label>

--- a/packages/@emulators/core/src/webhooks.ts
+++ b/packages/@emulators/core/src/webhooks.ts
@@ -105,8 +105,16 @@ export class WebhookDispatcher {
 
       const signatureHeaders: Record<string, string> = {};
       if (sub.secret) {
-        const hmac = createHmac("sha256", sub.secret).update(body).digest("hex");
-        signatureHeaders["X-Hub-Signature-256"] = `sha256=${hmac}`;
+        if (sub.owner === "stripe") {
+          const timestamp = Math.floor(Date.now() / 1000);
+          const hmac = createHmac("sha256", sub.secret).update(`${timestamp}.${body}`).digest("hex");
+          signatureHeaders["Stripe-Signature"] = `t=${timestamp},v1=${hmac}`;
+        } else if (sub.owner === "creem") {
+          signatureHeaders["Creem-Signature"] = createHmac("sha256", sub.secret).update(body).digest("hex");
+        } else {
+          const hmac = createHmac("sha256", sub.secret).update(body).digest("hex");
+          signatureHeaders["X-Hub-Signature-256"] = `sha256=${hmac}`;
+        }
       }
 
       try {

--- a/packages/@emulators/creem/README.md
+++ b/packages/@emulators/creem/README.md
@@ -1,0 +1,33 @@
+# @emulators/creem
+
+Stateful Creem Test Mode emulation with hosted product checkout, signed webhooks, subscriptions, cancellation, and a local inspector.
+
+## Install
+
+```bash
+npm install @emulators/creem
+```
+
+## Start
+
+```bash
+npx emulate --service creem
+```
+
+## Seed configuration
+
+```yaml
+creem:
+  products:
+    - id: prod_console_dev
+      name: YapHaus managed relay
+      amount: 6900
+      currency: USD
+      return_url: http://127.0.0.1:4322/welcome
+  webhooks:
+    - url: http://127.0.0.1:8787/webhooks/creem
+      events: ["*"]
+      secret: local-webhook-secret
+```
+
+No real payment is processed. Completing hosted checkout emits a `checkout.completed` event with a `Creem-Signature` HMAC header. Use `POST /_creem/subscriptions/:id/cancel` to emit the terminal cancellation lifecycle event.

--- a/packages/@emulators/creem/package.json
+++ b/packages/@emulators/creem/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@emulators/creem",
+  "version": "0.9.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/creem"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/creem/src/__tests__/creem.test.ts
+++ b/packages/@emulators/creem/src/__tests__/creem.test.ts
@@ -1,0 +1,113 @@
+import { createHmac } from "node:crypto";
+import { Hono, Store, WebhookDispatcher } from "@emulators/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { creemPlugin, getCreemStore, seedFromConfig } from "../index.js";
+
+const baseUrl = "http://127.0.0.1:14001";
+const webhookSecret = "creem-local-webhook-secret";
+
+describe("Creem plugin", () => {
+  let app: Hono;
+  let store: Store;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = new Store();
+    const webhooks = new WebhookDispatcher();
+    app = new Hono();
+    creemPlugin.register(app as never, store, webhooks, baseUrl);
+    seedFromConfig(
+      store,
+      baseUrl,
+      {
+        products: [
+          {
+            id: "prod_console_dev",
+            name: "YapHaus managed relay",
+            amount: 6900,
+            currency: "USD",
+            return_url: "http://127.0.0.1:4322/welcome",
+          },
+        ],
+        webhooks: [
+          {
+            url: "http://127.0.0.1:8787/webhooks/creem",
+            events: ["*"],
+            secret: webhookSecret,
+          },
+        ],
+      },
+      webhooks,
+    );
+    fetchMock = vi.fn(async () => new Response(JSON.stringify({ accepted: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("completes hosted checkout, signs the real Creem shape, and redirects", async () => {
+    const checkoutId = "ch_4cb64de3bb274d998a74f3cc191e3e14";
+    const open = await app.request(
+      `${baseUrl}/test/payment/prod_console_dev?checkout_id=${checkoutId}&metadata%5Btenant_slug%5D=alpha&metadata%5Boffer_intent_id%5D=4cb64de3-bb27-4d99-8a74-f3cc191e3e14`,
+    );
+    expect(open.status).toBe(200);
+    const openHtml = await open.text();
+    expect(openHtml).toContain("YapHaus managed relay");
+    expect(openHtml).toContain('id="checkout-email"');
+    expect(openHtml).toContain('autocomplete="email" required');
+
+    const missingEmail = await app.request(`${baseUrl}/checkout/${checkoutId}/complete`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "",
+    });
+    expect(missingEmail.status).toBe(422);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const complete = await app.request(`${baseUrl}/checkout/${checkoutId}/complete`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "email=buyer%40example.com",
+    });
+    expect(complete.status).toBe(302);
+    expect(complete.headers.get("location")).toBe(`http://127.0.0.1:4322/welcome/checkout/${checkoutId}`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = String(init.body);
+    const headers = init.headers as Record<string, string>;
+    const event = JSON.parse(body);
+    expect(event.eventType).toBe("checkout.completed");
+    expect(event.object.status).toBe("completed");
+    expect(event.object.product).toEqual({ id: "prod_console_dev" });
+    expect(event.object.order).toMatchObject({ status: "paid", amount: 6900, currency: "USD" });
+    expect(event.object.customer.email).toBe("buyer@example.com");
+    expect(event.object.metadata.tenant_slug).toBe("alpha");
+    expect(headers["Creem-Signature"]).toBe(createHmac("sha256", webhookSecret).update(body).digest("hex"));
+  });
+
+  it("cancels a subscription and sends a signed lifecycle webhook", async () => {
+    const checkoutId = "ch_cancel_test";
+    await app.request(`${baseUrl}/test/payment/prod_console_dev?checkout_id=${checkoutId}`);
+    await app.request(`${baseUrl}/checkout/${checkoutId}/complete`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "email=test%40example.com",
+    });
+    fetchMock.mockClear();
+
+    const subscription = getCreemStore(store).subscriptions.all()[0]!;
+    const canceled = await app.request(`${baseUrl}/_creem/subscriptions/${subscription.creem_id}/cancel`, {
+      method: "POST",
+    });
+    expect(canceled.status).toBe(200);
+    expect((await canceled.json()) as { status: string }).toMatchObject({ status: "canceled" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const event = JSON.parse(String(init.body));
+    expect(event.eventType).toBe("subscription.canceled");
+    expect(event.object.id).toBe(subscription.creem_id);
+  });
+});

--- a/packages/@emulators/creem/src/entities.ts
+++ b/packages/@emulators/creem/src/entities.ts
@@ -1,0 +1,31 @@
+import type { Entity } from "@emulators/core";
+
+export interface CreemProduct extends Entity {
+  creem_id: string;
+  name: string;
+  description: string | null;
+  amount: number;
+  currency: string;
+  return_url: string | null;
+}
+
+export interface CreemCheckout extends Entity {
+  creem_id: string;
+  product_id: string;
+  status: "open" | "completed";
+  mode: "test";
+  metadata: Record<string, string>;
+  customer_id: string | null;
+  customer_email: string | null;
+  order_id: string | null;
+  subscription_id: string | null;
+}
+
+export interface CreemSubscription extends Entity {
+  creem_id: string;
+  checkout_id: string;
+  customer_id: string;
+  customer_email: string;
+  status: "active" | "canceled";
+  current_period_end_date: string;
+}

--- a/packages/@emulators/creem/src/index.ts
+++ b/packages/@emulators/creem/src/index.ts
@@ -1,0 +1,61 @@
+import type { AppEnv, Hono, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { creemRoutes } from "./routes.js";
+import { getCreemStore } from "./store.js";
+
+export { getCreemStore, type CreemStore } from "./store.js";
+export * from "./entities.js";
+
+export interface CreemSeedConfig {
+  port?: number;
+  products?: Array<{
+    id?: string;
+    name: string;
+    description?: string;
+    amount: number;
+    currency?: string;
+    return_url?: string;
+  }>;
+  webhooks?: Array<{
+    url: string;
+    events: string[];
+    secret?: string;
+  }>;
+}
+
+export function seedFromConfig(
+  store: Store,
+  _baseUrl: string,
+  config: CreemSeedConfig,
+  webhooks?: WebhookDispatcher,
+): void {
+  const cs = getCreemStore(store);
+  for (const product of config.products ?? []) {
+    if (product.id && cs.products.findOneBy("creem_id", product.id)) continue;
+    cs.products.insert({
+      creem_id: product.id ?? `prod_${String(cs.products.all().length + 1).padStart(4, "0")}`,
+      name: product.name,
+      description: product.description ?? null,
+      amount: product.amount,
+      currency: (product.currency ?? "USD").toUpperCase(),
+      return_url: product.return_url ?? null,
+    });
+  }
+  for (const webhook of config.webhooks ?? []) {
+    webhooks?.register({
+      url: webhook.url,
+      events: webhook.events,
+      active: true,
+      secret: webhook.secret,
+      owner: "creem",
+    });
+  }
+}
+
+export const creemPlugin: ServicePlugin = {
+  name: "creem",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    creemRoutes({ app, store, webhooks, baseUrl, tokenMap });
+  },
+};
+
+export default creemPlugin;

--- a/packages/@emulators/creem/src/routes.ts
+++ b/packages/@emulators/creem/src/routes.ts
@@ -1,0 +1,263 @@
+import { randomBytes } from "node:crypto";
+import {
+  escapeHtml,
+  renderCardPage,
+  renderCheckoutPage,
+  renderInspectorPage,
+  type CheckoutLineItem,
+  type RouteContext,
+} from "@emulators/core";
+import { getCreemStore } from "./store.js";
+
+const SERVICE_LABEL = "Creem";
+
+function creemId(prefix: string): string {
+  return `${prefix}_${randomBytes(12).toString("base64url").slice(0, 24)}`;
+}
+
+function metadataFromUrl(url: string): Record<string, string> {
+  const metadata: Record<string, string> = {};
+  for (const [key, value] of new URL(url).searchParams) {
+    const match = /^metadata\[([A-Za-z0-9_-]+)\]$/.exec(key);
+    if (match && value) metadata[match[1]] = value;
+  }
+  return metadata;
+}
+
+function completeEvent(
+  checkout: {
+    creem_id: string;
+    mode: "test";
+    metadata: Record<string, string>;
+    customer_id: string | null;
+    customer_email: string | null;
+    order_id: string | null;
+    subscription_id: string | null;
+  },
+  product: {
+    creem_id: string;
+    amount: number;
+    currency: string;
+  },
+) {
+  return {
+    id: creemId("evt"),
+    eventType: "checkout.completed",
+    created_at: Math.floor(Date.now() / 1000),
+    object: {
+      id: checkout.creem_id,
+      object: "checkout",
+      status: "completed",
+      mode: checkout.mode,
+      product: {
+        id: product.creem_id,
+      },
+      customer: {
+        id: checkout.customer_id,
+        email: checkout.customer_email,
+      },
+      order: {
+        id: checkout.order_id,
+        status: "paid",
+        amount: product.amount,
+        currency: product.currency,
+      },
+      subscription: {
+        id: checkout.subscription_id,
+      },
+      metadata: checkout.metadata,
+    },
+  };
+}
+
+function checkoutReturnUrl(value: string | null, checkoutId: string): string | null {
+  if (!value) return null;
+  if (value.includes("{CHECKOUT_ID}")) {
+    return value.replace("{CHECKOUT_ID}", encodeURIComponent(checkoutId));
+  }
+  const url = new URL(value);
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/checkout/${encodeURIComponent(checkoutId)}`;
+  return url.toString();
+}
+
+export function creemRoutes({ app, store, webhooks }: RouteContext): void {
+  const cs = getCreemStore(store);
+
+  const renderProductCheckout = (requestUrl: string, productId: string) => {
+    const product = cs.products.findOneBy("creem_id", productId);
+    if (!product) {
+      return renderCardPage(
+        "Product Not Found",
+        "This Creem test product is not configured.",
+        `<p class="empty">${escapeHtml(productId)}</p>`,
+        SERVICE_LABEL,
+      );
+    }
+    const url = new URL(requestUrl);
+    const requestedId = url.searchParams.get("checkout_id");
+    const checkoutId = requestedId && /^ch_[A-Za-z0-9_-]+$/.test(requestedId) ? requestedId : creemId("ch");
+    let checkout = cs.checkouts.findOneBy("creem_id", checkoutId);
+    if (!checkout) {
+      checkout = cs.checkouts.insert({
+        creem_id: checkoutId,
+        product_id: product.creem_id,
+        status: "open",
+        mode: "test",
+        metadata: metadataFromUrl(requestUrl),
+        customer_id: null,
+        customer_email: null,
+        order_id: null,
+        subscription_id: null,
+      });
+    }
+    const lineItems: CheckoutLineItem[] = [
+      {
+        name: product.name,
+        quantity: 1,
+        unitPrice: product.amount,
+        totalPrice: product.amount,
+        currency: product.currency,
+      },
+    ];
+    return renderCheckoutPage(
+      {
+        merchantName: "YapHaus",
+        lineItems,
+        subtotal: product.amount,
+        total: product.amount,
+        currency: product.currency,
+        sessionId: checkout.creem_id,
+      },
+      SERVICE_LABEL,
+    );
+  };
+
+  app.get("/test/payment/:productId", (c) => c.html(renderProductCheckout(c.req.url, c.req.param("productId"))));
+  app.get("/payment/:productId", (c) => c.html(renderProductCheckout(c.req.url, c.req.param("productId"))));
+
+  app.post("/checkout/:id/complete", async (c) => {
+    const checkout = cs.checkouts.findOneBy("creem_id", c.req.param("id"));
+    if (!checkout || checkout.status !== "open") {
+      return c.redirect(`/checkout/${encodeURIComponent(c.req.param("id"))}`);
+    }
+    const product = cs.products.findOneBy("creem_id", checkout.product_id);
+    if (!product) {
+      return c.html(
+        renderCardPage(
+          "Product Not Found",
+          "This Creem test product is not configured.",
+          '<p class="empty">Payment was not completed.</p>',
+          SERVICE_LABEL,
+        ),
+        404,
+      );
+    }
+    const submitted = await c.req.parseBody();
+    const email =
+      typeof submitted.email === "string" && submitted.email.includes("@")
+        ? submitted.email.trim().toLowerCase()
+        : "";
+    if (!email) {
+      return c.html(
+        renderCardPage(
+          "Email Required",
+          "Enter a customer email address to complete this test checkout.",
+          '<p class="empty">Payment was not completed.</p>',
+          SERVICE_LABEL,
+        ),
+        422,
+      );
+    }
+    const customerId = creemId("cust");
+    const orderId = creemId("ord");
+    const subscriptionId = creemId("sub");
+    const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    const completed = cs.checkouts.update(checkout.id, {
+      status: "completed",
+      customer_id: customerId,
+      customer_email: email,
+      order_id: orderId,
+      subscription_id: subscriptionId,
+    })!;
+    cs.subscriptions.insert({
+      creem_id: subscriptionId,
+      checkout_id: completed.creem_id,
+      customer_id: customerId,
+      customer_email: email,
+      status: "active",
+      current_period_end_date: periodEnd,
+    });
+    await webhooks.dispatch(
+      "checkout.completed",
+      undefined,
+      completeEvent(completed, product),
+      "creem",
+    );
+    const destination = checkoutReturnUrl(product.return_url, completed.creem_id);
+    if (destination) return c.redirect(destination);
+    return c.html(
+      renderCardPage(
+        "Payment Complete",
+        "Your test payment was successful.",
+        '<p class="empty check">Payment received</p>',
+        SERVICE_LABEL,
+      ),
+    );
+  });
+
+  app.post("/_creem/subscriptions/:id/cancel", async (c) => {
+    const subscription = cs.subscriptions.findOneBy("creem_id", c.req.param("id"));
+    if (!subscription) {
+      return c.json({ error: "subscription_not_found" }, 404);
+    }
+    const canceled = cs.subscriptions.update(subscription.id, { status: "canceled" })!;
+    const event = {
+      id: creemId("evt"),
+      eventType: "subscription.canceled",
+      created_at: Math.floor(Date.now() / 1000),
+      object: {
+        object: "subscription",
+        id: canceled.creem_id,
+        status: canceled.status,
+        customer: {
+          id: canceled.customer_id,
+          email: canceled.customer_email,
+        },
+        current_period_end_date: canceled.current_period_end_date,
+      },
+    };
+    await webhooks.dispatch("subscription.canceled", undefined, event, "creem");
+    return c.json(event.object);
+  });
+
+  app.get("/", (c) => {
+    const checkouts = cs.checkouts
+      .all()
+      .map(
+        (checkout) =>
+          `<tr><td>${escapeHtml(checkout.creem_id)}</td><td>${escapeHtml(checkout.product_id)}</td><td>${escapeHtml(checkout.status)}</td></tr>`,
+      )
+      .join("");
+    const subscriptions = cs.subscriptions
+      .all()
+      .map(
+        (subscription) =>
+          `<tr><td>${escapeHtml(subscription.creem_id)}</td><td>${escapeHtml(subscription.customer_email)}</td><td>${escapeHtml(subscription.status)}</td></tr>`,
+      )
+      .join("");
+    return c.html(
+      renderInspectorPage(
+        "Creem",
+        [
+          { id: "checkouts", label: "Checkouts", href: "/?tab=checkouts" },
+          { id: "subscriptions", label: "Subscriptions", href: "/?tab=subscriptions" },
+        ],
+        c.req.query("tab") === "subscriptions" ? "subscriptions" : "checkouts",
+        c.req.query("tab") === "subscriptions"
+          ? `<section class="inspector-section"><h2>Subscriptions</h2><table class="inspector-table"><thead><tr><th>ID</th><th>Customer</th><th>Status</th></tr></thead><tbody>${subscriptions}</tbody></table></section>`
+          : `<section class="inspector-section"><h2>Checkouts</h2><table class="inspector-table"><thead><tr><th>ID</th><th>Product</th><th>Status</th></tr></thead><tbody>${checkouts}</tbody></table></section>`,
+        SERVICE_LABEL,
+      ),
+    );
+  });
+}

--- a/packages/@emulators/creem/src/store.ts
+++ b/packages/@emulators/creem/src/store.ts
@@ -1,0 +1,20 @@
+import { Store, type Collection } from "@emulators/core";
+import type { CreemCheckout, CreemProduct, CreemSubscription } from "./entities.js";
+
+export interface CreemStore {
+  products: Collection<CreemProduct>;
+  checkouts: Collection<CreemCheckout>;
+  subscriptions: Collection<CreemSubscription>;
+}
+
+export function getCreemStore(store: Store): CreemStore {
+  return {
+    products: store.collection<CreemProduct>("creem.products", ["creem_id"]),
+    checkouts: store.collection<CreemCheckout>("creem.checkouts", ["creem_id", "product_id"]),
+    subscriptions: store.collection<CreemSubscription>("creem.subscriptions", [
+      "creem_id",
+      "checkout_id",
+      "customer_id",
+    ]),
+  };
+}

--- a/packages/@emulators/creem/tsconfig.json
+++ b/packages/@emulators/creem/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/creem/tsup.config.ts
+++ b/packages/@emulators/creem/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/@emulators/creem/vitest.config.ts
+++ b/packages/@emulators/creem/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/@emulators/stripe/src/__tests__/stripe.test.ts
+++ b/packages/@emulators/stripe/src/__tests__/stripe.test.ts
@@ -414,7 +414,7 @@ describe("Stripe plugin", () => {
           livemode: false,
         });
         expect(session.customer.email).toBe("buyer@example.com");
-        expect(session.subscription.id).toMatch(/^sub_/);
+        expect(session.subscription.id).toMatch(/^sub_[A-Za-z0-9]+$/);
         expect(session.line_items.data[0].price).toMatchObject({
           id: "price_console_dev",
           type: "recurring",

--- a/packages/@emulators/stripe/src/__tests__/stripe.test.ts
+++ b/packages/@emulators/stripe/src/__tests__/stripe.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { createHmac } from "node:crypto";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Hono } from "@emulators/core";
 import {
   Store,
@@ -42,11 +43,13 @@ function auth(): Record<string, string> {
 describe("Stripe plugin", () => {
   let app: Hono;
   let webhooks: WebhookDispatcher;
+  let store: Store;
 
   beforeEach(() => {
     const ctx = createTestApp();
     app = ctx.app;
     webhooks = ctx.webhooks;
+    store = ctx.store;
   });
 
   describe("customers", () => {
@@ -325,6 +328,162 @@ describe("Stripe plugin", () => {
   });
 
   describe("checkout sessions", () => {
+    it("supports a packaged YapHaus subscription checkout with signed webhook and authoritative retrieval", async () => {
+      seedFromConfig(
+        store,
+        base,
+        {
+          api_version: "2026-06-24.preview",
+          products: [{ id: "prod_console_dev", name: "YapHaus managed relay" }],
+          prices: [
+            {
+              id: "price_console_dev",
+              product_name: "YapHaus managed relay",
+              currency: "usd",
+              unit_amount: 6900,
+              tax_behavior: "inclusive",
+              recurring: { interval: "month", interval_count: 1, usage_type: "licensed" },
+            },
+          ],
+          webhooks: [
+            {
+              url: "http://127.0.0.1:8787/webhooks/stripe",
+              events: ["*"],
+              secret: "whsec_local_stripe_secret",
+            },
+          ],
+        },
+        webhooks,
+      );
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify({ accepted: true }), { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      try {
+        const createRes = await app.request(`${base}/v1/checkout/sessions`, {
+          method: "POST",
+          headers: auth(),
+          body: JSON.stringify({
+            mode: "subscription",
+            line_items: [{ price: "price_console_dev", quantity: 1 }],
+            client_reference_id: "4cb64de3-bb27-4d99-8a74-f3cc191e3e14",
+            metadata: {
+              offer_intent_id: "4cb64de3-bb27-4d99-8a74-f3cc191e3e14",
+              terms_version: "2026-07-30",
+            },
+            success_url: "http://127.0.0.1:4322/welcome/checkout/{CHECKOUT_SESSION_ID}",
+          }),
+        });
+        expect(createRes.status).toBe(200);
+        const created = (await createRes.json()) as { id: string; url: string };
+        expect(created.id).toMatch(/^cs_test_/);
+        expect(created.url).toBe(`${base}/checkout/${created.id}`);
+
+        const hostedCheckout = await app.request(created.url);
+        const hostedCheckoutHtml = await hostedCheckout.text();
+        expect(hostedCheckoutHtml).toContain('id="checkout-email"');
+        expect(hostedCheckoutHtml).toContain('autocomplete="email" required');
+
+        const missingEmail = await app.request(`${base}/checkout/${created.id}/complete`, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "",
+        });
+        expect(missingEmail.status).toBe(422);
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        const completed = await app.request(`${base}/checkout/${created.id}/complete`, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "email=buyer%40example.com",
+        });
+        expect(completed.status).toBe(302);
+        expect(completed.headers.get("location")).toBe(`http://127.0.0.1:4322/welcome/checkout/${created.id}`);
+
+        const authoritative = await app.request(`${base}/v1/checkout/sessions/${created.id}`, {
+          headers: auth(),
+        });
+        const session = (await authoritative.json()) as Record<string, any>;
+        expect(session).toMatchObject({
+          id: created.id,
+          mode: "subscription",
+          status: "complete",
+          payment_status: "paid",
+          client_reference_id: "4cb64de3-bb27-4d99-8a74-f3cc191e3e14",
+          amount_subtotal: 6900,
+          currency: "usd",
+          livemode: false,
+        });
+        expect(session.customer.email).toBe("buyer@example.com");
+        expect(session.subscription.id).toMatch(/^sub_/);
+        expect(session.line_items.data[0].price).toMatchObject({
+          id: "price_console_dev",
+          type: "recurring",
+          billing_scheme: "per_unit",
+          tax_behavior: "inclusive",
+          unit_amount: 6900,
+          recurring: { interval: "month", interval_count: 1, usage_type: "licensed" },
+        });
+        const subscriptionResponse = await app.request(
+          `${base}/v1/subscriptions/${session.subscription.id}?expand[]=items.data.price.product`,
+          { headers: auth() },
+        );
+        const subscription = (await subscriptionResponse.json()) as Record<string, any>;
+        expect(subscription.items.data).toHaveLength(1);
+        expect(subscription.items.data[0]).toMatchObject({
+          quantity: 1,
+          price: {
+            id: "price_console_dev",
+            unit_amount: 6900,
+            currency: "usd",
+            tax_behavior: "inclusive",
+            product: { id: "prod_console_dev", active: true },
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const body = String(init.body);
+        const headers = init.headers as Record<string, string>;
+        const signature = headers["Stripe-Signature"];
+        expect(signature).toMatch(/^t=\d+,v1=[0-9a-f]{64}$/);
+        const timestamp = signature.split(",")[0]!.slice(2);
+        const expected = createHmac("sha256", "whsec_local_stripe_secret").update(`${timestamp}.${body}`).digest("hex");
+        expect(signature).toBe(`t=${timestamp},v1=${expected}`);
+        const event = JSON.parse(body);
+        expect(event).toMatchObject({
+          api_version: "2026-06-24.preview",
+          livemode: false,
+          type: "checkout.session.completed",
+        });
+
+        fetchMock.mockClear();
+        const canceledResponse = await app.request(
+          `${base}/v1/subscriptions/${session.subscription.id}`,
+          { method: "DELETE", headers: auth() },
+        );
+        const canceled = (await canceledResponse.json()) as Record<string, any>;
+        expect(canceled.status).toBe("canceled");
+        expect(canceled.items.data[0].price.product.id).toBe("prod_console_dev");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [, cancelInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const cancelBody = String(cancelInit.body);
+        const cancelHeaders = cancelInit.headers as Record<string, string>;
+        expect(cancelHeaders["Stripe-Signature"]).toMatch(/^t=\d+,v1=[0-9a-f]{64}$/);
+        expect(JSON.parse(cancelBody)).toMatchObject({
+          type: "customer.subscription.deleted",
+          data: {
+            object: {
+              id: session.subscription.id,
+              status: "canceled",
+              items: { data: [{ price: { id: "price_console_dev" } }] },
+            },
+          },
+        });
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
     it("creates and expires a checkout session", async () => {
       const createRes = await app.request(`${base}/v1/checkout/sessions`, {
         method: "POST",

--- a/packages/@emulators/stripe/src/__tests__/stripe.test.ts
+++ b/packages/@emulators/stripe/src/__tests__/stripe.test.ts
@@ -507,6 +507,80 @@ describe("Stripe plugin", () => {
       expect(expired.url).toBeNull();
     });
 
+    it("completes payment and setup sessions without creating subscriptions", async () => {
+      for (const mode of ["payment", "setup"] as const) {
+        const createRes = await app.request(`${base}/v1/checkout/sessions`, {
+          method: "POST",
+          headers: auth(),
+          body: JSON.stringify({ mode }),
+        });
+        expect(createRes.status).toBe(200);
+        const created = (await createRes.json()) as { id: string };
+
+        const completed = await app.request(`${base}/checkout/${created.id}/complete`, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: `email=${mode}%40example.com`,
+        });
+        expect(completed.status).toBe(200);
+
+        const authoritative = await app.request(`${base}/v1/checkout/sessions/${created.id}`, {
+          headers: auth(),
+        });
+        const session = (await authoritative.json()) as Record<string, any>;
+        expect(session).toMatchObject({
+          id: created.id,
+          mode,
+          status: "complete",
+          payment_status: mode === "setup" ? "no_payment_required" : "paid",
+          subscription: null,
+        });
+        if (mode === "payment") {
+          expect(session.payment_intent).toMatchObject({ status: "succeeded" });
+          const paymentIntent = await app.request(`${base}/v1/payment_intents/${session.payment_intent.id}`, {
+            headers: auth(),
+          });
+          expect(paymentIntent.status).toBe(200);
+          expect(await paymentIntent.json()).toMatchObject({
+            id: session.payment_intent.id,
+            amount: 0,
+            currency: "usd",
+            status: "succeeded",
+          });
+        } else {
+          expect(session.payment_intent).toBeNull();
+        }
+      }
+    });
+
+    it("rejects a subscription completion without a line item", async () => {
+      const createRes = await app.request(`${base}/v1/checkout/sessions`, {
+        method: "POST",
+        headers: auth(),
+        body: JSON.stringify({ mode: "subscription" }),
+      });
+      expect(createRes.status).toBe(200);
+      const created = (await createRes.json()) as { id: string };
+
+      const completed = await app.request(`${base}/checkout/${created.id}/complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: "email=subscription%40example.com",
+      });
+      expect(completed.status).toBe(422);
+      expect(await completed.text()).toContain("A subscription checkout needs at least one line item.");
+
+      const authoritative = await app.request(`${base}/v1/checkout/sessions/${created.id}`, {
+        headers: auth(),
+      });
+      expect(await authoritative.json()).toMatchObject({
+        id: created.id,
+        status: "open",
+        subscription: null,
+        payment_intent: null,
+      });
+    });
+
     it("lists with status filter", async () => {
       await app.request(`${base}/v1/checkout/sessions`, {
         method: "POST",

--- a/packages/@emulators/stripe/src/entities.ts
+++ b/packages/@emulators/stripe/src/entities.ts
@@ -22,6 +22,13 @@ export interface StripePrice extends Entity {
   currency: string;
   unit_amount: number | null;
   type: "one_time" | "recurring";
+  billing_scheme: "per_unit";
+  tax_behavior: "inclusive" | "exclusive" | "unspecified";
+  recurring: {
+    interval: "day" | "week" | "month" | "year";
+    interval_count: number;
+    usage_type: "licensed" | "metered" | null;
+  } | null;
   active: boolean;
   metadata: Record<string, string>;
 }
@@ -62,8 +69,23 @@ export interface StripeCheckoutSession extends Entity {
   status: "open" | "complete" | "expired";
   payment_status: "paid" | "unpaid" | "no_payment_required";
   customer_id: string | null;
+  client_reference_id: string | null;
   success_url: string | null;
   cancel_url: string | null;
+  expires_at: number | null;
   line_items: Array<{ price: string; quantity: number }>;
+  metadata: Record<string, string>;
+  subscription_id: string | null;
+  payment_intent_id: string | null;
+}
+
+export interface StripeSubscription extends Entity {
+  stripe_id: string;
+  customer_id: string;
+  price_id: string;
+  quantity: number;
+  status: "active" | "canceled";
+  current_period_end: number;
+  cancel_at_period_end: boolean;
   metadata: Record<string, string>;
 }

--- a/packages/@emulators/stripe/src/helpers.ts
+++ b/packages/@emulators/stripe/src/helpers.ts
@@ -14,7 +14,7 @@ const NUMERIC_KEYS = new Set([
 ]);
 
 export function stripeId(prefix: string): string {
-  return `${prefix}_${randomBytes(12).toString("base64url").slice(0, 24)}`;
+  return `${prefix}_${randomBytes(12).toString("hex")}`;
 }
 
 export function toUnixTimestamp(iso: string): number {

--- a/packages/@emulators/stripe/src/index.ts
+++ b/packages/@emulators/stripe/src/index.ts
@@ -10,6 +10,7 @@ import { productRoutes } from "./routes/products.js";
 import { priceRoutes } from "./routes/prices.js";
 import { checkoutSessionRoutes } from "./routes/checkout-sessions.js";
 import { customerSessionRoutes } from "./routes/customer-sessions.js";
+import { subscriptionRoutes } from "./routes/subscriptions.js";
 
 export { getStripeStore, type StripeStore } from "./store.js";
 export * from "./entities.js";
@@ -32,7 +33,14 @@ export interface StripeSeedConfig {
     product_name: string;
     currency: string;
     unit_amount: number;
+    tax_behavior?: "inclusive" | "exclusive" | "unspecified";
+    recurring?: {
+      interval?: "day" | "week" | "month" | "year";
+      interval_count?: number;
+      usage_type?: "licensed" | "metered";
+    };
   }>;
+  api_version?: string;
   webhooks?: Array<{
     url: string;
     events: string[];
@@ -59,6 +67,7 @@ export function seedFromConfig(
   webhooks?: WebhookDispatcher,
 ): void {
   const ss = getStripeStore(store);
+  store.setData("stripe.api_version", config.api_version ?? "2026-06-24.preview");
 
   if (config.customers) {
     for (const c of config.customers) {
@@ -93,7 +102,16 @@ export function seedFromConfig(
           product_id: product.stripe_id,
           currency: pr.currency.toLowerCase(),
           unit_amount: pr.unit_amount,
-          type: "one_time",
+          billing_scheme: "per_unit",
+          tax_behavior: pr.tax_behavior ?? "unspecified",
+          recurring: pr.recurring
+            ? {
+                interval: pr.recurring.interval ?? "month",
+                interval_count: pr.recurring.interval_count ?? 1,
+                usage_type: pr.recurring.usage_type ?? "licensed",
+              }
+            : null,
+          type: pr.recurring ? "recurring" : "one_time",
           active: true,
           metadata: {},
         });
@@ -125,6 +143,7 @@ export const stripePlugin: ServicePlugin = {
     productRoutes(ctx);
     priceRoutes(ctx);
     checkoutSessionRoutes(ctx);
+    subscriptionRoutes(ctx);
     customerSessionRoutes(ctx);
   },
   seed(store: Store, baseUrl: string): void {

--- a/packages/@emulators/stripe/src/routes/checkout-sessions.ts
+++ b/packages/@emulators/stripe/src/routes/checkout-sessions.ts
@@ -371,6 +371,18 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
         422,
       );
     }
+    const subscriptionLineItem = session.mode === "subscription" ? session.line_items[0] : null;
+    if (session.mode === "subscription" && !subscriptionLineItem) {
+      return c.html(
+        renderCardPage(
+          "Line Item Required",
+          "A subscription checkout needs at least one line item.",
+          '<p class="empty">Payment was not completed.</p>',
+          SERVICE_LABEL,
+        ),
+        422,
+      );
+    }
     let customer = session.customer_id ? ss.customers.findOneBy("stripe_id", session.customer_id) : undefined;
     if (!customer) {
       customer = ss.customers.insert({
@@ -381,22 +393,41 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
         metadata: {},
       });
     }
-    const paymentIntentId = stripeId("pi");
-    const subscription = ss.subscriptions.insert({
-      stripe_id: stripeId("sub"),
-      customer_id: customer.stripe_id,
-      price_id: session.line_items[0]!.price,
-      quantity: session.line_items[0]!.quantity,
-      status: "active",
-      current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
-      cancel_at_period_end: false,
-      metadata: { offer_intent_id: session.metadata.offer_intent_id ?? "" },
-    });
+    let paymentIntentId: string | null = null;
+    let subscriptionId: string | null = null;
+
+    if (subscriptionLineItem) {
+      paymentIntentId = stripeId("pi");
+      const subscription = ss.subscriptions.insert({
+        stripe_id: stripeId("sub"),
+        customer_id: customer.stripe_id,
+        price_id: subscriptionLineItem.price,
+        quantity: subscriptionLineItem.quantity,
+        status: "active",
+        current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+        cancel_at_period_end: false,
+        metadata: { offer_intent_id: session.metadata.offer_intent_id ?? "" },
+      });
+      subscriptionId = subscription.stripe_id;
+    } else if (session.mode === "payment") {
+      const paymentIntent = ss.paymentIntents.insert({
+        stripe_id: stripeId("pi"),
+        amount: sessionAmount(session, ss),
+        currency: sessionCurrency(session, ss),
+        status: "succeeded",
+        customer_id: customer.stripe_id,
+        description: "Checkout session payment",
+        payment_method: null,
+        metadata: session.metadata,
+      });
+      paymentIntentId = paymentIntent.stripe_id;
+    }
+
     const updated = ss.checkoutSessions.update(session.id, {
       status: "complete",
-      payment_status: "paid",
+      payment_status: session.mode === "setup" ? "no_payment_required" : "paid",
       customer_id: customer.stripe_id,
-      subscription_id: subscription.stripe_id,
+      subscription_id: subscriptionId,
       payment_intent_id: paymentIntentId,
     })!;
     const formatted = formatSession(updated, baseUrl, ss);

--- a/packages/@emulators/stripe/src/routes/checkout-sessions.ts
+++ b/packages/@emulators/stripe/src/routes/checkout-sessions.ts
@@ -1,26 +1,166 @@
-import type { RouteContext } from "@emulators/core";
-import { renderCardPage, renderCheckoutPage, escapeHtml, escapeAttr } from "@emulators/core";
-import type { CheckoutLineItem } from "@emulators/core";
-import { getStripeStore } from "../store.js";
+import type { RouteContext, CheckoutLineItem } from "@emulators/core";
+import { renderCardPage, renderCheckoutPage, escapeHtml } from "@emulators/core";
+import { getStripeStore, type StripeStore } from "../store.js";
 import { stripeId, toUnixTimestamp, parseStripeBody, stripeError, stripeList } from "../helpers.js";
-import type { StripeCheckoutSession } from "../entities.js";
+import type { StripeCheckoutSession, StripePrice, StripeProduct } from "../entities.js";
+import { formatSubscription } from "./subscriptions.js";
 
 const SERVICE_LABEL = "Stripe";
 
-function formatSession(s: StripeCheckoutSession, baseUrl: string) {
+function formatProduct(product: StripeProduct) {
   return {
-    id: s.stripe_id,
-    object: "checkout.session",
-    mode: s.mode,
-    status: s.status,
-    payment_status: s.payment_status,
-    customer: s.customer_id,
-    success_url: s.success_url,
-    cancel_url: s.cancel_url,
-    metadata: s.metadata,
-    created: toUnixTimestamp(s.created_at),
+    id: product.stripe_id,
+    object: "product",
+    name: product.name,
+    description: product.description,
+    active: product.active,
+    metadata: product.metadata,
+    created: toUnixTimestamp(product.created_at),
     livemode: false,
-    url: s.status === "open" ? `${baseUrl}/checkout/${s.stripe_id}` : null,
+  };
+}
+
+function formatPrice(price: StripePrice, ss: StripeStore) {
+  const product = ss.products.findOneBy("stripe_id", price.product_id);
+  return {
+    id: price.stripe_id,
+    object: "price",
+    product: product ? formatProduct(product) : price.product_id,
+    currency: price.currency,
+    unit_amount: price.unit_amount,
+    type: price.type,
+    billing_scheme: price.billing_scheme,
+    tax_behavior: price.tax_behavior,
+    recurring: price.recurring,
+    active: price.active,
+    metadata: price.metadata,
+    created: toUnixTimestamp(price.created_at),
+    livemode: false,
+  };
+}
+
+function sessionAmount(session: StripeCheckoutSession, ss: StripeStore): number {
+  return session.line_items.reduce((sum, item) => {
+    const price = ss.prices.findOneBy("stripe_id", item.price);
+    return sum + (price?.unit_amount ?? 0) * item.quantity;
+  }, 0);
+}
+
+function sessionCurrency(session: StripeCheckoutSession, ss: StripeStore): string {
+  const first = session.line_items[0];
+  return (first && ss.prices.findOneBy("stripe_id", first.price)?.currency) || "usd";
+}
+
+function formatSession(session: StripeCheckoutSession, baseUrl: string, ss: StripeStore) {
+  const customer = session.customer_id ? ss.customers.findOneBy("stripe_id", session.customer_id) : undefined;
+  const subscription = session.subscription_id
+    ? ss.subscriptions.findOneBy("stripe_id", session.subscription_id)
+    : undefined;
+  const amount = sessionAmount(session, ss);
+  const currency = sessionCurrency(session, ss);
+  const paymentIntent = session.payment_intent_id
+    ? {
+        id: session.payment_intent_id,
+        object: "payment_intent",
+        amount,
+        currency,
+        customer: session.customer_id,
+        status: "succeeded",
+        livemode: false,
+      }
+    : null;
+  const lineItems = session.line_items.map((item) => {
+    const price = ss.prices.findOneBy("stripe_id", item.price);
+    return {
+      id: stripeId("li"),
+      object: "item",
+      amount_subtotal: (price?.unit_amount ?? 0) * item.quantity,
+      amount_total: (price?.unit_amount ?? 0) * item.quantity,
+      currency: price?.currency ?? currency,
+      quantity: item.quantity,
+      price: price ? formatPrice(price, ss) : item.price,
+    };
+  });
+  return {
+    id: session.stripe_id,
+    object: "checkout.session",
+    mode: session.mode,
+    status: session.status,
+    payment_status: session.payment_status,
+    customer: customer
+      ? {
+          id: customer.stripe_id,
+          object: "customer",
+          email: customer.email,
+          name: customer.name,
+          livemode: false,
+        }
+      : null,
+    customer_details: customer ? { email: customer.email, name: customer.name } : null,
+    client_reference_id: session.client_reference_id,
+    success_url: session.success_url,
+    cancel_url: session.cancel_url,
+    expires_at: session.expires_at,
+    metadata: session.metadata,
+    amount_subtotal: amount,
+    amount_total: amount,
+    currency,
+    line_items: {
+      object: "list",
+      data: lineItems,
+      has_more: false,
+      url: `/v1/checkout/sessions/${session.stripe_id}/line_items`,
+    },
+    subscription: subscription
+      ? {
+          ...formatSubscription(subscription, ss),
+          customer: customer
+            ? {
+                id: customer.stripe_id,
+                object: "customer",
+                email: customer.email,
+                name: customer.name,
+                livemode: false,
+              }
+            : subscription.customer_id,
+          latest_invoice: {
+            id: stripeId("in"),
+            object: "invoice",
+            payment_intent: paymentIntent,
+            payments: {
+              object: "list",
+              data: paymentIntent
+                ? [
+                    {
+                      object: "invoice_payment",
+                      payment: {
+                        type: "payment_intent",
+                        payment_intent: paymentIntent.id,
+                      },
+                    },
+                  ]
+                : [],
+            },
+          },
+        }
+      : null,
+    payment_intent: paymentIntent,
+    created: toUnixTimestamp(session.created_at),
+    livemode: false,
+    url: session.status === "open" ? `${baseUrl}/checkout/${session.stripe_id}` : null,
+  };
+}
+
+function stripeEvent(store: RouteContext["store"], type: string, object: Record<string, unknown>) {
+  return {
+    id: stripeId("evt"),
+    object: "event",
+    api_version: store.getData<string>("stripe.api_version") ?? "2026-06-24.preview",
+    created: Math.floor(Date.now() / 1000),
+    data: { object },
+    livemode: false,
+    pending_webhooks: 1,
+    type,
   };
 }
 
@@ -29,9 +169,9 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
 
   app.post("/v1/checkout/sessions", async (c) => {
     const body = await parseStripeBody(c);
-    if (!body.mode)
+    if (!body.mode) {
       return stripeError(c, 400, "invalid_request_error", "Missing required param: mode.", undefined, "mode");
-
+    }
     if (body.customer && !ss.customers.findOneBy("stripe_id", body.customer as string)) {
       return stripeError(
         c,
@@ -49,18 +189,8 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
         return stripeError(c, 400, "invalid_request_error", "line_items must be an array.", undefined, "line_items");
       }
       for (let i = 0; i < body.line_items.length; i++) {
-        const li = body.line_items[i] as Record<string, unknown>;
-        if (!li || typeof li !== "object") {
-          return stripeError(
-            c,
-            400,
-            "invalid_request_error",
-            `Invalid line_items[${i}]: must be an object.`,
-            undefined,
-            `line_items[${i}]`,
-          );
-        }
-        if (!li.price || typeof li.price !== "string") {
+        const item = body.line_items[i] as Record<string, unknown>;
+        if (!item?.price || typeof item.price !== "string") {
           return stripeError(
             c,
             400,
@@ -70,18 +200,18 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
             `line_items[${i}][price]`,
           );
         }
-        if (!ss.prices.findOneBy("stripe_id", li.price)) {
+        if (!ss.prices.findOneBy("stripe_id", item.price)) {
           return stripeError(
             c,
             400,
             "invalid_request_error",
-            `No such price: '${li.price}'`,
+            `No such price: '${item.price}'`,
             "resource_missing",
             `line_items[${i}][price]`,
           );
         }
-        const qty = typeof li.quantity === "number" ? li.quantity : parseInt(li.quantity as string, 10);
-        if (!Number.isFinite(qty) || qty < 1) {
+        const quantity = typeof item.quantity === "number" ? item.quantity : Number(item.quantity ?? 1);
+        if (!Number.isSafeInteger(quantity) || quantity < 1) {
           return stripeError(
             c,
             400,
@@ -91,27 +221,31 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
             `line_items[${i}][quantity]`,
           );
         }
-        lineItems.push({ price: li.price, quantity: qty });
+        lineItems.push({ price: item.price, quantity });
       }
     }
 
     const session = ss.checkoutSessions.insert({
-      stripe_id: stripeId("cs"),
+      stripe_id: stripeId("cs_test"),
       mode: body.mode as StripeCheckoutSession["mode"],
       status: "open",
       payment_status: "unpaid",
       customer_id: (body.customer as string) ?? null,
+      client_reference_id: (body.client_reference_id as string) ?? null,
       success_url: (body.success_url as string) ?? null,
       cancel_url: (body.cancel_url as string) ?? null,
+      expires_at: typeof body.expires_at === "number" ? body.expires_at : null,
       line_items: lineItems,
       metadata: (body.metadata as Record<string, string>) ?? {},
+      subscription_id: null,
+      payment_intent_id: null,
     });
-    return c.json(formatSession(session, baseUrl), 200);
+    return c.json(formatSession(session, baseUrl, ss), 200);
   });
 
   app.get("/v1/checkout/sessions/:id", (c) => {
     const session = ss.checkoutSessions.findOneBy("stripe_id", c.req.param("id"));
-    if (!session)
+    if (!session) {
       return stripeError(
         c,
         404,
@@ -119,12 +253,13 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
         `No such checkout session: '${c.req.param("id")}'`,
         "resource_missing",
       );
-    return c.json(formatSession(session, baseUrl));
+    }
+    return c.json(formatSession(session, baseUrl, ss));
   });
 
   app.post("/v1/checkout/sessions/:id/expire", async (c) => {
     const session = ss.checkoutSessions.findOneBy("stripe_id", c.req.param("id"));
-    if (!session)
+    if (!session) {
       return stripeError(
         c,
         404,
@@ -132,6 +267,7 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
         `No such checkout session: '${c.req.param("id")}'`,
         "resource_missing",
       );
+    }
     if (session.status !== "open") {
       return stripeError(
         c,
@@ -142,15 +278,14 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
       );
     }
     const updated = ss.checkoutSessions.update(session.id, { status: "expired" })!;
-
+    const formatted = formatSession(updated, baseUrl, ss);
     await webhooks.dispatch(
       "checkout.session.expired",
       undefined,
-      { type: "checkout.session.expired", data: { object: formatSession(updated, baseUrl) } },
+      stripeEvent(store, "checkout.session.expired", formatted),
       "stripe",
     );
-
-    return c.json(formatSession(updated, baseUrl));
+    return c.json(formatted);
   });
 
   app.get("/v1/checkout/sessions", (c) => {
@@ -158,10 +293,10 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
     const customerId = c.req.query("customer");
     const status = c.req.query("status");
     const paymentStatus = c.req.query("payment_status");
-    if (customerId) items = items.filter((s) => s.customer_id === customerId);
-    if (status) items = items.filter((s) => s.status === status);
-    if (paymentStatus) items = items.filter((s) => s.payment_status === paymentStatus);
-    return stripeList(c, items, "/v1/checkout/sessions", (s) => formatSession(s, baseUrl));
+    if (customerId) items = items.filter((session) => session.customer_id === customerId);
+    if (status) items = items.filter((session) => session.status === status);
+    if (paymentStatus) items = items.filter((session) => session.payment_status === paymentStatus);
+    return stripeList(c, items, "/v1/checkout/sessions", (session) => formatSession(session, baseUrl, ss));
   });
 
   app.get("/checkout/:id", (c) => {
@@ -188,25 +323,24 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
       );
     }
 
-    const lineItems: CheckoutLineItem[] = session.line_items.map((li) => {
-      const priceObj = ss.prices.findOneBy("stripe_id", li.price);
-      const product = priceObj ? ss.products.findOneBy("stripe_id", priceObj.product_id) : null;
-      const unitPrice = priceObj?.unit_amount ?? 0;
+    const lineItems: CheckoutLineItem[] = session.line_items.map((item) => {
+      const price = ss.prices.findOneBy("stripe_id", item.price);
+      const product = price ? ss.products.findOneBy("stripe_id", price.product_id) : null;
+      const unitPrice = price?.unit_amount ?? 0;
       return {
-        name: product?.name ?? li.price,
-        quantity: li.quantity,
+        name: product?.name ?? item.price,
+        quantity: item.quantity,
         unitPrice,
-        totalPrice: unitPrice * li.quantity,
-        currency: priceObj?.currency ?? "usd",
+        totalPrice: unitPrice * item.quantity,
+        currency: price?.currency ?? "usd",
       };
     });
-
-    const subtotal = lineItems.reduce((sum, li) => sum + li.totalPrice, 0);
-    const currency = lineItems.length > 0 ? lineItems[0].currency : "usd";
-
+    const subtotal = lineItems.reduce((sum, item) => sum + item.totalPrice, 0);
+    const currency = lineItems[0]?.currency ?? "usd";
     return c.html(
       renderCheckoutPage(
         {
+          merchantName: "YapHaus",
           lineItems,
           subtotal,
           total: subtotal,
@@ -222,23 +356,59 @@ export function checkoutSessionRoutes({ app, store, webhooks, baseUrl }: RouteCo
   app.post("/checkout/:id/complete", async (c) => {
     const session = ss.checkoutSessions.findOneBy("stripe_id", c.req.param("id"));
     if (!session || session.status !== "open") {
-      return c.redirect("/checkout/" + c.req.param("id"));
+      return c.redirect(`/checkout/${c.req.param("id")}`);
     }
-
-    const updated = ss.checkoutSessions.update(session.id, { status: "complete", payment_status: "paid" })!;
-
+    const submitted = await c.req.parseBody();
+    const submittedEmail = typeof submitted.email === "string" ? submitted.email.trim().toLowerCase() : "";
+    if (!submittedEmail || !submittedEmail.includes("@")) {
+      return c.html(
+        renderCardPage(
+          "Email Required",
+          "Enter a customer email address to complete this test checkout.",
+          '<p class="empty">Payment was not completed.</p>',
+          SERVICE_LABEL,
+        ),
+        422,
+      );
+    }
+    let customer = session.customer_id ? ss.customers.findOneBy("stripe_id", session.customer_id) : undefined;
+    if (!customer) {
+      customer = ss.customers.insert({
+        stripe_id: stripeId("cus"),
+        email: submittedEmail,
+        name: "Test Customer",
+        description: "Hosted checkout customer",
+        metadata: {},
+      });
+    }
+    const paymentIntentId = stripeId("pi");
+    const subscription = ss.subscriptions.insert({
+      stripe_id: stripeId("sub"),
+      customer_id: customer.stripe_id,
+      price_id: session.line_items[0]!.price,
+      quantity: session.line_items[0]!.quantity,
+      status: "active",
+      current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+      cancel_at_period_end: false,
+      metadata: { offer_intent_id: session.metadata.offer_intent_id ?? "" },
+    });
+    const updated = ss.checkoutSessions.update(session.id, {
+      status: "complete",
+      payment_status: "paid",
+      customer_id: customer.stripe_id,
+      subscription_id: subscription.stripe_id,
+      payment_intent_id: paymentIntentId,
+    })!;
+    const formatted = formatSession(updated, baseUrl, ss);
     await webhooks.dispatch(
       "checkout.session.completed",
       undefined,
-      { type: "checkout.session.completed", data: { object: formatSession(updated, baseUrl) } },
+      stripeEvent(store, "checkout.session.completed", formatted),
       "stripe",
     );
-
     if (session.success_url) {
-      const url = session.success_url.replace("{CHECKOUT_SESSION_ID}", updated.stripe_id);
-      return c.redirect(url);
+      return c.redirect(session.success_url.replace("{CHECKOUT_SESSION_ID}", updated.stripe_id));
     }
-
     return c.html(
       renderCardPage(
         "Payment Complete",

--- a/packages/@emulators/stripe/src/routes/prices.ts
+++ b/packages/@emulators/stripe/src/routes/prices.ts
@@ -19,6 +19,9 @@ function formatPrice(p: StripePrice) {
     currency: p.currency,
     unit_amount: p.unit_amount,
     type: p.type,
+    billing_scheme: p.billing_scheme,
+    tax_behavior: p.tax_behavior,
+    recurring: p.recurring,
     active: p.active,
     metadata: p.metadata,
     created: toUnixTimestamp(p.created_at),
@@ -69,12 +72,26 @@ export function priceRoutes({ app, store, webhooks }: RouteContext): void {
         "product",
       );
     }
+    const recurringInput =
+      body.recurring && typeof body.recurring === "object" ? (body.recurring as Record<string, unknown>) : null;
+    const interval = recurringInput?.interval;
+    const normalizedInterval = interval === "day" || interval === "week" || interval === "year" ? interval : "month";
     const price = ss.prices.insert({
       stripe_id: stripeId("price"),
       product_id: body.product as string,
       currency: (body.currency as string).toLowerCase(),
       unit_amount: (body.unit_amount as number) ?? null,
       type: body.recurring ? "recurring" : "one_time",
+      billing_scheme: "per_unit",
+      tax_behavior:
+        body.tax_behavior === "inclusive" || body.tax_behavior === "exclusive" ? body.tax_behavior : "unspecified",
+      recurring: recurringInput
+        ? {
+            interval: normalizedInterval,
+            interval_count: Number(recurringInput.interval_count ?? 1),
+            usage_type: (recurringInput.usage_type as "licensed" | "metered" | undefined) ?? "licensed",
+          }
+        : null,
       active: (body.active as boolean) ?? true,
       metadata: (body.metadata as Record<string, string>) ?? {},
     });

--- a/packages/@emulators/stripe/src/routes/subscriptions.ts
+++ b/packages/@emulators/stripe/src/routes/subscriptions.ts
@@ -1,0 +1,117 @@
+import type { RouteContext } from "@emulators/core";
+import { getStripeStore } from "../store.js";
+import { stripeError, stripeId, toUnixTimestamp } from "../helpers.js";
+import type { StripeSubscription } from "../entities.js";
+
+export function formatSubscription(
+  subscription: StripeSubscription,
+  ss: ReturnType<typeof getStripeStore>,
+) {
+  const price = ss.prices.findOneBy("stripe_id", subscription.price_id);
+  const product = price
+    ? ss.products.findOneBy("stripe_id", price.product_id)
+    : null;
+  const formattedPrice = price
+    ? {
+        id: price.stripe_id,
+        object: "price",
+        product: product
+          ? {
+              id: product.stripe_id,
+              object: "product",
+              name: product.name,
+              active: product.active,
+              livemode: false,
+            }
+          : price.product_id,
+        currency: price.currency,
+        unit_amount: price.unit_amount,
+        type: price.type,
+        billing_scheme: price.billing_scheme,
+        tax_behavior: price.tax_behavior,
+        recurring: price.recurring,
+        active: price.active,
+        livemode: false,
+      }
+    : subscription.price_id;
+  return {
+    id: subscription.stripe_id,
+    object: "subscription",
+    customer: subscription.customer_id,
+    status: subscription.status,
+    cancel_at_period_end: subscription.cancel_at_period_end,
+    current_period_end: subscription.current_period_end,
+    items: {
+      object: "list",
+      data: [
+        {
+          id: `si_${subscription.stripe_id.slice(4)}`,
+          object: "subscription_item",
+          current_period_end: subscription.current_period_end,
+          price: formattedPrice,
+          quantity: subscription.quantity,
+        },
+      ],
+      has_more: false,
+    },
+    metadata: subscription.metadata,
+    created: toUnixTimestamp(subscription.created_at),
+    livemode: false,
+  };
+}
+
+function stripeEvent(store: RouteContext["store"], type: string, object: Record<string, unknown>) {
+  return {
+    id: stripeId("evt"),
+    object: "event",
+    api_version: store.getData<string>("stripe.api_version") ?? "2026-06-24.preview",
+    created: Math.floor(Date.now() / 1000),
+    data: { object },
+    livemode: false,
+    pending_webhooks: 1,
+    type,
+  };
+}
+
+export function subscriptionRoutes({ app, store, webhooks }: RouteContext): void {
+  const ss = getStripeStore(store);
+
+  app.get("/v1/subscriptions/:id", (c) => {
+    const subscription = ss.subscriptions.findOneBy("stripe_id", c.req.param("id"));
+    if (!subscription) {
+      return stripeError(
+        c,
+        404,
+        "invalid_request_error",
+        `No such subscription: '${c.req.param("id")}'`,
+        "resource_missing",
+      );
+    }
+    return c.json(formatSubscription(subscription, ss));
+  });
+
+  app.delete("/v1/subscriptions/:id", async (c) => {
+    const subscription = ss.subscriptions.findOneBy("stripe_id", c.req.param("id"));
+    if (!subscription) {
+      return stripeError(
+        c,
+        404,
+        "invalid_request_error",
+        `No such subscription: '${c.req.param("id")}'`,
+        "resource_missing",
+      );
+    }
+    const canceled = ss.subscriptions.update(subscription.id, {
+      status: "canceled",
+      cancel_at_period_end: false,
+    })!;
+    const formatted = formatSubscription(canceled, ss);
+    await webhooks.dispatch(
+      "customer.subscription.deleted",
+      undefined,
+      stripeEvent(store, "customer.subscription.deleted", formatted),
+      "stripe",
+    );
+    return c.json(formatted);
+  });
+}

--- a/packages/@emulators/stripe/src/store.ts
+++ b/packages/@emulators/stripe/src/store.ts
@@ -6,6 +6,7 @@ import type {
   StripePaymentIntent,
   StripeCharge,
   StripeCheckoutSession,
+  StripeSubscription,
 } from "./entities.js";
 
 export interface StripeStore {
@@ -15,6 +16,7 @@ export interface StripeStore {
   paymentIntents: Collection<StripePaymentIntent>;
   charges: Collection<StripeCharge>;
   checkoutSessions: Collection<StripeCheckoutSession>;
+  subscriptions: Collection<StripeSubscription>;
 }
 
 export function getStripeStore(store: Store): StripeStore {
@@ -25,5 +27,6 @@ export function getStripeStore(store: Store): StripeStore {
     paymentIntents: store.collection<StripePaymentIntent>("stripe.payment_intents", ["stripe_id", "customer_id"]),
     charges: store.collection<StripeCharge>("stripe.charges", ["stripe_id", "customer_id", "payment_intent_id"]),
     checkoutSessions: store.collection<StripeCheckoutSession>("stripe.checkout_sessions", ["stripe_id", "customer_id"]),
+    subscriptions: store.collection<StripeSubscription>("stripe.subscriptions", ["stripe_id", "customer_id"]),
   };
 }

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -68,6 +68,7 @@
     "@emulators/slack": "workspace:*",
     "@emulators/vercel": "workspace:*",
     "@emulators/resend": "workspace:*",
+    "@emulators/creem": "workspace:*",
     "@emulators/stripe": "workspace:*",
     "@emulators/clerk": "workspace:*",
     "@emulators/linear": "workspace:*",

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -24,6 +24,7 @@ const SERVICE_NAME_LIST = [
   "okta",
   "aws",
   "resend",
+  "creem",
   "stripe",
   "mongoatlas",
   "clerk",
@@ -420,6 +421,30 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
       resend: {
         domains: [{ name: "example.com", region: "us-east-1" }],
         contacts: [{ email: "test@example.com", first_name: "Test", last_name: "User" }],
+      },
+    },
+  },
+  creem: {
+    label: "Creem payments emulator",
+    endpoints: "hosted product checkout, signed webhooks, subscriptions, cancellation, inspector",
+    async load() {
+      const mod = await import("@emulators/creem");
+      return { plugin: mod.creemPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback() {
+      return { login: "creem_test_admin", id: 1, scopes: [] };
+    },
+    initConfig: {
+      creem: {
+        products: [
+          {
+            id: "prod_console_dev",
+            name: "YapHaus managed relay",
+            amount: 6900,
+            currency: "USD",
+            return_url: "http://127.0.0.1:4322/welcome",
+          },
+        ],
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,22 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
+  packages/@emulators/creem:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/@emulators/github:
     dependencies:
       '@emulators/core':
@@ -856,6 +872,9 @@ importers:
       '@emulators/core':
         specifier: workspace:*
         version: link:../@emulators/core
+      '@emulators/creem':
+        specifier: workspace:*
+        version: link:../@emulators/creem
       '@emulators/github':
         specifier: workspace:*
         version: link:../@emulators/github

--- a/skills/creem/SKILL.md
+++ b/skills/creem/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: creem
+description: Emulated Creem Test Mode checkout and subscription lifecycle for local development. Use for Creem hosted checkout, signed webhooks, subscriptions, cancellation, and offline payment integration testing.
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
+---
+
+# Creem emulator
+
+Start the service from an installed package:
+
+```bash
+npx emulate --service creem
+```
+
+Configure products and signed webhook destinations in `emulate.config.yaml`. Open `/test/payment/:productId` to complete a test checkout. Cancel a resulting subscription with `POST /_creem/subscriptions/:subscriptionId/cancel`.
+
+No real payment is processed and no Creem credential is required.

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -27,11 +27,12 @@ All services start with sensible defaults:
 | Okta      | 4006        |
 | AWS       | 4007        |
 | Resend    | 4008        |
-| Stripe    | 4009        |
-| MongoDB Atlas | 4010   |
-| Clerk     | 4011        |
-| Linear    | 4012        |
-| Twilio    | 4013        |
+| Creem     | 4009        |
+| Stripe    | 4010        |
+| MongoDB Atlas | 4011   |
+| Clerk     | 4012        |
+| Linear    | 4013        |
+| Twilio    | 4014        |
 
 ## CLI
 
@@ -97,7 +98,7 @@ await vercel.close()
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'creem'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |


### PR DESCRIPTION
## What changed

- Add a stateful Creem Test Mode emulator with hosted checkout, signed webhooks, subscriptions, cancellation, seed configuration, inspector UI, package documentation, and CLI registry support.
- Expand Stripe emulation for recurring prices, subscription checkout, richer checkout session responses, payment intents, invoices, subscription lifecycle routes, and versioned webhook events.
- Extend shared checkout and webhook helpers used by the billing emulators.
- Add Creem documentation to the repository README, agent skill, and docs website.
- Add focused Creem and Stripe tests for the supported billing flows.

## Why

Applications need realistic local billing flows without sending requests to Stripe or Creem. The existing Stripe emulator did not model the subscription response shapes and lifecycle events required by YapHaus, and Creem was not available as an emulated service.

## Impact

Developers can run subscription checkout, webhook delivery, retrieval, and cancellation locally using test state. No real payment is processed.

## Validation

- `pnpm --filter @emulators/creem... build`
- `pnpm --filter @emulators/stripe... build`
- `pnpm --filter @emulators/creem test` with 2 tests passing
- `pnpm --filter @emulators/stripe test` with 23 tests passing
- `pnpm --filter @emulators/creem type-check`
- `pnpm --filter @emulators/stripe type-check`
- `git diff --check upstream/main...HEAD`
- Leak audit result: Safe to publish
