### PR TITLE
feat(linear): Agent Interaction essentials for SDK-compatible sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,14 +839,20 @@ Current Slack limits: Slack Connect, Enterprise Grid admin APIs, Audit Logs API,
 
 ## Linear API
 
-Stateful Linear GraphQL API emulation with seeded organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and basic agent sessions. GraphQL reads and writes mutate in-memory state and use Relay-style connections with opaque cursors. OAuth supports authorization code, PKCE, refresh token, revoke, client credentials, and `actor=app` tokens for local app-actor tests. Supported writes dispatch Linear-shaped webhook payloads with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers when webhooks are configured.
+Stateful Linear GraphQL API emulation with seeded organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and production-shaped agent sessions (Agent Interaction). GraphQL reads and writes mutate in-memory state and use Relay-style connections with opaque cursors. OAuth supports authorization code, PKCE, refresh token, revoke, client credentials, and `actor=app` tokens for local app-actor tests. Supported writes dispatch Linear-shaped webhook payloads with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers when webhooks are configured.
 
 ### GraphQL
 
 - `POST /graphql` - GraphQL endpoint for queries and mutations
 - `GET /graphql` - query-string GraphQL endpoint for tooling
 - Queries: `viewer`, `organization`, `users`, `user`, `teams`, `team`, `workflowStates`, `workflowState`, `issues`, `issue`, `comments`, `comment`, `issueLabels`, `issueLabel`, `projects`, `project`, `cycles`, `cycle`, `webhooks`, `webhook`, `agentSessions`, `agentSession`
-- Mutations: `issueCreate`, `issueUpdate`, `issueDelete`, `issueArchive`, `issueUnarchive`, `commentCreate`, `commentUpdate`, `commentDelete`, `issueLabelCreate`, `issueLabelUpdate`, `issueLabelDelete`, `issueAddLabel`, `issueRemoveLabel`, `webhookCreate`, `webhookDelete`, `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`, `agentActivityCreate`
+- Mutations: `issueCreate`, `issueUpdate`, `issueDelete`, `issueArchive`, `issueUnarchive`, `commentCreate`, `commentUpdate`, `commentDelete`, `issueLabelCreate`, `issueLabelUpdate`, `issueLabelDelete`, `issueAddLabel`, `issueRemoveLabel`, `webhookCreate`, `webhookDelete`, `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`, `agentActivityCreate`, `agentActivityCreatePrompt`
+- Agent Interaction: `agentActivityCreate` (`agentSessionId` + nested `content`, optional signals), `agentSessionUpdate` (`plan`, `externalUrls`), activity-driven session status, production-shaped `AgentSessionEvent` webhooks with escaped issue, label, project, and directive-comment context
+- Human prompt simulation: `agentActivityCreatePrompt` mirrors Linear's internal user-input mutation so local tests can trigger `prompted` agent webhooks without allowing agents to create prompt activities
+- Activity lifecycle: ephemeral thoughts/actions are archived when the next agent activity arrives; queued prompts wait for the current turn to finish, then reopen the session and emit `prompted`
+- Activity connections support `filter`, `includeArchived`, `orderBy`, and Relay pagination
+
+Use the seeded `lin_test_agent` app-actor token for agent session, activity, and plan mutations. Use `lin_test_admin` for human operations, including `agentActivityCreatePrompt`.
 
 ### OAuth
 
@@ -862,9 +868,9 @@ OAuth app `actor` config is authoritative. Apps configured with `actor: user` us
 - `webhookCreate` / `webhookDelete` manage local webhook subscriptions
 - `GET /` - tabbed local inspector for issues, teams, users, projects, agents, auth records, webhook subscriptions, and deliveries
 
-Linear scope checks are relaxed by default so local tests can use simple bearer tokens or the seeded `lin_test_admin` token. Set `linear.strict_scopes: true` in seed config to require `read`, `write`, `issues:create`, `comments:create`, or `admin` on supported GraphQL operations.
+Linear scope checks are relaxed by default. The seeded `lin_test_admin` token represents a human administrator, while `lin_test_agent` represents the Emulate Agent OAuth app. Set `linear.strict_scopes: true` in seed config to require `read`, `write`, `issues:create`, `comments:create`, or `admin` on supported GraphQL operations.
 
-Current Linear limits: full schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and production agent behavior are not implemented. Agent support is a focused local-test subset.
+Current Linear limits: full schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, agent guidance storage, and repository suggestions are not implemented. Agent Interaction activity content, plans, external URLs, signals, status lifecycle, and session webhooks are supported.
 
 ## Twilio API
 

--- a/apps/web/app/docs/linear/page.mdx
+++ b/apps/web/app/docs/linear/page.mdx
@@ -1,6 +1,6 @@
 # Linear API
 
-Stateful Linear GraphQL API emulation with organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and basic agent sessions.
+Stateful Linear GraphQL API emulation with organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and production-shaped agent sessions (Agent Interaction).
 
 ## Start
 
@@ -48,12 +48,27 @@ Supported mutations:
 - `webhookCreate`, `webhookDelete`
 - `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`
 - `agentActivityCreate`
+- `agentActivityCreatePrompt` for local human-input simulation
+
+### Agent Interaction
+
+Essentials from [Linear Agent Interaction](https://linear.app/developers/agent-interaction):
+
+- `agentActivityCreate`: `agentSessionId` + nested `content` (`thought`, `action`, `elicitation`, `response`, `error`), optional `signal` / `signalMetadata`
+- `agentSessionUpdate`: `plan`, `externalUrls` / `externalLink` (status is activity-driven, not set here)
+- `AgentSessionEvent` webhooks (`created` / `prompted`) with `agentSession`, `agentActivity` on prompts, and escaped `promptContext` containing the modeled issue, labels, project, and primary directive comment
+- `agentActivityCreatePrompt`: emulator-exposed version of Linear's internal human-input mutation; agents cannot create `prompt` activities through `agentActivityCreate`
+- Ephemeral `thought` and `action` activities are archived when the next agent activity arrives and are hidden unless `includeArchived: true` is requested
+- Prompts created with `queued: true` wait for the current agent turn to complete or error, then become visible, reopen the session, and emit the `prompted` webhook
+- Activity connections honor `filter`, `includeArchived`, `orderBy`, and Relay pagination
+
+Use `lin_test_agent` for agent session, activity, and plan mutations. Use the human `lin_test_admin` token to simulate a prompt.
 
 Connections use Relay-style cursors with `nodes`, `edges`, and `pageInfo`.
 
 ## Auth
 
-GraphQL accepts `Authorization: Bearer <token>` or a bare personal API key value. The default seeded token is `lin_test_admin`.
+GraphQL accepts `Authorization: Bearer <token>` or a bare personal API key value. The default seeds include the human administrator token `lin_test_admin` and the OAuth app-actor token `lin_test_agent`.
 
 Scope checks are relaxed by default. Set `linear.strict_scopes: true` to require supported operation scopes such as `read`, `write`, `issues:create`, `comments:create`, and `admin`.
 
@@ -114,4 +129,4 @@ Create local webhook subscriptions through `webhookCreate` or seed config. Suppo
 
 ## Current Limits
 
-Full Linear schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and full production agent behavior are not implemented.
+Full Linear schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, agent guidance storage, and repository suggestions are not implemented. Agent Interaction activity content, plans, external URLs, signals, status lifecycle, and session webhooks are supported.

--- a/packages/@emulators/linear/README.md
+++ b/packages/@emulators/linear/README.md
@@ -20,12 +20,15 @@ npx emulate --service linear
 
 - `POST /graphql` for a focused Linear GraphQL subset.
 - Queries for viewer, organization, users, teams, workflow states, issues, comments, labels, projects, cycles, webhooks, and agent sessions.
-- Mutations for issues, comments, labels, webhooks, and basic agent sessions and activities.
+- Mutations for issues, comments, labels, webhooks, and production-shaped agent sessions and activities (nested activity content, plans, externalUrls, signals, ephemeral replacement, queued prompts, session status lifecycle, AgentSessionEvent webhooks, and local human prompt simulation).
+- Agent activity connections support archive visibility, filters, ordering, and Relay pagination. Created-session webhooks include escaped prompt context for modeled issue metadata and directive comments.
 - OAuth authorize, token, refresh, revoke, PKCE, client credentials, and app actor tokens.
 - Personal API key and OAuth bearer token auth.
 - Linear-shaped webhook delivery with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers.
 - Local inspector at `/`.
 
 OAuth app `actor` config is authoritative. Apps configured with `actor: user` use authorization code flows. Apps configured with `actor: app` use the app install flow and can request client credentials tokens.
+
+The default seeds provide `lin_test_admin` for human operations and `lin_test_agent` for Agent Interaction mutations. Human prompt simulation through `agentActivityCreatePrompt` requires the human token.
 
 This is not a complete Linear clone. Unsupported GraphQL fields return GraphQL errors.

--- a/packages/@emulators/linear/package.json
+++ b/packages/@emulators/linear/package.json
@@ -39,7 +39,7 @@
     "graphql": "^17.0.0"
   },
   "devDependencies": {
-    "@linear/sdk": "^86.0.0",
+    "@linear/sdk": "^89.0.0",
     "tsup": "^8",
     "typescript": "^5.7",
     "vitest": "^4.1.0"

--- a/packages/@emulators/linear/src/__tests__/agent-sdk.test.ts
+++ b/packages/@emulators/linear/src/__tests__/agent-sdk.test.ts
@@ -1,0 +1,198 @@
+import { AgentActivitySignal, LinearClient } from "@linear/sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono, Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
+import { getLinearStore, linearPlugin } from "../index.js";
+
+const base = "http://localhost:4301";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  const app = new Hono();
+  app.use("*", authMiddleware(tokenMap));
+  linearPlugin.register(app as any, store, webhooks, base, tokenMap);
+  linearPlugin.seed?.(store, base);
+  return { app, store };
+}
+
+/**
+ * Official @linear/sdk against the emulator — the highest-signal regression
+ * guard for Agent Interaction parity.
+ */
+describe("Linear Agent Interaction via official SDK", () => {
+  let app: Hono;
+  let store: Store;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    const setup = createTestApp();
+    app = setup.app;
+    store = setup.store;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.startsWith(`${base}/`)) {
+        return app.request(url, {
+          method: init?.method,
+          headers: init?.headers,
+          body: init?.body,
+        });
+      }
+      return originalFetch(input, init);
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("creates activities, plans, externalUrls, and status lifecycle with LinearClient", async () => {
+    const humanClient = new LinearClient({
+      apiKey: "lin_test_admin",
+      apiUrl: `${base}/graphql`,
+    });
+    const client = new LinearClient({
+      apiKey: "lin_test_agent",
+      apiUrl: `${base}/graphql`,
+    });
+
+    const teamId = getLinearStore(store).teams.findOneBy("key", "ENG")!.linear_id;
+    const createdIssue = await humanClient.createIssue({ teamId, title: "SDK agent parity" });
+    expect(createdIssue.success).toBe(true);
+    const issueId = createdIssue.issueId!;
+
+    const createdSession = await client.agentSessionCreateOnIssue({
+      issueId,
+      externalUrls: [{ label: "Dashboard", url: "https://agent.example/s/1" }],
+    });
+    expect(createdSession.success).toBe(true);
+    const sessionId = createdSession.agentSessionId!;
+    expect(sessionId).toBeTruthy();
+
+    const thought = await client.createAgentActivity({
+      agentSessionId: sessionId,
+      content: { type: "thought", body: "Reading context" },
+      ephemeral: true,
+    });
+    expect(thought.success).toBe(true);
+
+    const action = await client.createAgentActivity({
+      agentSessionId: sessionId,
+      content: {
+        type: "action",
+        action: "Searched",
+        parameter: "checkout",
+        result: "2 hits",
+      },
+    });
+    expect(action.success).toBe(true);
+
+    const elicitation = await client.createAgentActivity({
+      agentSessionId: sessionId,
+      content: { type: "elicitation", body: "Which package?" },
+      signal: AgentActivitySignal.Select,
+      signalMetadata: {
+        options: [
+          { label: "frontend", value: "src/frontend" },
+          { label: "backend", value: "src/backend" },
+        ],
+      },
+    });
+    expect(elicitation.success).toBe(true);
+
+    const afterElicitation = await client.agentSession(sessionId);
+    expect(afterElicitation.status).toBe("awaitingInput");
+    expect(afterElicitation.externalLinks.map(({ label, url }) => ({ label, url }))).toEqual([
+      { label: "Dashboard", url: "https://agent.example/s/1" },
+    ]);
+
+    const updated = await client.updateAgentSession(sessionId, {
+      plan: [
+        { content: "Inspect issue", status: "completed" },
+        { content: "Ship fix", status: "inProgress" },
+      ],
+      externalUrls: [
+        { label: "PR", url: "https://github.com/acme/app/pull/9" },
+        { label: "Logs", url: "https://agent.example/logs/9" },
+      ],
+    });
+    expect(updated.success).toBe(true);
+
+    // Status must remain activity-driven (still awaitingInput until response/error).
+    expect(getLinearStore(store).agentSessions.findOneBy("linear_id", sessionId)?.status).toBe("awaitingInput");
+
+    const prompt = await humanClient.client.rawRequest(
+      `mutation($input: AgentActivityCreatePromptInput!) {
+        agentActivityCreatePrompt(input: $input) { success }
+      }`,
+      {
+        input: {
+          agentSessionId: sessionId,
+          content: { type: "prompt", body: "Use frontend" },
+        },
+      },
+    );
+    expect((prompt.data as { agentActivityCreatePrompt: { success: boolean } }).agentActivityCreatePrompt.success).toBe(
+      true,
+    );
+
+    const response = await client.createAgentActivity({
+      agentSessionId: sessionId,
+      content: { type: "response", body: "Done" },
+    });
+    expect(response.success).toBe(true);
+
+    const finalSession = await client.agentSession(sessionId);
+    const activities = await finalSession.activities();
+    expect(finalSession.status).toBe("complete");
+    expect(finalSession.endedAt).toBeTruthy();
+    expect(getLinearStore(store).agentSessions.findOneBy("linear_id", sessionId)?.plan).toEqual([
+      { content: "Inspect issue", status: "completed" },
+      { content: "Ship fix", status: "inProgress" },
+    ]);
+    expect(finalSession.externalLinks).toHaveLength(2);
+    expect(activities.nodes.map((activity) => activity.content.type)).toEqual([
+      "action",
+      "elicitation",
+      "prompt",
+      "response",
+    ]);
+    expect(activities.nodes[1].signal).toBe("select");
+
+    const archivedThoughts = await client.client.rawRequest(
+      `query($id: String!) {
+        agentSession(id: $id) {
+          activities(includeArchived: true, orderBy: updatedAt, filter: { type: { eq: "thought" } }) {
+            nodes { archivedAt ephemeral }
+          }
+        }
+      }`,
+      { id: sessionId },
+    );
+    const archivedNodes = (archivedThoughts.data as any).agentSession.activities.nodes;
+    expect(archivedNodes).toHaveLength(1);
+    expect(archivedNodes[0]).toMatchObject({ archivedAt: expect.any(String), ephemeral: true });
+  });
+
+  it("rejects invalid activity content through the SDK path", async () => {
+    const humanClient = new LinearClient({
+      apiKey: "lin_test_admin",
+      apiUrl: `${base}/graphql`,
+    });
+    const client = new LinearClient({
+      apiKey: "lin_test_agent",
+      apiUrl: `${base}/graphql`,
+    });
+    const teamId = getLinearStore(store).teams.findOneBy("key", "ENG")!.linear_id;
+    const issue = await humanClient.createIssue({ teamId, title: "bad activity" });
+    const session = await client.agentSessionCreateOnIssue({ issueId: issue.issueId! });
+
+    await expect(
+      client.createAgentActivity({
+        agentSessionId: session.agentSessionId!,
+        content: { type: "thought" } as any,
+      }),
+    ).rejects.toThrow(/content\.body is required|body is required/i);
+  });
+});

--- a/packages/@emulators/linear/src/__tests__/agents.test.ts
+++ b/packages/@emulators/linear/src/__tests__/agents.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  activityContentAsJSON,
+  parseAgentActivityCreateInput,
+  parseActivityContentInput,
+  parseExternalUrlList,
+  parsePlanInput,
+  parseSignalAndMetadata,
+  statusFromActivity,
+} from "../agents.js";
+import type { LinearAgentActivityContent } from "../entities.js";
+
+describe("Linear agent helpers", () => {
+  it("parses nested content into a discriminated union", () => {
+    const thought = parseActivityContentInput({
+      content: { type: "thought", body: "Thinking" },
+    });
+    expect(thought).toEqual({ type: "thought", body: "Thinking" });
+
+    const action = parseActivityContentInput({
+      content: {
+        type: "action",
+        action: "Searched",
+        parameter: "query",
+        result: "ok",
+      },
+    });
+    expect(action).toEqual({
+      type: "action",
+      action: "Searched",
+      parameter: "query",
+      result: "ok",
+    });
+
+    const content: LinearAgentActivityContent = action;
+    switch (content.type) {
+      case "action":
+        expect(content.parameter).toBe("query");
+        break;
+      default:
+        throw new Error("expected action");
+    }
+  });
+
+  it("rejects incomplete content shapes", () => {
+    expect(() => parseActivityContentInput({ content: { type: "thought" } })).toThrow("content.body is required");
+    expect(() => parseActivityContentInput({ content: { type: "action", action: "Run" } })).toThrow(
+      "content.parameter is required",
+    );
+  });
+
+  it("parses auth and select signal metadata", () => {
+    expect(
+      parseSignalAndMetadata("auth", {
+        url: "https://auth.example/link",
+        providerName: "Orbit",
+      }),
+    ).toEqual({
+      signal: "auth",
+      signalMetadata: { url: "https://auth.example/link", providerName: "Orbit" },
+    });
+
+    expect(
+      parseSignalAndMetadata("select", {
+        options: [{ label: "frontend", value: "src/frontend" }],
+      }),
+    ).toEqual({
+      signal: "select",
+      signalMetadata: { options: [{ label: "frontend", value: "src/frontend" }] },
+    });
+  });
+
+  it("parses agentActivityCreate input", () => {
+    const parsed = parseAgentActivityCreateInput({
+      agentSessionId: "sess_1",
+      content: { type: "elicitation", body: "Pick one" },
+      signal: "select",
+      signalMetadata: { options: [{ value: "a" }] },
+    });
+    expect(parsed.agentSessionId).toBe("sess_1");
+    expect(parsed.content.type).toBe("elicitation");
+    expect(parsed.signal).toBe("select");
+  });
+
+  it("maps activities to session status", () => {
+    expect(statusFromActivity("thought", null)).toBe("active");
+    expect(statusFromActivity("elicitation", null)).toBe("awaitingInput");
+    expect(statusFromActivity("response", null)).toBe("complete");
+    expect(statusFromActivity("error", null)).toBe("error");
+    expect(statusFromActivity("prompt", "stop")).toBe("active");
+  });
+
+  it("serializes content without padded null fields", () => {
+    expect(activityContentAsJSON({ type: "thought", body: "hi" })).toEqual({
+      type: "thought",
+      body: "hi",
+    });
+    expect(activityContentAsJSON({ type: "action", action: "Run", parameter: "tests" })).toEqual({
+      type: "action",
+      action: "Run",
+      parameter: "tests",
+    });
+  });
+
+  it("parses plan steps", () => {
+    expect(
+      parsePlanInput([
+        { content: "Step 1", status: "inProgress" },
+        { content: "Step 2", status: "pending" },
+      ]),
+    ).toEqual([
+      { content: "Step 1", status: "inProgress" },
+      { content: "Step 2", status: "pending" },
+    ]);
+  });
+
+  it("rejects duplicate external URLs", () => {
+    expect(() =>
+      parseExternalUrlList(
+        [
+          { label: "Dashboard", url: "https://agent.example/session" },
+          { label: "Logs", url: "https://agent.example/session" },
+        ],
+        "externalUrls",
+      ),
+    ).toThrow("externalUrls URLs must be unique");
+  });
+});

--- a/packages/@emulators/linear/src/__tests__/linear.test.ts
+++ b/packages/@emulators/linear/src/__tests__/linear.test.ts
@@ -28,6 +28,10 @@ async function gql(app: Hono, query: string, variables?: Record<string, unknown>
   });
 }
 
+async function agentGql(app: Hono, query: string, variables?: Record<string, unknown>) {
+  return gql(app, query, variables, "lin_test_agent");
+}
+
 describe("Linear emulator", () => {
   let app: Hono;
   let store: Store;
@@ -60,6 +64,9 @@ describe("Linear emulator", () => {
     expect(body.data.teams.nodes[0].key).toBe("ENG");
     expect(body.data.issues.nodes[0].identifier).toBe("ENG-1");
     expect(body.data.issues.nodes[0].comments.nodes[0].body).toContain("seeded");
+    const agentToken = getLinearStore(store).tokens.findOneBy("token", "lin_test_agent");
+    expect(agentToken?.actor_type).toBe("app");
+    expect(getLinearStore(store).users.findOneBy("linear_id", agentToken!.user_id!)?.app).toBe(true);
   });
 
   it("creates issues and comments that can be read back", async () => {
@@ -201,34 +208,470 @@ describe("Linear emulator", () => {
     expect(linearStore.webhooks.all()).toHaveLength(webhookCount);
   });
 
-  it("rejects explicit unknown agent user IDs", async () => {
-    const linearStore = getLinearStore(store);
-    const issue = linearStore.issues.findOneBy("identifier", "ENG-1")!;
-    const comment = linearStore.comments.findBy("issue_id", issue.linear_id)[0]!;
-    const sessionCount = linearStore.agentSessions.all().length;
+  it("supports production Agent Interaction activity content and session fields", async () => {
+    const deliveries: Array<{ url: string; body: any; headers: Record<string, string> }> = [];
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("webhook-agent.test")) {
+        deliveries.push({
+          url,
+          body: JSON.parse(String(init?.body ?? "{}")),
+          headers: Object.fromEntries(new Headers(init?.headers).entries()),
+        });
+        return new Response("ok", { status: 200 });
+      }
+      return originalFetch(input, init);
+    };
 
-    const issueSession = await gql(
+    const team = getLinearStore(store).teams.findOneBy("key", "ENG")!;
+    await gql(
+      app,
+      `mutation CreateWebhook($input: WebhookCreateInput!) {
+        webhookCreate(input: $input) { webhook { id } }
+      }`,
+      {
+        input: {
+          url: "https://webhook-agent.test/hooks",
+          resourceTypes: ["AgentSessionEvent"],
+          teamId: team.linear_id,
+          secret: "agent-secret",
+        },
+      },
+    );
+
+    const issue = getLinearStore(store).issues.findOneBy("identifier", "ENG-1")!;
+    getLinearStore(store).issues.update(issue.id, { title: "Ship <safe> & sound" });
+    const createSession = await agentGql(
+      app,
+      `mutation CreateSession($input: AgentSessionCreateOnIssue!) {
+        agentSessionCreateOnIssue(input: $input) {
+          success
+          agentSession {
+            id
+            status
+            plan
+            externalUrls
+            externalLinks { label url }
+            appUser { id }
+          }
+        }
+      }`,
+      {
+        input: {
+          issueId: issue.linear_id,
+          externalUrls: [{ label: "Dashboard", url: "https://agent.example/session/1" }],
+        },
+      },
+    );
+    expect(createSession.status).toBe(200);
+    const sessionBody = (await createSession.json()) as any;
+    expect(sessionBody.errors).toBeUndefined();
+    const session = sessionBody.data.agentSessionCreateOnIssue.agentSession;
+    expect(session.status).toBe("pending");
+    expect(session.plan).toBeNull();
+    expect(session.externalUrls).toEqual([{ label: "Dashboard", url: "https://agent.example/session/1" }]);
+    expect(session.externalLinks).toEqual(session.externalUrls);
+    expect(session.appUser.id).toBeTruthy();
+
+    const createdEvent = deliveries.find((d) => d.body.action === "created");
+    expect(createdEvent).toBeTruthy();
+    expect(Object.keys(createdEvent!.body).sort()).toEqual([
+      "action",
+      "agentSession",
+      "appUserId",
+      "createdAt",
+      "guidance",
+      "oauthClientId",
+      "organizationId",
+      "promptContext",
+      "type",
+      "webhookId",
+      "webhookTimestamp",
+    ]);
+    expect(Object.keys(createdEvent!.body.agentSession).sort()).toEqual([
+      "appUserId",
+      "archivedAt",
+      "comment",
+      "commentId",
+      "createdAt",
+      "creator",
+      "creatorId",
+      "endedAt",
+      "id",
+      "issue",
+      "issueId",
+      "organizationId",
+      "sourceCommentId",
+      "sourceMetadata",
+      "startedAt",
+      "status",
+      "summary",
+      "type",
+      "updatedAt",
+      "url",
+    ]);
+    expect(createdEvent!.body.type).toBe("AgentSessionEvent");
+    expect(createdEvent!.body.agentSession.id).toBe(session.id);
+    expect(createdEvent!.body.agentSession.status).toBe("pending");
+    expect(createdEvent!.body.appUserId).toBe(session.appUser.id);
+    expect(createdEvent!.body.oauthClientId).toBe("lin_agent_client_id");
+    expect(createdEvent!.body.agentSession.creator).toBeNull();
+    expect(createdEvent!.body.agentSession.issue.team).toMatchObject({ key: "ENG", name: "Engineering" });
+    expect(createdEvent!.body.agentSession.type).toBe("commentThread");
+    expect(createdEvent!.body).not.toHaveProperty("previousComments");
+    expect(createdEvent!.body.agentSession).not.toHaveProperty("plan");
+    expect(createdEvent!.body.agentSession).not.toHaveProperty("externalUrls");
+    expect(typeof createdEvent!.body.promptContext).toBe("string");
+    expect(createdEvent!.body.promptContext).toContain("ENG-1");
+    expect(createdEvent!.body.promptContext).toContain("<title>Ship &lt;safe&gt; &amp; sound</title>");
+    expect(createdEvent!.body.promptContext).toContain("<label>Bug</label>");
+    expect(createdEvent!.body.promptContext).toContain('<project name="Local Project"></project>');
+    expect(createdEvent!.headers["linear-event"]).toBe("AgentSessionEvent");
+    expect(createdEvent!.headers["linear-timestamp"]).toBe(String(createdEvent!.body.webhookTimestamp));
+
+    const thought = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) {
+          success
+          agentActivity {
+            id
+            content { ... on AgentActivityThoughtContent { type body } }
+            signal
+            ephemeral
+            agentSession { id status }
+          }
+        }
+      }`,
+      {
+        input: {
+          agentSessionId: session.id,
+          content: { type: "thought", body: "Reading the issue context." },
+          ephemeral: true,
+        },
+      },
+    );
+    expect(thought.status).toBe(200);
+    const thoughtBody = (await thought.json()) as any;
+    expect(thoughtBody.errors).toBeUndefined();
+    expect(thoughtBody.data.agentActivityCreate.agentActivity.content).toEqual({
+      type: "thought",
+      body: "Reading the issue context.",
+    });
+    expect(thoughtBody.data.agentActivityCreate.agentActivity.agentSession.status).toBe("active");
+
+    const action = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) {
+          agentActivity {
+            content { ... on AgentActivityActionContent { type action parameter result } }
+            agentSession { status }
+          }
+        }
+      }`,
+      {
+        input: {
+          agentSessionId: session.id,
+          content: {
+            type: "action",
+            action: "Searched",
+            parameter: "checkout a11y",
+            result: "Found 2 issues",
+          },
+        },
+      },
+    );
+    const actionBody = (await action.json()) as any;
+    expect(actionBody.errors).toBeUndefined();
+    expect(actionBody.data.agentActivityCreate.agentActivity.content.action).toBe("Searched");
+    expect(actionBody.data.agentActivityCreate.agentActivity.agentSession.status).toBe("active");
+
+    const elicitation = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) {
+          agentActivity {
+            content { ... on AgentActivityElicitationContent { type body } }
+            signal
+            signalMetadata
+            agentSession { status }
+          }
+        }
+      }`,
+      {
+        input: {
+          agentSessionId: session.id,
+          content: { type: "elicitation", body: "Which package?" },
+          signal: "select",
+          signalMetadata: {
+            options: [
+              { label: "frontend", value: "src/packages/frontend" },
+              { label: "backend", value: "src/packages/backend" },
+            ],
+          },
+        },
+      },
+    );
+    const elicitationBody = (await elicitation.json()) as any;
+    expect(elicitationBody.errors).toBeUndefined();
+    expect(elicitationBody.data.agentActivityCreate.agentActivity.signal).toBe("select");
+    expect(elicitationBody.data.agentActivityCreate.agentActivity.signalMetadata.options).toHaveLength(2);
+    expect(elicitationBody.data.agentActivityCreate.agentActivity.agentSession.status).toBe("awaitingInput");
+
+    const prompt = await gql(
+      app,
+      `mutation CreatePrompt($input: AgentActivityCreatePromptInput!) {
+        agentActivityCreatePrompt(input: $input) {
+          agentActivity {
+            id
+            content { ... on AgentActivityPromptContent { type body bodyData } }
+            contextualMetadata
+            queued
+            sentAt
+            agentSession { status }
+          }
+        }
+      }`,
+      {
+        input: {
+          agentSessionId: session.id,
+          id: "a6757a12-9bb1-4935-a24e-9d5f29444d32",
+          content: {
+            bodyData: {
+              type: "doc",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Use the frontend package." }],
+                },
+              ],
+            },
+          },
+          contextualMetadata: { source: "test" },
+          queued: true,
+        },
+      },
+    );
+    const promptBody = (await prompt.json()) as any;
+    expect(promptBody.errors).toBeUndefined();
+    const promptActivity = promptBody.data.agentActivityCreatePrompt.agentActivity;
+    expect(promptActivity.id).toBe("a6757a12-9bb1-4935-a24e-9d5f29444d32");
+    expect(promptActivity.content.body).toBe("Use the frontend package.");
+    expect(promptActivity.content.bodyData).toMatchObject({ type: "doc" });
+    expect(promptActivity.contextualMetadata).toEqual({ source: "test" });
+    expect(promptActivity.queued).toBe(true);
+    expect(promptActivity.sentAt).toBeNull();
+    expect(promptActivity.agentSession.status).toBe("awaitingInput");
+    expect(deliveries.find((d) => d.body.action === "prompted")).toBeUndefined();
+
+    const response = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) {
+          agentActivity {
+            content { ... on AgentActivityResponseContent { type body } }
+            agentSession { status endedAt }
+          }
+        }
+      }`,
+      {
+        input: {
+          agentSessionId: session.id,
+          content: { type: "response", body: "Done. Frontend package updated." },
+        },
+      },
+    );
+    const responseBody = (await response.json()) as any;
+    expect(responseBody.errors).toBeUndefined();
+    expect(responseBody.data.agentActivityCreate.agentActivity.agentSession.status).toBe("active");
+    expect(responseBody.data.agentActivityCreate.agentActivity.agentSession.endedAt).toBeNull();
+
+    const promptedEvent = deliveries.find((d) => d.body.action === "prompted");
+    expect(promptedEvent).toBeTruthy();
+    expect(Object.keys(promptedEvent!.body).sort()).toEqual([
+      "action",
+      "agentActivity",
+      "agentSession",
+      "appUserId",
+      "createdAt",
+      "guidance",
+      "oauthClientId",
+      "organizationId",
+      "type",
+      "webhookId",
+      "webhookTimestamp",
+    ]);
+    expect(Object.keys(promptedEvent!.body.agentActivity).sort()).toEqual([
+      "agentSessionId",
+      "archivedAt",
+      "content",
+      "createdAt",
+      "id",
+      "signal",
+      "signalMetadata",
+      "sourceCommentId",
+      "updatedAt",
+      "user",
+      "userId",
+    ]);
+    expect(promptedEvent!.body.agentActivity.content.type).toBe("prompt");
+    expect(promptedEvent!.body.agentActivity.content.body).toBe("Use the frontend package.");
+    expect(promptedEvent!.body.agentActivity.user).toMatchObject({
+      id: expect.any(String),
+      email: "admin@linear.local",
+    });
+    expect(promptedEvent!.body).not.toHaveProperty("promptContext");
+    expect(promptedEvent!.body).not.toHaveProperty("previousComments");
+
+    const deliveredPrompt = await gql(
+      app,
+      `query PromptDelivery($sessionId: String!, $activityId: String!) {
+        agentSession(id: $sessionId) {
+          activities(includeArchived: true, filter: { id: { eq: $activityId } }) {
+            nodes { queued sentAt }
+          }
+        }
+      }`,
+      { sessionId: session.id, activityId: promptActivity.id },
+    );
+    const deliveredPromptBody = (await deliveredPrompt.json()) as any;
+    expect(deliveredPromptBody.data.agentSession.activities.nodes[0]).toMatchObject({
+      queued: false,
+      sentAt: expect.any(String),
+    });
+
+    const finalResponse = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) {
+          agentActivity { agentSession { status endedAt } }
+        }
+      }`,
+      {
+        input: {
+          agentSessionId: session.id,
+          content: { type: "response", body: "Queued prompt handled." },
+        },
+      },
+    );
+    const finalResponseBody = (await finalResponse.json()) as any;
+    expect(finalResponseBody.data.agentActivityCreate.agentActivity.agentSession.status).toBe("complete");
+    expect(finalResponseBody.data.agentActivityCreate.agentActivity.agentSession.endedAt).toBeTruthy();
+
+    const update = await agentGql(
+      app,
+      `mutation UpdateSession($id: String!, $input: AgentSessionUpdateInput!) {
+        agentSessionUpdate(id: $id, input: $input) {
+          agentSession {
+            plan
+            externalUrls
+            externalLink
+            status
+          }
+        }
+      }`,
+      {
+        id: session.id,
+        input: {
+          plan: [{ content: "All done", status: "completed" }],
+          externalUrls: [
+            { label: "PR", url: "https://github.com/acme/app/pull/1" },
+            { label: "Logs", url: "https://agent.example/logs/1" },
+          ],
+        },
+      },
+    );
+    const updateBody = (await update.json()) as any;
+    expect(updateBody.errors).toBeUndefined();
+    expect(updateBody.data.agentSessionUpdate.agentSession.plan).toEqual([
+      { content: "All done", status: "completed" },
+    ]);
+    expect(updateBody.data.agentSessionUpdate.agentSession.externalUrls).toHaveLength(2);
+    // Status is activity-driven; update must not change it.
+    expect(updateBody.data.agentSessionUpdate.agentSession.status).toBe("complete");
+
+    const mention = await gql(
+      app,
+      `mutation CreateComment($input: CommentCreateInput!) {
+        commentCreate(input: $input) { comment { id } }
+      }`,
+      {
+        input: {
+          issueId: issue.linear_id,
+          body: "Emulate Agent please inspect <frontend> & report back.",
+        },
+      },
+    );
+    expect(mention.status).toBe(200);
+    const commentCreatedEvent = deliveries.filter((delivery) => delivery.body.action === "created")[1];
+    expect(commentCreatedEvent.body.promptContext).toContain("<primary-directive-thread");
+    expect(commentCreatedEvent.body.promptContext).toContain("&lt;frontend&gt; &amp; report back.");
+    expect(commentCreatedEvent.body.previousComments).toHaveLength(1);
+    expect(commentCreatedEvent.body.previousComments[0].body).toContain("seeded by the Linear emulator");
+  });
+
+  it("rejects invalid agent activity content shapes", async () => {
+    const issue = getLinearStore(store).issues.findOneBy("identifier", "ENG-1")!;
+    const humanSession = await gql(
       app,
       `mutation CreateSession($input: AgentSessionCreateOnIssue!) {
         agentSessionCreateOnIssue(input: $input) { agentSession { id } }
       }`,
-      { input: { issueId: issue.linear_id, agentUserId: "missing-user" } },
+      { input: { issueId: issue.linear_id } },
     );
-    expect(issueSession.status).toBe(400);
-    const issueSessionBody = (await issueSession.json()) as any;
-    expect(issueSessionBody.errors[0].message).toContain("User not found: missing-user");
+    expect(humanSession.status).toBe(400);
+    expect(((await humanSession.json()) as any).errors[0].message).toContain("OAuth app actor");
 
-    const commentSession = await gql(
+    const createSession = await agentGql(
       app,
-      `mutation CreateSession($input: AgentSessionCreateOnComment!) {
-        agentSessionCreateOnComment(input: $input) { agentSession { id } }
+      `mutation CreateSession($input: AgentSessionCreateOnIssue!) {
+        agentSessionCreateOnIssue(input: $input) { agentSession { id } }
       }`,
-      { input: { commentId: comment.linear_id, agentUserId: "missing-user" } },
+      { input: { issueId: issue.linear_id } },
     );
-    expect(commentSession.status).toBe(400);
-    const commentSessionBody = (await commentSession.json()) as any;
-    expect(commentSessionBody.errors[0].message).toContain("User not found: missing-user");
-    expect(linearStore.agentSessions.all()).toHaveLength(sessionCount);
+    const sessionId = ((await createSession.json()) as any).data.agentSessionCreateOnIssue.agentSession.id;
+
+    const missingBody = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) { agentActivity { id } }
+      }`,
+      { input: { agentSessionId: sessionId, content: { type: "thought" } } },
+    );
+    expect(missingBody.status).toBe(400);
+    expect(((await missingBody.json()) as any).errors[0].message).toContain("content.body is required");
+
+    const badSignal = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) { agentActivity { id } }
+      }`,
+      {
+        input: {
+          agentSessionId: sessionId,
+          content: { type: "thought", body: "hi" },
+          signal: "select",
+        },
+      },
+    );
+    expect(badSignal.status).toBe(400);
+    expect(((await badSignal.json()) as any).errors[0].message).toContain("select signal is only valid");
+
+    const agentPrompt = await agentGql(
+      app,
+      `mutation CreateActivity($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) { agentActivity { id } }
+      }`,
+      {
+        input: {
+          agentSessionId: sessionId,
+          content: { type: "prompt", body: "Agents cannot send this." },
+        },
+      },
+    );
+    expect(agentPrompt.status).toBe(400);
+    expect(((await agentPrompt.json()) as any).errors[0].message).toContain("Agents cannot create prompt activities");
   });
 
   it("rejects adding an issue label from another team", async () => {
@@ -274,22 +717,22 @@ describe("Linear emulator", () => {
       }`,
       { input: { issueId, body: "Remove me with the issue." } },
     );
-    const sessionRes = await gql(
+    const sessionRes = await agentGql(
       app,
       `mutation CreateSession($input: AgentSessionCreateOnIssue!) {
         agentSessionCreateOnIssue(input: $input) { agentSession { id } }
       }`,
-      { input: { issueId, plan: "Clean up child records" } },
+      { input: { issueId } },
     );
     const sessionBody = (await sessionRes.json()) as any;
     const sessionId = sessionBody.data.agentSessionCreateOnIssue.agentSession.id;
 
-    await gql(
+    await agentGql(
       app,
       `mutation CreateActivity($input: AgentActivityCreateInput!) {
         agentActivityCreate(input: $input) { agentActivity { id } }
       }`,
-      { input: { sessionId, type: "response", body: "Done." } },
+      { input: { agentSessionId: sessionId, content: { type: "response", body: "Done." } } },
     );
 
     const deleteIssue = await gql(
@@ -321,22 +764,22 @@ describe("Linear emulator", () => {
     const commentBody = (await commentRes.json()) as any;
     const commentId = commentBody.data.commentCreate.comment.id;
 
-    const sessionRes = await gql(
+    const sessionRes = await agentGql(
       app,
       `mutation CreateSession($input: AgentSessionCreateOnComment!) {
         agentSessionCreateOnComment(input: $input) { agentSession { id } }
       }`,
-      { input: { commentId, plan: "Handle the comment." } },
+      { input: { commentId } },
     );
     const sessionBody = (await sessionRes.json()) as any;
     const sessionId = sessionBody.data.agentSessionCreateOnComment.agentSession.id;
 
-    await gql(
+    await agentGql(
       app,
       `mutation CreateActivity($input: AgentActivityCreateInput!) {
         agentActivityCreate(input: $input) { agentActivity { id } }
       }`,
-      { input: { sessionId, type: "response", body: "Done." } },
+      { input: { agentSessionId: sessionId, content: { type: "response", body: "Done." } } },
     );
 
     const deleteComment = await gql(
@@ -1017,6 +1460,10 @@ describe("Linear emulator", () => {
       apiKey: "lin_test_admin",
       apiUrl: `${base}/graphql`,
     });
+    const agentClient = new LinearClient({
+      apiKey: "lin_test_agent",
+      apiUrl: `${base}/graphql`,
+    });
 
     const viewer = await client.viewer;
     expect(viewer.email).toBe("admin@linear.local");
@@ -1045,7 +1492,7 @@ describe("Linear emulator", () => {
     expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.title).toBe("Updated from SDK");
     expect(getLinearStore(store).issues.findOneBy("linear_id", issueId)?.priority).toBe(1);
 
-    const createAgentSession = await client.agentSessionCreateOnIssue({ issueId });
+    const createAgentSession = await agentClient.agentSessionCreateOnIssue({ issueId });
     expect(createAgentSession.success).toBe(true);
     expect(createAgentSession.agentSessionId).toBeTruthy();
 

--- a/packages/@emulators/linear/src/agents.ts
+++ b/packages/@emulators/linear/src/agents.ts
@@ -1,0 +1,439 @@
+import type {
+  LinearAgentActivityContent,
+  LinearAgentActivitySignal,
+  LinearAgentActivityType,
+  LinearAgentAuthSignalMetadata,
+  LinearAgentExternalUrl,
+  LinearAgentPlanStep,
+  LinearAgentPlanStepStatus,
+  LinearAgentSelectOption,
+  LinearAgentSelectSignalMetadata,
+  LinearAgentSessionStatus,
+  LinearAgentActivitySignalMetadata,
+} from "./entities.js";
+
+export interface SessionLinks {
+  external_link: string | null;
+  external_urls: LinearAgentExternalUrl[];
+}
+
+export interface ParsedAgentActivityCreate {
+  agentSessionId: string;
+  content: LinearAgentActivityContent;
+  ephemeral: boolean;
+  signal: LinearAgentActivitySignal | null;
+  signalMetadata: LinearAgentActivitySignalMetadata | null;
+}
+
+export interface ParsedAgentPromptActivityCreate {
+  agentSessionId: string;
+  content: Extract<LinearAgentActivityContent, { type: "prompt" }>;
+  signal: "stop" | null;
+  signalMetadata: null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`${field} is required`);
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function stringInput(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function arrayInput(value: unknown, fallback: string[] = []): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.length > 0)
+    : fallback;
+}
+
+export function normalizeActivityType(value: string): LinearAgentActivityType {
+  if (
+    value === "thought" ||
+    value === "elicitation" ||
+    value === "action" ||
+    value === "response" ||
+    value === "error" ||
+    value === "prompt"
+  ) {
+    return value;
+  }
+  throw new Error(`Unsupported agent activity type: ${value}`);
+}
+
+export function normalizeActivitySignal(value: string | undefined): LinearAgentActivitySignal | null {
+  if (!value) return null;
+  if (value === "auth" || value === "continue" || value === "select" || value === "stop") return value;
+  throw new Error(`Unsupported agent activity signal: ${value}`);
+}
+
+export function normalizePlanStepStatus(value: string): LinearAgentPlanStepStatus {
+  if (value === "pending" || value === "inProgress" || value === "completed" || value === "canceled") {
+    return value;
+  }
+  throw new Error(`Unsupported plan step status: ${value}`);
+}
+
+export function parsePlanInput(value: unknown): LinearAgentPlanStep[] | null {
+  if (value == null) return null;
+  if (!Array.isArray(value)) {
+    throw new Error("plan must be an array of { content, status } steps");
+  }
+  if (value.length === 0) return [];
+  return value.map((step, index) => {
+    if (!isRecord(step)) throw new Error(`plan[${index}] must be an object`);
+    return {
+      content: requiredString(step.content, `plan[${index}].content`),
+      status: normalizePlanStepStatus(requiredString(step.status, `plan[${index}].status`)),
+    };
+  });
+}
+
+export function parseExternalUrlList(value: unknown, field: string): LinearAgentExternalUrl[] {
+  if (value == null) return [];
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  const urls = value.map((item, index) => {
+    if (!isRecord(item)) throw new Error(`${field}[${index}] must be an object`);
+    return {
+      label: requiredString(item.label, `${field}[${index}].label`),
+      url: requiredString(item.url, `${field}[${index}].url`),
+    };
+  });
+  const seen = new Set<string>();
+  for (const item of urls) {
+    if (seen.has(item.url)) throw new Error(`${field} URLs must be unique`);
+    seen.add(item.url);
+  }
+  return urls;
+}
+
+export function parseSessionLinksInput(input: Record<string, unknown>): SessionLinks {
+  const externalLink = nullableString(input.externalLink);
+  const externalUrls = "externalUrls" in input ? parseExternalUrlList(input.externalUrls, "externalUrls") : [];
+  if (externalLink && !externalUrls.some((link) => link.url === externalLink)) {
+    externalUrls.unshift({ label: "Open", url: externalLink });
+  }
+  return {
+    external_link: externalLink ?? externalUrls[0]?.url ?? null,
+    external_urls: externalUrls,
+  };
+}
+
+export function applyExternalUrlUpdates(current: SessionLinks, input: Record<string, unknown>): SessionLinks {
+  let externalUrls = [...current.external_urls];
+  let externalLink = current.external_link;
+
+  if ("externalUrls" in input) {
+    externalUrls = parseExternalUrlList(input.externalUrls, "externalUrls");
+  } else {
+    if ("addedExternalUrls" in input) {
+      const added = parseExternalUrlList(input.addedExternalUrls, "addedExternalUrls");
+      for (const link of added) {
+        const idx = externalUrls.findIndex((existing) => existing.url === link.url);
+        if (idx >= 0) externalUrls[idx] = link;
+        else externalUrls.push(link);
+      }
+    }
+    if ("removedExternalUrls" in input) {
+      const removed = arrayInput(input.removedExternalUrls);
+      externalUrls = externalUrls.filter((link) => !removed.includes(link.url));
+    }
+  }
+
+  if ("externalLink" in input) {
+    externalLink = nullableString(input.externalLink);
+    if (externalLink && !externalUrls.some((link) => link.url === externalLink)) {
+      externalUrls = [{ label: "Open", url: externalLink }, ...externalUrls];
+    }
+  } else if (!externalLink) {
+    externalLink = externalUrls[0]?.url ?? null;
+  }
+
+  if (externalLink && !externalUrls.some((link) => link.url === externalLink)) {
+    externalLink = externalUrls[0]?.url ?? null;
+  }
+
+  return { external_link: externalLink, external_urls: externalUrls };
+}
+
+function parseSelectOptions(value: unknown, field: string): LinearAgentSelectOption[] {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  return value.map((option, index) => {
+    if (!isRecord(option)) throw new Error(`${field}[${index}] must be an object`);
+    const parsed: LinearAgentSelectOption = {
+      value: requiredString(option.value, `${field}[${index}].value`),
+    };
+    if (typeof option.label === "string") parsed.label = option.label;
+    return parsed;
+  });
+}
+
+/**
+ * Parse and validate nested activity content into a discriminated union.
+ * Invalid type-specific fields throw.
+ */
+export function parseActivityContentInput(input: Record<string, unknown>): LinearAgentActivityContent {
+  if (isRecord(input.content)) {
+    return buildActivityContent(input.content, "content");
+  }
+  throw new Error("agentActivityCreate requires content { type, ... }");
+}
+
+function buildActivityContent(raw: Record<string, unknown>, prefix: string): LinearAgentActivityContent {
+  const type = normalizeActivityType(requiredString(raw.type, `${prefix}.type`));
+
+  switch (type) {
+    case "thought":
+    case "elicitation":
+    case "response":
+      return { type, body: requiredString(raw.body, `${prefix}.body`) };
+    case "error": {
+      const content: Extract<LinearAgentActivityContent, { type: "error" }> = {
+        type,
+        body: requiredString(raw.body, `${prefix}.body`),
+      };
+      if (typeof raw.reasonCode === "string" && raw.reasonCode.trim()) {
+        content.reasonCode = raw.reasonCode;
+      }
+      return content;
+    }
+    case "prompt": {
+      const content: Extract<LinearAgentActivityContent, { type: "prompt" }> = {
+        type,
+        body: activityBody(raw, prefix),
+      };
+      if (typeof raw.title === "string" && raw.title.trim()) {
+        content.title = raw.title;
+      }
+      return content;
+    }
+    case "action": {
+      const content: Extract<LinearAgentActivityContent, { type: "action" }> = {
+        type,
+        action: requiredString(raw.action, `${prefix}.action`),
+        parameter: requiredString(raw.parameter, `${prefix}.parameter`),
+      };
+      if (typeof raw.result === "string") {
+        content.result = raw.result;
+      }
+      return content;
+    }
+  }
+}
+
+/**
+ * Parse signal metadata and enforce shape based on signal type.
+ * Returns null when no signal is set.
+ */
+export function parseSignalAndMetadata(
+  signalRaw: string | undefined,
+  metadataRaw: unknown,
+): {
+  signal: LinearAgentActivitySignal | null;
+  signalMetadata: LinearAgentActivitySignalMetadata | null;
+} {
+  const signal = normalizeActivitySignal(signalRaw);
+  if (!signal) {
+    if (metadataRaw != null) {
+      throw new Error("signalMetadata requires signal");
+    }
+    return { signal: null, signalMetadata: null };
+  }
+
+  if (signal === "stop" || signal === "continue") {
+    if (metadataRaw != null && isRecord(metadataRaw) && Object.keys(metadataRaw).length > 0) {
+      throw new Error(`${signal} signal does not accept signalMetadata fields`);
+    }
+    return { signal, signalMetadata: null };
+  }
+
+  if (signal === "auth") {
+    if (!isRecord(metadataRaw)) throw new Error("auth signal requires signalMetadata with url");
+    const metadata: LinearAgentAuthSignalMetadata = {
+      url: requiredString(metadataRaw.url, "signalMetadata.url"),
+    };
+    if (typeof metadataRaw.userId === "string" && metadataRaw.userId.trim()) {
+      metadata.userId = metadataRaw.userId;
+    }
+    if (typeof metadataRaw.providerName === "string" && metadataRaw.providerName.trim()) {
+      metadata.providerName = metadataRaw.providerName;
+    }
+    return { signal, signalMetadata: metadata };
+  }
+
+  // select
+  if (!isRecord(metadataRaw)) throw new Error("select signal requires signalMetadata with options");
+  const metadata: LinearAgentSelectSignalMetadata = {
+    options: parseSelectOptions(metadataRaw.options, "signalMetadata.options"),
+  };
+  if (metadata.options.length === 0) {
+    throw new Error("select signal requires at least one option");
+  }
+  return { signal, signalMetadata: metadata };
+}
+
+export function validateSignalForActivityType(
+  type: LinearAgentActivityType,
+  signal: LinearAgentActivitySignal | null,
+): void {
+  if (!signal) return;
+  if (signal === "stop" && type !== "prompt") {
+    throw new Error("stop signal is only valid on prompt activities");
+  }
+  if ((signal === "auth" || signal === "select") && type !== "elicitation") {
+    throw new Error(`${signal} signal is only valid on elicitation activities`);
+  }
+  // continue is accepted on any type; production uses it as a soft modifier.
+  void type;
+}
+
+export function parseAgentActivityCreateInput(input: Record<string, unknown>): ParsedAgentActivityCreate {
+  const agentSessionId = stringInput(input.agentSessionId);
+  if (!agentSessionId) {
+    throw new Error("agentSessionId is required");
+  }
+
+  const content = parseActivityContentInput(input);
+  if (content.type === "prompt") {
+    throw new Error("Agents cannot create prompt activities");
+  }
+  // Validate signal/type pairing before requiring metadata so callers get the clearer error first.
+  const signal = normalizeActivitySignal(stringInput(input.signal));
+  validateSignalForActivityType(content.type, signal);
+  const { signalMetadata } = parseSignalAndMetadata(stringInput(input.signal), input.signalMetadata);
+
+  const ephemeral = typeof input.ephemeral === "boolean" ? input.ephemeral : false;
+  if (ephemeral && content.type !== "thought" && content.type !== "action") {
+    throw new Error("Only thought or action activities can be marked ephemeral");
+  }
+
+  return {
+    agentSessionId,
+    content,
+    ephemeral,
+    signal,
+    signalMetadata,
+  };
+}
+
+export function parseAgentPromptActivityCreateInput(input: Record<string, unknown>): ParsedAgentPromptActivityCreate {
+  const agentSessionId = stringInput(input.agentSessionId);
+  if (!agentSessionId) throw new Error("agentSessionId is required");
+  if (!isRecord(input.content)) throw new Error("content is required");
+  const content = buildActivityContent(input.content, "content");
+  if (content.type !== "prompt") throw new Error("content.type must be prompt");
+  const signal = normalizeActivitySignal(stringInput(input.signal));
+  if (signal !== null && signal !== "stop") {
+    throw new Error("Only the stop signal is valid on prompt activities");
+  }
+  parseSignalAndMetadata(signal ?? undefined, input.signalMetadata);
+  return {
+    agentSessionId,
+    content,
+    signal,
+    signalMetadata: null,
+  };
+}
+
+export function statusFromActivity(
+  type: LinearAgentActivityType,
+  _signal: LinearAgentActivitySignal | null,
+): LinearAgentSessionStatus {
+  switch (type) {
+    case "thought":
+    case "action":
+    case "prompt":
+      return "active";
+    case "elicitation":
+      return "awaitingInput";
+    case "response":
+      return "complete";
+    case "error":
+      return "error";
+  }
+}
+
+/** Production-shaped content JSON: only fields for the activity type. */
+export function activityContentAsJSON(content: LinearAgentActivityContent): Record<string, unknown> {
+  switch (content.type) {
+    case "thought":
+    case "elicitation":
+    case "response":
+      return { type: content.type, body: content.body };
+    case "error":
+      return content.reasonCode
+        ? { type: content.type, body: content.body, reasonCode: content.reasonCode }
+        : { type: content.type, body: content.body };
+    case "prompt":
+      return content.title
+        ? { type: content.type, body: content.body, title: content.title }
+        : { type: content.type, body: content.body };
+    case "action":
+      return content.result !== undefined
+        ? {
+            type: content.type,
+            action: content.action,
+            parameter: content.parameter,
+            result: content.result,
+          }
+        : { type: content.type, action: content.action, parameter: content.parameter };
+  }
+}
+
+export function activityContentAsGraphQL(content: LinearAgentActivityContent): Record<string, unknown> {
+  const typeNames: Record<LinearAgentActivityType, string> = {
+    action: "AgentActivityActionContent",
+    elicitation: "AgentActivityElicitationContent",
+    error: "AgentActivityErrorContent",
+    prompt: "AgentActivityPromptContent",
+    response: "AgentActivityResponseContent",
+    thought: "AgentActivityThoughtContent",
+  };
+  const json = activityContentAsJSON(content);
+  if (content.type === "action") {
+    return {
+      __typename: typeNames[content.type],
+      ...json,
+      resultData: content.result === undefined ? null : proseMirrorDocument(content.result),
+    };
+  }
+  return {
+    __typename: typeNames[content.type],
+    ...json,
+    bodyData: proseMirrorDocument(content.body),
+  };
+}
+
+function activityBody(raw: Record<string, unknown>, prefix: string): string {
+  if (typeof raw.body === "string" && raw.body.trim()) return raw.body;
+  const body = proseMirrorText(raw.bodyData).trim();
+  if (body) return body;
+  throw new Error(`${prefix}.body or ${prefix}.bodyData is required`);
+}
+
+function proseMirrorText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(proseMirrorText).join("");
+  if (!isRecord(value)) return "";
+  const ownText = typeof value.text === "string" ? value.text : "";
+  return ownText + proseMirrorText(value.content);
+}
+
+function proseMirrorDocument(text: string): Record<string, unknown> {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: text ? [{ type: "text", text }] : [],
+      },
+    ],
+  };
+}

--- a/packages/@emulators/linear/src/entities.ts
+++ b/packages/@emulators/linear/src/entities.ts
@@ -5,6 +5,45 @@ export type LinearTokenType = "personal" | "oauth_access" | "oauth_refresh" | "c
 export type LinearTokenActorType = "user" | "app";
 export type LinearIssuePriority = 0 | 1 | 2 | 3 | 4;
 export type LinearAgentActivityType = "thought" | "elicitation" | "action" | "response" | "error" | "prompt";
+export type LinearAgentActivitySignal = "auth" | "continue" | "select" | "stop";
+export type LinearAgentSessionStatus = "pending" | "active" | "awaitingInput" | "complete" | "error" | "stale";
+export type LinearAgentPlanStepStatus = "pending" | "inProgress" | "completed" | "canceled";
+
+export interface LinearAgentPlanStep {
+  content: string;
+  status: LinearAgentPlanStepStatus;
+}
+
+export interface LinearAgentExternalUrl {
+  label: string;
+  url: string;
+}
+
+/** Discriminated activity content matching Linear Agent Interaction payloads. */
+export type LinearAgentActivityContent =
+  | { type: "thought"; body: string }
+  | { type: "elicitation"; body: string }
+  | { type: "response"; body: string }
+  | { type: "error"; body: string; reasonCode?: string }
+  | { type: "prompt"; body: string; title?: string }
+  | { type: "action"; action: string; parameter: string; result?: string };
+
+export interface LinearAgentSelectOption {
+  label?: string;
+  value: string;
+}
+
+export interface LinearAgentAuthSignalMetadata {
+  url: string;
+  userId?: string;
+  providerName?: string;
+}
+
+export interface LinearAgentSelectSignalMetadata {
+  options: LinearAgentSelectOption[];
+}
+
+export type LinearAgentActivitySignalMetadata = LinearAgentAuthSignalMetadata | LinearAgentSelectSignalMetadata;
 
 export interface LinearOrganization extends Entity {
   linear_id: string;
@@ -155,16 +194,28 @@ export interface LinearAgentSession extends Entity {
   issue_id: string | null;
   comment_id: string | null;
   agent_user_id: string;
-  state: "pending" | "active" | "completed" | "failed" | "canceled";
-  plan: string | null;
-  external_url: string | null;
+  creator_id: string | null;
+  oauth_client_id: string;
+  status: LinearAgentSessionStatus;
+  plan: LinearAgentPlanStep[] | null;
+  external_link: string | null;
+  external_urls: LinearAgentExternalUrl[];
+  started_at: string | null;
+  ended_at: string | null;
+  summary: string | null;
 }
 
 export interface LinearAgentActivity extends Entity {
   linear_id: string;
   session_id: string;
-  user_id: string | null;
-  type: LinearAgentActivityType;
-  body: string;
+  user_id: string;
+  source_comment_id: string | null;
+  content: LinearAgentActivityContent;
+  contextual_metadata: Record<string, unknown> | null;
+  archived_at: string | null;
   ephemeral: boolean;
+  queued: boolean;
+  sent_at: string | null;
+  signal: LinearAgentActivitySignal | null;
+  signal_metadata: LinearAgentActivitySignalMetadata | null;
 }

--- a/packages/@emulators/linear/src/index.ts
+++ b/packages/@emulators/linear/src/index.ts
@@ -226,6 +226,23 @@ function seedDefaults(store: Store, baseUrl: string): void {
     });
   }
 
+  let agentApp = ls.oauthApps.findOneBy("client_id", "lin_agent_client_id");
+  if (!agentApp) {
+    const agentUser = ensureAppUser(store, "Emulate Agent");
+    agentApp = ls.oauthApps.insert({
+      linear_id: linearId(),
+      client_id: "lin_agent_client_id",
+      client_secret: "agent_client_secret",
+      name: "Emulate Agent",
+      redirect_uris: [],
+      scopes: DEFAULT_SCOPES,
+      actor: "app",
+      assignable: true,
+      mentionable: true,
+      app_user_id: agentUser.linear_id,
+    });
+  }
+
   if (!ls.tokens.findOneBy("token", "lin_test_admin")) {
     ls.tokens.insert({
       token: "lin_test_admin",
@@ -233,6 +250,20 @@ function seedDefaults(store: Store, baseUrl: string): void {
       actor_type: "user",
       user_id: admin.linear_id,
       app_id: null,
+      scopes: DEFAULT_SCOPES,
+      expires_at: null,
+      revoked: false,
+      refresh_token: null,
+    });
+  }
+
+  if (!ls.tokens.findOneBy("token", "lin_test_agent")) {
+    ls.tokens.insert({
+      token: "lin_test_agent",
+      type: "client_credentials",
+      actor_type: "app",
+      user_id: agentApp.app_user_id,
+      app_id: agentApp.linear_id,
       scopes: DEFAULT_SCOPES,
       expires_at: null,
       revoked: false,

--- a/packages/@emulators/linear/src/json-object.ts
+++ b/packages/@emulators/linear/src/json-object.ts
@@ -1,0 +1,57 @@
+import {
+  GraphQLScalarType,
+  Kind,
+  type GraphQLSchema,
+  type ValueNode,
+  type ObjectValueNode,
+  type ListValueNode,
+} from "graphql";
+
+function parseLiteral(ast: ValueNode): unknown {
+  switch (ast.kind) {
+    case Kind.STRING:
+    case Kind.BOOLEAN:
+      return ast.value;
+    case Kind.INT:
+    case Kind.FLOAT:
+      return Number(ast.value);
+    case Kind.NULL:
+      return null;
+    case Kind.LIST:
+      return (ast as ListValueNode).values.map(parseLiteral);
+    case Kind.OBJECT: {
+      const value = Object.create(null) as Record<string, unknown>;
+      for (const field of (ast as ObjectValueNode).fields) {
+        value[field.name.value] = parseLiteral(field.value);
+      }
+      return value;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Wire implementations onto the bare `JSONObject` scalar produced by `buildSchema`.
+ * Production Linear uses JSONObject for activity content, plan, and signalMetadata.
+ *
+ * Mutates the existing type in place so field references stay valid (no duplicate
+ * type names in the schema).
+ */
+export function withJSONObjectScalar(schema: GraphQLSchema): GraphQLSchema {
+  const type = schema.getType("JSONObject");
+  if (!(type instanceof GraphQLScalarType)) {
+    throw new Error("Expected JSONObject scalar in Linear GraphQL schema");
+  }
+
+  // GraphQLScalarType methods from SDL throw until configured; overwrite in place.
+  const scalar = type as GraphQLScalarType & {
+    serialize: (value: unknown) => unknown;
+    parseValue: (value: unknown) => unknown;
+    parseLiteral: (ast: ValueNode) => unknown;
+  };
+  scalar.serialize = (value: unknown) => value;
+  scalar.parseValue = (value: unknown) => value;
+  scalar.parseLiteral = (ast: ValueNode) => parseLiteral(ast);
+  return schema;
+}

--- a/packages/@emulators/linear/src/routes/graphql.ts
+++ b/packages/@emulators/linear/src/routes/graphql.ts
@@ -1,5 +1,5 @@
 import { buildSchema, graphql } from "graphql";
-import type { Context, RouteContext, Store } from "@emulators/core";
+import { escapeAttr, escapeHtml, type Context, type RouteContext, type Store } from "@emulators/core";
 import { getLinearStore } from "../store.js";
 import { linearId } from "../ids.js";
 import { connectionFromArray, type ConnectionArgs } from "../pagination.js";
@@ -16,7 +16,7 @@ import {
 } from "../index.js";
 import type {
   LinearAgentActivity,
-  LinearAgentActivityType,
+  LinearAgentPlanStep,
   LinearAgentSession,
   LinearComment,
   LinearCycle,
@@ -29,11 +29,33 @@ import type {
   LinearWebhook,
   LinearWorkflowState,
 } from "../entities.js";
-import { dispatchLinearWebhook } from "../webhooks.js";
+import {
+  activityContentAsGraphQL,
+  activityContentAsJSON,
+  applyExternalUrlUpdates,
+  parseAgentActivityCreateInput,
+  parseAgentPromptActivityCreateInput,
+  parsePlanInput,
+  parseSessionLinksInput,
+  statusFromActivity,
+  type SessionLinks,
+} from "../agents.js";
+import { withJSONObjectScalar } from "../json-object.js";
+import {
+  dispatchLinearWebhook,
+  type LinearAgentActivityWebhookPayload,
+  type LinearCommentWebhookPayload,
+  type LinearIssueWebhookPayload,
+  type LinearAgentSessionWebhookPayload,
+  type LinearUserWebhookPayload,
+} from "../webhooks.js";
 
-const schema = buildSchema(`
+const schema = withJSONObjectScalar(
+  buildSchema(`
   scalar TeamFilter
-  scalar PaginationOrderBy
+  scalar JSONObject
+
+  enum PaginationOrderBy { createdAt updatedAt }
 
   type Query {
     viewer: User!
@@ -86,8 +108,9 @@ const schema = buildSchema(`
     webhookDelete(id: String!): DeletePayload!
     agentSessionCreateOnIssue(input: AgentSessionCreateOnIssue!): AgentSessionPayload!
     agentSessionCreateOnComment(input: AgentSessionCreateOnComment!): AgentSessionPayload!
-    agentSessionUpdate(id: String, input: AgentSessionUpdateInput!): AgentSessionPayload!
+    agentSessionUpdate(id: String!, input: AgentSessionUpdateInput!): AgentSessionPayload!
     agentActivityCreate(input: AgentActivityCreateInput!): AgentActivityPayload!
+    agentActivityCreatePrompt(input: AgentActivityCreatePromptInput!): AgentActivityPayload!
   }
 
   type Organization {
@@ -187,6 +210,7 @@ const schema = buildSchema(`
     retiredAt: String
     timezone: String
     issueCount: Int
+    ledInitiativeCount: Int!
     visibility: String
     mergeWorkflowState: WorkflowState
     draftWorkflowState: WorkflowState
@@ -322,29 +346,101 @@ const schema = buildSchema(`
     team: Team
   }
 
+  type AgentSessionExternalLink {
+    label: String!
+    url: String!
+  }
+
   type AgentSession {
     id: String!
-    state: String!
-    plan: String
-    externalUrl: String
+    status: AgentSessionStatus!
+    plan: JSONObject
+    externalLink: String
+    externalUrls: JSONObject!
+    externalLinks: [AgentSessionExternalLink!]!
+    sourceMetadata: JSONObject
+    context: JSONObject!
+    url: String
+    slugId: String!
+    type: AgentSessionType
+    archivedAt: String
+    dismissedAt: String
+    dismissedBy: User
+    startedAt: String
+    endedAt: String
+    summary: String
     createdAt: String!
     updatedAt: String!
     issue: Issue
+    sourceComment: Comment
     comment: Comment
-    agentUser: User!
-    activities(first: Int, after: String, last: Int, before: String): AgentActivityConnection!
+    appUser: User!
+    creator: User
+    activities(
+      first: Int
+      after: String
+      last: Int
+      before: String
+      filter: AgentActivityFilter
+      includeArchived: Boolean
+      orderBy: PaginationOrderBy
+    ): AgentActivityConnection!
   }
 
   type AgentActivity {
     id: String!
-    type: String!
-    body: String!
+    content: AgentActivityContent!
+    contextualMetadata: JSONObject
     ephemeral: Boolean!
+    pushSummary: AgentActivityPushSummary
+    queued: Boolean!
+    sentAt: String
+    signal: AgentActivitySignal
+    signalMetadata: JSONObject
+    sourceMetadata: JSONObject
+    sourceComment: Comment
+    archivedAt: String
     createdAt: String!
     updatedAt: String!
-    session: AgentSession!
-    user: User
+    agentSession: AgentSession!
+    user: User!
   }
+
+  union AgentActivityContent = AgentActivityActionContent | AgentActivityElicitationContent | AgentActivityErrorContent | AgentActivityPromptContent | AgentActivityResponseContent | AgentActivityThoughtContent
+
+  type AgentActivityActionContent {
+    type: AgentActivityType!
+    action: String!
+    parameter: String!
+    result: String
+    resultData: JSONObject
+  }
+
+  type AgentActivityElicitationContent { type: AgentActivityType! body: String! bodyData: JSONObject! }
+  type AgentActivityErrorContent { type: AgentActivityType! body: String! bodyData: JSONObject! reasonCode: String }
+  type AgentActivityPromptContent { type: AgentActivityType! body: String! bodyData: JSONObject! title: String }
+  type AgentActivityResponseContent { type: AgentActivityType! body: String! bodyData: JSONObject! }
+  type AgentActivityThoughtContent { type: AgentActivityType! body: String! bodyData: JSONObject! }
+
+  type AgentActivityPushSummary {
+    additionalCommitShas: [String!]!
+    baseSha: String!
+    commitCount: Int!
+    commits: [AgentActivityPushCommit!]!
+    headSha: String!
+  }
+
+  type AgentActivityPushCommit {
+    additions: Int!
+    changedFiles: Int!
+    deletions: Int!
+    sha: String!
+  }
+
+  enum AgentActivityType { action elicitation error prompt response thought }
+  enum AgentActivitySignal { auth continue select stop }
+  enum AgentSessionStatus { active awaitingInput complete error pending stale }
+  enum AgentSessionType { commentThread }
 
   type NodeRef {
     id: String!
@@ -492,34 +588,71 @@ const schema = buildSchema(`
     enabled: Boolean
   }
 
+  input AgentSessionExternalUrlInput {
+    label: String!
+    url: String!
+  }
+
   input AgentSessionCreateOnIssue {
     issueId: String!
-    agentUserId: String
-    plan: String
-    externalUrl: String
+    externalLink: String
+    externalUrls: [AgentSessionExternalUrlInput!]
   }
 
   input AgentSessionCreateOnComment {
     commentId: String!
-    agentUserId: String
-    plan: String
-    externalUrl: String
+    externalLink: String
+    externalUrls: [AgentSessionExternalUrlInput!]
   }
 
+  """
+  Production Linear AgentSessionUpdateInput. Session status is driven by
+  activities, not set here.
+  """
   input AgentSessionUpdateInput {
-    id: String
-    state: String
-    plan: String
-    externalUrl: String
+    addedExternalUrls: [AgentSessionExternalUrlInput!]
+    externalLink: String
+    externalUrls: [AgentSessionExternalUrlInput!]
+    plan: JSONObject
+    removedExternalUrls: [String!]
   }
 
   input AgentActivityCreateInput {
-    sessionId: String!
-    type: String!
-    body: String!
+    agentSessionId: String!
+    content: JSONObject!
+    contextualMetadata: JSONObject
     ephemeral: Boolean
+    id: String
+    signal: AgentActivitySignal
+    signalMetadata: JSONObject
   }
-`);
+
+  input AgentActivityPromptCreateInputContent {
+    body: String
+    bodyData: JSONObject
+    type: AgentActivityType = prompt
+  }
+
+  input AgentActivityCreatePromptInput {
+    agentSessionId: String!
+    content: AgentActivityPromptCreateInputContent!
+    contextualMetadata: JSONObject
+    id: String
+    queued: Boolean
+    signal: AgentActivitySignal
+    signalMetadata: JSONObject
+    sourceCommentId: String
+  }
+
+  input AgentActivityFilter {
+    agentSessionId: StringComparator
+    and: [AgentActivityFilter!]
+    id: StringComparator
+    or: [AgentActivityFilter!]
+    type: StringComparator
+  }
+`),
+);
 
 interface LinearGraphQLContext {
   store: Store;
@@ -1053,21 +1186,14 @@ function createRoot(context: LinearGraphQLContext) {
     agentSessionCreateOnIssue: async ({ input }: { input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
       const issue = requireIssue(store, input.issueId);
-      const actor = requireCurrentUser(context);
-      const agentUserRef = stringInput(input.agentUserId);
-      const agentUser =
-        (agentUserRef ? requireUser(store, agentUserRef) : undefined) ??
-        ls()
-          .users.all()
-          .find((user) => user.app) ??
-        actor;
+      const actor = requireAgentAppActor(context);
       const session = await createAgentSessionForIssue(
         context,
         issue,
-        agentUser.linear_id,
-        actor,
-        nullableString(input.plan),
-        nullableString(input.externalUrl),
+        actor.linear_id,
+        null,
+        null,
+        parseSessionLinksInput(input),
       );
       return mutationPayload({ success: true, agentSession: formatAgentSession(context, session) });
     },
@@ -1075,57 +1201,122 @@ function createRoot(context: LinearGraphQLContext) {
     agentSessionCreateOnComment: async ({ input }: { input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
       const comment = requireComment(store, input.commentId);
-      const actor = requireCurrentUser(context);
-      const agentUserRef = stringInput(input.agentUserId);
-      const agentUser =
-        (agentUserRef ? requireUser(store, agentUserRef) : undefined) ??
-        ls()
-          .users.all()
-          .find((user) => user.app) ??
-        actor;
+      const actor = requireAgentAppActor(context);
       const session = await createAgentSessionForComment(
         context,
         comment,
-        agentUser.linear_id,
-        actor,
-        nullableString(input.plan),
-        nullableString(input.externalUrl),
+        actor.linear_id,
+        null,
+        null,
+        parseSessionLinksInput(input),
       );
       return mutationPayload({ success: true, agentSession: formatAgentSession(context, session) });
     },
 
-    agentSessionUpdate: ({ id, input }: { id?: string; input: Record<string, unknown> }) => {
+    agentSessionUpdate: ({ id, input }: { id: string; input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
-      const session = requireAgentSession(store, id ?? input.id);
+      const actor = requireAgentAppActor(context);
+      // Production drives status from activities; update only mutates plan/links.
+      const session = requireAgentSession(store, id);
+      requireAgentSessionOwner(context, session, actor);
+      const plan = "plan" in input ? parsePlanInput(input.plan) : session.plan;
+      const links = applyExternalUrlUpdates(
+        { external_link: session.external_link, external_urls: session.external_urls },
+        input,
+      );
       const updated = ls().agentSessions.update(session.id, {
-        state: normalizeSessionState(stringInput(input.state)) ?? session.state,
-        plan: "plan" in input ? nullableString(input.plan) : session.plan,
-        external_url: "externalUrl" in input ? nullableString(input.externalUrl) : session.external_url,
+        plan,
+        external_link: links.external_link,
+        external_urls: links.external_urls,
       })!;
       return mutationPayload({ success: true, agentSession: formatAgentSession(context, updated) });
     },
 
     agentActivityCreate: async ({ input }: { input: Record<string, unknown> }) => {
       requireLinearScopes(store, c, ["write"]);
-      const session = requireAgentSession(store, input.sessionId);
-      const type = normalizeActivityType(requiredString(input.type, "type"));
+      const parsed = parseAgentActivityCreateInput(input);
+      const session = requireAgentSession(store, parsed.agentSessionId);
+      const actor = requireAgentAppActor(context);
+      requireAgentSessionOwner(context, session, actor);
+      const now = new Date().toISOString();
       const activity = ls().agentActivities.insert({
-        linear_id: linearId(),
+        linear_id: stringInput(input.id) ?? linearId(),
         session_id: session.linear_id,
-        user_id: requireCurrentUser(context).linear_id,
-        type,
-        body: requiredString(input.body, "body"),
-        ephemeral: typeof input.ephemeral === "boolean" ? input.ephemeral : type === "thought" || type === "action",
+        user_id: actor.linear_id,
+        source_comment_id: null,
+        content: parsed.content,
+        contextual_metadata: recordInput(input.contextualMetadata),
+        archived_at: null,
+        ephemeral: parsed.ephemeral,
+        queued: false,
+        sent_at: null,
+        signal: parsed.signal,
+        signal_metadata: parsed.signalMetadata,
       });
-      if (type === "prompt") {
-        await dispatchLinearWebhook(store, {
-          type: "AgentSessionEvent",
-          action: "prompted",
-          data: agentSessionWebhookPayload(context, session),
-          actor: requireCurrentUser(context),
-          teamId: session.issue_id ? requireIssue(store, session.issue_id).team_id : null,
-        });
+      archiveEphemeralAgentActivities(context, session.linear_id, activity.linear_id, now);
+
+      const nextStatus = statusFromActivity(parsed.content.type, parsed.signal);
+      const updatedSession = ls().agentSessions.update(session.id, {
+        status: nextStatus,
+        started_at:
+          nextStatus === "active" || nextStatus === "awaitingInput" ? (session.started_at ?? now) : session.started_at,
+        ended_at:
+          nextStatus === "complete" || nextStatus === "error"
+            ? now
+            : nextStatus === "active" || nextStatus === "awaitingInput" || nextStatus === "pending"
+              ? null
+              : session.ended_at,
+      })!;
+
+      if (nextStatus === "complete" || nextStatus === "error") {
+        await deliverNextQueuedPrompt(context, updatedSession);
       }
+
+      return mutationPayload({ success: true, agentActivity: formatAgentActivity(context, activity) });
+    },
+
+    agentActivityCreatePrompt: async ({ input }: { input: Record<string, unknown> }) => {
+      requireLinearScopes(store, c, ["write"]);
+      const parsed = parseAgentPromptActivityCreateInput(input);
+      const session = requireAgentSession(store, parsed.agentSessionId);
+      const actor = requireCurrentUser(context);
+      if (actor.app) throw new Error("Prompt activities must be created by a human user");
+      const sourceCommentId = stringInput(input.sourceCommentId);
+      if (sourceCommentId) {
+        const sourceComment = requireComment(store, sourceCommentId);
+        if (sourceComment.issue_id !== session.issue_id) {
+          throw new Error("sourceCommentId must belong to the agent session issue");
+        }
+      }
+      const activity = ls().agentActivities.insert({
+        linear_id: stringInput(input.id) ?? linearId(),
+        session_id: session.linear_id,
+        user_id: actor.linear_id,
+        source_comment_id: sourceCommentId ?? null,
+        content: parsed.content,
+        contextual_metadata: recordInput(input.contextualMetadata),
+        archived_at: null,
+        ephemeral: false,
+        queued: input.queued === true && session.status !== "complete" && session.status !== "error",
+        sent_at: null,
+        signal: parsed.signal,
+        signal_metadata: parsed.signalMetadata,
+      });
+      if (activity.queued) {
+        return mutationPayload({ success: true, agentActivity: formatAgentActivity(context, activity) });
+      }
+      const now = new Date().toISOString();
+      const updatedSession = ls().agentSessions.update(session.id, {
+        status: "active",
+        started_at: session.started_at ?? now,
+        ended_at: null,
+      })!;
+      await dispatchAgentSessionEvent(context, {
+        action: "prompted",
+        session: updatedSession,
+        activity,
+        actor,
+      });
       return mutationPayload({ success: true, agentActivity: formatAgentActivity(context, activity) });
     },
   };
@@ -1258,6 +1449,7 @@ function formatTeam(context: LinearGraphQLContext, team: LinearTeam) {
     retiredAt: null,
     timezone: "UTC",
     issueCount: () => ls.issues.count((issue) => issue.team_id === team.linear_id),
+    ledInitiativeCount: 0,
     visibility: team.private ? "private" : "public",
     mergeWorkflowState: () => formatOptionalState(stateByType("completed")),
     draftWorkflowState: () => formatOptionalState(stateByType("backlog")),
@@ -1472,36 +1664,66 @@ function formatWebhook(context: LinearGraphQLContext, webhook: LinearWebhook) {
 }
 
 function formatAgentSession(context: LinearGraphQLContext, session: LinearAgentSession) {
+  const externalLinks = session.external_urls.map((link) => ({ label: link.label, url: link.url }));
+  const appUser = () => formatUser(context, requireUser(context.store, session.agent_user_id));
+  const issue = () => (session.issue_id ? formatIssue(context, requireIssue(context.store, session.issue_id)) : null);
   return {
     id: session.linear_id,
-    state: session.state,
+    status: session.status,
     plan: session.plan,
-    externalUrl: session.external_url,
+    externalLink: session.external_link,
+    externalUrls: externalLinks,
+    externalLinks,
+    sourceMetadata: null,
+    context: {},
+    url: session.issue_id ? requireIssue(context.store, session.issue_id).url : null,
+    slugId: session.linear_id,
+    type: "commentThread",
+    archivedAt: null,
+    dismissedAt: null,
+    dismissedBy: null,
+    startedAt: session.started_at,
+    endedAt: session.ended_at,
+    summary: session.summary,
     createdAt: session.created_at,
     updatedAt: session.updated_at,
-    issue: () => (session.issue_id ? formatIssue(context, requireIssue(context.store, session.issue_id)) : null),
+    issue,
+    sourceComment: null,
     comment: () =>
       session.comment_id ? formatComment(context, requireComment(context.store, session.comment_id)) : null,
-    agentUser: () => formatUser(context, requireUser(context.store, session.agent_user_id)),
-    activities: (args: ConnectionArgs) =>
+    appUser,
+    creator: () => (session.creator_id ? formatUser(context, requireUser(context.store, session.creator_id)) : null),
+    activities: (args: AgentActivityConnectionArgs) =>
       connectAgentActivities(
         context,
-        sortByCreated(getLinearStore(context.store).agentActivities.findBy("session_id", session.linear_id)),
+        getLinearStore(context.store).agentActivities.findBy("session_id", session.linear_id),
         args,
       ),
   };
 }
 
 function formatAgentActivity(context: LinearGraphQLContext, activity: LinearAgentActivity) {
+  const agentSession = () => formatAgentSession(context, requireAgentSession(context.store, activity.session_id));
   return {
     id: activity.linear_id,
-    type: activity.type,
-    body: activity.body,
+    content: activityContentAsGraphQL(activity.content),
+    contextualMetadata: activity.contextual_metadata,
     ephemeral: activity.ephemeral,
+    pushSummary: null,
+    queued: activity.queued,
+    sentAt: activity.sent_at,
+    signal: activity.signal,
+    signalMetadata: activity.signal_metadata,
+    sourceMetadata: null,
+    sourceComment: () =>
+      activity.source_comment_id
+        ? formatComment(context, requireComment(context.store, activity.source_comment_id))
+        : null,
+    archivedAt: activity.archived_at,
     createdAt: activity.created_at,
     updatedAt: activity.updated_at,
-    session: () => formatAgentSession(context, requireAgentSession(context.store, activity.session_id)),
-    user: () => (activity.user_id ? formatUser(context, requireUser(context.store, activity.user_id)) : null),
+    agentSession,
+    user: () => formatUser(context, requireUser(context.store, activity.user_id)),
   };
 }
 
@@ -1545,8 +1767,41 @@ function connectAgentSessions(context: LinearGraphQLContext, items: LinearAgentS
   return mapConnection(items, args, (item) => formatAgentSession(context, item));
 }
 
-function connectAgentActivities(context: LinearGraphQLContext, items: LinearAgentActivity[], args: ConnectionArgs) {
-  return mapConnection(items, args, (item) => formatAgentActivity(context, item));
+type AgentActivityConnectionArgs = ConnectionArgs & {
+  filter?: Record<string, unknown>;
+  includeArchived?: boolean;
+  orderBy?: string;
+};
+
+function connectAgentActivities(
+  context: LinearGraphQLContext,
+  items: LinearAgentActivity[],
+  args: AgentActivityConnectionArgs,
+) {
+  const filtered = filterAgentActivities(items, args);
+  return mapConnection(filtered, args, (item) => formatAgentActivity(context, item));
+}
+
+function filterAgentActivities(items: LinearAgentActivity[], args: AgentActivityConnectionArgs): LinearAgentActivity[] {
+  const activities = args.includeArchived ? [...items] : items.filter((activity) => activity.archived_at === null);
+  activities.sort((a, b) =>
+    args.orderBy === "updatedAt" ? a.updated_at.localeCompare(b.updated_at) : a.created_at.localeCompare(b.created_at),
+  );
+  return args.filter ? activities.filter((activity) => agentActivityMatchesFilter(activity, args.filter!)) : activities;
+}
+
+function agentActivityMatchesFilter(activity: LinearAgentActivity, filter: Record<string, unknown>): boolean {
+  const ownMatch =
+    comparatorMatches(activity.linear_id, filter.id) &&
+    comparatorMatches(activity.session_id, filter.agentSessionId) &&
+    comparatorMatches(activity.content.type, filter.type);
+  const andFilters = Array.isArray(filter.and) ? filter.and.filter(isRecord) : [];
+  const orFilters = Array.isArray(filter.or) ? filter.or.filter(isRecord) : [];
+  return (
+    ownMatch &&
+    andFilters.every((child) => agentActivityMatchesFilter(activity, child)) &&
+    (orFilters.length === 0 || orFilters.some((child) => agentActivityMatchesFilter(activity, child)))
+  );
 }
 
 function mapConnection<T, U>(items: T[], args: ConnectionArgs, mapper: (item: T) => U) {
@@ -1591,28 +1846,11 @@ function filteredTeams(
   orderBy?: unknown,
 ): LinearTeam[] {
   let teams = sortByCreated(getLinearStore(context.store).teams.all());
-  if (isRecord(orderBy)) {
-    const field = typeof orderBy.field === "string" ? orderBy.field : Object.keys(orderBy)[0];
-    const direction =
-      typeof orderBy.direction === "string"
-        ? orderBy.direction
-        : field && typeof orderBy[field] === "string"
-          ? orderBy[field]
-          : undefined;
-    const multiplier = direction?.toLowerCase().startsWith("desc") ? -1 : 1;
-    if (field === "key" || field === "name" || field === "createdAt" || field === "updatedAt") {
-      teams = [...teams].sort((a, b) => teamOrderValue(a, field).localeCompare(teamOrderValue(b, field)) * multiplier);
-    }
+  if (orderBy === "updatedAt") {
+    teams = [...teams].sort((a, b) => a.updated_at.localeCompare(b.updated_at));
   }
   if (!isRecord(filter)) return teams;
   return teams.filter((team) => teamMatchesFilter(team, filter));
-}
-
-function teamOrderValue(team: LinearTeam, field: string): string {
-  if (field === "key") return team.key;
-  if (field === "name") return team.name;
-  if (field === "updatedAt") return team.updated_at;
-  return team.created_at;
 }
 
 function teamMatchesFilter(team: LinearTeam, filter: Record<string, unknown>): boolean {
@@ -1758,6 +1996,19 @@ function requireCurrentUser(context: LinearGraphQLContext): LinearUser {
   return user;
 }
 
+function requireAgentAppActor(context: LinearGraphQLContext): LinearUser {
+  const actor = requireCurrentUser(context);
+  if (!actor.app) throw new Error("Agent mutations require an OAuth app actor");
+  return actor;
+}
+
+function requireAgentSessionOwner(context: LinearGraphQLContext, session: LinearAgentSession, actor: LinearUser): void {
+  const oauthClientId = oauthClientIdForAgent(context, actor.linear_id);
+  if (session.agent_user_id !== actor.linear_id || session.oauth_client_id !== oauthClientId) {
+    throw new Error("Agent session belongs to a different OAuth application");
+  }
+}
+
 function requireUser(store: Store, id: string): LinearUser {
   const user = resolveUser(store, id);
   if (!user) throw new Error(`User not found: ${id}`);
@@ -1865,31 +2116,37 @@ async function createAgentSessionForIssue(
   context: LinearGraphQLContext,
   issue: LinearIssue,
   agentUserId: string,
-  actor: LinearUser,
-  plan?: string | null,
-  externalUrl?: string | null,
+  actor: LinearUser | null,
+  plan: LinearAgentPlanStep[] | null = null,
+  links: SessionLinks = { external_link: null, external_urls: [] },
 ): Promise<LinearAgentSession> {
   const ls = getLinearStore(context.store);
+  const oauthClientId = oauthClientIdForAgent(context, agentUserId);
   const existing = ls.agentSessions
     .findBy("issue_id", issue.linear_id)
-    .find((session) => session.agent_user_id === agentUserId && session.state !== "completed");
+    .find(
+      (session) => session.agent_user_id === agentUserId && session.status !== "complete" && session.status !== "error",
+    );
   if (existing) return existing;
   const session = ls.agentSessions.insert({
     linear_id: linearId(),
     issue_id: issue.linear_id,
     comment_id: null,
     agent_user_id: agentUserId,
-    state: "pending",
-    plan: plan ?? null,
-    external_url: externalUrl ?? null,
+    creator_id: actor?.linear_id ?? null,
+    oauth_client_id: oauthClientId,
+    status: "pending",
+    plan,
+    external_link: links.external_link,
+    external_urls: links.external_urls,
+    started_at: null,
+    ended_at: null,
+    summary: null,
   });
-  await dispatchLinearWebhook(context.store, {
-    type: "AgentSessionEvent",
+  await dispatchAgentSessionEvent(context, {
     action: "created",
-    data: agentSessionWebhookPayload(context, session),
+    session,
     actor,
-    teamId: issue.team_id,
-    url: issue.url,
   });
   return session;
 }
@@ -1898,29 +2155,86 @@ async function createAgentSessionForComment(
   context: LinearGraphQLContext,
   comment: LinearComment,
   agentUserId: string,
-  actor: LinearUser,
-  plan?: string | null,
-  externalUrl?: string | null,
+  actor: LinearUser | null,
+  plan: LinearAgentPlanStep[] | null = null,
+  links: SessionLinks = { external_link: null, external_urls: [] },
 ): Promise<LinearAgentSession> {
   const issue = requireIssue(context.store, comment.issue_id);
+  const oauthClientId = oauthClientIdForAgent(context, agentUserId);
   const session = getLinearStore(context.store).agentSessions.insert({
     linear_id: linearId(),
     issue_id: issue.linear_id,
     comment_id: comment.linear_id,
     agent_user_id: agentUserId,
-    state: "pending",
-    plan: plan ?? null,
-    external_url: externalUrl ?? null,
+    creator_id: actor?.linear_id ?? null,
+    oauth_client_id: oauthClientId,
+    status: "pending",
+    plan,
+    external_link: links.external_link,
+    external_urls: links.external_urls,
+    started_at: null,
+    ended_at: null,
+    summary: null,
   });
-  await dispatchLinearWebhook(context.store, {
-    type: "AgentSessionEvent",
+  await dispatchAgentSessionEvent(context, {
     action: "created",
-    data: agentSessionWebhookPayload(context, session),
+    session,
     actor,
-    teamId: issue.team_id,
-    url: issue.url,
   });
   return session;
+}
+
+function archiveEphemeralAgentActivities(
+  context: LinearGraphQLContext,
+  sessionId: string,
+  currentActivityId: string,
+  archivedAt: string,
+): void {
+  const activities = getLinearStore(context.store).agentActivities.findBy("session_id", sessionId);
+  for (const activity of activities) {
+    if (activity.linear_id !== currentActivityId && activity.ephemeral && activity.archived_at === null) {
+      getLinearStore(context.store).agentActivities.update(activity.id, { archived_at: archivedAt });
+    }
+  }
+}
+
+async function deliverNextQueuedPrompt(
+  context: LinearGraphQLContext,
+  session: LinearAgentSession,
+): Promise<LinearAgentSession> {
+  const ls = getLinearStore(context.store);
+  const queuedPrompt = sortByCreated(ls.agentActivities.findBy("session_id", session.linear_id)).find(
+    (activity) => activity.queued && activity.sent_at === null && activity.archived_at === null,
+  );
+  if (!queuedPrompt) return session;
+
+  const now = new Date().toISOString();
+  const deliveredPrompt = ls.agentActivities.update(queuedPrompt.id, {
+    queued: false,
+    sent_at: now,
+  })!;
+  const activeSession = ls.agentSessions.update(session.id, {
+    status: "active",
+    started_at: session.started_at ?? now,
+    ended_at: null,
+  })!;
+  await dispatchAgentSessionEvent(context, {
+    action: "prompted",
+    session: activeSession,
+    activity: deliveredPrompt,
+    actor: requireUser(context.store, deliveredPrompt.user_id),
+  });
+  return activeSession;
+}
+
+function oauthClientIdForAgent(context: LinearGraphQLContext, agentUserId: string): string {
+  const ls = getLinearStore(context.store);
+  const owningApp = ls.oauthApps.all().find((app) => app.app_user_id === agentUserId);
+  if (owningApp) return owningApp.client_id;
+  const requestToken = context.c.get("authToken");
+  const token = requestToken ? ls.tokens.findOneBy("token", requestToken) : undefined;
+  const authenticatedApp = token?.app_id ? ls.oauthApps.findOneBy("linear_id", token.app_id) : undefined;
+  return authenticatedApp?.client_id ?? ls.oauthApps.all()[0]?.client_id ?? "linear-emulator";
 }
 
 function issueWebhookPayload(context: LinearGraphQLContext, issue: LinearIssue) {
@@ -1968,18 +2282,172 @@ function labelWebhookPayload(_context: LinearGraphQLContext, label: LinearIssueL
   };
 }
 
-function agentSessionWebhookPayload(_context: LinearGraphQLContext, session: LinearAgentSession) {
+function agentSessionWebhookPayload(
+  context: LinearGraphQLContext,
+  session: LinearAgentSession,
+): LinearAgentSessionWebhookPayload {
+  const organization = getLinearStore(context.store).organizations.all()[0];
+  if (!organization) throw new Error("Linear organization has not been seeded");
+  const issue = session.issue_id ? getLinearStore(context.store).issues.findOneBy("linear_id", session.issue_id) : null;
+  const comment = session.comment_id
+    ? getLinearStore(context.store).comments.findOneBy("linear_id", session.comment_id)
+    : null;
+  const creator = session.creator_id
+    ? getLinearStore(context.store).users.findOneBy("linear_id", session.creator_id)
+    : null;
   return {
     id: session.linear_id,
+    appUserId: session.agent_user_id,
+    organizationId: organization.linear_id,
     issueId: session.issue_id,
     commentId: session.comment_id,
-    agentUserId: session.agent_user_id,
-    state: session.state,
-    plan: session.plan,
-    externalUrl: session.external_url,
+    creatorId: session.creator_id,
+    creator: creator ? userWebhookPayload(creator) : null,
+    status: session.status,
+    archivedAt: null,
+    sourceCommentId: null,
+    sourceMetadata: null,
+    startedAt: session.started_at,
+    endedAt: session.ended_at,
+    summary: session.summary,
+    type: "commentThread",
     createdAt: session.created_at,
     updatedAt: session.updated_at,
+    url: issue?.url ?? null,
+    issue: issue ? issueWebhookChildPayload(context, issue) : null,
+    comment: comment ? commentWebhookChildPayload(comment) : null,
   };
+}
+
+function agentActivityWebhookPayload(
+  context: LinearGraphQLContext,
+  activity: LinearAgentActivity,
+): LinearAgentActivityWebhookPayload {
+  const user = requireUser(context.store, activity.user_id);
+  return {
+    id: activity.linear_id,
+    agentSessionId: activity.session_id,
+    content: activityContentAsJSON(activity.content),
+    signal: activity.signal,
+    signalMetadata: activity.signal_metadata ? ({ ...activity.signal_metadata } as Record<string, unknown>) : null,
+    createdAt: activity.created_at,
+    updatedAt: activity.updated_at,
+    archivedAt: activity.archived_at,
+    sourceCommentId: activity.source_comment_id,
+    userId: activity.user_id,
+    user: userWebhookPayload(user),
+  };
+}
+
+function userWebhookPayload(user: LinearUser): LinearUserWebhookPayload {
+  return {
+    id: user.linear_id,
+    url: `https://linear.app/user/${encodeURIComponent(user.email)}`,
+    avatarUrl: user.avatar_url,
+    email: user.email,
+    name: user.name,
+  };
+}
+
+function commentWebhookChildPayload(comment: LinearComment): LinearCommentWebhookPayload {
+  return {
+    id: comment.linear_id,
+    body: comment.body,
+    documentContentId: null,
+    initiativeId: null,
+    initiativeUpdateId: null,
+    issueId: comment.issue_id,
+    projectId: null,
+    projectUpdateId: null,
+    userId: comment.user_id,
+  };
+}
+
+function issueWebhookChildPayload(context: LinearGraphQLContext, issue: LinearIssue): LinearIssueWebhookPayload {
+  const team = requireTeam(context.store, issue.team_id);
+  return {
+    id: issue.linear_id,
+    identifier: issue.identifier,
+    title: issue.title,
+    description: issue.description,
+    url: issue.url,
+    teamId: issue.team_id,
+    team: { id: team.linear_id, key: team.key, name: team.name },
+  };
+}
+
+async function dispatchAgentSessionEvent(
+  context: LinearGraphQLContext,
+  opts: {
+    action: "created" | "prompted";
+    session: LinearAgentSession;
+    activity?: LinearAgentActivity;
+    actor: LinearUser | null;
+  },
+): Promise<void> {
+  const issue = opts.session.issue_id
+    ? getLinearStore(context.store).issues.findOneBy("linear_id", opts.session.issue_id)
+    : null;
+  const teamId = issue?.team_id ?? null;
+
+  await dispatchLinearWebhook(context.store, {
+    type: "AgentSessionEvent",
+    action: opts.action,
+    agentSession: agentSessionWebhookPayload(context, opts.session),
+    agentActivity: opts.activity ? agentActivityWebhookPayload(context, opts.activity) : undefined,
+    appUserId: opts.session.agent_user_id,
+    oauthClientId: opts.session.oauth_client_id,
+    // Essential context for agent loops; full Linear guidance/threads can come later.
+    promptContext: opts.action === "created" ? buildPromptContext(context, opts.session) : null,
+    guidance: [],
+    previousComments:
+      opts.action === "created" && opts.session.comment_id ? previousCommentsForSession(context, opts.session) : null,
+    actor: opts.actor,
+    teamId,
+    url: issue?.url ?? null,
+  });
+}
+
+function previousCommentsForSession(
+  context: LinearGraphQLContext,
+  session: LinearAgentSession,
+): LinearCommentWebhookPayload[] {
+  if (!session.comment_id || !session.issue_id) return [];
+  const comments = sortByCreated(getLinearStore(context.store).comments.findBy("issue_id", session.issue_id));
+  const sessionCommentIndex = comments.findIndex((comment) => comment.linear_id === session.comment_id);
+  return comments.slice(0, sessionCommentIndex < 0 ? 0 : sessionCommentIndex).map(commentWebhookChildPayload);
+}
+
+function buildPromptContext(context: LinearGraphQLContext, session: LinearAgentSession): string {
+  if (!session.issue_id) return "";
+  const issue = requireIssue(context.store, session.issue_id);
+  const team = requireTeam(context.store, issue.team_id);
+  const ls = getLinearStore(context.store);
+  const parts = [`<issue identifier="${escapeAttr(issue.identifier)}">`, `<title>${escapeHtml(issue.title)}</title>`];
+  if (issue.description) parts.push(`<description>${escapeHtml(issue.description)}</description>`);
+  parts.push(`<team name="${escapeAttr(team.name)}"/>`);
+  for (const labelId of issue.label_ids) {
+    const label = ls.issueLabels.findOneBy("linear_id", labelId);
+    if (label) parts.push(`<label>${escapeHtml(label.name)}</label>`);
+  }
+  if (issue.project_id) {
+    const project = ls.projects.findOneBy("linear_id", issue.project_id);
+    if (project) {
+      parts.push(
+        `<project name="${escapeAttr(project.name)}">${project.description ? escapeHtml(project.description) : ""}</project>`,
+      );
+    }
+  }
+  parts.push(`</issue>`);
+  if (session.comment_id) {
+    const comment = requireComment(context.store, session.comment_id);
+    const author = comment.user_id ? ls.users.findOneBy("linear_id", comment.user_id) : undefined;
+    const user = author ? `<user id="${escapeAttr(author.linear_id)}">${escapeHtml(author.display_name)}</user> ` : "";
+    parts.push(
+      `<primary-directive-thread comment-id="${escapeAttr(comment.linear_id)}"><comment author="${escapeAttr(author?.name ?? "Unknown")}" created-at="${escapeAttr(comment.created_at)}">${user}${escapeHtml(comment.body)}</comment></primary-directive-thread>`,
+    );
+  }
+  return parts.join("\n");
 }
 
 function mentionsAppUser(context: LinearGraphQLContext, body: string): boolean {
@@ -1995,33 +2463,6 @@ function normalizePriority(value: unknown): LinearIssuePriority {
   return value as LinearIssuePriority;
 }
 
-function normalizeSessionState(value: string | undefined | null): LinearAgentSession["state"] | undefined {
-  if (
-    value === "pending" ||
-    value === "active" ||
-    value === "completed" ||
-    value === "failed" ||
-    value === "canceled"
-  ) {
-    return value;
-  }
-  return undefined;
-}
-
-function normalizeActivityType(value: string): LinearAgentActivityType {
-  if (
-    value === "thought" ||
-    value === "elicitation" ||
-    value === "action" ||
-    value === "response" ||
-    value === "error" ||
-    value === "prompt"
-  ) {
-    return value;
-  }
-  throw new Error(`Unsupported agent activity type: ${value}`);
-}
-
 function requiredString(value: unknown, field: string): string {
   if (typeof value === "string" && value.trim()) return value;
   throw new Error(`${field} is required`);
@@ -2033,6 +2474,10 @@ function nullableString(value: unknown): string | null {
 
 function stringInput(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function recordInput(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
 }
 
 function arrayInput(value: unknown, fallback: string[] = []): string[] {

--- a/packages/@emulators/linear/src/routes/inspector.ts
+++ b/packages/@emulators/linear/src/routes/inspector.ts
@@ -140,7 +140,7 @@ export function inspectorRoutes({ app, store }: RouteContext): void {
         const agent = ls().users.findOneBy("linear_id", session.agent_user_id);
         return [
           escapeHtml(session.linear_id),
-          escapeHtml(session.state),
+          escapeHtml(session.status),
           escapeHtml(issue?.identifier ?? ""),
           escapeHtml(userLabel(agent)),
           escapeHtml(String(ls().agentActivities.count((activity) => activity.session_id === session.linear_id))),
@@ -149,7 +149,7 @@ export function inspectorRoutes({ app, store }: RouteContext): void {
       });
     return section(
       "Agent Sessions",
-      table(["ID", "State", "Issue", "Agent", "Activities", "Updated"], rows, "No agent sessions."),
+      table(["ID", "Status", "Issue", "Agent", "Activities", "Updated"], rows, "No agent sessions."),
     );
   }
 

--- a/packages/@emulators/linear/src/webhooks.ts
+++ b/packages/@emulators/linear/src/webhooks.ts
@@ -4,14 +4,89 @@ import { getLinearStore } from "./store.js";
 import { linearId } from "./ids.js";
 import type { LinearUser } from "./entities.js";
 
+export interface LinearAgentSessionWebhookPayload {
+  id: string;
+  appUserId: string;
+  organizationId: string;
+  issueId: string | null;
+  commentId: string | null;
+  creatorId: string | null;
+  creator: LinearUserWebhookPayload | null;
+  status: string;
+  archivedAt: string | null;
+  sourceCommentId: string | null;
+  sourceMetadata: Record<string, unknown> | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  summary: string | null;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+  url: string | null;
+  issue: LinearIssueWebhookPayload | null;
+  comment: LinearCommentWebhookPayload | null;
+}
+
+export interface LinearAgentActivityWebhookPayload {
+  id: string;
+  agentSessionId: string;
+  content: Record<string, unknown>;
+  signal: string | null;
+  signalMetadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+  archivedAt: string | null;
+  sourceCommentId: string | null;
+  userId: string;
+  user: LinearUserWebhookPayload;
+}
+
+export interface LinearUserWebhookPayload {
+  id: string;
+  url: string;
+  avatarUrl: string | null;
+  email: string;
+  name: string;
+}
+
+export interface LinearCommentWebhookPayload {
+  id: string;
+  body: string;
+  documentContentId: string | null;
+  initiativeId: string | null;
+  initiativeUpdateId: string | null;
+  issueId: string | null;
+  projectId: string | null;
+  projectUpdateId: string | null;
+  userId: string | null;
+}
+
+export interface LinearIssueWebhookPayload {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  teamId: string;
+  team: { id: string; key: string; name: string };
+}
+
 export interface LinearWebhookEvent {
   type: string;
   action: string;
-  data: unknown;
+  data?: unknown;
   actor?: LinearUser | null;
   teamId?: string | null;
   url?: string | null;
   updatedFrom?: Record<string, unknown>;
+  /** AgentSessionEvent fields (production Linear shape). */
+  agentSession?: LinearAgentSessionWebhookPayload;
+  agentActivity?: LinearAgentActivityWebhookPayload;
+  appUserId?: string | null;
+  oauthClientId?: string | null;
+  promptContext?: string | null;
+  guidance?: unknown[] | null;
+  previousComments?: LinearCommentWebhookPayload[] | null;
 }
 
 export async function dispatchLinearWebhook(store: Store, event: LinearWebhookEvent): Promise<void> {
@@ -28,31 +103,49 @@ export async function dispatchLinearWebhook(store: Store, event: LinearWebhookEv
   });
 
   for (const webhook of webhooks) {
-    const payload = {
-      action: event.action,
-      type: event.type,
-      actor: event.actor
-        ? {
-            id: event.actor.linear_id,
-            name: event.actor.name,
-            displayName: event.actor.display_name,
-            email: event.actor.email,
-          }
-        : null,
-      data: event.data,
-      url: event.url ?? null,
-      createdAt: new Date().toISOString(),
-      organizationId: organization?.linear_id ?? null,
-      webhookTimestamp: Date.now(),
-      webhookId: webhook.linear_id,
-      ...(event.updatedFrom ? { updatedFrom: event.updatedFrom } : {}),
-    };
+    const isAgentSessionEvent = event.type === "AgentSessionEvent";
+    const payload = isAgentSessionEvent
+      ? {
+          action: event.action,
+          type: event.type,
+          agentSession: event.agentSession ?? null,
+          ...(event.agentActivity !== undefined ? { agentActivity: event.agentActivity } : {}),
+          appUserId: event.appUserId ?? null,
+          oauthClientId: event.oauthClientId ?? null,
+          organizationId: organization?.linear_id ?? null,
+          ...(event.promptContext != null ? { promptContext: event.promptContext } : {}),
+          guidance: event.guidance ?? [],
+          ...(event.previousComments != null ? { previousComments: event.previousComments } : {}),
+          createdAt: new Date().toISOString(),
+          webhookTimestamp: Date.now(),
+          webhookId: webhook.linear_id,
+        }
+      : {
+          action: event.action,
+          type: event.type,
+          actor: event.actor
+            ? {
+                id: event.actor.linear_id,
+                name: event.actor.name,
+                displayName: event.actor.display_name,
+                email: event.actor.email,
+              }
+            : null,
+          data: event.data,
+          url: event.url ?? null,
+          createdAt: new Date().toISOString(),
+          organizationId: organization?.linear_id ?? null,
+          webhookTimestamp: Date.now(),
+          webhookId: webhook.linear_id,
+          ...(event.updatedFrom ? { updatedFrom: event.updatedFrom } : {}),
+        };
     const body = JSON.stringify(payload);
     const headers: Record<string, string> = {
       "Accept-Charset": "utf-8",
       "Content-Type": "application/json; charset=utf-8",
       "Linear-Delivery": linearId(),
       "Linear-Event": event.type,
+      "Linear-Timestamp": String(payload.webhookTimestamp),
       "User-Agent": "Linear-Webhook",
     };
     if (webhook.secret) {

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -507,7 +507,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   linear: {
     label: "Linear GraphQL API emulator",
     endpoints:
-      "GraphQL, OAuth, issues, teams, users, workflow states, comments, labels, projects, cycles, webhooks, agents, inspector",
+      "GraphQL, OAuth, issues, teams, users, workflow states, comments, labels, projects, cycles, webhooks, Agent Interaction lifecycle with lin_test_agent, inspector",
     async load() {
       const mod = await import("@emulators/linear");
       return { plugin: mod.linearPlugin, seedFromConfig: mod.seedFromConfig };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,8 +677,8 @@ importers:
         version: 17.0.0
     devDependencies:
       '@linear/sdk':
-        specifier: ^86.0.0
-        version: 86.0.0(graphql@17.0.0)
+        specifier: ^89.0.0
+        version: 89.0.0(graphql@17.0.0)
       tsup:
         specifier: ^8
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
@@ -2017,8 +2017,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@linear/sdk@86.0.0':
-    resolution: {integrity: sha512-Lr47874CGGPCDiPQoKYjcZDWyyu18N8zzEGvss86uzjZaeZrhNsuwKTARswG27VAJ3fPVJAvl/5dPl8QwndSlg==}
+  '@linear/sdk@89.0.0':
+    resolution: {integrity: sha512-LiV2wsIg1Wym4GgaAUMrALo953WEgIAAceyK8qL91q75Ws8+lqwAkPW252MHtwktZCR7exMBd5wCAdct3yLU7w==}
     engines: {node: '>=18.x'}
 
   '@mapbox/node-pre-gyp@2.0.3':
@@ -11098,7 +11098,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@linear/sdk@86.0.0(graphql@17.0.0)':
+  '@linear/sdk@89.0.0(graphql@17.0.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.0)
     transitivePeerDependencies:

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx emulate:*)
 
 # Linear API Emulator
 
-Stateful Linear GraphQL API emulation with organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and basic agent sessions.
+Stateful Linear GraphQL API emulation with organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and production-shaped agent sessions (Agent Interaction).
 
 ## Start
 
@@ -38,6 +38,8 @@ curl "$LINEAR_EMULATOR_URL/graphql" \
 ```
 
 Scope checks are relaxed by default. Set `linear.strict_scopes: true` in seed config to require supported operation scopes such as `read`, `write`, `issues:create`, `comments:create`, and `admin`.
+
+Use `lin_test_agent` for agent session, activity, and plan mutations. Use `lin_test_admin` for human operations such as `agentActivityCreatePrompt`.
 
 ## Seed Config
 
@@ -100,6 +102,20 @@ Supported mutations:
 - `webhookCreate`, `webhookDelete`
 - `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`
 - `agentActivityCreate`
+- `agentActivityCreatePrompt` for local human-input simulation
+
+### Agent Interaction
+
+Matches [Linear Agent Interaction](https://linear.app/developers/agent-interaction) essentials:
+
+- `agentActivityCreate`: `agentSessionId` + `content` JSON (`thought` | `action` | `elicitation` | `response` | `error`), optional `signal` / `signalMetadata`
+- `agentSessionUpdate`: `plan` steps, `externalUrls` / `externalLink` (does not set status)
+- Session `status` is driven by activities (`active`, `awaitingInput`, `complete`, `error`, …)
+- Production-shaped `AgentSessionEvent` webhooks (`created` / `prompted`) with `agentSession`, escaped issue/label/project/directive-comment `promptContext`, `agentActivity`, OAuth client identity, and structured child payloads
+- `agentActivityCreatePrompt`: emulator-exposed version of Linear's internal human-input mutation; agents cannot create `prompt` activities through `agentActivityCreate`
+- Ephemeral `thought` and `action` activities are archived when the next agent activity arrives; query with `includeArchived: true` to include them
+- `queued: true` prompts wait for the current turn to complete or error, then reopen the session and emit `prompted`
+- Activity connections honor `filter`, `includeArchived`, `orderBy`, and Relay pagination
 
 Connections use Relay-style cursors with `nodes`, `edges`, and `pageInfo`.
 
@@ -122,4 +138,4 @@ Open `GET /` in the Linear emulator to inspect issues, teams, users, projects, a
 
 ## Current Limits
 
-Full Linear schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and full production agent behavior are not implemented.
+Full Linear schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, agent guidance configuration storage, and repository suggestions are not implemented. Agent sessions follow production Agent Interaction shapes for activities, plans, external URLs, signals, status lifecycle, and session webhooks.


### PR DESCRIPTION
## Summary

- Align `@emulators/linear` with the current production [Linear Agent Interaction](https://linear.app/developers/agent-interaction) contract and `@linear/sdk` v89.
- Model agent activity content as the production GraphQL union, accept the production nested input shape, and validate type-specific content, signals, IDs, context metadata, plans, and unique external URLs.
- Implement the activity lifecycle: newer ephemeral thoughts and actions archive the previous active ephemeral activity, while activity connections support production-style filters, archive visibility, ordering, and Relay pagination.
- Keep the actor boundary explicit: the seeded `lin_test_agent` OAuth app token owns agent sessions and activities, while human prompts use the separate internal-style `agentActivityCreatePrompt` mutation with `lin_test_admin`.
- Queue prompts while an agent turn is active, deliver the oldest prompt after a terminal response, and reopen the session for the next turn without emitting premature webhook events.
- Emit production-shaped `AgentSessionEvent` payloads for `created` and `prompted`, including OAuth client identity, structured child objects, exact optional fields, and `Linear-Timestamp`.
- Build escaped prompt context from the issue, team, labels, project, directive comment, and prior comments instead of interpolating raw user content.
- Remove the legacy flat activity input, legacy session aliases, and other compatibility-only fields.
- Update the README, package docs, docs site, Linear skill, and CLI help surface.

The emulator remains a focused Linear subset. Rich guidance storage, repository suggestions, and the rest of Linear's unrelated product schema remain outside this PR.

## Test plan

- [x] `pnpm --filter @emulators/linear test` (37 tests, including end-to-end `@linear/sdk` v89 coverage)
- [x] `pnpm --filter @emulators/linear type-check`
- [x] `pnpm --filter @emulators/linear lint`
- [x] `pnpm --filter @emulators/linear build`
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [ ] Hosted CI green on this PR

The full monorepo test aggregate was also attempted locally. It is blocked in this sandbox by an unrelated Vercel Blob test trying to listen on `0.0.0.0` and receiving `EPERM`; the Linear suite passes independently.
