### PR TITLE
feat: add Facebook emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All services start with sensible defaults. No config file needed:
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
 - **Twilio** on `http://localhost:4013`
+- **Facebook** on `http://localhost:4014`
 
 ## CLI
 
@@ -148,7 +149,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, `'twilio'`, or `'facebook'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -364,6 +364,32 @@ resend:
     - name: default
 ```
 
+## Facebook Seed Config
+
+    facebook:
+      users:
+        - id: "1001"
+          name: Test User
+          email: test@example.com
+      oauth_apps:
+        - app_id: "123456"
+          app_secret: example_secret
+          name: My Facebook App
+          redirect_uris:
+            - http://localhost:3000/api/auth/callback/facebook
+      pages:
+        - id: "2001"
+          name: Test Page
+          owner_user_ids: ["1001"]
+      page_videos:
+        - id: "3001"
+          page_id: "2001"
+          views: 1200
+          likes: 80
+          comments: 12
+
+Applications need a Facebook client and a configurable Graph API base URL to consume this emulator.
+
 ## Stripe Seed Config
 
 ```yaml

--- a/apps/web/app/docs/facebook/layout.tsx
+++ b/apps/web/app/docs/facebook/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("facebook");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/facebook/page.mdx
+++ b/apps/web/app/docs/facebook/page.mdx
@@ -1,0 +1,44 @@
+# Facebook Login and Graph API
+
+The Facebook emulator provides a focused foundation for server-side Page integrations. It seeds users, OAuth apps, Pages, and Page videos, then models the authorization code and Page-token flow.
+
+## Endpoints
+
+- GET /dialog/oauth and GET /vXX.X/dialog/oauth render the shared sign-in UI
+- GET or POST /oauth/access_token exchanges a single-use code
+- GET /debug_token validates user and Page tokens with an app access token
+- GET /me returns the token subject
+- GET /me/accounts returns Pages owned by the user and their Page access tokens
+- GET /:pageId returns an owned Page
+- GET /:videoId returns Page video fields including views and likes/comments summary counts
+
+Graph reads support bearer tokens and the access_token query parameter. The same Graph endpoints accept version prefixes such as /v23.0.
+
+## Seed configuration
+
+    facebook:
+      users:
+        - id: "1001"
+          name: Test User
+          email: test@example.com
+      oauth_apps:
+        - app_id: "123456"
+          app_secret: example_secret
+          name: My App
+          redirect_uris:
+            - http://localhost:3000/api/auth/callback/facebook
+      pages:
+        - id: "2001"
+          name: Test Page
+          owner_user_ids: ["1001"]
+      page_videos:
+        - id: "3001"
+          page_id: "2001"
+          title: Campaign video
+          views: 1200
+          likes: 80
+          comments: 12
+
+## Present limitation
+
+This does not claim complete Meta Graph API coverage. Applications need Facebook Page OAuth, a Facebook metrics client, and a configurable Graph API base URL to consume this emulator.

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -1,6 +1,6 @@
 # Getting Started
 
-Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, and Linear APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
+Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, Linear, Twilio, and Facebook APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
 
 ## Quick Start
 
@@ -23,6 +23,8 @@ All services start with sensible defaults. No config file needed:
 - **MongoDB Atlas** on `http://localhost:4010`
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
+- **Twilio** on `http://localhost:4013`
+- **Facebook** on `http://localhost:4014`
 
 ## CLI
 

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -59,7 +59,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>service</code></td>
       <td><em>(required)</em></td>
-      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, <code>'clerk'</code>, or <code>'linear'</code></td>
+      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, <code>'clerk'</code>, <code>'linear'</code>, <code>'twilio'</code>, or <code>'facebook'</code></td>
     </tr>
     <tr>
       <td><code>port</code></td>

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -35,6 +35,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/facebook", label: "Facebook" },
     ],
   },
   {

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -33,6 +33,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/facebook", label: "Facebook" },
     ],
   },
   {

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -22,6 +22,7 @@ export const allDocsPages: NavItem[] = [
   { name: "MongoDB Atlas", href: "/docs/mongoatlas" },
   { name: "Resend", href: "/docs/resend" },
   { name: "Stripe", href: "/docs/stripe" },
+  { name: "Facebook and Meta", href: "/docs/facebook" },
   { name: "Authentication", href: "/docs/authentication" },
   { name: "Architecture", href: "/docs/architecture" },
 ];

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -13,6 +13,7 @@ export const PAGE_TITLES: Record<string, string> = {
   apple: "Apple Sign In",
   microsoft: "Microsoft Entra ID",
   aws: "AWS",
+  facebook: "Facebook and Meta",
   okta: "Okta",
   mongoatlas: "MongoDB Atlas",
   resend: "Resend",

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -128,3 +128,30 @@ google:
       mime_type: application/vnd.google-apps.folder
       parent_ids:
         - root
+facebook:
+  users:
+    - id: "100000000000001"
+      name: Test User
+      email: testuser@example.com
+  oauth_apps:
+    - app_id: "123456789012345"
+      app_secret: example_app_secret
+      name: Emulate Facebook App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/facebook
+  pages:
+    - id: "200000000000001"
+      name: Emulate Page
+      category: Digital creator
+      owner_user_ids:
+        - "100000000000001"
+  page_videos:
+    - id: "300000000000001"
+      page_id: "200000000000001"
+      title: Welcome video
+      description: A seeded Facebook Page video
+      permalink_url: https://www.facebook.com/200000000000001/videos/300000000000001
+      created_time: 2025-01-01T00:00:00+0000
+      views: 1200
+      likes: 80
+      comments: 12

--- a/packages/@emulators/facebook/README.md
+++ b/packages/@emulators/facebook/README.md
@@ -1,0 +1,36 @@
+# @emulators/facebook
+
+Local Facebook Login and Graph API emulation for server-side Page integrations.
+
+## Scope
+
+The package provides seedable users, OAuth apps, Pages, and Page videos. It supports authorization code login, app-secret validation, single-use codes, user and Page access tokens, token debugging, /me, /me/accounts, Page lookup, and Page video lookup. Graph endpoints accept bearer or access_token query authentication and are also available below versioned paths such as /v23.0.
+
+Video responses expose views plus likes and comments summary counts. This is a focused foundation, not the complete Meta Graph API.
+
+## Seed
+
+    facebook:
+      users:
+        - id: "1001"
+          name: Test User
+          email: test@example.com
+      oauth_apps:
+        - app_id: "123456"
+          app_secret: example_secret
+          name: My App
+          redirect_uris:
+            - http://localhost:3000/api/auth/callback/facebook
+      pages:
+        - id: "2001"
+          name: Test Page
+          owner_user_ids: ["1001"]
+      page_videos:
+        - id: "3001"
+          page_id: "2001"
+          title: Campaign video
+          views: 1200
+          likes: 80
+          comments: 12
+
+To consume this emulator, an application needs a Facebook platform client, Page OAuth integration, and a configurable Graph API base URL.

--- a/packages/@emulators/facebook/package.json
+++ b/packages/@emulators/facebook/package.json
@@ -19,6 +19,6 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint src"
   },
-  "dependencies": { "@emulators/core": "workspace:*", "hono": "^4" },
+  "dependencies": { "@emulators/core": "workspace:*" },
   "devDependencies": { "tsup": "^8", "typescript": "^5.7", "vitest": "^4.1.0" }
 }

--- a/packages/@emulators/facebook/package.json
+++ b/packages/@emulators/facebook/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@emulators/facebook",
+  "version": "0.4.1",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
+  "homepage": "https://emulate.dev",
+  "repository": { "type": "git", "url": "https://github.com/vercel-labs/emulate.git", "directory": "packages/@emulators/facebook" },
+  "bugs": { "url": "https://github.com/vercel-labs/emulate/issues" },
+  "publishConfig": { "access": "public" },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": { "@emulators/core": "workspace:*", "hono": "^4" },
+  "devDependencies": { "tsup": "^8", "typescript": "^5.7", "vitest": "^4.1.0" }
+}

--- a/packages/@emulators/facebook/src/__tests__/facebook.test.ts
+++ b/packages/@emulators/facebook/src/__tests__/facebook.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { Hono } from "hono";
-import { Store, WebhookDispatcher, type AppEnv, type TokenMap } from "@emulators/core";
+import { Hono, Store, WebhookDispatcher, type AppEnv, type TokenMap } from "@emulators/core";
 import { facebookPlugin, seedFromConfig } from "../index.js";
 
 const base = "http://localhost:4007";

--- a/packages/@emulators/facebook/src/__tests__/facebook.test.ts
+++ b/packages/@emulators/facebook/src/__tests__/facebook.test.ts
@@ -1,0 +1,403 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { Store, WebhookDispatcher, type AppEnv, type TokenMap } from "@emulators/core";
+import { facebookPlugin, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4007";
+const callback = "http://localhost:3000/callback";
+const appId = "app-1";
+const appSecret = "secret-1";
+
+function setup() {
+  const store = new Store();
+  const app = new Hono<AppEnv>();
+  const tokenMap: TokenMap = new Map();
+  facebookPlugin.register(app, store, new WebhookDispatcher(), base, tokenMap);
+  facebookPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [
+      { id: "user-1", name: "Owner", email: "owner@example.com" },
+      { id: "user-2", name: "Other", email: "other@example.com" },
+    ],
+    oauth_apps: [{ app_id: appId, app_secret: appSecret, name: "Test App", redirect_uris: [callback] }],
+    pages: [
+      { id: "page-1", name: "Owner Page", owner_user_ids: ["user-1"] },
+      { id: "page-2", name: "Other Page", owner_user_ids: ["user-2"] },
+    ],
+    page_videos: [
+      { id: "video-1", page_id: "page-1", title: "Metrics", views: 42, likes: 7, comments: 3 },
+      { id: "video-2", page_id: "page-2", title: "Private", views: 99 },
+    ],
+  });
+  return { app, store, tokenMap };
+}
+
+async function authorize(
+  app: Hono<AppEnv>,
+  userId = "user-1",
+  scope = "public_profile,pages_show_list,pages_read_engagement",
+) {
+  const authorizeQuery = new URLSearchParams({
+    client_id: appId,
+    redirect_uri: callback,
+    response_type: "code",
+    scope,
+    state: "state-123",
+  });
+  const authorizeResponse = await app.request(base + "/dialog/oauth?" + authorizeQuery);
+  const html = await authorizeResponse.text();
+  const transactionId = html.match(/name="transaction_id" value="([^"]+)"/)?.[1] ?? "";
+  const form = new URLSearchParams({
+    user_id: userId,
+    transaction_id: transactionId,
+  });
+  const response = await app.request(base + "/dialog/oauth/callback", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: form,
+  });
+  const location = new URL(response.headers.get("location") ?? "");
+  return { response, code: location.searchParams.get("code") ?? "", state: location.searchParams.get("state") };
+}
+
+async function exchange(app: Hono<AppEnv>, code: string, secret = appSecret, redirectUri = callback) {
+  const query = new URLSearchParams({
+    client_id: appId,
+    client_secret: secret,
+    redirect_uri: redirectUri,
+    code,
+  });
+  return app.request(base + "/v23.0/oauth/access_token?" + query);
+}
+
+async function userToken(app: Hono<AppEnv>, userId = "user-1", scope?: string) {
+  const auth = await authorize(app, userId, scope);
+  const response = await exchange(app, auth.code);
+  const body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+describe("Facebook emulator", () => {
+  let app: Hono<AppEnv>;
+  let store: Store;
+  let tokenMap: TokenMap;
+
+  beforeEach(() => {
+    ({ app, store, tokenMap } = setup());
+  });
+
+  it("accepts a preseeded shared bearer token for the first user", async () => {
+    tokenMap.set("test_token_admin", {
+      login: "unmatched-admin",
+      id: 1,
+      scopes: ["public_profile", "pages_show_list", "pages_read_engagement", "email"],
+    });
+    const response = await app.request(base + "/me?fields=id,name,email", {
+      headers: { authorization: "Bearer test_token_admin" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: "100000000000001",
+      name: "Test User",
+      email: "testuser@example.com",
+    });
+  });
+
+  it("continues to resolve privately issued tokens", async () => {
+    const token = await userToken(app, "user-1", "public_profile,email");
+    tokenMap.clear();
+    const response = await app.request(base + "/me?fields=id,name,email&access_token=" + token);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "user-1", name: "Owner", email: "owner@example.com" });
+  });
+
+  it("rejects an unknown token when the shared token map is empty", async () => {
+    tokenMap.clear();
+    const response = await app.request(base + "/me?access_token=unknown");
+    expect(response.status).toBe(401);
+    expect(((await response.json()) as { error: { code: number } }).error.code).toBe(190);
+  });
+
+  it("renders shared OAuth UI through versioned and unversioned endpoints", async () => {
+    for (const path of ["/dialog/oauth", "/v23.0/dialog/oauth"]) {
+      const query = new URLSearchParams({ client_id: appId, redirect_uri: callback, response_type: "code" });
+      const response = await app.request(base + path + "?" + query);
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("Log in with Facebook");
+    }
+  });
+
+  it("passes state through and exchanges a code once", async () => {
+    const auth = await authorize(app);
+    expect(auth.response.status).toBe(302);
+    expect(auth.state).toBe("state-123");
+    const first = await exchange(app, auth.code);
+    expect(first.status).toBe(200);
+    expect(((await first.json()) as { access_token: string }).access_token).toMatch(/^EAA/);
+    const second = await exchange(app, auth.code);
+    expect(second.status).toBe(400);
+    expect(((await second.json()) as { error: { code: number } }).error.code).toBe(100);
+  });
+
+  it("exchanges a short-lived token for a long-lived one via fb_exchange_token", async () => {
+    const shortLived = await userToken(app);
+    const query = new URLSearchParams({
+      grant_type: "fb_exchange_token",
+      client_id: appId,
+      client_secret: appSecret,
+      fb_exchange_token: shortLived,
+    });
+    const response = await app.request(base + "/oauth/access_token?" + query);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { access_token: string; token_type: string; expires_in: number };
+    expect(body.access_token).toMatch(/^EAA/);
+    expect(body.access_token).not.toBe(shortLived);
+    expect(body.token_type).toBe("bearer");
+    expect(body.expires_in).toBe(5184000);
+    const me = await app.request(base + "/me?access_token=" + body.access_token);
+    expect(await me.json()).toEqual({ id: "user-1", name: "Owner" });
+  });
+
+  it("rejects fb_exchange_token with wrong app credentials", async () => {
+    const shortLived = await userToken(app);
+    const query = new URLSearchParams({
+      grant_type: "fb_exchange_token",
+      client_id: appId,
+      client_secret: "wrong",
+      fb_exchange_token: shortLived,
+    });
+    const response = await app.request(base + "/oauth/access_token?" + query);
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as { error: { code: number } }).error.code).toBe(101);
+  });
+
+  it("rejects fb_exchange_token for a token issued to another app", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [{ app_id: "app-2", app_secret: "secret-2", name: "Other App", redirect_uris: [callback] }],
+    });
+    const shortLived = await userToken(app);
+    const query = new URLSearchParams({
+      grant_type: "fb_exchange_token",
+      client_id: "app-2",
+      client_secret: "secret-2",
+      fb_exchange_token: shortLived,
+    });
+    const response = await app.request(base + "/oauth/access_token?" + query);
+    expect(response.status).toBe(401);
+    expect(((await response.json()) as { error: { code: number } }).error.code).toBe(190);
+  });
+
+  it("returns a clear error for an unknown grant_type instead of the code error", async () => {
+    const query = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: appId,
+      client_secret: appSecret,
+    });
+    const response = await app.request(base + "/oauth/access_token?" + query);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { code: number; message: string } };
+    expect(body.error.code).toBe(100);
+    expect(body.error.message).toContain("Unsupported grant_type");
+    expect(body.error.message).not.toContain("authorization code");
+  });
+
+  it("rejects invalid clients, secrets, redirects, and codes", async () => {
+    const invalidClient = await app.request(
+      base + "/dialog/oauth?client_id=missing&redirect_uri=" + encodeURIComponent(callback),
+    );
+    expect(invalidClient.status).toBe(400);
+    const invalidRedirect = await app.request(
+      base + "/dialog/oauth?client_id=" + appId + "&redirect_uri=http%3A%2F%2Fevil.test",
+    );
+    expect(invalidRedirect.status).toBe(400);
+    const auth = await authorize(app);
+    expect((await exchange(app, auth.code, "wrong")).status).toBe(400);
+    expect((await exchange(app, auth.code, appSecret, "http://evil.test")).status).toBe(400);
+    expect((await exchange(app, "missing")).status).toBe(400);
+  });
+
+  it("rejects forged callbacks and ignores altered callback inputs", async () => {
+    const forged = await app.request(base + "/dialog/oauth/callback", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        user_id: "user-1",
+        client_id: appId,
+        redirect_uri: callback,
+        scope: "public_profile",
+        state: "forged",
+      }),
+    });
+    expect(forged.status).toBe(400);
+    expect(forged.headers.get("location")).toBeNull();
+
+    const query = new URLSearchParams({
+      client_id: appId,
+      redirect_uri: callback,
+      response_type: "code",
+      scope: "public_profile",
+      state: "original",
+    });
+    const page = await app.request(base + "/dialog/oauth?" + query);
+    const transactionId = (await page.text()).match(/name="transaction_id" value="([^"]+)"/)?.[1] ?? "";
+    const altered = await app.request(base + "/dialog/oauth/callback", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        transaction_id: transactionId,
+        user_id: "user-1",
+        client_id: "missing",
+        redirect_uri: "http://evil.test",
+        scope: "pages_show_list",
+        state: "altered",
+      }),
+    });
+    const location = new URL(altered.headers.get("location") ?? "");
+    expect(location.origin + location.pathname).toBe(callback);
+    expect(location.searchParams.get("state")).toBe("original");
+    const tokenResponse = await exchange(app, location.searchParams.get("code") ?? "");
+    const token = ((await tokenResponse.json()) as { access_token: string }).access_token;
+    expect((await app.request(base + "/me/accounts?access_token=" + token)).status).toBe(403);
+    expect(
+      (
+        await app.request(base + "/dialog/oauth/callback", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ transaction_id: transactionId, user_id: "user-1" }),
+        })
+      ).status,
+    ).toBe(400);
+  });
+
+  it("supports bearer and query tokens for user /me", async () => {
+    const token = await userToken(app, "user-1", "public_profile,pages_show_list,pages_read_engagement,email");
+    const bearer = await app.request(base + "/me?fields=id,name,email", {
+      headers: { authorization: "Bearer " + token },
+    });
+    expect(await bearer.json()).toEqual({ id: "user-1", name: "Owner", email: "owner@example.com" });
+    const query = await app.request(base + "/v23.0/me?access_token=" + token);
+    expect(await query.json()).toEqual({ id: "user-1", name: "Owner" });
+  });
+
+  it("omits email from /me when the token lacks the email scope", async () => {
+    const token = await userToken(app);
+    const response = await app.request(base + "/me?fields=id,name,email&access_token=" + token);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "user-1", name: "Owner" });
+  });
+
+  it("enumerates only owned pages and issues a page token", async () => {
+    const token = await userToken(app);
+    const response = await app.request(base + "/me/accounts?access_token=" + token);
+    const body = (await response.json()) as { data: Array<{ id: string; access_token: string }> };
+    expect(body.data.map((page) => page.id)).toEqual(["page-1"]);
+    const me = await app.request(base + "/me?access_token=" + body.data[0]?.access_token);
+    expect(await me.json()).toEqual({ id: "page-1", name: "Owner Page" });
+  });
+
+  it("issues a fresh random page access token on every /me/accounts call", async () => {
+    const token = await userToken(app);
+    const first = (await (await app.request(base + "/me/accounts?access_token=" + token)).json()) as {
+      data: Array<{ access_token: string }>;
+    };
+    const second = (await (await app.request(base + "/me/accounts?access_token=" + token)).json()) as {
+      data: Array<{ access_token: string }>;
+    };
+    const firstToken = first.data[0]?.access_token ?? "";
+    const secondToken = second.data[0]?.access_token ?? "";
+    expect(firstToken).toMatch(/^EAA/);
+    expect(firstToken).not.toContain(appId);
+    expect(firstToken).not.toBe(secondToken);
+    // Both tokens must still work independently.
+    const meFirst = await app.request(base + "/me?access_token=" + firstToken);
+    expect(((await meFirst.json()) as { id: string }).id).toBe("page-1");
+    const meSecond = await app.request(base + "/me?access_token=" + secondToken);
+    expect(((await meSecond.json()) as { id: string }).id).toBe("page-1");
+  });
+
+  it("returns page and video metrics only to the owning user or page", async () => {
+    const token = await userToken(app);
+    const video = await app.request(
+      base + "/video-1?fields=id,views,likes.summary(true),comments.summary(true)&access_token=" + token,
+    );
+    expect(await video.json()).toEqual({
+      id: "video-1",
+      views: 42,
+      likes: { summary: { total_count: 7 } },
+      comments: { summary: { total_count: 3 } },
+    });
+    const denied = await app.request(base + "/video-2?access_token=" + token);
+    expect(denied.status).toBe(403);
+  });
+
+  it("enforces Page permissions and returns deterministic unknown-object errors", async () => {
+    const token = await userToken(app, "user-1", "public_profile");
+    expect((await app.request(base + "/me/accounts?access_token=" + token)).status).toBe(403);
+    expect((await app.request(base + "/page-1?access_token=" + token)).status).toBe(403);
+    const unknown = await app.request(base + "/missing?access_token=" + token);
+    expect(unknown.status).toBe(404);
+    expect(((await unknown.json()) as { error: { error_subcode: number } }).error.error_subcode).toBe(33);
+  });
+
+  it("debugs valid tokens with an app access token", async () => {
+    const token = await userToken(app);
+    const response = await app.request(
+      base + "/debug_token?input_token=" + token + "&access_token=" + appId + "|" + appSecret,
+    );
+    expect(((await response.json()) as { data: { is_valid: boolean; user_id: string } }).data).toMatchObject({
+      is_valid: true,
+      user_id: "user-1",
+    });
+  });
+
+  it("does not debug a token issued to another app", async () => {
+    seedFromConfig(store, base, {
+      oauth_apps: [{ app_id: "app-2", app_secret: "secret-2", name: "Other App", redirect_uris: [callback] }],
+    });
+    const token = await userToken(app);
+    const response = await app.request(base + "/debug_token?input_token=" + token + "&access_token=app-2|secret-2");
+    expect(await response.json()).toEqual({ data: { is_valid: false } });
+  });
+
+  it("rejects dangling Page owner and video Page references", () => {
+    expect(() =>
+      seedFromConfig(new Store(), base, {
+        pages: [{ id: "bad-page", name: "Bad Page", owner_user_ids: ["missing-user"] }],
+      }),
+    ).toThrow('Facebook Page "bad-page" references unknown owner user ID "missing-user".');
+    expect(() =>
+      seedFromConfig(new Store(), base, {
+        page_videos: [{ id: "bad-video", page_id: "missing-page" }],
+      }),
+    ).toThrow('Facebook Page video "bad-video" references unknown Page ID "missing-page".');
+  });
+
+  it("rejects unsupported Graph fields with code 100", async () => {
+    const token = await userToken(app);
+    for (const path of ["/me", "/page-1", "/video-1"]) {
+      const response = await app.request(base + path + "?fields=id,unknown&access_token=" + token);
+      expect(response.status).toBe(400);
+      expect((await response.json()) as object).toMatchObject({
+        error: { code: 100, type: "GraphMethodException", message: expect.stringContaining("unknown") },
+      });
+    }
+  });
+
+  it("clears authorization state on reset", async () => {
+    const query = new URLSearchParams({ client_id: appId, redirect_uri: callback, response_type: "code" });
+    const page = await app.request(base + "/dialog/oauth?" + query);
+    const transactionId = (await page.text()).match(/name="transaction_id" value="([^"]+)"/)?.[1] ?? "";
+    const token = await userToken(app);
+    store.reset();
+    tokenMap.clear();
+    facebookPlugin.seed?.(store, base);
+    const response = await app.request(base + "/me?access_token=" + token);
+    expect(response.status).toBe(401);
+    const callbackResponse = await app.request(base + "/dialog/oauth/callback", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ transaction_id: transactionId, user_id: "100000000000001" }),
+    });
+    expect(callbackResponse.status).toBe(400);
+  });
+});

--- a/packages/@emulators/facebook/src/__tests__/facebook.test.ts
+++ b/packages/@emulators/facebook/src/__tests__/facebook.test.ts
@@ -86,21 +86,33 @@ describe("Facebook emulator", () => {
     ({ app, store, tokenMap } = setup());
   });
 
-  it("accepts a preseeded shared bearer token for the first user", async () => {
-    tokenMap.set("test_token_admin", {
-      login: "unmatched-admin",
+  it("resolves a shared bearer token by configured user ID and preserves its scopes", async () => {
+    tokenMap.set("configured-token", {
+      login: "user-2",
       id: 1,
-      scopes: ["public_profile", "pages_show_list", "pages_read_engagement", "email"],
+      scopes: ["public_profile"],
     });
     const response = await app.request(base + "/me?fields=id,name,email", {
-      headers: { authorization: "Bearer test_token_admin" },
+      headers: { authorization: "Bearer configured-token" },
     });
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
-      id: "100000000000001",
-      name: "Test User",
-      email: "testuser@example.com",
+      id: "user-2",
+      name: "Other",
     });
+
+    const accounts = await app.request(base + "/me/accounts?access_token=configured-token");
+    expect(accounts.status).toBe(403);
+  });
+
+  it("does not silently authenticate an unmatched shared token as the first user", async () => {
+    tokenMap.set("unmatched-token", {
+      login: "missing-user",
+      id: 1,
+      scopes: ["public_profile", "email"],
+    });
+    const response = await app.request(base + "/me?access_token=unmatched-token");
+    expect(response.status).toBe(401);
   });
 
   it("continues to resolve privately issued tokens", async () => {

--- a/packages/@emulators/facebook/src/entities.ts
+++ b/packages/@emulators/facebook/src/entities.ts
@@ -1,0 +1,30 @@
+import type { Entity } from "@emulators/core";
+
+export interface FacebookUser extends Entity {
+  user_id: string;
+  name: string;
+  email: string;
+}
+export interface FacebookOAuthApp extends Entity {
+  app_id: string;
+  app_secret: string;
+  name: string;
+  redirect_uris: string[];
+}
+export interface FacebookPage extends Entity {
+  page_id: string;
+  name: string;
+  category: string;
+  owner_user_ids: string[];
+}
+export interface FacebookVideo extends Entity {
+  video_id: string;
+  page_id: string;
+  title: string;
+  description: string;
+  permalink_url: string;
+  created_time: string;
+  views: number;
+  likes: number;
+  comments: number;
+}

--- a/packages/@emulators/facebook/src/index.ts
+++ b/packages/@emulators/facebook/src/index.ts
@@ -1,0 +1,118 @@
+import type { Hono } from "hono";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { facebookRoutes } from "./routes/facebook.js";
+import { getFacebookStore } from "./store.js";
+
+export { getFacebookStore, type FacebookStore } from "./store.js";
+export * from "./entities.js";
+
+export interface FacebookSeedConfig {
+  users?: Array<{ id?: string; name: string; email?: string }>;
+  oauth_apps?: Array<{ app_id: string; app_secret: string; name: string; redirect_uris: string[] }>;
+  pages?: Array<{ id?: string; name: string; category?: string; owner_user_ids?: string[] }>;
+  page_videos?: Array<{
+    id?: string;
+    page_id: string;
+    title?: string;
+    description?: string;
+    permalink_url?: string;
+    created_time?: string;
+    views?: number;
+    likes?: number;
+    comments?: number;
+  }>;
+}
+
+function seedDefaults(store: Store): void {
+  const fs = getFacebookStore(store);
+  fs.users.insert({ user_id: "100000000000001", name: "Test User", email: "testuser@example.com" });
+  fs.oauthApps.insert({
+    app_id: "123456789012345",
+    app_secret: "example_app_secret",
+    name: "Emulate Facebook App",
+    redirect_uris: ["http://localhost:3000/api/auth/callback/facebook"],
+  });
+  fs.pages.insert({
+    page_id: "200000000000001",
+    name: "Emulate Page",
+    category: "Digital creator",
+    owner_user_ids: ["100000000000001"],
+  });
+  fs.videos.insert({
+    video_id: "300000000000001",
+    page_id: "200000000000001",
+    title: "Welcome video",
+    description: "A seeded Facebook Page video",
+    permalink_url: "https://www.facebook.com/200000000000001/videos/300000000000001",
+    created_time: "2025-01-01T00:00:00+0000",
+    views: 1200,
+    likes: 80,
+    comments: 12,
+  });
+}
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: FacebookSeedConfig): void {
+  const fs = getFacebookStore(store);
+  for (const [index, user] of (config.users ?? []).entries()) {
+    const userId = user.id ?? String(100000000000002 + index);
+    if (!fs.users.findOneBy("user_id", userId)) {
+      fs.users.insert({ user_id: userId, name: user.name, email: user.email ?? "user" + index + "@example.com" });
+    }
+  }
+  for (const oauthApp of config.oauth_apps ?? []) {
+    if (!fs.oauthApps.findOneBy("app_id", oauthApp.app_id)) fs.oauthApps.insert(oauthApp);
+  }
+  for (const [index, page] of (config.pages ?? []).entries()) {
+    const pageId = page.id ?? String(200000000000002 + index);
+    const ownerUserIds =
+      page.owner_user_ids ??
+      fs.users
+        .all()
+        .slice(0, 1)
+        .map((user) => user.user_id);
+    const missingOwner = ownerUserIds.find((userId) => !fs.users.findOneBy("user_id", userId));
+    if (missingOwner) {
+      throw new Error('Facebook Page "' + pageId + '" references unknown owner user ID "' + missingOwner + '".');
+    }
+    if (!fs.pages.findOneBy("page_id", pageId)) {
+      fs.pages.insert({
+        page_id: pageId,
+        name: page.name,
+        category: page.category ?? "Digital creator",
+        owner_user_ids: ownerUserIds,
+      });
+    }
+  }
+  for (const [index, video] of (config.page_videos ?? []).entries()) {
+    const videoId = video.id ?? String(300000000000002 + index);
+    if (!fs.pages.findOneBy("page_id", video.page_id)) {
+      throw new Error('Facebook Page video "' + videoId + '" references unknown Page ID "' + video.page_id + '".');
+    }
+    if (!fs.videos.findOneBy("video_id", videoId)) {
+      fs.videos.insert({
+        video_id: videoId,
+        page_id: video.page_id,
+        title: video.title ?? "Untitled video",
+        description: video.description ?? "",
+        permalink_url: video.permalink_url ?? "https://www.facebook.com/" + video.page_id + "/videos/" + videoId,
+        created_time: video.created_time ?? "2025-01-01T00:00:00+0000",
+        views: video.views ?? 0,
+        likes: video.likes ?? 0,
+        comments: video.comments ?? 0,
+      });
+    }
+  }
+}
+
+export const facebookPlugin: ServicePlugin = {
+  name: "facebook",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const context: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    facebookRoutes(context);
+  },
+  seed(store: Store): void {
+    seedDefaults(store);
+  },
+};
+
+export default facebookPlugin;

--- a/packages/@emulators/facebook/src/index.ts
+++ b/packages/@emulators/facebook/src/index.ts
@@ -1,5 +1,4 @@
-import type { Hono } from "hono";
-import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import type { AppEnv, Hono, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
 import { facebookRoutes } from "./routes/facebook.js";
 import { getFacebookStore } from "./store.js";
 

--- a/packages/@emulators/facebook/src/routes/facebook.ts
+++ b/packages/@emulators/facebook/src/routes/facebook.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "node:crypto";
-import type { Context } from "hono";
-import type { RouteContext, Store } from "@emulators/core";
+import type { Context, RouteContext, Store } from "@emulators/core";
 import {
   bodyStr,
   constantTimeSecretEqual,

--- a/packages/@emulators/facebook/src/routes/facebook.ts
+++ b/packages/@emulators/facebook/src/routes/facebook.ts
@@ -139,15 +139,18 @@ export function facebookRoutes({ app, store, tokenMap }: RouteContext): void {
     const sharedToken = tokenMap?.get(value);
     if (!sharedToken) return undefined;
     const users = fs().users.all();
-    const user =
-      users.find((candidate) => candidate.name === sharedToken.login || candidate.email === sharedToken.login) ??
-      users[0];
+    const user = users.find(
+      (candidate) =>
+        candidate.user_id === sharedToken.login ||
+        candidate.name === sharedToken.login ||
+        candidate.email === sharedToken.login,
+    );
     if (!user) return undefined;
     return {
       kind: "user",
       subjectId: user.user_id,
       appId: fs().oauthApps.all()[0]?.app_id ?? "",
-      scopes: GRANTABLE_SCOPES,
+      scopes: sharedToken.scopes,
       issuedAt: Date.now(),
     };
   };

--- a/packages/@emulators/facebook/src/routes/facebook.ts
+++ b/packages/@emulators/facebook/src/routes/facebook.ts
@@ -1,0 +1,455 @@
+import { randomBytes } from "node:crypto";
+import type { Context } from "hono";
+import type { RouteContext, Store } from "@emulators/core";
+import {
+  bodyStr,
+  constantTimeSecretEqual,
+  escapeHtml,
+  matchesRedirectUri,
+  renderCardPage,
+  renderErrorPage,
+  renderUserButton,
+} from "@emulators/core";
+import { getFacebookStore } from "../store.js";
+
+type Code = { userId: string; appId: string; redirectUri: string; scopes: string[]; createdAt: number };
+type Token = { kind: "user" | "page"; subjectId: string; appId: string; scopes: string[]; issuedAt: number };
+type AuthorizationTransaction = {
+  appId: string;
+  redirectUri: string;
+  state: string;
+  scopes: string[];
+  createdAt: number;
+};
+
+const DEFAULT_SCOPES = ["public_profile", "pages_show_list", "pages_read_engagement"];
+const GRANTABLE_SCOPES = [...DEFAULT_SCOPES, "email"];
+const SERVICE_LABEL = "Facebook";
+const AUTHORIZATION_TRANSACTION_TTL_MS = 5 * 60_000;
+
+function authorizationTransactions(store: Store): Map<string, AuthorizationTransaction> {
+  let value = store.getData<Map<string, AuthorizationTransaction>>("facebook.oauth.authorization_transactions");
+  if (!value) {
+    value = new Map();
+    store.setData("facebook.oauth.authorization_transactions", value);
+  }
+  return value;
+}
+
+function codes(store: Store): Map<string, Code> {
+  let value = store.getData<Map<string, Code>>("facebook.oauth.codes");
+  if (!value) {
+    value = new Map();
+    store.setData("facebook.oauth.codes", value);
+  }
+  return value;
+}
+
+function tokens(store: Store): Map<string, Token> {
+  let value = store.getData<Map<string, Token>>("facebook.oauth.tokens");
+  if (!value) {
+    value = new Map();
+    store.setData("facebook.oauth.tokens", value);
+  }
+  return value;
+}
+
+function graphError(
+  c: Context,
+  message: string,
+  type: string,
+  code: number,
+  status: 400 | 401 | 403 | 404 = 400,
+  subcode?: number,
+) {
+  return c.json(
+    {
+      error: {
+        message,
+        type,
+        code,
+        ...(subcode === undefined ? {} : { error_subcode: subcode }),
+        fbtrace_id: "EMULATE_FACEBOOK",
+      },
+    },
+    status,
+  );
+}
+
+async function requestParams(c: Context): Promise<Record<string, string>> {
+  const query = Object.fromEntries(new URL(c.req.url).searchParams);
+  if (c.req.method === "GET") return query;
+  const body = await c.req.parseBody();
+  return { ...query, ...Object.fromEntries(Object.entries(body).map(([key, value]) => [key, bodyStr(value)])) };
+}
+
+function accessToken(c: Context): string {
+  return c.req.query("access_token") ?? (c.req.header("authorization") ?? "").replace(/^Bearer\s+/i, "").trim();
+}
+
+function requireToken(c: Context, resolveToken: (value: string) => Token | undefined): Token | Response {
+  const token = resolveToken(accessToken(c));
+  return (
+    token ??
+    graphError(
+      c,
+      "An active access token must be used to query information about the current user.",
+      "OAuthException",
+      190,
+      401,
+    )
+  );
+}
+
+function fieldName(raw: string): string {
+  return raw.split(".")[0]?.split("{")[0] ?? raw;
+}
+
+function requestedFields(c: Context, defaults: string[], supported: string[]): string[] | Response {
+  const requested = (c.req.query("fields") ?? defaults.join(","))
+    .split(",")
+    .map((field) => field.trim())
+    .filter(Boolean);
+  const unsupported = requested.find((field) => !supported.includes(fieldName(field)));
+  if (unsupported) {
+    return graphError(
+      c,
+      "Tried accessing nonexisting field (" + fieldName(unsupported) + ") on node type (FacebookObject)",
+      "GraphMethodException",
+      100,
+    );
+  }
+  return requested;
+}
+
+function pick(source: Record<string, unknown>, requested: string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const raw of requested) {
+    const field = raw.split(".")[0]?.split("{")[0] ?? raw;
+    if (field in source) result[field] = source[field];
+  }
+  return result;
+}
+
+export function facebookRoutes({ app, store, tokenMap }: RouteContext): void {
+  const fs = () => getFacebookStore(store);
+  const resolveToken = (value: string): Token | undefined => {
+    const privateToken = tokens(store).get(value);
+    if (privateToken) return privateToken;
+    const sharedToken = tokenMap?.get(value);
+    if (!sharedToken) return undefined;
+    const users = fs().users.all();
+    const user =
+      users.find((candidate) => candidate.name === sharedToken.login || candidate.email === sharedToken.login) ??
+      users[0];
+    if (!user) return undefined;
+    return {
+      kind: "user",
+      subjectId: user.user_id,
+      appId: fs().oauthApps.all()[0]?.app_id ?? "",
+      scopes: GRANTABLE_SCOPES,
+      issuedAt: Date.now(),
+    };
+  };
+  const shareToken = (value: string, token: Token): void => {
+    if (!tokenMap) return;
+    if (token.kind === "user") {
+      const users = fs().users.all();
+      const user = users.find((candidate) => candidate.user_id === token.subjectId);
+      tokenMap.set(value, {
+        login: user?.email ?? user?.name ?? token.subjectId,
+        id: Math.max(1, user ? users.indexOf(user) + 1 : 1),
+        scopes: token.scopes,
+      });
+      return;
+    }
+    const pages = fs().pages.all();
+    const page = pages.find((candidate) => candidate.page_id === token.subjectId);
+    tokenMap.set(value, {
+      login: page?.name ?? token.subjectId,
+      id: Math.max(1, page ? pages.indexOf(page) + 1 : 1),
+      scopes: token.scopes,
+    });
+  };
+
+  const authorize = (c: Context) => {
+    const appId = c.req.query("client_id") ?? "";
+    const redirectUri = c.req.query("redirect_uri") ?? "";
+    const oauthApp = fs().oauthApps.findOneBy("app_id", appId);
+    if (!oauthApp) {
+      return c.html(renderErrorPage("Application not found", "The app ID is not registered.", SERVICE_LABEL), 400);
+    }
+    if (!matchesRedirectUri(redirectUri, oauthApp.redirect_uris)) {
+      return c.html(
+        renderErrorPage(
+          "Redirect URI mismatch",
+          "The redirect URI is not registered for this application.",
+          SERVICE_LABEL,
+        ),
+        400,
+      );
+    }
+    if ((c.req.query("response_type") ?? "code") !== "code") {
+      return c.html(
+        renderErrorPage("Unsupported response type", "Only the authorization code flow is supported.", SERVICE_LABEL),
+        400,
+      );
+    }
+    const requestedScopes = (c.req.query("scope") ?? DEFAULT_SCOPES.join(",")).split(/[ ,]+/).filter(Boolean);
+    const transactionId = randomBytes(32).toString("base64url");
+    authorizationTransactions(store).set(transactionId, {
+      appId,
+      redirectUri,
+      state: c.req.query("state") ?? "",
+      scopes: requestedScopes.filter((scope) => GRANTABLE_SCOPES.includes(scope)),
+      createdAt: Date.now(),
+    });
+    const users = fs().users.all();
+    const body = users.length
+      ? users
+          .map((user) =>
+            renderUserButton({
+              letter: (user.name[0] ?? "?").toUpperCase(),
+              login: user.name,
+              name: user.email,
+              formAction: "/dialog/oauth/callback",
+              hiddenFields: { transaction_id: transactionId, user_id: user.user_id },
+            }),
+          )
+          .join("\n")
+      : '<p class="empty">No users in the emulator store.</p>';
+    return c.html(
+      renderCardPage(
+        "Log in with Facebook",
+        "Continue to <strong>" + escapeHtml(oauthApp.name) + "</strong>.",
+        body,
+        SERVICE_LABEL,
+      ),
+    );
+  };
+
+  app.get("/dialog/oauth", authorize);
+
+  app.post("/dialog/oauth/callback", async (c) => {
+    const p = await requestParams(c);
+    const transaction = authorizationTransactions(store).get(p.transaction_id ?? "");
+    authorizationTransactions(store).delete(p.transaction_id ?? "");
+    const user = fs().users.findOneBy("user_id", p.user_id ?? "");
+    if (!transaction || Date.now() - transaction.createdAt > AUTHORIZATION_TRANSACTION_TTL_MS || !user) {
+      return c.html(
+        renderErrorPage(
+          "Invalid authorization request",
+          "The authorization transaction or selected user is invalid.",
+          SERVICE_LABEL,
+        ),
+        400,
+      );
+    }
+    const code = "AQ" + randomBytes(24).toString("base64url");
+    codes(store).set(code, {
+      userId: user.user_id,
+      appId: transaction.appId,
+      redirectUri: transaction.redirectUri,
+      scopes: transaction.scopes,
+      createdAt: Date.now(),
+    });
+    const target = new URL(transaction.redirectUri);
+    target.searchParams.set("code", code);
+    if (transaction.state) target.searchParams.set("state", transaction.state);
+    return c.redirect(target.toString(), 302);
+  });
+
+  const exchange = async (c: Context) => {
+    const p = await requestParams(c);
+    const oauthApp = fs().oauthApps.findOneBy("app_id", p.client_id ?? "");
+    if (!oauthApp || !constantTimeSecretEqual(p.client_secret ?? "", oauthApp.app_secret)) {
+      return graphError(c, "Error validating client secret.", "OAuthException", 101);
+    }
+    const grantType = p.grant_type ?? "authorization_code";
+    if (grantType === "fb_exchange_token") {
+      const existing = tokens(store).get(p.fb_exchange_token ?? "");
+      if (!existing || existing.appId !== oauthApp.app_id) {
+        return graphError(c, "Error validating access token.", "OAuthException", 190, 401);
+      }
+      const token = "EAA" + randomBytes(32).toString("base64url");
+      const longLivedToken: Token = {
+        kind: existing.kind,
+        subjectId: existing.subjectId,
+        appId: existing.appId,
+        scopes: existing.scopes,
+        issuedAt: Date.now(),
+      };
+      tokens(store).set(token, longLivedToken);
+      shareToken(token, longLivedToken);
+      return c.json({ access_token: token, token_type: "bearer", expires_in: 5184000 });
+    }
+    if (grantType !== "authorization_code") {
+      return graphError(c, "Unsupported grant_type: " + grantType + ".", "OAuthException", 100);
+    }
+    const pending = codes(store).get(p.code ?? "");
+    if (
+      !pending ||
+      pending.appId !== oauthApp.app_id ||
+      pending.redirectUri !== (p.redirect_uri ?? "") ||
+      Date.now() - pending.createdAt > 600_000
+    ) {
+      return graphError(c, "This authorization code has been used or is invalid.", "OAuthException", 100);
+    }
+    codes(store).delete(p.code ?? "");
+    const token = "EAA" + randomBytes(32).toString("base64url");
+    const userToken: Token = {
+      kind: "user",
+      subjectId: pending.userId,
+      appId: pending.appId,
+      scopes: pending.scopes,
+      issuedAt: Date.now(),
+    };
+    tokens(store).set(token, userToken);
+    shareToken(token, userToken);
+    return c.json({ access_token: token, token_type: "bearer", expires_in: 5184000 });
+  };
+  app.get("/oauth/access_token", exchange);
+  app.post("/oauth/access_token", exchange);
+
+  const debugToken = async (c: Context) => {
+    const p = await requestParams(c);
+    const [appId, appSecret] = (p.access_token ?? "").split("|");
+    const oauthApp = fs().oauthApps.findOneBy("app_id", appId ?? "");
+    if (!oauthApp || !constantTimeSecretEqual(appSecret ?? "", oauthApp.app_secret)) {
+      return graphError(c, "Invalid app access token.", "OAuthException", 190, 401);
+    }
+    const token = resolveToken(p.input_token ?? "");
+    const validToken = token?.appId === oauthApp.app_id ? token : undefined;
+    return c.json({
+      data: validToken
+        ? {
+            app_id: validToken.appId,
+            type: validToken.kind === "user" ? "USER" : "PAGE",
+            application: oauthApp.name,
+            is_valid: true,
+            issued_at: Math.floor(validToken.issuedAt / 1000),
+            scopes: validToken.scopes,
+            user_id: validToken.subjectId,
+          }
+        : { is_valid: false },
+    });
+  };
+  app.get("/debug_token", debugToken);
+
+  const me = (c: Context) => {
+    const auth = requireToken(c, resolveToken);
+    if (auth instanceof Response) return auth;
+    if (auth.kind === "user") {
+      const user = fs().users.findOneBy("user_id", auth.subjectId);
+      if (!user)
+        return graphError(c, "Unsupported get request. Object does not exist.", "GraphMethodException", 100, 404);
+      const fields = requestedFields(c, ["id", "name"], ["id", "name", "email"]);
+      if (fields instanceof Response) return fields;
+      const source: Record<string, unknown> = { id: user.user_id, name: user.name };
+      if (auth.scopes.includes("email")) source.email = user.email;
+      return c.json(pick(source, fields));
+    }
+    const page = fs().pages.findOneBy("page_id", auth.subjectId);
+    if (!page)
+      return graphError(c, "Unsupported get request. Object does not exist.", "GraphMethodException", 100, 404);
+    const fields = requestedFields(c, ["id", "name"], ["id", "name", "category"]);
+    if (fields instanceof Response) return fields;
+    return c.json(pick({ id: page.page_id, name: page.name, category: page.category }, fields));
+  };
+  app.get("/me", me);
+
+  const accounts = (c: Context) => {
+    const auth = requireToken(c, resolveToken);
+    if (auth instanceof Response) return auth;
+    if (auth.kind !== "user" || !auth.scopes.includes("pages_show_list")) {
+      return graphError(c, "Permissions error", "OAuthException", 200, 403);
+    }
+    const data = fs()
+      .pages.all()
+      .filter((page) => page.owner_user_ids.includes(auth.subjectId))
+      .map((page) => {
+        const token = "EAA" + randomBytes(32).toString("base64url");
+        const pageToken: Token = {
+          kind: "page",
+          subjectId: page.page_id,
+          appId: auth.appId,
+          scopes: auth.scopes,
+          issuedAt: Date.now(),
+        };
+        tokens(store).set(token, pageToken);
+        shareToken(token, pageToken);
+        return {
+          id: page.page_id,
+          name: page.name,
+          category: page.category,
+          access_token: token,
+          tasks: ["ANALYZE", "CREATE_CONTENT", "MODERATE"],
+        };
+      });
+    return c.json({ data, paging: { cursors: { before: "", after: "" } } });
+  };
+  app.get("/me/accounts", accounts);
+
+  const object = (c: Context, explicitObjectId?: string) => {
+    const auth = requireToken(c, resolveToken);
+    if (auth instanceof Response) return auth;
+    const objectId = explicitObjectId ?? c.req.param("objectId") ?? "";
+    const page = fs().pages.findOneBy("page_id", objectId);
+    if (page) {
+      const allowed =
+        auth.kind === "page" ? auth.subjectId === page.page_id : page.owner_user_ids.includes(auth.subjectId);
+      if (!allowed || !auth.scopes.includes("pages_read_engagement")) {
+        return graphError(c, "Permissions error", "OAuthException", 200, 403);
+      }
+      const fields = requestedFields(c, ["id", "name"], ["id", "name", "category"]);
+      if (fields instanceof Response) return fields;
+      return c.json(pick({ id: page.page_id, name: page.name, category: page.category }, fields));
+    }
+    const video = fs().videos.findOneBy("video_id", objectId);
+    if (video) {
+      const videoPage = fs().pages.findOneBy("page_id", video.page_id);
+      const allowed =
+        auth.kind === "page" ? auth.subjectId === video.page_id : videoPage?.owner_user_ids.includes(auth.subjectId);
+      if (!allowed || !auth.scopes.includes("pages_read_engagement")) {
+        return graphError(c, "Permissions error", "OAuthException", 200, 403);
+      }
+      const fields = requestedFields(
+        c,
+        ["id", "title", "views", "likes", "comments"],
+        ["id", "title", "description", "permalink_url", "created_time", "views", "likes", "comments"],
+      );
+      if (fields instanceof Response) return fields;
+      return c.json(
+        pick(
+          {
+            id: video.video_id,
+            title: video.title,
+            description: video.description,
+            permalink_url: video.permalink_url,
+            created_time: video.created_time,
+            views: video.views,
+            likes: { summary: { total_count: video.likes } },
+            comments: { summary: { total_count: video.comments } },
+          },
+          fields,
+        ),
+      );
+    }
+    return graphError(
+      c,
+      "Unsupported get request. Object does not exist, cannot be loaded due to missing permissions, or does not support this operation.",
+      "GraphMethodException",
+      100,
+      404,
+      33,
+    );
+  };
+  app.get("/:objectId", (c) => object(c));
+  app.get("/:version{v\\d+\\.\\d+}/dialog/oauth", authorize);
+  app.get("/:version{v\\d+\\.\\d+}/oauth/access_token", exchange);
+  app.post("/:version{v\\d+\\.\\d+}/oauth/access_token", exchange);
+  app.get("/:version{v\\d+\\.\\d+}/debug_token", debugToken);
+  app.get("/:version{v\\d+\\.\\d+}/me", me);
+  app.get("/:version{v\\d+\\.\\d+}/me/accounts", accounts);
+  app.get("/:version{v\\d+\\.\\d+}/:objectId", (c) => object(c));
+}

--- a/packages/@emulators/facebook/src/store.ts
+++ b/packages/@emulators/facebook/src/store.ts
@@ -1,0 +1,18 @@
+import { Store, type Collection } from "@emulators/core";
+import type { FacebookOAuthApp, FacebookPage, FacebookUser, FacebookVideo } from "./entities.js";
+
+export interface FacebookStore {
+  users: Collection<FacebookUser>;
+  oauthApps: Collection<FacebookOAuthApp>;
+  pages: Collection<FacebookPage>;
+  videos: Collection<FacebookVideo>;
+}
+
+export function getFacebookStore(store: Store): FacebookStore {
+  return {
+    users: store.collection<FacebookUser>("facebook.users", ["user_id", "email"]),
+    oauthApps: store.collection<FacebookOAuthApp>("facebook.oauth_apps", ["app_id"]),
+    pages: store.collection<FacebookPage>("facebook.pages", ["page_id"]),
+    videos: store.collection<FacebookVideo>("facebook.videos", ["video_id", "page_id"]),
+  };
+}

--- a/packages/@emulators/facebook/tsconfig.json
+++ b/packages/@emulators/facebook/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": { "outDir": "./dist", "rootDir": "./src" },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/facebook/tsup.config.ts
+++ b/packages/@emulators/facebook/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/@emulators/facebook/vitest.config.ts
+++ b/packages/@emulators/facebook/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({ test: { globals: true } });

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -63,6 +63,7 @@
     "@emulators/microsoft": "workspace:*",
     "@emulators/okta": "workspace:*",
     "@emulators/aws": "workspace:*",
+    "@emulators/facebook": "workspace:*",
     "@emulators/google": "workspace:*",
     "@emulators/mongoatlas": "workspace:*",
     "@emulators/slack": "workspace:*",

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -27,7 +27,10 @@ program
   .command("start", { isDefault: true })
   .description("Start the emulator server")
   .option("-p, --port <port>", "Base port", defaultPort)
-  .option("-s, --service <services>", "Comma-separated services to enable")
+  .option(
+    "-s, --service <services>",
+    "Comma-separated services to enable, including facebook; run list for all services",
+  )
   .option("--seed <file>", "Path to seed config file")
   .option("--base-url <url>", "Override advertised base URL (supports {service} template)")
   .option("--portless", "Serve over HTTPS via portless (auto-registers aliases)")
@@ -49,7 +52,7 @@ program
 program
   .command("init")
   .description("Generate a starter config file")
-  .option("-s, --service <service>", "Service to generate config for", "all")
+  .option("-s, --service <service>", "Service to generate config for, including facebook", "all")
   .action((opts) => {
     initCommand({ service: opts.service });
   });

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -29,6 +29,7 @@ const SERVICE_NAME_LIST = [
   "clerk",
   "linear",
   "twilio",
+  "facebook",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -567,6 +568,54 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
           },
         ],
         strict_scopes: false,
+      },
+    },
+  },
+
+  facebook: {
+    label: "Facebook Login and Graph API emulator",
+    endpoints: "OAuth authorization, token exchange, token debugging, users, Pages, Page tokens, Page videos",
+    async load() {
+      const mod = await import("@emulators/facebook");
+      return { plugin: mod.facebookPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback(cfg) {
+      const firstUser = (cfg?.users as Array<{ id?: string }> | undefined)?.[0]?.id ?? "100000000000001";
+      return {
+        login: firstUser,
+        id: 1,
+        scopes: ["public_profile", "pages_show_list", "pages_read_engagement", "email"],
+      };
+    },
+    initConfig: {
+      facebook: {
+        users: [{ id: "100000000000001", name: "Test User", email: "testuser@example.com" }],
+        oauth_apps: [
+          {
+            app_id: "123456789012345",
+            app_secret: "example_app_secret",
+            name: "My Facebook App",
+            redirect_uris: ["http://localhost:3000/api/auth/callback/facebook"],
+          },
+        ],
+        pages: [
+          {
+            id: "200000000000001",
+            name: "My Page",
+            category: "Digital creator",
+            owner_user_ids: ["100000000000001"],
+          },
+        ],
+        page_videos: [
+          {
+            id: "300000000000001",
+            page_id: "200000000000001",
+            title: "Campaign video",
+            views: 1200,
+            likes: 80,
+            comments: 12,
+          },
+        ],
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,25 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
+  packages/@emulators/facebook:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+      hono:
+        specifier: ^4
+        version: 4.12.12
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+
   packages/@emulators/github:
     dependencies:
       '@emulators/core':
@@ -856,6 +875,9 @@ importers:
       '@emulators/core':
         specifier: workspace:*
         version: link:../@emulators/core
+      '@emulators/facebook':
+        specifier: workspace:*
+        version: link:../@emulators/facebook
       '@emulators/github':
         specifier: workspace:*
         version: link:../@emulators/github

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,19 +637,16 @@ importers:
       '@emulators/core':
         specifier: workspace:*
         version: link:../core
-      hono:
-        specifier: ^4
-        version: 4.12.12
     devDependencies:
       tsup:
         specifier: ^8
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.7
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(msw@2.12.13(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   packages/@emulators/github:
     dependencies:

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: emulate
-description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, and other developer APIs. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation.
+description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, Facebook, and other developer APIs. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation.
 allowed-tools: Bash(npx emulate:*)
 ---
 
@@ -32,6 +32,7 @@ All services start with sensible defaults:
 | Clerk     | 4011        |
 | Linear    | 4012        |
 | Twilio    | 4013        |
+| Facebook  | 4014        |
 
 ## CLI
 
@@ -97,7 +98,7 @@ await vercel.close()
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, `'twilio'`, or `'facebook'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |

--- a/skills/facebook/SKILL.md
+++ b/skills/facebook/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: facebook
+description: Use the local Facebook Login and Graph API emulator for Page OAuth and Page video metric integration tests.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# Facebook emulation
+
+Start only this service with npx emulate --service facebook. Its default port is 4014 when all services start from port 4000.
+
+Seed users, oauth_apps, Pages, and page_videos under the facebook configuration key. Registered redirect URIs are enforced.
+
+The focused API surface includes:
+
+- /dialog/oauth and versioned /vXX.X/dialog/oauth
+- /oauth/access_token
+- /debug_token
+- /me and /me/accounts
+- /:pageId and /:videoId
+
+Graph reads accept bearer access tokens or the access_token query parameter. /me/accounts exchanges an authorized user context for owned Page access tokens. Page and video reads require ownership plus pages_read_engagement.
+
+This is not full Meta Graph API coverage. Applications need a Facebook client and a configurable Graph API base URL to use this emulator.


### PR DESCRIPTION
## Summary

- add Facebook Login and Graph API emulation
- support scoped users, Pages, videos, token exchange, and token debugging
- integrate seed configuration, CLI discovery, documentation, and agent guidance
- preserve configured token scopes and resolve seeded identities by user ID
- align the package with the current core HTTP implementation

## Validation

- `pnpm type-check`
- `pnpm test`
- `pnpm format:check`
- `pnpm --filter @emulators/facebook lint`
- workspace lint excluding `nuxt-embedded`, whose lint configuration is generated by the CI build step
- `git diff --check`
- Facebook tests: 23 passed