### PR TITLE
fix(stripe): send Stripe webhook signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ All services start with sensible defaults. No config file needed:
 - **Linear** on `http://localhost:4012`
 - **Twilio** on `http://localhost:4013`
 
+Stripe webhooks configured with a secret include a `Stripe-Signature` header signed over the timestamp and raw request body.
+
 ## CLI
 
 ```bash

--- a/apps/web/app/docs/stripe/page.mdx
+++ b/apps/web/app/docs/stripe/page.mdx
@@ -57,5 +57,6 @@ Stripe API emulation with customers, payment methods, customer sessions, payment
 
 Events are delivered to configured webhook URLs:
 
+- Webhooks configured with a secret include `Stripe-Signature: t=<timestamp>,v1=<signature>`, signed over `<timestamp>.<raw body>`
 - `checkout.session.completed` — when a checkout session is completed
 - `checkout.session.expired` — when a checkout session expires

--- a/packages/@emulators/core/src/__tests__/webhooks.test.ts
+++ b/packages/@emulators/core/src/__tests__/webhooks.test.ts
@@ -245,6 +245,31 @@ describe("WebhookDispatcher", () => {
       expect(deliveries[0]!.duration).not.toBeNull();
     });
 
+    it("records a failed delivery when the header factory throws", async () => {
+      const d = new WebhookDispatcher();
+      const sub = d.register({
+        url: "https://hooks.example/fail",
+        events: ["push"],
+        active: true,
+        owner: "o",
+      });
+      d.setHeaderFactory(() => {
+        throw new Error("signing failed");
+      });
+
+      await d.dispatch("push", undefined, { x: 1 }, "o");
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(d.getDeliveries()).toEqual([
+        expect.objectContaining({
+          hook_id: sub.id,
+          status_code: null,
+          duration: 0,
+          success: false,
+        }),
+      ]);
+    });
+
     it("sets X-Hub-Signature-256 from HMAC-SHA256 when secret is set", async () => {
       const d = new WebhookDispatcher();
       const secret = "my-secret";

--- a/packages/@emulators/core/src/index.ts
+++ b/packages/@emulators/core/src/index.ts
@@ -29,7 +29,13 @@ export {
   type ServeOptions,
 } from "./http.js";
 export { type ServicePlugin, type RouteContext } from "./plugin.js";
-export { WebhookDispatcher, type WebhookSubscription, type WebhookDelivery } from "./webhooks.js";
+export {
+  WebhookDispatcher,
+  type WebhookSubscription,
+  type WebhookDelivery,
+  type WebhookHeaderContext,
+  type WebhookHeaderFactory,
+} from "./webhooks.js";
 export {
   errorHandler,
   createErrorHandler,

--- a/packages/@emulators/core/src/webhooks.ts
+++ b/packages/@emulators/core/src/webhooks.ts
@@ -22,13 +22,43 @@ export interface WebhookDelivery {
   success: boolean;
 }
 
+export interface WebhookHeaderContext {
+  event: string;
+  action?: string;
+  body: string;
+  subscription: Readonly<WebhookSubscription>;
+  deliveryId: number;
+}
+
+export type WebhookHeaderFactory = (context: WebhookHeaderContext) => Record<string, string>;
+
 const MAX_DELIVERIES = 1000;
+
+function githubHeaders({ event, body, subscription, deliveryId }: WebhookHeaderContext): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-GitHub-Event": event,
+    "X-GitHub-Delivery": String(deliveryId),
+  };
+
+  if (subscription.secret) {
+    const hmac = createHmac("sha256", subscription.secret).update(body).digest("hex");
+    headers["X-Hub-Signature-256"] = `sha256=${hmac}`;
+  }
+
+  return headers;
+}
 
 export class WebhookDispatcher {
   private subscriptions: WebhookSubscription[] = [];
   private deliveries: WebhookDelivery[] = [];
   private subscriptionIdCounter = 1;
   private deliveryIdCounter = 1;
+  private headerFactory: WebhookHeaderFactory = githubHeaders;
+
+  setHeaderFactory(factory: WebhookHeaderFactory): void {
+    this.headerFactory = factory;
+  }
 
   register(sub: Omit<WebhookSubscription, "id"> & { id?: number }): WebhookSubscription {
     const { id: explicitId, ...rest } = sub;
@@ -103,22 +133,12 @@ export class WebhookDispatcher {
 
       const body = JSON.stringify(payload);
 
-      const signatureHeaders: Record<string, string> = {};
-      if (sub.secret) {
-        const hmac = createHmac("sha256", sub.secret).update(body).digest("hex");
-        signatureHeaders["X-Hub-Signature-256"] = `sha256=${hmac}`;
-      }
-
       try {
+        const headers = this.headerFactory({ event, action, body, subscription: sub, deliveryId: delivery.id });
         const start = Date.now();
         const response = await fetch(sub.url, {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-GitHub-Event": event,
-            "X-GitHub-Delivery": String(delivery.id),
-            ...signatureHeaders,
-          },
+          headers,
           body,
           signal: AbortSignal.timeout(10000),
         });

--- a/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
+++ b/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
@@ -86,9 +86,13 @@ describe("webhook installation enrichment", () => {
     expect(mockFetch).toHaveBeenCalled();
     const [, init] = mockFetch.mock.calls[0]!;
     const body = JSON.parse((init as RequestInit).body as string);
+    const headers = (init as RequestInit).headers as Record<string, string>;
     expect(body.installation).toBeDefined();
     expect(body.installation.id).toBe(42);
     expect(body.installation.node_id).toBeTruthy();
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["X-GitHub-Event"]).toBe("issues");
+    expect(headers["X-GitHub-Delivery"]).toBe("1");
   });
 
   it("does not include installation when no app is installed", async () => {

--- a/packages/@emulators/stripe/README.md
+++ b/packages/@emulators/stripe/README.md
@@ -58,6 +58,7 @@ npm install @emulators/stripe
 ## Webhooks
 
 Events are delivered to configured webhook URLs:
+- Webhooks configured with a secret include `Stripe-Signature: t=<timestamp>,v1=<signature>`, signed over `<timestamp>.<raw body>`
 - `checkout.session.completed` — when a checkout session is completed
 - `checkout.session.expired` — when a checkout session expires
 

--- a/packages/@emulators/stripe/src/__tests__/stripe.test.ts
+++ b/packages/@emulators/stripe/src/__tests__/stripe.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { createHmac } from "crypto";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "@emulators/core";
 import {
   Store,
@@ -41,12 +42,51 @@ function auth(): Record<string, string> {
 
 describe("Stripe plugin", () => {
   let app: Hono;
-  let webhooks: WebhookDispatcher;
 
   beforeEach(() => {
     const ctx = createTestApp();
     app = ctx.app;
-    webhooks = ctx.webhooks;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("webhooks", () => {
+    it("sends Stripe signatures without GitHub headers from standalone seed config", async () => {
+      const secret = "whsec_test";
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      vi.stubGlobal("fetch", mockFetch);
+      const standaloneWebhooks = new WebhookDispatcher();
+
+      seedFromConfig(
+        new Store(),
+        base,
+        {
+          webhooks: [{ url: "https://hooks.example/stripe", events: ["customer.created"], secret }],
+        },
+        standaloneWebhooks,
+      );
+
+      const payload = { type: "customer.created", data: { object: { id: "cus_test" } } };
+      await standaloneWebhooks.dispatch("customer.created", undefined, payload, "stripe");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0]!;
+      const body = (init as RequestInit).body as string;
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      const signature = headers["Stripe-Signature"];
+      expect(signature).toMatch(/^t=\d+,v1=[a-f0-9]{64}$/);
+      const match = signature.match(/^t=(\d+),v1=([a-f0-9]{64})$/);
+
+      const timestamp = match![1];
+      const expectedSignature = createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex");
+      expect(match![2]).toBe(expectedSignature);
+      expect(headers["Content-Type"]).toBe("application/json");
+      expect(headers["X-GitHub-Event"]).toBeUndefined();
+      expect(headers["X-GitHub-Delivery"]).toBeUndefined();
+      expect(headers["X-Hub-Signature-256"]).toBeUndefined();
+    });
   });
 
   describe("customers", () => {

--- a/packages/@emulators/stripe/src/index.ts
+++ b/packages/@emulators/stripe/src/index.ts
@@ -1,5 +1,14 @@
+import { createHmac } from "crypto";
 import type { Hono } from "@emulators/core";
-import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@emulators/core";
+import type {
+  ServicePlugin,
+  Store,
+  WebhookDispatcher,
+  WebhookHeaderContext,
+  TokenMap,
+  AppEnv,
+  RouteContext,
+} from "@emulators/core";
 import { getStripeStore } from "./store.js";
 import { stripeId } from "./helpers.js";
 import { customerRoutes } from "./routes/customers.js";
@@ -38,6 +47,20 @@ export interface StripeSeedConfig {
     events: string[];
     secret?: string;
   }>;
+}
+
+function stripeWebhookHeaders({ body, subscription }: WebhookHeaderContext): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (subscription.secret) {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = createHmac("sha256", subscription.secret).update(`${timestamp}.${body}`).digest("hex");
+    headers["Stripe-Signature"] = `t=${timestamp},v1=${signature}`;
+  }
+
+  return headers;
 }
 
 function seedDefaults(store: Store, _baseUrl: string): void {
@@ -102,6 +125,7 @@ export function seedFromConfig(
   }
 
   if (config.webhooks && webhooks) {
+    webhooks.setHeaderFactory(stripeWebhookHeaders);
     for (const wh of config.webhooks) {
       webhooks.register({
         url: wh.url,
@@ -117,6 +141,8 @@ export function seedFromConfig(
 export const stripePlugin: ServicePlugin = {
   name: "stripe",
   register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    webhooks.setHeaderFactory(stripeWebhookHeaders);
+
     const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
     customerRoutes(ctx);
     paymentMethodRoutes(ctx);

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -20,6 +20,9 @@ program
 Framework adapters:
   Embed emulators in app routes with @emulators/adapter-next or @emulators/adapter-nuxt.
   Docs: https://emulate.dev/docs/nextjs and https://emulate.dev/docs/nuxt
+
+Webhook signatures:
+  Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.
 `,
   );
 

--- a/skills/stripe/SKILL.md
+++ b/skills/stripe/SKILL.md
@@ -291,6 +291,7 @@ curl http://localhost:4000/v1/payment_methods
 ## Webhooks
 
 The emulator dispatches webhook events when state changes. Register webhooks via seed config or programmatically.
+Webhooks configured with a `secret` include `Stripe-Signature: t=<timestamp>,v1=<signature>`. The signature is an HMAC SHA-256 over `<timestamp>.<raw body>`.
 
 ### Events dispatched
 


### PR DESCRIPTION
## Summary

Fixes Stripe webhook signing for configured Stripe webhooks.

The shared dispatcher now supports an instance-scoped header factory. GitHub-compatible headers remain the default, while Stripe installs its own wire format and sends `Stripe-Signature: t=<timestamp>,v1=<hmac>` over `<timestamp>.<raw body>`.

## Details

- preserves GitHub header formats through the existing `dispatch()` wrapper
- signs Stripe deliveries without GitHub-specific headers
- configures standalone `seedFromConfig()` webhook registration as well as the plugin path
- preserves failed-delivery logging when header construction throws
- documents the behavior in README, the Stripe skill, docs site, package README, and CLI help
- credits @EfeDurmaz16 for the original design direction in #100

## Validation

- `pnpm type-check` — 34 tasks passed
- `pnpm test` — 33 tasks passed
- core — 70 tests passed
- Stripe — 23 tests passed
- GitHub — 17 tests passed
- affected lint commands — no errors, only pre-existing warnings
- Prettier, `git diff --check`, style gate, and surface gate passed
- force-red verification confirmed the Stripe regression test fails without the factory
- built CLI help verified

Closes #97.
Closes #98.
