### PR TITLE
fix(github): verify App JWTs with public key material

### DIFF
--- a/packages/@emulators/core/src/__tests__/auth.test.ts
+++ b/packages/@emulators/core/src/__tests__/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { generateKeyPairSync, sign } from "crypto";
 import { Hono } from "../http.js";
 import {
   authMiddleware,
@@ -84,6 +85,30 @@ describe("authMiddleware", () => {
     restoreTokenMap(restored, serializeTokenMap(tokenMap));
     expect(restored.get("installation-token")).toEqual(tokenMap.get("installation-token"));
   });
+
+  it.each(["pkcs8", "pkcs1"] as const)("sets authApp for a valid GitHub App JWT signed with %s", async (format) => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPem = privateKey.export({ type: format, format: "pem" }).toString();
+    const jwt = createAppJwt("42", privateKeyPem);
+
+    const app = new Hono<AppEnv>();
+    app.use(
+      "*",
+      authMiddleware(tokenMap, (appId) => {
+        if (appId !== 42) return null;
+        return { privateKey: privateKeyPem, slug: "my-app", name: "My App" };
+      }),
+    );
+    app.get("/test", (c) => c.json({ app: c.get("authApp") }));
+
+    const res = await app.request("/test", {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { app: { appId: number; slug: string; name: string } };
+    expect(body.app).toEqual({ appId: 42, slug: "my-app", name: "My App" });
+  });
 });
 
 describe("requireAuth", () => {
@@ -123,6 +148,18 @@ describe("requireAuth", () => {
     expect(body.user?.login).toBe("alice");
   });
 });
+
+function createAppJwt(appId: string, privateKey: string): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = { iat: nowSeconds - 60, exp: nowSeconds + 9 * 60, iss: appId };
+  const unsigned = `${base64UrlJson(header)}.${base64UrlJson(payload)}`;
+  return `${unsigned}.${sign("RSA-SHA256", Buffer.from(unsigned), privateKey).toString("base64url")}`;
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
 
 describe("requireAppAuth", () => {
   it("returns 401 when authApp is not set", async () => {

--- a/packages/@emulators/core/src/middleware/auth.ts
+++ b/packages/@emulators/core/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "../http.js";
-import { jwtVerify, importPKCS8 } from "jose";
+import { createPublicKey } from "crypto";
+import { jwtVerify } from "jose";
 import { debug } from "../debug.js";
 
 export interface AuthUser {
@@ -92,8 +93,8 @@ export function authMiddleware(tokens: TokenMap, appKeyResolver?: AppKeyResolver
           if (typeof appId === "number" && !isNaN(appId)) {
             const appInfo = appKeyResolver(appId);
             if (appInfo) {
-              const key = await importPKCS8(appInfo.privateKey, "RS256");
-              await jwtVerify(token, key, { algorithms: ["RS256"] });
+              const publicKey = createPublicKey(appInfo.privateKey);
+              await jwtVerify(token, publicKey, { algorithms: ["RS256"] });
               c.set("authApp", {
                 appId,
                 slug: appInfo.slug,

--- a/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
+++ b/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
@@ -1,9 +1,9 @@
-import { createHmac } from "crypto";
+import { createHmac, generateKeyPairSync, sign } from "crypto";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "@emulators/core";
 import { Store, WebhookDispatcher } from "@emulators/core";
 import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
-import { githubPlugin, seedFromConfig } from "../index.js";
+import { githubPlugin, seedFromConfig, getGitHubStore } from "../index.js";
 
 const base = "http://localhost:4000";
 
@@ -16,7 +16,15 @@ function createTestApp(seedConfig?: Parameters<typeof seedFromConfig>[2]) {
   const app = new Hono();
   app.onError(createApiErrorHandler());
   app.use("*", createErrorHandler());
-  app.use("*", authMiddleware(tokenMap));
+  app.use(
+    "*",
+    authMiddleware(tokenMap, (appId) => {
+      const gh = getGitHubStore(store);
+      const ghApp = gh.apps.all().find((a) => a.app_id === appId);
+      if (!ghApp) return null;
+      return { privateKey: ghApp.private_key, slug: ghApp.slug, name: ghApp.name };
+    }),
+  );
   githubPlugin.register(app as any, store, webhooks, base, tokenMap);
   githubPlugin.seed?.(store, base);
   seedFromConfig(
@@ -29,6 +37,18 @@ function createTestApp(seedConfig?: Parameters<typeof seedFromConfig>[2]) {
   );
 
   return { app, store, webhooks, tokenMap };
+}
+
+function createAppJwt(appId: string, privateKey: string): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = { iat: nowSeconds - 60, exp: nowSeconds + 9 * 60, iss: appId };
+  const unsigned = `${base64UrlJson(header)}.${base64UrlJson(payload)}`;
+  return `${unsigned}.${sign("RSA-SHA256", Buffer.from(unsigned), privateKey).toString("base64url")}`;
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
 }
 
 function authHeaders(): Record<string, string> {
@@ -291,6 +311,53 @@ describe("webhook installation enrichment", () => {
     expect(excludedCall).toBeDefined();
     const excludedBody = JSON.parse((excludedCall![1] as RequestInit).body as string);
     expect(excludedBody.installation).toBeUndefined();
+  });
+});
+
+describe("GitHub App installation token flow", () => {
+  it("accepts a valid App JWT and mints an installation token", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+    const { app } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [
+        {
+          app_id: 800,
+          slug: "token-app",
+          name: "Token App",
+          private_key: privateKeyPem,
+          permissions: { contents: "read", issues: "write" },
+          installations: [
+            {
+              installation_id: 99,
+              account: "octocat",
+              repository_selection: "selected",
+              repositories: ["octocat/hello-world"],
+            },
+          ],
+        },
+      ],
+    });
+
+    const response = await app.request(`${base}/app/installations/99/access_tokens`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${createAppJwt("800", privateKeyPem)}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ permissions: { contents: "read" } }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      token: string;
+      permissions: Record<string, string>;
+      repositories?: Array<{ full_name: string }>;
+    };
+    expect(body.token).toMatch(/^ghs_/);
+    expect(body.permissions).toEqual({ contents: "read" });
+    expect(body.repositories).toEqual([expect.objectContaining({ full_name: "octocat/hello-world" })]);
   });
 });
 


### PR DESCRIPTION
## Summary

- verify GitHub App JWTs using public key material derived from the configured private key
- cover PKCS#1 and PKCS#8 private keys in middleware tests
- add an end-to-end App JWT to installation token test

Fixes #96.

Based on @sidpalas’ original patch in sidpalas/emulate#1. The commit preserves Sid as the author.

## Verification

- build: 26/26
- tests: 33/33
- type-check: 34/34
- lint: 42/42, warnings only
- core package: 73 tests
- GitHub package: 81 tests
- Prettier and `git diff --check`

Dogfooded the built CLI using a documented PKCS#1 key: valid App JWT returned a `ghs_` installation token and repository requests succeeded; an invalid JWT returned 401.