### PR TITLE
feat(github): generate App keys for createEmulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ await github.close()
 await vercel.close()
 ```
 
+When a GitHub App omits `private_key`, `createEmulator` generates an RSA-2048 PKCS#1 key for that emulator instance:
+
+```typescript
+const github = await createEmulator({
+  service: 'github',
+  seed: {
+    github: {
+      users: [{ login: 'octocat' }],
+      apps: [{
+        app_id: 12345,
+        slug: 'my-github-app',
+        name: 'My GitHub App',
+        installations: [{ installation_id: 100, account: 'octocat' }],
+      }],
+    },
+  },
+})
+
+const privateKey = github.generatedSecrets.find(
+  secret => secret.kind === 'github.app_private_key' && secret.id === '12345',
+)?.value
+```
+
+Generated keys remain stable across `reset()` calls and appear only in `generatedSecrets`. Explicitly configured keys are never returned there. A new `createEmulator` call generates a new key.
+
 ### Vitest / Jest setup
 
 ```typescript
@@ -160,6 +185,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 | Method | Description |
 |--------|-------------|
 | `url` | Base URL of the running server |
+| `generatedSecrets` | Readonly secrets generated while preparing seed data |
 | `reset()` | Wipe the store and replay seed data |
 | `close()` | Shut down the HTTP server, returns a Promise |
 

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -137,6 +137,8 @@ github:
 
 JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's private key (RS256). The emulator verifies the signature and resolves the app.
 
+When using the programmatic `createEmulator` API, `private_key` may be omitted. The instance generates an RSA-2048 PKCS#1 key, exposes it through `generatedSecrets`, and keeps it stable across `reset()` calls. Seed files used by the CLI still require an explicit private key.
+
 ## Google Seed Config
 
 ```yaml

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -2,6 +2,33 @@
 
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.
 
+## GitHub App keys
+
+The programmatic `createEmulator` API can generate a GitHub App key when `private_key` is omitted:
+
+```typescript
+const github = await createEmulator({
+  service: 'github',
+  seed: {
+    github: {
+      users: [{ login: 'octocat' }],
+      apps: [{
+        app_id: 12345,
+        slug: 'my-github-app',
+        name: 'My GitHub App',
+        installations: [{ installation_id: 100, account: 'octocat' }],
+      }],
+    },
+  },
+})
+
+const privateKey = github.generatedSecrets.find(
+  secret => secret.kind === 'github.app_private_key' && secret.id === '12345',
+)?.value
+```
+
+The generated RSA-2048 PKCS#1 key remains stable across `reset()` calls. Explicit keys are never included in `generatedSecrets`. CLI seed files and direct `seedFromConfig` calls still require `private_key`.
+
 ## Users
 
 - `GET /user` - authenticated user

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -23,6 +23,33 @@ await github.close()
 await vercel.close()
 ```
 
+### Generated secrets
+
+When a GitHub App omits `private_key`, `createEmulator` generates an RSA-2048 PKCS#1 key for that emulator instance:
+
+```typescript
+const github = await createEmulator({
+  service: 'github',
+  seed: {
+    github: {
+      users: [{ login: 'octocat' }],
+      apps: [{
+        app_id: 12345,
+        slug: 'my-github-app',
+        name: 'My GitHub App',
+        installations: [{ installation_id: 100, account: 'octocat' }],
+      }],
+    },
+  },
+})
+
+const privateKey = github.generatedSecrets.find(
+  secret => secret.kind === 'github.app_private_key' && secret.id === '12345',
+)?.value
+```
+
+Generated keys remain stable across `reset()` calls and appear only in `generatedSecrets`. Explicitly configured keys are never returned there. A new `createEmulator` call generates a new key.
+
 ### Vitest / Jest setup
 
 ```typescript
@@ -92,6 +119,10 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>url</code></td>
       <td>Base URL of the running server</td>
+    </tr>
+    <tr>
+      <td><code>generatedSecrets</code></td>
+      <td>Readonly secrets generated while preparing seed data</td>
     </tr>
     <tr>
       <td><code>reset()</code></td>

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -182,6 +182,21 @@ github:
           repository_selection: all
 ```
 
+The `private_key` field is required when calling `seedFromConfig` directly. To generate omitted keys before seeding, use `materializeGitHubSeedConfig` and retain the returned key material:
+
+```typescript
+import { materializeGitHubSeedConfig, seedFromConfig } from '@emulators/github'
+
+const materialized = materializeGitHubSeedConfig({
+  apps: [{ app_id: 12345, slug: 'my-github-app', name: 'My GitHub App' }],
+})
+
+seedFromConfig(store, baseUrl, materialized.config)
+const privateKey = materialized.generatedPrivateKeys[0]?.private_key
+```
+
+The `emulate` package performs this materialization automatically in `createEmulator` and exposes generated keys through `generatedSecrets`.
+
 ## Links
 
 - [Full documentation](https://emulate.dev/github)

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -187,7 +187,7 @@ The `private_key` field is required when calling `seedFromConfig` directly. To g
 ```typescript
 import { materializeGitHubSeedConfig, seedFromConfig } from '@emulators/github'
 
-const materialized = materializeGitHubSeedConfig({
+const materialized = await materializeGitHubSeedConfig({
   apps: [{ app_id: 12345, slug: 'my-github-app', name: 'My GitHub App' }],
 })
 

--- a/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
+++ b/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
@@ -56,27 +56,84 @@ function authHeaders(): Record<string, string> {
 }
 
 describe("GitHub App seed materialization", () => {
-  it("generates omitted keys without changing explicit keys", () => {
+  it("generates omitted keys without changing explicit keys", async () => {
     const explicitKey = "explicit-key-bytes";
     const seed = {
       apps: [
         { app_id: 10, slug: "generated", name: "Generated" },
         { app_id: 11, slug: "explicit", name: "Explicit", private_key: explicitKey },
+        { app_id: 12, slug: "generated-second", name: "Generated Second" },
       ],
     };
 
-    const materialized = materializeGitHubSeedConfig(seed);
+    const materialized = await materializeGitHubSeedConfig(seed);
 
     expect(seed.apps[0]).not.toHaveProperty("private_key");
     expect(materialized.config.apps?.[0]?.private_key).toMatch(/^-----BEGIN RSA PRIVATE KEY-----/);
     expect(materialized.config.apps?.[1]?.private_key).toBe(explicitKey);
+    expect(materialized.config.apps?.[2]?.private_key).toMatch(/^-----BEGIN RSA PRIVATE KEY-----/);
+    expect(materialized.config.apps?.map((app) => app.slug)).toEqual(["generated", "explicit", "generated-second"]);
     expect(materialized.generatedPrivateKeys).toEqual([
       expect.objectContaining({
         app_id: 10,
         slug: "generated",
         private_key: materialized.config.apps?.[0]?.private_key,
       }),
+      expect.objectContaining({
+        app_id: 12,
+        slug: "generated-second",
+        private_key: materialized.config.apps?.[2]?.private_key,
+      }),
     ]);
+  });
+
+  it.each([
+    {
+      name: "app ID",
+      apps: [
+        { app_id: 20, slug: "generated", name: "Generated" },
+        { app_id: 21, slug: "explicit", name: "Explicit", private_key: "explicit-key" },
+        { app_id: 20, slug: "duplicate-last", name: "Duplicate Last" },
+      ],
+      message: "Duplicate GitHub App app_id: 20",
+    },
+    {
+      name: "slug",
+      apps: [
+        { app_id: 22, slug: "duplicate", name: "Generated" },
+        { app_id: 23, slug: "explicit", name: "Explicit", private_key: "explicit-key" },
+        { app_id: 24, slug: "duplicate", name: "Duplicate Last" },
+      ],
+      message: 'Duplicate GitHub App slug: "duplicate"',
+    },
+  ])("rejects a duplicate $name before generating keys", async ({ apps, message }) => {
+    const timer = vi.fn();
+    setTimeout(timer, 0);
+
+    await expect(materializeGitHubSeedConfig({ apps })).rejects.toThrow(message);
+    expect(timer).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(timer).toHaveBeenCalled();
+  });
+
+  it("yields the event loop while generating multiple keys", async () => {
+    let timerRan = false;
+    setTimeout(() => {
+      timerRan = true;
+    }, 0);
+
+    const materialized = await materializeGitHubSeedConfig({
+      apps: Array.from({ length: 4 }, (_, index) => ({
+        app_id: 30 + index,
+        slug: `async-${index}`,
+        name: `Async ${index}`,
+      })),
+    });
+
+    expect(timerRan).toBe(true);
+    expect(materialized.generatedPrivateKeys).toHaveLength(4);
   });
 
   it("requires direct seed callers to provide a private key", () => {

--- a/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
+++ b/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "@emulators/core";
 import { Store, WebhookDispatcher } from "@emulators/core";
 import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
-import { githubPlugin, seedFromConfig, getGitHubStore } from "../index.js";
+import { githubPlugin, seedFromConfig, getGitHubStore, materializeGitHubSeedConfig } from "../index.js";
 
 const base = "http://localhost:4000";
 
@@ -54,6 +54,44 @@ function base64UrlJson(value: unknown): string {
 function authHeaders(): Record<string, string> {
   return { Authorization: "Bearer test-token" };
 }
+
+describe("GitHub App seed materialization", () => {
+  it("generates omitted keys without changing explicit keys", () => {
+    const explicitKey = "explicit-key-bytes";
+    const seed = {
+      apps: [
+        { app_id: 10, slug: "generated", name: "Generated" },
+        { app_id: 11, slug: "explicit", name: "Explicit", private_key: explicitKey },
+      ],
+    };
+
+    const materialized = materializeGitHubSeedConfig(seed);
+
+    expect(seed.apps[0]).not.toHaveProperty("private_key");
+    expect(materialized.config.apps?.[0]?.private_key).toMatch(/^-----BEGIN RSA PRIVATE KEY-----/);
+    expect(materialized.config.apps?.[1]?.private_key).toBe(explicitKey);
+    expect(materialized.generatedPrivateKeys).toEqual([
+      expect.objectContaining({
+        app_id: 10,
+        slug: "generated",
+        private_key: materialized.config.apps?.[0]?.private_key,
+      }),
+    ]);
+  });
+
+  it("requires direct seed callers to provide a private key", () => {
+    const store = new Store();
+    githubPlugin.seed?.(store, base);
+
+    expect(() =>
+      seedFromConfig(store, base, {
+        users: [{ login: "should-not-exist" }],
+        apps: [{ app_id: 12, slug: "missing", name: "Missing" }],
+      }),
+    ).toThrow("requires private_key when seedFromConfig is called directly");
+    expect(getGitHubStore(store).users.findOneBy("login", "should-not-exist")).toBeUndefined();
+  });
+});
 
 describe("webhook installation enrichment", () => {
   const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "crypto";
+import { createHmac, generateKeyPairSync } from "crypto";
 import type { Hono } from "@emulators/core";
 import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@emulators/core";
 import { getGitHubStore } from "./store.js";
@@ -70,7 +70,7 @@ export interface GitHubSeedConfig {
     app_id: number;
     slug: string;
     name: string;
-    private_key: string;
+    private_key?: string;
     permissions?: Record<string, string>;
     events?: string[];
     webhook_url?: string;
@@ -85,6 +85,48 @@ export interface GitHubSeedConfig {
       events?: string[];
     }>;
   }>;
+}
+
+export interface GeneratedGitHubAppPrivateKey {
+  app_id: number;
+  slug: string;
+  name: string;
+  private_key: string;
+}
+
+export interface MaterializedGitHubSeedConfig {
+  config: GitHubSeedConfig;
+  generatedPrivateKeys: GeneratedGitHubAppPrivateKey[];
+}
+
+export function materializeGitHubSeedConfig(config: GitHubSeedConfig): MaterializedGitHubSeedConfig {
+  const generatedPrivateKeys: GeneratedGitHubAppPrivateKey[] = [];
+  const apps = config.apps?.map((app) => {
+    if (app.private_key === "") {
+      throw new Error(`GitHub App "${app.slug}" private_key must not be empty`);
+    }
+    if (app.private_key !== undefined) {
+      return { ...app };
+    }
+
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+      publicKeyEncoding: { type: "pkcs1", format: "pem" },
+    });
+    generatedPrivateKeys.push({
+      app_id: app.app_id,
+      slug: app.slug,
+      name: app.name,
+      private_key: privateKey,
+    });
+    return { ...app, private_key: privateKey };
+  });
+
+  return {
+    config: apps ? { ...config, apps } : { ...config },
+    generatedPrivateKeys,
+  };
 }
 
 function seedDefaults(store: Store, baseUrl: string): void {
@@ -136,6 +178,14 @@ function seedDefaults(store: Store, baseUrl: string): void {
 }
 
 export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeedConfig): void {
+  for (const app of config.apps ?? []) {
+    if (!app.private_key) {
+      throw new Error(
+        `GitHub App "${app.slug}" requires private_key when seedFromConfig is called directly; use createEmulator to generate one`,
+      );
+    }
+  }
+
   const gh = getGitHubStore(store);
 
   if (config.users) {
@@ -319,12 +369,16 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
     for (const a of config.apps) {
       const existingApp = gh.apps.findOneBy("slug", a.slug);
       if (existingApp) continue;
+      const privateKey = a.private_key;
+      if (!privateKey) {
+        throw new Error(`GitHub App "${a.slug}" requires private_key`);
+      }
 
       gh.apps.insert({
         app_id: a.app_id,
         slug: a.slug,
         name: a.name,
-        private_key: a.private_key,
+        private_key: privateKey,
         permissions: a.permissions ?? {},
         events: a.events ?? [],
         webhook_url: a.webhook_url ?? null,

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -1,4 +1,4 @@
-import { createHmac, generateKeyPairSync } from "crypto";
+import { createHmac, generateKeyPair } from "crypto";
 import type { Hono } from "@emulators/core";
 import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@emulators/core";
 import { getGitHubStore } from "./store.js";
@@ -99,32 +99,60 @@ export interface MaterializedGitHubSeedConfig {
   generatedPrivateKeys: GeneratedGitHubAppPrivateKey[];
 }
 
-export function materializeGitHubSeedConfig(config: GitHubSeedConfig): MaterializedGitHubSeedConfig {
-  const generatedPrivateKeys: GeneratedGitHubAppPrivateKey[] = [];
-  const apps = config.apps?.map((app) => {
+function generateAppPrivateKey(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    generateKeyPair(
+      "rsa",
+      {
+        modulusLength: 2048,
+        privateKeyEncoding: { type: "pkcs1", format: "pem" },
+        publicKeyEncoding: { type: "pkcs1", format: "pem" },
+      },
+      (error, _publicKey, privateKey) => {
+        if (error) reject(error);
+        else resolve(privateKey);
+      },
+    );
+  });
+}
+
+export async function materializeGitHubSeedConfig(config: GitHubSeedConfig): Promise<MaterializedGitHubSeedConfig> {
+  const appIds = new Set<number>();
+  const slugs = new Set<string>();
+  for (const app of config.apps ?? []) {
     if (app.private_key === "") {
       throw new Error(`GitHub App "${app.slug}" private_key must not be empty`);
     }
+    if (appIds.has(app.app_id)) {
+      throw new Error(`Duplicate GitHub App app_id: ${app.app_id}`);
+    }
+    if (slugs.has(app.slug)) {
+      throw new Error(`Duplicate GitHub App slug: "${app.slug}"`);
+    }
+    appIds.add(app.app_id);
+    slugs.add(app.slug);
+  }
+
+  const generatedPrivateKeys: GeneratedGitHubAppPrivateKey[] = [];
+  const apps = [];
+  for (const app of config.apps ?? []) {
     if (app.private_key !== undefined) {
-      return { ...app };
+      apps.push({ ...app });
+      continue;
     }
 
-    const { privateKey } = generateKeyPairSync("rsa", {
-      modulusLength: 2048,
-      privateKeyEncoding: { type: "pkcs1", format: "pem" },
-      publicKeyEncoding: { type: "pkcs1", format: "pem" },
-    });
+    const privateKey = await generateAppPrivateKey();
     generatedPrivateKeys.push({
       app_id: app.app_id,
       slug: app.slug,
       name: app.name,
       private_key: privateKey,
     });
-    return { ...app, private_key: privateKey };
-  });
+    apps.push({ ...app, private_key: privateKey });
+  }
 
   return {
-    config: apps ? { ...config, apps } : { ...config },
+    config: config.apps ? { ...config, apps } : { ...config },
     generatedPrivateKeys,
   };
 }

--- a/packages/emulate/src/__tests__/api.test.ts
+++ b/packages/emulate/src/__tests__/api.test.ts
@@ -196,6 +196,35 @@ describe("createEmulator", () => {
     ).rejects.toThrow('GitHub App "empty-key-app" private_key must not be empty');
   });
 
+  it.each([
+    {
+      name: "app ID",
+      apps: [
+        { app_id: 940, slug: "first-app", name: "First App" },
+        { app_id: 940, slug: "second-app", name: "Second App" },
+      ],
+      message: "Duplicate GitHub App app_id: 940",
+    },
+    {
+      name: "slug",
+      apps: [
+        { app_id: 950, slug: "duplicate-app", name: "First App" },
+        { app_id: 951, slug: "duplicate-app", name: "Second App" },
+      ],
+      message: 'Duplicate GitHub App slug: "duplicate-app"',
+    },
+  ])("rejects a duplicate GitHub App $name before startup", async ({ apps, message }) => {
+    await expect(
+      createEmulator({
+        service: "github",
+        port: 14044,
+        seed: { github: { apps } },
+      }),
+    ).rejects.toThrow(message);
+
+    await expect(fetch("http://localhost:14044/user")).rejects.toThrow();
+  });
+
   it("does not grant Slack fallback scopes in strict mode", async () => {
     const slack = await createEmulator({
       service: "slack",

--- a/packages/emulate/src/__tests__/api.test.ts
+++ b/packages/emulate/src/__tests__/api.test.ts
@@ -1,5 +1,23 @@
+import { generateKeyPairSync, sign } from "crypto";
 import { describe, it, expect } from "vitest";
 import { createEmulator } from "../api.js";
+
+function createAppJwt(appId: string, privateKey: string): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ iat: nowSeconds - 60, exp: nowSeconds + 9 * 60, iss: appId })).toString(
+    "base64url",
+  );
+  const unsigned = `${header}.${payload}`;
+  return `${unsigned}.${sign("RSA-SHA256", Buffer.from(unsigned), privateKey).toString("base64url")}`;
+}
+
+async function createInstallationToken(url: string, appId: string, installationId: number, privateKey: string) {
+  return fetch(`${url}/app/installations/${installationId}/access_tokens`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${createAppJwt(appId, privateKey)}` },
+  });
+}
 
 describe("createEmulator", () => {
   it("starts github and returns a url", async () => {
@@ -25,6 +43,7 @@ describe("createEmulator", () => {
 
     expect(github.url).toBe("http://localhost:14010");
     expect(vercel.url).toBe("http://localhost:14011");
+    expect(vercel.generatedSecrets).toEqual([]);
 
     await Promise.all([github.close(), vercel.close()]);
   });
@@ -56,6 +75,125 @@ describe("createEmulator", () => {
     expect(repos).toHaveLength(0);
 
     await github.close();
+  });
+
+  it("generates a GitHub App key once and keeps it across reset", async () => {
+    const github = await createEmulator({
+      service: "github",
+      port: 14040,
+      seed: {
+        github: {
+          users: [{ login: "octocat" }],
+          apps: [
+            {
+              app_id: 900,
+              slug: "generated-key-app",
+              name: "Generated Key App",
+              installations: [{ installation_id: 901, account: "octocat" }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(github.generatedSecrets).toHaveLength(1);
+    expect(github.generatedSecrets[0]).toMatchObject({
+      service: "github",
+      kind: "github.app_private_key",
+      id: "900",
+      label: "Generated Key App",
+    });
+    const privateKey = github.generatedSecrets[0]!.value;
+    expect(privateKey).toMatch(/^-----BEGIN RSA PRIVATE KEY-----/);
+
+    const firstToken = await createInstallationToken(github.url, "900", 901, privateKey);
+    expect(firstToken.status).toBe(201);
+    expect(((await firstToken.json()) as { token: string }).token).toMatch(/^ghs_/);
+
+    github.reset();
+
+    const tokenAfterReset = await createInstallationToken(github.url, "900", 901, privateKey);
+    expect(tokenAfterReset.status).toBe(201);
+    expect(((await tokenAfterReset.json()) as { token: string }).token).toMatch(/^ghs_/);
+    expect(github.generatedSecrets[0]!.value).toBe(privateKey);
+
+    await github.close();
+  });
+
+  it("uses an explicit GitHub App key without exposing it", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+      publicKeyEncoding: { type: "pkcs1", format: "pem" },
+    });
+    const github = await createEmulator({
+      service: "github",
+      port: 14041,
+      seed: {
+        github: {
+          users: [{ login: "octocat" }],
+          apps: [
+            {
+              app_id: 910,
+              slug: "explicit-key-app",
+              name: "Explicit Key App",
+              private_key: privateKey,
+              installations: [{ installation_id: 911, account: "octocat" }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(github.generatedSecrets).toEqual([]);
+    const token = await createInstallationToken(github.url, "910", 911, privateKey);
+    expect(token.status).toBe(201);
+
+    await github.close();
+  });
+
+  it("rejects a JWT signed with the wrong GitHub App key", async () => {
+    const github = await createEmulator({
+      service: "github",
+      port: 14042,
+      seed: {
+        github: {
+          users: [{ login: "octocat" }],
+          apps: [
+            {
+              app_id: 920,
+              slug: "wrong-key-app",
+              name: "Wrong Key App",
+              installations: [{ installation_id: 921, account: "octocat" }],
+            },
+          ],
+        },
+      },
+    });
+    const { privateKey: wrongKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+      publicKeyEncoding: { type: "pkcs1", format: "pem" },
+    });
+
+    const response = await createInstallationToken(github.url, "920", 921, wrongKey);
+    expect(response.status).toBe(401);
+
+    await github.close();
+  });
+
+  it("rejects an empty explicit GitHub App key", async () => {
+    await expect(
+      createEmulator({
+        service: "github",
+        port: 14043,
+        seed: {
+          github: {
+            apps: [{ app_id: 930, slug: "empty-key-app", name: "Empty Key App", private_key: "" }],
+          },
+        },
+      }),
+    ).rejects.toThrow('GitHub App "empty-key-app" private_key must not be empty');
   });
 
   it("does not grant Slack fallback scopes in strict mode", async () => {

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -52,7 +52,8 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
   }
 
   const inputSvcSeedConfig = seedConfig?.[service] as Record<string, unknown> | undefined;
-  const preparedSeed = inputSvcSeedConfig && loaded.prepareSeed ? loaded.prepareSeed(inputSvcSeedConfig) : undefined;
+  const preparedSeed =
+    inputSvcSeedConfig && loaded.prepareSeed ? await loaded.prepareSeed(inputSvcSeedConfig) : undefined;
   const svcSeedConfig = preparedSeed?.config ?? inputSvcSeedConfig;
   const generatedSecrets: readonly GeneratedSecret[] = Object.freeze(
     (preparedSeed?.generatedSecrets ?? []).map((secret) => Object.freeze({ service, ...secret })),

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -1,4 +1,4 @@
-import { createServer, serve, type AppKeyResolver, type Store } from "@emulators/core";
+import { createServer, serve, type AppKeyResolver } from "@emulators/core";
 import { SERVICE_REGISTRY } from "./registry.js";
 export type { ServiceName } from "./registry.js";
 import type { ServiceName } from "./registry.js";
@@ -16,8 +16,17 @@ export interface EmulatorOptions {
   baseUrl?: string;
 }
 
+export interface GeneratedSecret {
+  readonly service: ServiceName;
+  readonly kind: string;
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+}
+
 export interface Emulator {
   url: string;
+  readonly generatedSecrets: readonly GeneratedSecret[];
   reset(): void;
   close(): Promise<void>;
 }
@@ -42,7 +51,12 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
     tokens["test_token_admin"] = { login: "admin", id: 2, scopes: ["repo", "user", "admin:org", "admin:repo_hook"] };
   }
 
-  const svcSeedConfig = seedConfig?.[service] as Record<string, unknown> | undefined;
+  const inputSvcSeedConfig = seedConfig?.[service] as Record<string, unknown> | undefined;
+  const preparedSeed = inputSvcSeedConfig && loaded.prepareSeed ? loaded.prepareSeed(inputSvcSeedConfig) : undefined;
+  const svcSeedConfig = preparedSeed?.config ?? inputSvcSeedConfig;
+  const generatedSecrets: readonly GeneratedSecret[] = Object.freeze(
+    (preparedSeed?.generatedSecrets ?? []).map((secret) => Object.freeze({ service, ...secret })),
+  );
   const seedBaseUrl =
     typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0 ? svcSeedConfig.baseUrl : undefined;
   const baseUrl = resolveBaseUrl({ service, port, baseUrl: options.baseUrl, seedBaseUrl });
@@ -70,6 +84,7 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
 
   return {
     url: baseUrl,
+    generatedSecrets,
     reset() {
       store.reset();
       seed();

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -14,7 +14,7 @@ export interface LoadedService {
   plugin: ServicePlugin;
   seedFromConfig?(store: Store, baseUrl: string, config: unknown, webhooks?: WebhookDispatcher): void;
   createAppKeyResolver?(store: Store): AppKeyResolver;
-  prepareSeed?(config: Record<string, unknown>): PreparedServiceSeed;
+  prepareSeed?(config: Record<string, unknown>): Promise<PreparedServiceSeed>;
 }
 
 export interface ServiceEntry {
@@ -82,8 +82,8 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
       return {
         plugin: mod.githubPlugin,
         seedFromConfig: mod.seedFromConfig,
-        prepareSeed(config) {
-          const materialized = mod.materializeGitHubSeedConfig(config);
+        async prepareSeed(config) {
+          const materialized = await mod.materializeGitHubSeedConfig(config);
           return {
             config: materialized.config as Record<string, unknown>,
             generatedSecrets: materialized.generatedPrivateKeys.map((key) => ({

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -1,9 +1,20 @@
 import type { ServicePlugin, Store, AppKeyResolver, AuthFallback, WebhookDispatcher } from "@emulators/core";
 
+export interface PreparedServiceSeed {
+  config: Record<string, unknown>;
+  generatedSecrets: Array<{
+    kind: string;
+    id: string;
+    label: string;
+    value: string;
+  }>;
+}
+
 export interface LoadedService {
   plugin: ServicePlugin;
   seedFromConfig?(store: Store, baseUrl: string, config: unknown, webhooks?: WebhookDispatcher): void;
   createAppKeyResolver?(store: Store): AppKeyResolver;
+  prepareSeed?(config: Record<string, unknown>): PreparedServiceSeed;
 }
 
 export interface ServiceEntry {
@@ -71,6 +82,18 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
       return {
         plugin: mod.githubPlugin,
         seedFromConfig: mod.seedFromConfig,
+        prepareSeed(config) {
+          const materialized = mod.materializeGitHubSeedConfig(config);
+          return {
+            config: materialized.config as Record<string, unknown>,
+            generatedSecrets: materialized.generatedPrivateKeys.map((key) => ({
+              kind: "github.app_private_key",
+              id: String(key.app_id),
+              label: key.name,
+              value: key.private_key,
+            })),
+          };
+        },
         createAppKeyResolver(store: Store): AppKeyResolver {
           return (appId: number) => {
             try {

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -27,6 +27,32 @@ const github = await createEmulator({ service: 'github', port: 4001 })
 // github.url === 'http://localhost:4001'
 ```
 
+For a programmatic GitHub App, omit `private_key` and read the generated RSA key from the instance:
+
+```typescript
+const github = await createEmulator({
+  service: 'github',
+  port: 4001,
+  seed: {
+    github: {
+      users: [{ login: 'octocat' }],
+      apps: [{
+        app_id: 12345,
+        slug: 'my-github-app',
+        name: 'My GitHub App',
+        installations: [{ installation_id: 100, account: 'octocat' }],
+      }],
+    },
+  },
+})
+
+const privateKey = github.generatedSecrets.find(
+  secret => secret.kind === 'github.app_private_key' && secret.id === '12345',
+)?.value
+```
+
+The key remains stable across `github.reset()`. Explicit keys are not included in `generatedSecrets`. CLI seed files still require `private_key`.
+
 ## Auth
 
 Pass tokens as `Authorization: Bearer <token>` or `Authorization: token <token>`.


### PR DESCRIPTION
## Summary

- generate RSA-2048 PKCS#1 keys when a programmatic GitHub App seed omits `private_key`
- expose only generated keys through readonly `Emulator.generatedSecrets`
- retain the materialized seed so the same key works after `reset()`
- reject duplicate GitHub App IDs and slugs before generating keys or starting the server
- generate keys asynchronously and sequentially to preserve order, bound crypto concurrency, and keep the event loop responsive
- keep CLI and Next/Nuxt adapter key delivery out of scope; direct seed callers still require an explicit key

## Example

```ts
const github = await createEmulator({
  service: "github",
  seed: {
    github: {
      users: [{ login: "octocat" }],
      apps: [{
        app_id: 12345,
        slug: "my-github-app",
        name: "My GitHub App",
        installations: [{ installation_id: 100, account: "octocat" }],
      }],
    },
  },
})

const privateKey = github.generatedSecrets.find(
  secret => secret.kind === "github.app_private_key" && secret.id === "12345",
)?.value
```

## Verification

- `@emulators/github`: type-check, 86 tests, build
- `emulate`: type-check, 11 tests, build
- workspace type-check, tests, build, lint, formatting, and `git diff --check`
- force-red for missing generation, reset rotation, removed exposure, duplicate identity validation, and event-loop yielding
- built artifact minted installation tokens before and after reset with the same captured key
- duplicate IDs and slugs reject before startup and before any RSA generation
- interleaved generated and explicit Apps preserve seed and generated-secret order
- different-family review with Claude Sonnet, approved with no bugs found
- Review Gate passes for exact head `865c7fb`

## Resilience status

The two findings introduced by this slice are fixed:

1. Duplicate App IDs or slugs now reject before any key is generated, so every exposed secret maps one-to-one to a stored App.
2. RSA generation now uses asynchronous `generateKeyPair` sequentially. A zero-delay timer remains responsive for seeds with up to 50 Apps while crypto concurrency stays bounded to one operation.

The resilience audit also found pre-existing `createEmulator` lifecycle issues around reset state, port collisions, nested seed mutation, and repeated close. Those remain separate follow-ups and are not introduced by generated-key materialization.

## Scope

No CLI key output, HTTP secret endpoint, Next/Nuxt adapter support, persistence change, or entity-shape change.
