### PR TITLE
Add Autodesk Platform Services (APS) OAuth emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,7 @@ aps:
       name: My APS App
       redirect_uris:
         - http://localhost:3000/api/auth/callback/aps
+        - http://localhost:3000/api/auth/oauth2/callback/aps
     - client_id: aps-test-app
       type: public
       redirect_uris:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All services start with sensible defaults. No config file needed:
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
 - **Twilio** on `http://localhost:4013`
+- **Autodesk Platform Services (APS)** on `http://localhost:4014`
 
 Stripe webhooks configured with a secret include a `Stripe-Signature` header signed over the timestamp and raw request body.
 
@@ -188,7 +189,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
+| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, `'twilio'`, or `'aps'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -974,6 +975,49 @@ To test inbound SMS webhooks, configure a seeded phone number `sms_url`, then ca
 
 Current Twilio limits: no carrier delivery, A2P 10DLC, toll-free verification, real phone number purchasing, exact rate limits, Studio, Flex, TaskRouter, Video, Sync, Segment, SendGrid, Conversations SDK websocket behavior, or complete TwiML interpreter.
 
+## Autodesk Platform Services (APS) OAuth
+
+Autodesk Platform Services (formerly Forge) authentication v2 emulation with the 3-legged authorization code flow, PKCE, the 2-legged client credentials flow, rotating single-use refresh tokens, RS256 access tokens, token introspection and revocation, and OIDC discovery.
+
+- `GET /.well-known/openid-configuration` - OIDC discovery document
+- `GET /authentication/v2/keys` - JSON Web Key Set (JWKS)
+- `GET /authentication/v2/authorize` - authorization endpoint (shows user picker)
+- `POST /authentication/v2/token` - token exchange (authorization code, refresh token, client credentials)
+- `POST /authentication/v2/revoke` - token revocation
+- `POST /authentication/v2/introspect` - token introspection
+- `GET /authentication/v2/logout` - end session / logout
+- `GET /userinfo` - user profile
+
+Real APS paths map 1:1 onto the emulator:
+
+| Real APS URL | Emulator URL |
+|--------------|--------------|
+| `https://developer.api.autodesk.com/authentication/v2/...` | `$APS_EMULATOR_URL/authentication/v2/...` |
+| `https://api.userprofile.autodesk.com/userinfo` | `$APS_EMULATOR_URL/userinfo` |
+
+With no config, the emulator seeds a confidential client `aps-test-client` / `aps-test-secret`, a public client `aps-test-app`, and a user `testuser@autodesk.local`. Access tokens are RS256 JWTs verifiable against the JWKS endpoint and expire after one hour (`expires_in` 3599). Authorization codes are single use and expire after 5 minutes. Refresh tokens live for 15 days and are single use: every refresh returns a new refresh token, and replaying an already-used refresh token invalidates the whole grant family, matching real APS behavior. PKCE supports `S256` only and is required for public clients.
+
+```yaml
+aps:
+  users:
+    - email: testuser@autodesk.local
+      name: Test User
+  clients:
+    - client_id: aps-test-client
+      client_secret: aps-test-secret
+      name: My APS App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/aps
+    - client_id: aps-test-app
+      type: public
+      redirect_uris:
+        - http://localhost:3000/callback
+```
+
+Client `type` is inferred when omitted: confidential when a `client_secret` is present, public otherwise.
+
+Current APS limits: only authentication v2 and the user profile endpoint are emulated. Data APIs such as Data Management, Model Derivative, ACC/BIM 360, and APS webhooks are not included yet.
+
 ## Apple Sign In
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
@@ -1253,6 +1297,7 @@ packages/
     slack/          # Slack Web API, OAuth v2, incoming webhooks
     linear/         # Linear GraphQL API, OAuth, webhooks
     twilio/         # Twilio Messaging, Verify, Voice, webhooks
+    aps/            # Autodesk Platform Services OAuth 2.0 / OIDC
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
@@ -1277,6 +1322,8 @@ Tokens are configured in the seed config and map to users. Pass them as `Authori
 **Linear**: GraphQL accepts `Authorization: Bearer <token>` or a bare personal API key value. Seeded Linear tokens map to users or app actors, OAuth apps support local authorization code and client credentials flows, and optional strict scope mode checks supported GraphQL operations.
 
 **Twilio**: HTTP Basic auth accepts the seeded Account SID/Auth Token pair or API Key/API Secret pair. Product-host APIs are exposed under local prefixes such as `/messaging/v1` and `/verify/v2`; the 2010 API lives at `/2010-04-01`.
+
+**APS**: OAuth 2.0 authorization code flow with PKCE and client credentials grants. Access tokens are RS256 JWTs verifiable against the JWKS endpoint; refresh tokens rotate on every use.
 
 **Apple**: OIDC authorization code flow with RS256 ID tokens. On first auth per user/client pair, a `user` JSON blob is included.
 

--- a/apps/web/app/docs/aps/layout.tsx
+++ b/apps/web/app/docs/aps/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("aps");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/aps/page.mdx
+++ b/apps/web/app/docs/aps/page.mdx
@@ -51,6 +51,7 @@ aps:
       name: My APS App
       redirect_uris:
         - http://localhost:3000/api/auth/callback/aps
+        - http://localhost:3000/api/auth/oauth2/callback/aps
     - client_id: aps-test-app
       type: public
       redirect_uris:

--- a/apps/web/app/docs/aps/page.mdx
+++ b/apps/web/app/docs/aps/page.mdx
@@ -1,0 +1,64 @@
+# Autodesk Platform Services (APS)
+
+Autodesk Platform Services (formerly Forge) authentication v2 emulation with the 3-legged authorization code flow, PKCE, the 2-legged client credentials flow, rotating single-use refresh tokens, RS256 access tokens, token introspection and revocation, and OIDC discovery.
+
+## Start
+
+```bash
+npx emulate --service aps
+```
+
+When APS is the only enabled service, it starts on `http://localhost:4000`. When all services are started, it uses `http://localhost:4014`.
+
+## Defaults
+
+With no config, the emulator seeds a confidential client `aps-test-client` / `aps-test-secret`, a public client `aps-test-app`, and a user `testuser@autodesk.local`.
+
+## URL Mapping
+
+Real APS paths map 1:1 onto the emulator:
+
+| Real APS URL                                               | Emulator URL                              |
+| ---------------------------------------------------------- | ----------------------------------------- |
+| `https://developer.api.autodesk.com/authentication/v2/...` | `$APS_EMULATOR_URL/authentication/v2/...` |
+| `https://api.userprofile.autodesk.com/userinfo`            | `$APS_EMULATOR_URL/userinfo`              |
+
+## Endpoints
+
+- `GET /.well-known/openid-configuration` — OIDC discovery document
+- `GET /authentication/v2/keys` — JSON Web Key Set (JWKS)
+- `GET /authentication/v2/authorize` — authorization endpoint (shows user picker)
+- `POST /authentication/v2/token` — token exchange (authorization code, refresh token, client credentials)
+- `POST /authentication/v2/revoke` — token revocation
+- `POST /authentication/v2/introspect` — token introspection
+- `GET /authentication/v2/logout` — end session / logout
+- `GET /userinfo` — user profile
+
+## Token Behavior
+
+Access tokens are RS256 JWTs verifiable against the JWKS endpoint and expire after one hour (`expires_in` 3599). Authorization codes are single use and expire after 5 minutes. Refresh tokens live for 15 days and are single use: every refresh returns a new refresh token, and replaying an already-used refresh token invalidates the whole grant family, matching real APS behavior. PKCE supports `S256` only and is required for public clients.
+
+## Seed Config
+
+```yaml
+aps:
+  users:
+    - email: testuser@autodesk.local
+      name: Test User
+  clients:
+    - client_id: aps-test-client
+      client_secret: aps-test-secret
+      name: My APS App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/aps
+    - client_id: aps-test-app
+      type: public
+      redirect_uris:
+        - http://localhost:3000/callback
+```
+
+Client `type` is inferred when omitted: confidential when a `client_secret` is present, public otherwise.
+
+## Current Limits
+
+Only authentication v2 and the user profile endpoint are emulated. Data APIs such as Data Management, Model Derivative, ACC/BIM 360, and APS webhooks are not included yet.

--- a/apps/web/app/docs/architecture/page.mdx
+++ b/apps/web/app/docs/architecture/page.mdx
@@ -12,6 +12,7 @@ packages/
     google/         # Google OAuth 2.0 / OIDC + Gmail, Calendar, Drive
     slack/          # Slack Web API, OAuth v2, incoming webhooks
     linear/         # Linear GraphQL API, OAuth, webhooks
+    twilio/         # Twilio Messaging, Verify, Voice, webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
@@ -20,6 +21,7 @@ packages/
     resend/         # Resend email API
     stripe/         # Stripe billing and payments API
     clerk/          # Clerk Backend API and OAuth
+    aps/            # Autodesk Platform Services OAuth 2.0 / OIDC
 apps/
   web/              # Documentation site (Next.js)
 ```

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -391,3 +391,24 @@ stripe:
       recurring:
         interval: month
 ```
+
+## APS Seed Config
+
+```yaml
+aps:
+  users:
+    - email: testuser@autodesk.local
+      name: Test User
+  clients:
+    - client_id: aps-test-client
+      client_secret: aps-test-secret
+      name: My APS App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/aps
+    - client_id: aps-test-app
+      type: public
+      redirect_uris:
+        - http://localhost:3000/callback
+```
+
+Client `type` is inferred when omitted: confidential when a `client_secret` is present, public otherwise.

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -1,6 +1,6 @@
 # Getting Started
 
-Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, and Linear APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
+Local drop-in replacement for Vercel, GitHub, Google, Slack, Apple, Microsoft, Okta, AWS, Resend, Stripe, MongoDB Atlas, Clerk, Linear, Twilio, and Autodesk Platform Services (APS) APIs. Built for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation. Not mocks.
 
 ## Quick Start
 
@@ -23,6 +23,8 @@ All services start with sensible defaults. No config file needed:
 - **MongoDB Atlas** on `http://localhost:4010`
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
+- **Twilio** on `http://localhost:4013`
+- **Autodesk Platform Services (APS)** on `http://localhost:4014`
 
 ## CLI
 

--- a/apps/web/app/docs/programmatic-api/page.mdx
+++ b/apps/web/app/docs/programmatic-api/page.mdx
@@ -86,7 +86,7 @@ afterAll(() => Promise.all([github.close(), vercel.close()]))
     <tr>
       <td><code>service</code></td>
       <td><em>(required)</em></td>
-      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, <code>'clerk'</code>, or <code>'linear'</code></td>
+      <td>Service name: <code>'vercel'</code>, <code>'github'</code>, <code>'google'</code>, <code>'slack'</code>, <code>'apple'</code>, <code>'microsoft'</code>, <code>'okta'</code>, <code>'aws'</code>, <code>'resend'</code>, <code>'stripe'</code>, <code>'mongoatlas'</code>, <code>'clerk'</code>, <code>'linear'</code>, <code>'twilio'</code>, or <code>'aps'</code></td>
     </tr>
     <tr>
       <td><code>port</code></td>
@@ -158,6 +158,7 @@ npm install @emulators/github @emulators/google @emulators/linear
     <tr><td><code>@emulators/google</code></td><td>Google OAuth, Gmail, Calendar, Drive</td></tr>
     <tr><td><code>@emulators/slack</code></td><td>Slack Web API, OAuth v2, webhooks</td></tr>
     <tr><td><code>@emulators/linear</code></td><td>Linear GraphQL API, OAuth, webhooks</td></tr>
+    <tr><td><code>@emulators/twilio</code></td><td>Twilio Messaging, Verify, Voice, webhooks</td></tr>
     <tr><td><code>@emulators/apple</code></td><td>Apple Sign In / OIDC</td></tr>
     <tr><td><code>@emulators/microsoft</code></td><td>Microsoft Entra ID, Graph API</td></tr>
     <tr><td><code>@emulators/aws</code></td><td>AWS S3, SQS, IAM, STS</td></tr>
@@ -166,6 +167,7 @@ npm install @emulators/github @emulators/google @emulators/linear
     <tr><td><code>@emulators/resend</code></td><td>Resend email API</td></tr>
     <tr><td><code>@emulators/stripe</code></td><td>Stripe billing and payments API</td></tr>
     <tr><td><code>@emulators/clerk</code></td><td>Clerk Backend API and OAuth</td></tr>
+    <tr><td><code>@emulators/aps</code></td><td>Autodesk Platform Services OAuth 2.0 / OIDC</td></tr>
     <tr><td><code>@emulators/core</code></td><td>Shared store, middleware, and utilities</td></tr>
     <tr><td><code>@emulators/adapter-next</code></td><td>Next.js App Router integration</td></tr>
     <tr><td><code>@emulators/adapter-nuxt</code></td><td>Nuxt server route integration</td></tr>

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -28,6 +28,7 @@ const sections: NavSection[] = [
       { href: "/docs/google", label: "Google" },
       { href: "/docs/slack", label: "Slack" },
       { href: "/docs/linear", label: "Linear" },
+      { href: "/docs/twilio", label: "Twilio" },
       { href: "/docs/apple", label: "Apple" },
       { href: "/docs/microsoft", label: "Microsoft Entra ID" },
       { href: "/docs/aws", label: "AWS" },
@@ -35,6 +36,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/aps", label: "Autodesk APS" },
     ],
   },
   {

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -26,6 +26,7 @@ const sections: NavSection[] = [
       { href: "/docs/google", label: "Google" },
       { href: "/docs/slack", label: "Slack" },
       { href: "/docs/linear", label: "Linear" },
+      { href: "/docs/twilio", label: "Twilio" },
       { href: "/docs/apple", label: "Apple" },
       { href: "/docs/microsoft", label: "Microsoft Entra ID" },
       { href: "/docs/aws", label: "AWS" },
@@ -33,6 +34,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/aps", label: "Autodesk APS" },
     ],
   },
   {

--- a/apps/web/components/hero-terminal.tsx
+++ b/apps/web/components/hero-terminal.tsx
@@ -9,11 +9,15 @@ const services = [
   { name: "Slack", port: 4003, slug: "slack" },
   { name: "Apple", port: 4004, slug: "apple" },
   { name: "Microsoft", port: 4005, slug: "microsoft" },
-  { name: "AWS", port: 4006, slug: "aws" },
-  { name: "Okta", port: 4007, slug: "okta" },
-  { name: "MongoDB Atlas", port: 4008, slug: "mongoatlas" },
-  { name: "Resend", port: 4009, slug: "resend" },
-  { name: "Stripe", port: 4010, slug: "stripe" },
+  { name: "Okta", port: 4006, slug: "okta" },
+  { name: "AWS", port: 4007, slug: "aws" },
+  { name: "Resend", port: 4008, slug: "resend" },
+  { name: "Stripe", port: 4009, slug: "stripe" },
+  { name: "MongoDB Atlas", port: 4010, slug: "mongoatlas" },
+  { name: "Clerk", port: 4011, slug: "clerk" },
+  { name: "Linear", port: 4012, slug: "linear" },
+  { name: "Twilio", port: 4013, slug: "twilio" },
+  { name: "APS", port: 4014, slug: "aps" },
 ];
 
 export function HeroTerminal({ pixelFont }: { pixelFont: string }) {

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -22,6 +22,7 @@ export const allDocsPages: NavItem[] = [
   { name: "MongoDB Atlas", href: "/docs/mongoatlas" },
   { name: "Resend", href: "/docs/resend" },
   { name: "Stripe", href: "/docs/stripe" },
+  { name: "Autodesk Platform Services", href: "/docs/aps" },
   { name: "Authentication", href: "/docs/authentication" },
   { name: "Architecture", href: "/docs/architecture" },
 ];

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -17,6 +17,7 @@ export const PAGE_TITLES: Record<string, string> = {
   mongoatlas: "MongoDB Atlas",
   resend: "Resend",
   stripe: "Stripe",
+  aps: "Autodesk Platform Services",
   authentication: "Authentication",
   architecture: "Architecture",
 };

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -128,3 +128,18 @@ google:
       mime_type: application/vnd.google-apps.folder
       parent_ids:
         - root
+
+aps:
+  users:
+    - email: testuser@autodesk.local
+      name: Test User
+  clients:
+    - client_id: emu_aps_client_id
+      client_secret: emu_aps_client_secret
+      name: Code App (APS)
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/aps
+    - client_id: emu_aps_desktop_client
+      type: public
+      redirect_uris:
+        - http://localhost:3000/callback

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -139,6 +139,7 @@ aps:
       name: Code App (APS)
       redirect_uris:
         - http://localhost:3000/api/auth/callback/aps
+        - http://localhost:3000/api/auth/oauth2/callback/aps
     - client_id: emu_aps_desktop_client
       type: public
       redirect_uris:

--- a/packages/@emulators/aps/README.md
+++ b/packages/@emulators/aps/README.md
@@ -1,0 +1,63 @@
+# @emulators/aps
+
+Autodesk Platform Services (APS) authentication v2 emulation with the 3-legged authorization code flow, PKCE, the 2-legged client credentials flow, rotating single-use refresh tokens, RS256 access tokens, token introspection and revocation, and OIDC discovery.
+
+Part of [emulate](https://github.com/vercel-labs/emulate) — local drop-in replacement services for CI and no-network sandboxes.
+
+## Install
+
+```bash
+npm install @emulators/aps
+```
+
+## Endpoints
+
+- `GET /.well-known/openid-configuration` — OIDC discovery document
+- `GET /authentication/v2/keys` — JSON Web Key Set (JWKS)
+- `GET /authentication/v2/authorize` — authorization endpoint (shows user picker)
+- `POST /authentication/v2/token` — token exchange (authorization code, refresh token, client credentials)
+- `POST /authentication/v2/revoke` — token revocation
+- `POST /authentication/v2/introspect` — token introspection
+- `GET /authentication/v2/logout` — end session / logout
+- `GET /userinfo` — user profile
+
+## URL Mapping
+
+Real APS paths map 1:1 onto the emulator:
+
+| Real APS URL                                               | Emulator URL                              |
+| ---------------------------------------------------------- | ----------------------------------------- |
+| `https://developer.api.autodesk.com/authentication/v2/...` | `$APS_EMULATOR_URL/authentication/v2/...` |
+| `https://api.userprofile.autodesk.com/userinfo`            | `$APS_EMULATOR_URL/userinfo`              |
+
+## Behavior
+
+Access tokens are RS256 JWTs verifiable against the JWKS endpoint and expire after one hour (`expires_in` 3599). Authorization codes are single use and expire after 5 minutes. Refresh tokens live for 15 days and are single use: every refresh returns a new refresh token, and replaying an already-used refresh token invalidates the whole grant family, matching real APS behavior. PKCE supports `S256` only and is required for public clients.
+
+With no config, the emulator seeds a confidential client `aps-test-client` / `aps-test-secret`, a public client `aps-test-app`, and a user `testuser@autodesk.local`.
+
+## Seed Configuration
+
+```yaml
+aps:
+  users:
+    - email: testuser@autodesk.local
+      name: Test User
+  clients:
+    - client_id: aps-test-client
+      client_secret: aps-test-secret
+      name: My APS App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/aps
+    - client_id: aps-test-app
+      type: public
+      redirect_uris:
+        - http://localhost:3000/callback
+```
+
+Client `type` is inferred when omitted: confidential when a `client_secret` is present, public otherwise.
+
+## Links
+
+- [Full documentation](https://emulate.dev)
+- [GitHub](https://github.com/vercel-labs/emulate)

--- a/packages/@emulators/aps/README.md
+++ b/packages/@emulators/aps/README.md
@@ -49,6 +49,7 @@ aps:
       name: My APS App
       redirect_uris:
         - http://localhost:3000/api/auth/callback/aps
+        - http://localhost:3000/api/auth/oauth2/callback/aps
     - client_id: aps-test-app
       type: public
       redirect_uris:

--- a/packages/@emulators/aps/package.json
+++ b/packages/@emulators/aps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/aps",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/aps/package.json
+++ b/packages/@emulators/aps/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@emulators/aps",
+  "version": "0.9.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/aps"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*",
+    "jose": "^6"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/aps/src/__tests__/aps.test.ts
+++ b/packages/@emulators/aps/src/__tests__/aps.test.ts
@@ -1,0 +1,914 @@
+import { createHash } from "node:crypto";
+import { createLocalJWKSet, decodeJwt, jwtVerify } from "jose";
+import { Hono } from "@emulators/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
+import { apsPlugin, getApsStore, seedFromConfig } from "../index.js";
+
+const base = "http://localhost:4000";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+
+  const app = new Hono();
+  app.use("*", authMiddleware(tokenMap));
+  apsPlugin.register(app as any, store, webhooks, base, tokenMap);
+  apsPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ email: "alice@example.com", name: "Alice Example" }],
+    clients: [
+      {
+        client_id: "custom-client",
+        client_secret: "custom-secret",
+        name: "Custom App",
+        redirect_uris: ["http://localhost:3000/custom-callback"],
+      },
+    ],
+  });
+  return { app, store, tokenMap };
+}
+
+async function getAuthCode(
+  app: Hono,
+  store: Store,
+  options: {
+    userId?: string;
+    redirectUri?: string;
+    clientId?: string;
+    scope?: string;
+    state?: string;
+    nonce?: string;
+    responseMode?: string;
+    codeChallenge?: string;
+  } = {},
+): Promise<{ code: string; state: string; response: Response }> {
+  const aps = getApsStore(store);
+  const userId = options.userId ?? aps.users.all()[0]?.user_id ?? "";
+  const redirectUri = options.redirectUri ?? "http://localhost:3000/callback";
+  const clientId = options.clientId ?? "aps-test-client";
+  const scope = options.scope ?? "data:read openid";
+  const state = options.state ?? "state-1";
+  const nonce = options.nonce ?? "nonce-1";
+  const responseMode = options.responseMode ?? "query";
+
+  const formData = new URLSearchParams({
+    user_id: userId,
+    redirect_uri: redirectUri,
+    scope,
+    state,
+    nonce,
+    client_id: clientId,
+    response_mode: responseMode,
+    code_challenge: options.codeChallenge ?? "",
+  });
+
+  const response = await app.request(`${base}/authentication/v2/authorize/callback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: formData.toString(),
+  });
+
+  if (responseMode === "form_post") {
+    const html = await response.text();
+    const code = html.match(/name="code" value="([^"]+)"/)?.[1] ?? "";
+    const returnedState = html.match(/name="state" value="([^"]+)"/)?.[1] ?? "";
+    return { code, state: returnedState, response };
+  }
+
+  const location = response.headers.get("location") ?? "";
+  const locationUrl = new URL(location);
+  return {
+    code: locationUrl.searchParams.get("code") ?? "",
+    state: locationUrl.searchParams.get("state") ?? "",
+    response,
+  };
+}
+
+async function exchangeCode(
+  app: Hono,
+  code: string,
+  options: {
+    clientId?: string;
+    clientSecret?: string;
+    includeClientSecret?: boolean;
+    redirectUri?: string;
+    codeVerifier?: string;
+    useBasicAuth?: boolean;
+  } = {},
+): Promise<Response> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    client_id: options.clientId ?? "aps-test-client",
+    redirect_uri: options.redirectUri ?? "http://localhost:3000/callback",
+  });
+  if (options.includeClientSecret ?? true) {
+    body.set("client_secret", options.clientSecret ?? "aps-test-secret");
+  }
+  if (options.codeVerifier) {
+    body.set("code_verifier", options.codeVerifier);
+  }
+
+  const headers: Record<string, string> = { "Content-Type": "application/x-www-form-urlencoded" };
+  if (options.useBasicAuth) {
+    const creds = Buffer.from(
+      `${options.clientId ?? "aps-test-client"}:${options.clientSecret ?? "aps-test-secret"}`,
+    ).toString("base64");
+    headers.Authorization = `Basic ${creds}`;
+    body.delete("client_id");
+    body.delete("client_secret");
+  }
+
+  return app.request(`${base}/authentication/v2/token`, {
+    method: "POST",
+    headers,
+    body: body.toString(),
+  });
+}
+
+async function refreshGrant(app: Hono, refreshToken: string, options: { scope?: string } = {}): Promise<Response> {
+  const body = new URLSearchParams({ grant_type: "refresh_token", refresh_token: refreshToken });
+  if (options.scope) body.set("scope", options.scope);
+  const creds = Buffer.from("aps-test-client:aps-test-secret").toString("base64");
+  return app.request(`${base}/authentication/v2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Authorization: `Basic ${creds}` },
+    body: body.toString(),
+  });
+}
+
+async function introspect(app: Hono, token: string): Promise<Record<string, unknown>> {
+  const res = await app.request(`${base}/authentication/v2/introspect`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      token,
+      client_id: "aps-test-client",
+      client_secret: "aps-test-secret",
+    }).toString(),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+describe("APS plugin integration", () => {
+  let app: Hono;
+  let store: Store;
+  let tokenMap: TokenMap;
+
+  beforeEach(() => {
+    const setup = createTestApp();
+    app = setup.app;
+    store = setup.store;
+    tokenMap = setup.tokenMap;
+  });
+
+  describe("OIDC discovery and keys", () => {
+    it("returns discovery document with emulator URLs", async () => {
+      const res = await app.request(`${base}/.well-known/openid-configuration`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.issuer).toBe(base);
+      expect(body.authorization_endpoint).toBe(`${base}/authentication/v2/authorize`);
+      expect(body.token_endpoint).toBe(`${base}/authentication/v2/token`);
+      expect(body.userinfo_endpoint).toBe(`${base}/userinfo`);
+      expect(body.jwks_uri).toBe(`${base}/authentication/v2/keys`);
+      expect(body.revoke_endpoint).toBe(`${base}/authentication/v2/revoke`);
+      expect(body.introspect_endpoint).toBe(`${base}/authentication/v2/introspect`);
+      expect(body.response_types_supported).toEqual(["code", "code id_token", "id_token"]);
+      expect(body.grant_types_supported).toEqual(["authorization_code", "client_credentials", "refresh_token"]);
+      expect(body.id_token_signing_alg_values_supported).toEqual(["RS256"]);
+      expect(body.scopes_supported).toContain("data:read");
+      expect(body.scopes_supported).toContain("openid");
+    });
+
+    it("returns JWKS with the signing key", async () => {
+      const res = await app.request(`${base}/authentication/v2/keys`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("max-age=604800");
+      const body = (await res.json()) as { keys: Array<Record<string, unknown>> };
+      expect(body.keys).toHaveLength(1);
+      expect(body.keys[0].kty).toBe("RSA");
+      expect(body.keys[0].kid).toBe("emulate-aps-1");
+      expect(body.keys[0].use).toBe("sig");
+      expect(body.keys[0].n).toBeDefined();
+      expect(body.keys[0].e).toBe("AQAB");
+    });
+  });
+
+  describe("authorization page and callback", () => {
+    it("returns sign-in HTML page with seeded users", async () => {
+      const res = await app.request(
+        `${base}/authentication/v2/authorize?client_id=aps-test-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=data:read`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toMatch(/text\/html/);
+      const html = await res.text();
+      expect(html).toContain("Sign in with Autodesk");
+      expect(html).toContain("testuser@autodesk.local");
+      expect(html).toContain("alice@example.com");
+    });
+
+    it("renders error page for unknown client without redirecting", async () => {
+      const res = await app.request(
+        `${base}/authentication/v2/authorize?client_id=unknown-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code`,
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("Application not found");
+    });
+
+    it("renders error page for unregistered redirect_uri without redirecting", async () => {
+      const res = await app.request(
+        `${base}/authentication/v2/authorize?client_id=aps-test-client&redirect_uri=${encodeURIComponent("http://evil.local/callback")}&response_type=code`,
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("Redirect URI mismatch");
+    });
+
+    it("redirects with error for an unsupported response_type", async () => {
+      const res = await app.request(
+        `${base}/authentication/v2/authorize?client_id=aps-test-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=token&state=abc`,
+      );
+      expect(res.status).toBe(302);
+      const url = new URL(res.headers.get("location") ?? "");
+      expect(url.searchParams.get("error")).toBe("unsupported_response_type");
+      expect(url.searchParams.get("state")).toBe("abc");
+    });
+
+    it("redirects with error for an invalid scope", async () => {
+      const res = await app.request(
+        `${base}/authentication/v2/authorize?client_id=aps-test-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=bogus:scope&state=xyz`,
+      );
+      expect(res.status).toBe(302);
+      const url = new URL(res.headers.get("location") ?? "");
+      expect(url.searchParams.get("error")).toBe("invalid_scope");
+      expect(url.searchParams.get("state")).toBe("xyz");
+    });
+
+    it("redirects with error when a public client omits code_challenge", async () => {
+      const res = await app.request(
+        `${base}/authentication/v2/authorize?client_id=aps-test-app&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&scope=data:read`,
+      );
+      expect(res.status).toBe(302);
+      const url = new URL(res.headers.get("location") ?? "");
+      expect(url.searchParams.get("error")).toBe("invalid_request");
+    });
+
+    it("redirects with error for a non-S256 code_challenge_method", async () => {
+      const res = await app.request(
+        `${base}/authentication/v2/authorize?client_id=aps-test-client&redirect_uri=${encodeURIComponent("http://localhost:3000/callback")}&response_type=code&code_challenge=abc&code_challenge_method=plain`,
+      );
+      expect(res.status).toBe(302);
+      const url = new URL(res.headers.get("location") ?? "");
+      expect(url.searchParams.get("error")).toBe("invalid_request");
+    });
+
+    it("issues a 40 character code and echoes state on the redirect", async () => {
+      const { code, state, response } = await getAuthCode(app, store, { state: "round-trip" });
+      expect(response.status).toBe(302);
+      expect(code).toHaveLength(40);
+      expect(state).toBe("round-trip");
+    });
+
+    it("preserves existing query params on the redirect_uri", async () => {
+      const { response } = await getAuthCode(app, store, {
+        redirectUri: "http://localhost:3000/callback?foo=bar",
+      });
+      const url = new URL(response.headers.get("location") ?? "");
+      expect(url.searchParams.get("foo")).toBe("bar");
+      expect(url.searchParams.get("code")).toBeTruthy();
+    });
+
+    it("supports form_post response mode", async () => {
+      const { code, state } = await getAuthCode(app, store, { responseMode: "form_post" });
+      expect(code).toBeTruthy();
+      expect(state).toBe("state-1");
+    });
+  });
+
+  describe("authorization_code grant", () => {
+    it("completes the 3-legged flow with PKCE and body credentials", async () => {
+      const verifier = "pkce-verifier-1234567890-1234567890-1234567890";
+      const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+      const { code } = await getAuthCode(app, store, { codeChallenge: challenge });
+      const tokenRes = await exchangeCode(app, code, { codeVerifier: verifier });
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as Record<string, unknown>;
+      expect(body.token_type).toBe("Bearer");
+      expect(body.expires_in).toBe(3599);
+      expect(body.access_token).toBeDefined();
+      expect(body.refresh_token).toHaveLength(42);
+
+      const claims = decodeJwt(body.access_token as string);
+      expect(claims.scope).toEqual(["data:read", "openid"]);
+      expect(claims.client_id).toBe("aps-test-client");
+      expect(claims.iss).toBe("https://developer.api.autodesk.com");
+      expect(claims.aud).toBe("https://autodesk.com");
+      expect(claims.jti).toHaveLength(64);
+      expect(claims.userid).toMatch(/^[A-Z0-9]{12}$/);
+      expect(claims.exp).toBeDefined();
+      expect(claims.iat).toBeUndefined();
+    });
+
+    it("completes the flow with Basic header credentials", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenRes = await exchangeCode(app, code, { useBasicAuth: true });
+      expect(tokenRes.status).toBe(200);
+    });
+
+    it("returns an id_token when scope includes openid", async () => {
+      const { code } = await getAuthCode(app, store, { scope: "data:read openid", nonce: "nonce-42" });
+      const tokenRes = await exchangeCode(app, code);
+      const body = (await tokenRes.json()) as Record<string, unknown>;
+      expect(body.id_token).toBeDefined();
+
+      const claims = decodeJwt(body.id_token as string);
+      expect(claims.iss).toBe(base);
+      expect(claims.aud).toBe("aps-test-client");
+      expect(claims.nonce).toBe("nonce-42");
+      expect(claims.user_email).toBe("testuser@autodesk.local");
+      expect(claims.first_name).toBe("Test");
+      expect(claims.last_name).toBe("User");
+      expect(claims.userid).toBeDefined();
+      expect(claims.analytics_id).toBeDefined();
+    });
+
+    it("omits the id_token when scope does not include openid", async () => {
+      const { code } = await getAuthCode(app, store, { scope: "data:read" });
+      const tokenRes = await exchangeCode(app, code);
+      const body = (await tokenRes.json()) as Record<string, unknown>;
+      expect(body.id_token).toBeUndefined();
+    });
+
+    it("signs access tokens verifiable against the JWKS endpoint", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenRes = await exchangeCode(app, code);
+      const body = (await tokenRes.json()) as Record<string, unknown>;
+
+      const keysRes = await app.request(`${base}/authentication/v2/keys`);
+      const jwks = createLocalJWKSet((await keysRes.json()) as Parameters<typeof createLocalJWKSet>[0]);
+      const { payload, protectedHeader } = await jwtVerify(body.access_token as string, jwks, {
+        issuer: "https://developer.api.autodesk.com",
+        audience: "https://autodesk.com",
+      });
+      expect(protectedHeader.alg).toBe("RS256");
+      expect(protectedHeader.kid).toBe("emulate-aps-1");
+      expect(payload.client_id).toBe("aps-test-client");
+    });
+
+    it("rejects a second use of the authorization code", async () => {
+      const { code } = await getAuthCode(app, store);
+      const first = await exchangeCode(app, code);
+      expect(first.status).toBe(200);
+      const second = await exchangeCode(app, code);
+      expect(second.status).toBe(400);
+      const body = (await second.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toBe("The authorization code is invalid or has expired.");
+    });
+
+    it("rejects an expired authorization code", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+        const { code } = await getAuthCode(app, store);
+        vi.setSystemTime(new Date("2026-01-01T00:05:01Z"));
+        const res = await exchangeCode(app, code);
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.error).toBe("invalid_grant");
+        expect(body.error_description).toBe("The authorization code is invalid or has expired.");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("rejects a code issued to another client", async () => {
+      const { code } = await getAuthCode(app, store);
+      const res = await exchangeCode(app, code, { clientId: "custom-client", clientSecret: "custom-secret" });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toBe("The grant was issued to another client.");
+    });
+
+    it("rejects a mismatched redirect_uri", async () => {
+      const { code } = await getAuthCode(app, store);
+      const res = await exchangeCode(app, code, { redirectUri: "http://localhost:3000/other" });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toBe("The 'redirect_uri' is invalid.");
+    });
+
+    it("rejects a missing code parameter", async () => {
+      const res = await exchangeCode(app, "");
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toBe("The request is missing a required parameter 'code'.");
+    });
+
+    it("rejects an invalid grant_type", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "password",
+          client_id: "aps-test-client",
+          client_secret: "aps-test-secret",
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toBe("The token request must specify a valid 'grant_type'.");
+    });
+
+    it("rejects client_id in the body when an Authorization header is present", async () => {
+      const creds = Buffer.from("aps-test-client:aps-test-secret").toString("base64");
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: `Basic ${creds}`,
+        },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "aps-test-client",
+          scope: "data:read",
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toBe(
+        "The 'client_id' is not supported in the request body when Authorization headers are present.",
+      );
+    });
+  });
+
+  describe("PKCE", () => {
+    it("requires code_verifier when a code_challenge was specified", async () => {
+      const verifier = "pkce-verifier-1234567890-1234567890-1234567890";
+      const challenge = createHash("sha256").update(verifier).digest("base64url");
+      const { code } = await getAuthCode(app, store, { codeChallenge: challenge });
+
+      const res = await exchangeCode(app, code);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toBe("The request is missing a required parameter 'code_verifier'.");
+    });
+
+    it("rejects an incorrect code_verifier", async () => {
+      const verifier = "pkce-verifier-1234567890-1234567890-1234567890";
+      const challenge = createHash("sha256").update(verifier).digest("base64url");
+      const { code } = await getAuthCode(app, store, { codeChallenge: challenge });
+
+      const res = await exchangeCode(app, code, { codeVerifier: "wrong-verifier-1234567890-1234567890-12345" });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toBe("PKCE verification failed.");
+    });
+
+    it("supports public clients with PKCE and no client_secret", async () => {
+      const verifier = "public-pkce-verifier-1234567890-1234567890-123";
+      const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+      const { code } = await getAuthCode(app, store, {
+        clientId: "aps-test-app",
+        codeChallenge: challenge,
+      });
+      const tokenRes = await exchangeCode(app, code, {
+        clientId: "aps-test-app",
+        codeVerifier: verifier,
+        includeClientSecret: false,
+      });
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as Record<string, unknown>;
+      const claims = decodeJwt(body.access_token as string);
+      expect(claims.client_id).toBe("aps-test-app");
+    });
+
+    it("still requires the client_secret for confidential clients", async () => {
+      const verifier = "confidential-pkce-verifier-1234567890-123456";
+      const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+      const { code } = await getAuthCode(app, store, { codeChallenge: challenge });
+      const res = await exchangeCode(app, code, { codeVerifier: verifier, includeClientSecret: false });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_client");
+    });
+  });
+
+  describe("refresh_token grant", () => {
+    it("rotates the refresh token on every refresh", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+      const refreshToken = tokenBody.refresh_token as string;
+
+      const refreshRes = await refreshGrant(app, refreshToken);
+      expect(refreshRes.status).toBe(200);
+      const refreshBody = (await refreshRes.json()) as Record<string, unknown>;
+      expect(refreshBody.token_type).toBe("Bearer");
+      expect(refreshBody.expires_in).toBe(3599);
+      expect(refreshBody.refresh_token).toHaveLength(42);
+      expect(refreshBody.refresh_token).not.toBe(refreshToken);
+      expect(refreshBody.id_token).toBeUndefined();
+    });
+
+    it("rejects a replayed refresh token and invalidates the grant family", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+      const firstRefreshToken = tokenBody.refresh_token as string;
+
+      const refreshBody = (await (await refreshGrant(app, firstRefreshToken)).json()) as Record<string, unknown>;
+      const secondRefreshToken = refreshBody.refresh_token as string;
+      const secondAccessToken = refreshBody.access_token as string;
+
+      const replay = await refreshGrant(app, firstRefreshToken);
+      expect(replay.status).toBe(400);
+      const replayBody = (await replay.json()) as Record<string, unknown>;
+      expect(replayBody.error).toBe("invalid_grant");
+      expect(replayBody.error_description).toBe("The refresh token is invalid or expired.");
+
+      const afterReplay = await refreshGrant(app, secondRefreshToken);
+      expect(afterReplay.status).toBe(400);
+      const afterReplayBody = (await afterReplay.json()) as Record<string, unknown>;
+      expect(afterReplayBody.error).toBe("invalid_grant");
+
+      const introspection = await introspect(app, secondAccessToken);
+      expect(introspection).toEqual({ active: false });
+    });
+
+    it("rejects an unknown refresh token", async () => {
+      const res = await refreshGrant(app, "not-a-real-refresh-token");
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toBe("The refresh token is invalid or expired.");
+    });
+
+    it("allows downscoping on refresh", async () => {
+      const { code } = await getAuthCode(app, store, { scope: "data:read data:write openid" });
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+
+      const refreshRes = await refreshGrant(app, tokenBody.refresh_token as string, { scope: "data:read" });
+      expect(refreshRes.status).toBe(200);
+      const refreshBody = (await refreshRes.json()) as Record<string, unknown>;
+      const claims = decodeJwt(refreshBody.access_token as string);
+      expect(claims.scope).toEqual(["data:read"]);
+    });
+
+    it("rejects a scope superset on refresh", async () => {
+      const { code } = await getAuthCode(app, store, { scope: "data:read" });
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+
+      const refreshRes = await refreshGrant(app, tokenBody.refresh_token as string, {
+        scope: "data:read bucket:read",
+      });
+      expect(refreshRes.status).toBe(400);
+      const body = (await refreshRes.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_scope");
+      expect(body.error_description).toBe(
+        "The requested scope is invalid, unknown, malformed or exceeds the scope granted by the resource owner.",
+      );
+    });
+
+    it("rejects a refresh token issued to another client", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: tokenBody.refresh_token as string,
+          client_id: "custom-client",
+          client_secret: "custom-secret",
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toBe("The grant was issued to another client.");
+    });
+
+    it("rejects a missing refresh_token parameter", async () => {
+      const res = await refreshGrant(app, "");
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toBe("The request is missing a required parameter 'refresh_token'.");
+    });
+  });
+
+  describe("client_credentials grant", () => {
+    it("issues a 2-legged access token without refresh or id token", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "aps-test-client",
+          client_secret: "aps-test-secret",
+          scope: "data:read bucket:read",
+        }).toString(),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.token_type).toBe("Bearer");
+      expect(body.expires_in).toBe(3599);
+      expect(body.refresh_token).toBeUndefined();
+      expect(body.id_token).toBeUndefined();
+
+      const claims = decodeJwt(body.access_token as string);
+      expect(claims.scope).toEqual(["data:read", "bucket:read"]);
+      expect(claims.userid).toBeUndefined();
+    });
+
+    it("rejects public clients", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "aps-test-app",
+          scope: "data:read",
+        }).toString(),
+      });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_client");
+      expect(body.error_description).toBe("The client credentials are invalid.");
+    });
+
+    it("rejects a wrong client secret", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "aps-test-client",
+          client_secret: "wrong-secret",
+          scope: "data:read",
+        }).toString(),
+      });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_client");
+      expect(body.error_description).toBe("The client credentials are invalid.");
+    });
+
+    it("rejects a request without client credentials", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ grant_type: "client_credentials", scope: "data:read" }).toString(),
+      });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_client");
+      expect(body.error_description).toBe("No client credentials found.");
+      expect(res.headers.get("WWW-Authenticate")).toBe("Basic");
+    });
+
+    it("rejects a request without scope", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "aps-test-client",
+          client_secret: "aps-test-secret",
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_scope");
+    });
+  });
+
+  describe("introspect and revoke", () => {
+    it("introspects an active 3-legged token with the documented shape", async () => {
+      const { code } = await getAuthCode(app, store, { scope: "data:read" });
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+      const accessToken = tokenBody.access_token as string;
+
+      const body = await introspect(app, accessToken);
+      expect(body.active).toBe(true);
+      expect(body.scope).toBe("data:read");
+      expect(body.client_id).toBe("aps-test-client");
+      expect(typeof body.exp).toBe("number");
+      expect(body.userid).toMatch(/^[A-Z0-9]{12}$/);
+    });
+
+    it("introspects a 2-legged token without userid", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "aps-test-client",
+          client_secret: "aps-test-secret",
+          scope: "data:read",
+        }).toString(),
+      });
+      const tokenBody = (await res.json()) as Record<string, unknown>;
+
+      const body = await introspect(app, tokenBody.access_token as string);
+      expect(body.active).toBe(true);
+      expect(body.userid).toBeUndefined();
+    });
+
+    it("returns only active false for an unknown token", async () => {
+      const body = await introspect(app, "unknown-token");
+      expect(body).toEqual({ active: false });
+    });
+
+    it("returns active false after revocation", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+      const accessToken = tokenBody.access_token as string;
+      expect(tokenMap.has(accessToken)).toBe(true);
+
+      const creds = Buffer.from("aps-test-client:aps-test-secret").toString("base64");
+      const revoke = await app.request(`${base}/authentication/v2/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Authorization: `Basic ${creds}` },
+        body: new URLSearchParams({ token: accessToken, token_type_hint: "access_token" }).toString(),
+      });
+      expect(revoke.status).toBe(200);
+      expect(await revoke.text()).toBe("");
+      expect(tokenMap.has(accessToken)).toBe(false);
+
+      const body = await introspect(app, accessToken);
+      expect(body).toEqual({ active: false });
+    });
+
+    it("revokes refresh tokens", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+      const refreshToken = tokenBody.refresh_token as string;
+
+      const creds = Buffer.from("aps-test-client:aps-test-secret").toString("base64");
+      const revoke = await app.request(`${base}/authentication/v2/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Authorization: `Basic ${creds}` },
+        body: new URLSearchParams({ token: refreshToken, token_type_hint: "refresh_token" }).toString(),
+      });
+      expect(revoke.status).toBe(200);
+
+      const refreshRes = await refreshGrant(app, refreshToken);
+      expect(refreshRes.status).toBe(400);
+    });
+
+    it("returns 200 when revoking an unknown token", async () => {
+      const creds = Buffer.from("aps-test-client:aps-test-secret").toString("base64");
+      const res = await app.request(`${base}/authentication/v2/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Authorization: `Basic ${creds}` },
+        body: new URLSearchParams({ token: "unknown-token" }).toString(),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects revocation without a token parameter", async () => {
+      const creds = Buffer.from("aps-test-client:aps-test-secret").toString("base64");
+      const res = await app.request(`${base}/authentication/v2/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Authorization: `Basic ${creds}` },
+        body: "",
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toBe("The request is missing a required parameter 'token'.");
+    });
+  });
+
+  describe("userinfo and logout", () => {
+    it("returns userinfo for a valid 3-legged token", async () => {
+      const { code } = await getAuthCode(app, store);
+      const tokenBody = (await (await exchangeCode(app, code)).json()) as Record<string, unknown>;
+
+      const res = await app.request(`${base}/userinfo`, {
+        headers: { Authorization: `Bearer ${tokenBody.access_token as string}` },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.sub).toMatch(/^[A-Z0-9]{12}$/);
+      expect(body.email).toBe("testuser@autodesk.local");
+      expect(body.given_name).toBe("Test");
+      expect(body.family_name).toBe("User");
+      expect(body.email_verified).toBe(true);
+    });
+
+    it("returns 401 for userinfo with a 2-legged token", async () => {
+      const res = await app.request(`${base}/authentication/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "aps-test-client",
+          client_secret: "aps-test-secret",
+          scope: "data:read",
+        }).toString(),
+      });
+      const tokenBody = (await res.json()) as Record<string, unknown>;
+
+      const userinfoRes = await app.request(`${base}/userinfo`, {
+        headers: { Authorization: `Bearer ${tokenBody.access_token as string}` },
+      });
+      expect(userinfoRes.status).toBe(401);
+      const body = (await userinfoRes.json()) as Record<string, unknown>;
+      expect(body.errorCode).toBe("AUTH-006");
+    });
+
+    it("returns 401 for userinfo without a valid token", async () => {
+      const res = await app.request(`${base}/userinfo`, {
+        headers: { Authorization: "Bearer missing-token" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("logout redirects to an allow-listed post_logout_redirect_uri", async () => {
+      const uri = "http://localhost:3000/goodbye";
+      const res = await app.request(
+        `${base}/authentication/v2/logout?post_logout_redirect_uri=${encodeURIComponent(uri)}`,
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(uri);
+    });
+
+    it("logout renders an error screen for a non allow-listed domain", async () => {
+      const uri = "http://evil.local/callback";
+      const res = await app.request(
+        `${base}/authentication/v2/logout?post_logout_redirect_uri=${encodeURIComponent(uri)}`,
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("Redirect not allowed");
+    });
+
+    it("logout without a redirect renders a signed out page", async () => {
+      const res = await app.request(`${base}/authentication/v2/logout`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Signed out");
+    });
+  });
+
+  describe("seed from config", () => {
+    it("seeds clients and users and deduplicates", () => {
+      const seedStore = new Store();
+      const webhooks = new WebhookDispatcher();
+      const localTokenMap: TokenMap = new Map();
+      const localApp = new Hono();
+      localApp.use("*", authMiddleware(localTokenMap));
+      apsPlugin.register(localApp as any, seedStore, webhooks, base, localTokenMap);
+      apsPlugin.seed?.(seedStore, base);
+
+      seedFromConfig(seedStore, base, {
+        users: [
+          { email: "config-user@example.com", name: "Config User" },
+          { email: "config-user@example.com", name: "Config User" },
+        ],
+        clients: [
+          {
+            client_id: "config-client",
+            client_secret: "config-secret",
+            name: "Config Client",
+            redirect_uris: ["http://localhost:3000/config-callback"],
+          },
+          {
+            client_id: "config-public",
+            name: "Config Public Client",
+            redirect_uris: ["http://localhost:3000/config-callback"],
+          },
+        ],
+      });
+      seedFromConfig(seedStore, base, {
+        users: [{ email: "config-user@example.com", name: "Config User" }],
+      });
+
+      const aps = getApsStore(seedStore);
+      expect(aps.users.findBy("email", "config-user@example.com")).toHaveLength(1);
+      expect(aps.clients.findBy("client_id", "config-client")).toHaveLength(1);
+      expect(aps.clients.findOneBy("client_id", "config-client")?.type).toBe("confidential");
+      expect(aps.clients.findOneBy("client_id", "config-public")?.type).toBe("public");
+      expect(aps.clients.findOneBy("client_id", "aps-test-client")).toBeDefined();
+      expect(aps.clients.findOneBy("client_id", "aps-test-app")?.type).toBe("public");
+      expect(aps.users.findOneBy("email", "testuser@autodesk.local")).toBeDefined();
+    });
+  });
+});

--- a/packages/@emulators/aps/src/entities.ts
+++ b/packages/@emulators/aps/src/entities.ts
@@ -1,0 +1,20 @@
+import type { Entity } from "@emulators/core";
+
+export type ApsClientType = "confidential" | "public";
+
+export interface ApsClient extends Entity {
+  client_id: string;
+  client_secret: string;
+  name: string;
+  type: ApsClientType;
+  redirect_uris: string[];
+}
+
+export interface ApsUser extends Entity {
+  user_id: string;
+  email: string;
+  name: string;
+  first_name: string;
+  last_name: string;
+  picture: string | null;
+}

--- a/packages/@emulators/aps/src/helpers.ts
+++ b/packages/@emulators/aps/src/helpers.ts
@@ -1,0 +1,121 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { ApsClient, ApsUser, ApsClientType } from "./entities.js";
+
+export const DEFAULT_CONFIDENTIAL_CLIENT_ID = "aps-test-client";
+export const DEFAULT_CONFIDENTIAL_CLIENT_SECRET = "aps-test-secret";
+export const DEFAULT_PUBLIC_CLIENT_ID = "aps-test-app";
+export const DEFAULT_USER_EMAIL = "testuser@autodesk.local";
+
+export const SUPPORTED_SCOPES = [
+  "user-profile:read",
+  "user:read",
+  "user:write",
+  "viewables:read",
+  "data:read",
+  "data:write",
+  "data:create",
+  "data:search",
+  "bucket:create",
+  "bucket:read",
+  "bucket:update",
+  "bucket:delete",
+  "code:all",
+  "account:read",
+  "account:write",
+  "openid",
+];
+
+const ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const UPPER_ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+function randomString(alphabet: string, length: number): string {
+  const bytes = randomBytes(length);
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += alphabet[bytes[i] % alphabet.length];
+  }
+  return out;
+}
+
+export function generateAuthorizationCode(): string {
+  return randomBytes(30).toString("base64url");
+}
+
+export function generateRefreshToken(): string {
+  return randomString(ALPHANUMERIC, 42);
+}
+
+export function generateJti(): string {
+  return randomString(ALPHANUMERIC, 64);
+}
+
+export function generateUserId(): string {
+  return randomString(UPPER_ALPHANUMERIC, 12);
+}
+
+export function analyticsIdFor(userId: string): string {
+  return createHash("sha256").update(userId).digest("hex").slice(0, 32);
+}
+
+export function parseScope(scope: string): string[] {
+  return scope
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function isSupportedScope(scope: string): boolean {
+  if (SUPPORTED_SCOPES.includes(scope)) return true;
+  return /^data:read:[^*\\"]+$/.test(scope);
+}
+
+export function splitName(name: string, email: string): { first_name: string; last_name: string } {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    const local = email.split("@")[0] ?? "Test";
+    return { first_name: local, last_name: "User" };
+  }
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return { first_name: parts[0], last_name: "" };
+  return { first_name: parts.slice(0, -1).join(" "), last_name: parts[parts.length - 1] };
+}
+
+export function userNameFor(user: Pick<ApsUser, "email">): string {
+  return user.email.split("@")[0] ?? user.email;
+}
+
+export function normalizeClientType(type: string | undefined, fallback: ApsClientType): ApsClientType {
+  if (type === "confidential" || type === "public") return type;
+  return fallback;
+}
+
+export function createDefaultConfidentialClient(): Omit<ApsClient, "id" | "created_at" | "updated_at"> {
+  return {
+    client_id: DEFAULT_CONFIDENTIAL_CLIENT_ID,
+    client_secret: DEFAULT_CONFIDENTIAL_CLIENT_SECRET,
+    name: "Sample APS Web App",
+    type: "confidential",
+    redirect_uris: ["http://localhost:3000/api/auth/callback/aps", "http://localhost:3000/callback"],
+  };
+}
+
+export function createDefaultPublicClient(): Omit<ApsClient, "id" | "created_at" | "updated_at"> {
+  return {
+    client_id: DEFAULT_PUBLIC_CLIENT_ID,
+    client_secret: "",
+    name: "Sample APS Desktop App",
+    type: "public",
+    redirect_uris: ["http://localhost:3000/callback"],
+  };
+}
+
+export function createDefaultUser(): Omit<ApsUser, "id" | "created_at" | "updated_at"> {
+  return {
+    user_id: generateUserId(),
+    email: DEFAULT_USER_EMAIL,
+    name: "Test User",
+    first_name: "Test",
+    last_name: "User",
+    picture: null,
+  };
+}

--- a/packages/@emulators/aps/src/helpers.ts
+++ b/packages/@emulators/aps/src/helpers.ts
@@ -95,7 +95,11 @@ export function createDefaultConfidentialClient(): Omit<ApsClient, "id" | "creat
     client_secret: DEFAULT_CONFIDENTIAL_CLIENT_SECRET,
     name: "Sample APS Web App",
     type: "confidential",
-    redirect_uris: ["http://localhost:3000/api/auth/callback/aps", "http://localhost:3000/callback"],
+    redirect_uris: [
+      "http://localhost:3000/api/auth/callback/aps",
+      "http://localhost:3000/api/auth/oauth2/callback/aps",
+      "http://localhost:3000/callback",
+    ],
   };
 }
 

--- a/packages/@emulators/aps/src/index.ts
+++ b/packages/@emulators/aps/src/index.ts
@@ -1,0 +1,98 @@
+import type { Hono } from "@emulators/core";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import type { ApsClientType } from "./entities.js";
+import {
+  createDefaultConfidentialClient,
+  createDefaultPublicClient,
+  createDefaultUser,
+  DEFAULT_CONFIDENTIAL_CLIENT_ID,
+  DEFAULT_PUBLIC_CLIENT_ID,
+  DEFAULT_USER_EMAIL,
+  generateUserId,
+  normalizeClientType,
+  splitName,
+} from "./helpers.js";
+import { oauthRoutes } from "./routes/oauth.js";
+import { getApsStore } from "./store.js";
+
+export { getApsStore, type ApsStore } from "./store.js";
+export * from "./entities.js";
+
+export interface ApsSeedConfig {
+  clients?: Array<{
+    client_id: string;
+    client_secret?: string;
+    name?: string;
+    type?: ApsClientType;
+    redirect_uris: string[];
+  }>;
+  users?: Array<{
+    user_id?: string;
+    email: string;
+    name?: string;
+    picture?: string;
+  }>;
+}
+
+function seedDefaults(store: Store, _baseUrl: string): void {
+  const aps = getApsStore(store);
+
+  if (!aps.clients.findOneBy("client_id", DEFAULT_CONFIDENTIAL_CLIENT_ID)) {
+    aps.clients.insert(createDefaultConfidentialClient());
+  }
+  if (!aps.clients.findOneBy("client_id", DEFAULT_PUBLIC_CLIENT_ID)) {
+    aps.clients.insert(createDefaultPublicClient());
+  }
+  if (!aps.users.findOneBy("email", DEFAULT_USER_EMAIL)) {
+    aps.users.insert(createDefaultUser());
+  }
+}
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: ApsSeedConfig): void {
+  const aps = getApsStore(store);
+
+  if (config.clients) {
+    for (const client of config.clients) {
+      const existing = aps.clients.findOneBy("client_id", client.client_id);
+      if (existing) continue;
+      const type = normalizeClientType(client.type, client.client_secret ? "confidential" : "public");
+      aps.clients.insert({
+        client_id: client.client_id,
+        client_secret: client.client_secret ?? "",
+        name: client.name ?? client.client_id,
+        type,
+        redirect_uris: client.redirect_uris,
+      });
+    }
+  }
+
+  if (config.users) {
+    for (const user of config.users) {
+      const byEmail = aps.users.findOneBy("email", user.email);
+      if (byEmail) continue;
+      const name = user.name ?? "Test User";
+      const { first_name, last_name } = splitName(name, user.email);
+      aps.users.insert({
+        user_id: user.user_id ?? generateUserId(),
+        email: user.email,
+        name,
+        first_name,
+        last_name,
+        picture: user.picture ?? null,
+      });
+    }
+  }
+}
+
+export const apsPlugin: ServicePlugin = {
+  name: "aps",
+  register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    oauthRoutes(ctx);
+  },
+  seed(store: Store, baseUrl: string): void {
+    seedDefaults(store, baseUrl);
+  },
+};
+
+export default apsPlugin;

--- a/packages/@emulators/aps/src/routes/oauth.ts
+++ b/packages/@emulators/aps/src/routes/oauth.ts
@@ -1,0 +1,790 @@
+import { createHash, randomBytes } from "node:crypto";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
+import type { Context } from "@emulators/core";
+import type { AppEnv, RouteContext, Store, TokenMap } from "@emulators/core";
+import {
+  bodyStr,
+  debug,
+  escapeHtml,
+  matchesRedirectUri,
+  constantTimeSecretEqual,
+  renderCardPage,
+  renderErrorPage,
+  renderFormPostPage,
+  renderUserButton,
+} from "@emulators/core";
+import type { ApsClient, ApsUser } from "../entities.js";
+import {
+  analyticsIdFor,
+  generateAuthorizationCode,
+  generateJti,
+  generateRefreshToken,
+  isSupportedScope,
+  parseScope,
+  userNameFor,
+  SUPPORTED_SCOPES,
+} from "../helpers.js";
+import { getApsStore, type ApsStore } from "../store.js";
+
+const SERVICE_LABEL = "Autodesk Platform Services";
+const KID = "emulate-aps-1";
+const TOKEN_ISSUER = "https://developer.api.autodesk.com";
+const TOKEN_AUDIENCE = "https://autodesk.com";
+const AUTHORIZATION_CODE_TTL_MS = 5 * 60 * 1000;
+const ACCESS_TOKEN_TTL_SECONDS = 3600;
+const ACCESS_TOKEN_EXPIRES_IN = 3599;
+const ID_TOKEN_TTL_SECONDS = 60 * 60;
+const REFRESH_TOKEN_TTL_MS = 15 * 24 * 60 * 60 * 1000;
+
+type PendingCode = {
+  userId: string;
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  nonce: string | null;
+  codeChallenge: string | null;
+  createdAt: number;
+};
+
+type StoredAccessToken = {
+  clientId: string;
+  scope: string;
+  issuedAt: number;
+  expiresAt: number;
+  apsUserId: string | null;
+  familyId: string | null;
+};
+
+type StoredRefreshToken = {
+  clientId: string;
+  scope: string;
+  apsUserId: string;
+  familyId: string;
+  expiresAt: number;
+};
+
+type KeyPair = Awaited<ReturnType<typeof generateKeyPair>>;
+
+function getKeyPair(store: Store): Promise<KeyPair> {
+  let pair = store.getData<Promise<KeyPair>>("aps.oauth.keyPair");
+  if (!pair) {
+    pair = generateKeyPair("RS256");
+    store.setData("aps.oauth.keyPair", pair);
+  }
+  return pair;
+}
+
+function getPendingCodes(store: Store): Map<string, PendingCode> {
+  let map = store.getData<Map<string, PendingCode>>("aps.oauth.pendingCodes");
+  if (!map) {
+    map = new Map();
+    store.setData("aps.oauth.pendingCodes", map);
+  }
+  return map;
+}
+
+function getAccessTokens(store: Store): Map<string, StoredAccessToken> {
+  let map = store.getData<Map<string, StoredAccessToken>>("aps.oauth.accessTokens");
+  if (!map) {
+    map = new Map();
+    store.setData("aps.oauth.accessTokens", map);
+  }
+  return map;
+}
+
+function getRefreshTokens(store: Store): Map<string, StoredRefreshToken> {
+  let map = store.getData<Map<string, StoredRefreshToken>>("aps.oauth.refreshTokens");
+  if (!map) {
+    map = new Map();
+    store.setData("aps.oauth.refreshTokens", map);
+  }
+  return map;
+}
+
+function getConsumedRefreshTokens(store: Store): Map<string, string> {
+  let map = store.getData<Map<string, string>>("aps.oauth.consumedRefreshTokens");
+  if (!map) {
+    map = new Map();
+    store.setData("aps.oauth.consumedRefreshTokens", map);
+  }
+  return map;
+}
+
+function invalidateGrantFamily(store: Store, tokenMap: TokenMap | undefined, familyId: string): void {
+  const refreshTokens = getRefreshTokens(store);
+  for (const [token, record] of refreshTokens) {
+    if (record.familyId === familyId) refreshTokens.delete(token);
+  }
+  const accessTokens = getAccessTokens(store);
+  for (const [token, record] of accessTokens) {
+    if (record.familyId === familyId) {
+      accessTokens.delete(token);
+      tokenMap?.delete(token);
+    }
+  }
+}
+
+async function parseTokenLikeBody(c: Context<AppEnv>): Promise<Record<string, string>> {
+  const contentType = c.req.header("Content-Type") ?? "";
+  const raw = await c.req.text();
+
+  if (contentType.includes("application/json")) {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const out: Record<string, string> = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "string") out[key] = value;
+      }
+      return out;
+    } catch {
+      return {};
+    }
+  }
+
+  return Object.fromEntries(new URLSearchParams(raw));
+}
+
+function oauthError(c: Context<AppEnv>, status: 400, error: string, description: string): Response {
+  return c.json({ error, error_description: description }, status);
+}
+
+function invalidClient(c: Context<AppEnv>, description: string): Response {
+  c.header("WWW-Authenticate", "Basic");
+  return c.json({ error: "invalid_client", error_description: description }, 401);
+}
+
+function parseBasicAuth(header: string): { clientId: string; clientSecret: string } | null {
+  if (!header.startsWith("Basic ")) return null;
+  const decoded = Buffer.from(header.slice(6), "base64").toString("utf8");
+  const sep = decoded.indexOf(":");
+  if (sep === -1) return null;
+  return { clientId: decoded.slice(0, sep), clientSecret: decoded.slice(sep + 1) };
+}
+
+function authenticateClient(
+  c: Context<AppEnv>,
+  aps: ApsStore,
+  body: Record<string, string>,
+): { client: ApsClient } | { response: Response } {
+  const authHeader = c.req.header("Authorization") ?? "";
+  if (authHeader && body.client_id) {
+    return {
+      response: oauthError(
+        c,
+        400,
+        "invalid_request",
+        "The 'client_id' is not supported in the request body when Authorization headers are present.",
+      ),
+    };
+  }
+
+  const basic = parseBasicAuth(authHeader);
+  const clientId = basic ? basic.clientId : (body.client_id ?? "");
+  const clientSecret = basic ? basic.clientSecret : (body.client_secret ?? "");
+
+  if (!clientId) {
+    return { response: invalidClient(c, "No client credentials found.") };
+  }
+
+  const client = aps.clients.findOneBy("client_id", clientId);
+  if (!client) {
+    return { response: invalidClient(c, "The client credentials are invalid.") };
+  }
+
+  if (client.type === "confidential" && !constantTimeSecretEqual(client.client_secret, clientSecret)) {
+    return { response: invalidClient(c, "The client credentials are invalid.") };
+  }
+
+  return { client };
+}
+
+function userProfileError(c: Context<AppEnv>): Response {
+  return c.json(
+    {
+      developerMessage: "The provided access token is invalid, expired, or does not carry a user context.",
+      userMessage: " ",
+      errorCode: "AUTH-006",
+      "more info": "https://developer.api.autodesk.com/documentation/v2/errors/AUTH-006",
+    },
+    401,
+  );
+}
+
+async function signAccessToken(
+  store: Store,
+  options: { clientId: string; scope: string; apsUserId: string | null; now: number },
+): Promise<string> {
+  const { privateKey } = await getKeyPair(store);
+  const claims: Record<string, unknown> = {
+    scope: parseScope(options.scope),
+    client_id: options.clientId,
+    jti: generateJti(),
+  };
+  if (options.apsUserId) claims.userid = options.apsUserId;
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: KID })
+    .setIssuer(TOKEN_ISSUER)
+    .setAudience(TOKEN_AUDIENCE)
+    .setExpirationTime(options.now + ACCESS_TOKEN_TTL_SECONDS)
+    .sign(privateKey);
+}
+
+async function createIdToken(
+  store: Store,
+  user: ApsUser,
+  clientId: string,
+  nonce: string | null,
+  baseUrl: string,
+  now: number,
+): Promise<string> {
+  const { privateKey } = await getKeyPair(store);
+  const claims: Record<string, unknown> = {
+    sub: user.user_id,
+    first_name: user.first_name,
+    last_name: user.last_name,
+    user_name: userNameFor(user),
+    user_email: user.email,
+    userid: user.user_id,
+    analytics_id: analyticsIdFor(user.user_id),
+  };
+  if (nonce) claims.nonce = nonce;
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: KID, typ: "JWT" })
+    .setIssuer(baseUrl)
+    .setAudience(clientId)
+    .setIssuedAt(now)
+    .setExpirationTime(now + ID_TOKEN_TTL_SECONDS)
+    .sign(privateKey);
+}
+
+export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): void {
+  const aps = getApsStore(store);
+
+  app.get("/.well-known/openid-configuration", (c) => {
+    return c.json({
+      issuer: baseUrl,
+      authorization_endpoint: `${baseUrl}/authentication/v2/authorize`,
+      token_endpoint: `${baseUrl}/authentication/v2/token`,
+      userinfo_endpoint: `${baseUrl}/userinfo`,
+      jwks_uri: `${baseUrl}/authentication/v2/keys`,
+      revoke_endpoint: `${baseUrl}/authentication/v2/revoke`,
+      introspect_endpoint: `${baseUrl}/authentication/v2/introspect`,
+      scopes_supported: SUPPORTED_SCOPES,
+      response_types_supported: ["code", "code id_token", "id_token"],
+      response_modes_supported: ["fragment", "form_post", "query"],
+      grant_types_supported: ["authorization_code", "client_credentials", "refresh_token"],
+      subject_types_supported: ["public"],
+      id_token_signing_alg_values_supported: ["RS256"],
+    });
+  });
+
+  app.get("/authentication/v2/keys", async (c) => {
+    const { publicKey } = await getKeyPair(store);
+    const jwk = await exportJWK(publicKey);
+    c.header("Cache-Control", "max-age=604800");
+    return c.json({
+      keys: [{ kty: jwk.kty, kid: KID, use: "sig", n: jwk.n, e: jwk.e }],
+    });
+  });
+
+  app.get("/authentication/v2/authorize", (c) => {
+    const clientId = c.req.query("client_id") ?? "";
+    const redirectUri = c.req.query("redirect_uri") ?? "";
+    const responseType = c.req.query("response_type") ?? "";
+    const scope = c.req.query("scope") ?? "";
+    const state = c.req.query("state") ?? "";
+    const nonce = c.req.query("nonce") ?? "";
+    const responseMode = c.req.query("response_mode") ?? "query";
+    const codeChallenge = c.req.query("code_challenge") ?? "";
+    const codeChallengeMethod = c.req.query("code_challenge_method") ?? "";
+
+    if (!clientId) {
+      return c.html(renderErrorPage("Missing client_id", "The client_id parameter is required.", SERVICE_LABEL), 400);
+    }
+    if (!redirectUri) {
+      return c.html(
+        renderErrorPage("Missing redirect URI", "The redirect_uri parameter is required.", SERVICE_LABEL),
+        400,
+      );
+    }
+    const client = aps.clients.findOneBy("client_id", clientId);
+    if (!client) {
+      return c.html(
+        renderErrorPage("Application not found", `The client_id '${clientId}' is not registered.`, SERVICE_LABEL),
+        400,
+      );
+    }
+    if (!matchesRedirectUri(redirectUri, client.redirect_uris)) {
+      return c.html(
+        renderErrorPage(
+          "Redirect URI mismatch",
+          "The redirect_uri does not match the callback URL registered for this application.",
+          SERVICE_LABEL,
+        ),
+        400,
+      );
+    }
+
+    const redirectWithError = (error: string, description: string): Response => {
+      const url = new URL(redirectUri);
+      url.searchParams.set("error", error);
+      url.searchParams.set("error_description", description);
+      url.searchParams.set("state", state);
+      return c.redirect(url.toString(), 302);
+    };
+
+    if (responseType !== "code") {
+      return redirectWithError("unsupported_response_type", "The response_type must be 'code'.");
+    }
+    if (codeChallenge && codeChallengeMethod !== "S256") {
+      return redirectWithError("invalid_request", "The 'code_challenge_method' must be the string 'S256'.");
+    }
+    if (!codeChallenge && client.type === "public") {
+      return redirectWithError("invalid_request", "A 'code_challenge' is required for public clients.");
+    }
+    const invalidScope = parseScope(scope).find((entry) => !isSupportedScope(entry));
+    if (invalidScope) {
+      return redirectWithError("invalid_scope", "The scope is invalid.");
+    }
+
+    const users = aps.users.all();
+    const buttons = users
+      .map((user) =>
+        renderUserButton({
+          letter: (user.name[0] ?? user.email[0] ?? "?").toUpperCase(),
+          login: user.email,
+          name: user.name,
+          email: user.email,
+          formAction: "/authentication/v2/authorize/callback",
+          hiddenFields: {
+            user_id: user.user_id,
+            redirect_uri: redirectUri,
+            scope,
+            state,
+            nonce,
+            client_id: clientId,
+            response_mode: responseMode,
+            code_challenge: codeChallenge,
+          },
+        }),
+      )
+      .join("\n");
+
+    const subtitle = `Sign in to <strong>${escapeHtml(client.name)}</strong> with your Autodesk account.`;
+
+    return c.html(
+      renderCardPage(
+        "Sign in with Autodesk",
+        subtitle,
+        users.length > 0 ? buttons : '<p class="empty">No users in the emulator store.</p>',
+        SERVICE_LABEL,
+      ),
+    );
+  });
+
+  app.post("/authentication/v2/authorize/callback", async (c) => {
+    const body = await c.req.parseBody();
+    const userId = bodyStr(body.user_id);
+    const redirectUri = bodyStr(body.redirect_uri);
+    const scope = bodyStr(body.scope);
+    const state = bodyStr(body.state);
+    const nonce = bodyStr(body.nonce);
+    const clientId = bodyStr(body.client_id);
+    const responseMode = bodyStr(body.response_mode) || "query";
+    const codeChallenge = bodyStr(body.code_challenge);
+
+    if (!redirectUri) {
+      return c.html(
+        renderErrorPage("Missing redirect URI", "The redirect_uri parameter is required.", SERVICE_LABEL),
+        400,
+      );
+    }
+    const client = aps.clients.findOneBy("client_id", clientId);
+    if (!client) {
+      return c.html(
+        renderErrorPage("Application not found", `The client_id '${clientId}' is not registered.`, SERVICE_LABEL),
+        400,
+      );
+    }
+    if (!matchesRedirectUri(redirectUri, client.redirect_uris)) {
+      return c.html(
+        renderErrorPage(
+          "Redirect URI mismatch",
+          "The redirect_uri does not match the callback URL registered for this application.",
+          SERVICE_LABEL,
+        ),
+        400,
+      );
+    }
+    const user = aps.users.findOneBy("user_id", userId);
+    if (!user) {
+      return c.html(renderErrorPage("Unknown user", "The selected user is not available.", SERVICE_LABEL), 400);
+    }
+
+    const code = generateAuthorizationCode();
+    getPendingCodes(store).set(code, {
+      userId: user.user_id,
+      clientId,
+      redirectUri,
+      scope,
+      nonce: nonce || null,
+      codeChallenge: codeChallenge || null,
+      createdAt: Date.now(),
+    });
+
+    debug("aps.oauth", `[callback] code=${code.slice(0, 8)}... user=${user.email}`);
+
+    if (responseMode === "form_post") {
+      return c.html(renderFormPostPage(redirectUri, { code, state }, SERVICE_LABEL));
+    }
+    if (responseMode === "fragment") {
+      const url = new URL(redirectUri);
+      url.hash = new URLSearchParams({ code, state }).toString();
+      return c.redirect(url.toString(), 302);
+    }
+    const url = new URL(redirectUri);
+    url.searchParams.set("code", code);
+    url.searchParams.set("state", state);
+    return c.redirect(url.toString(), 302);
+  });
+
+  app.post("/authentication/v2/token", async (c) => {
+    const body = await parseTokenLikeBody(c);
+    const auth = authenticateClient(c, aps, body);
+    if ("response" in auth) return auth.response;
+    const client = auth.client;
+    const grantType = body.grant_type ?? "";
+
+    if (grantType === "authorization_code") {
+      const code = body.code ?? "";
+      const redirectUri = body.redirect_uri ?? "";
+      const codeVerifier = body.code_verifier ?? "";
+
+      if (!code) {
+        return oauthError(c, 400, "invalid_request", "The request is missing a required parameter 'code'.");
+      }
+      if (!redirectUri) {
+        return oauthError(c, 400, "invalid_request", "The request is missing a required parameter 'redirect_uri'.");
+      }
+
+      const pendingCodes = getPendingCodes(store);
+      const pending = pendingCodes.get(code);
+      if (!pending || Date.now() - pending.createdAt > AUTHORIZATION_CODE_TTL_MS) {
+        if (pending) pendingCodes.delete(code);
+        return oauthError(c, 400, "invalid_grant", "The authorization code is invalid or has expired.");
+      }
+      if (pending.clientId !== client.client_id) {
+        return oauthError(c, 400, "invalid_grant", "The grant was issued to another client.");
+      }
+      if (redirectUri !== pending.redirectUri) {
+        return oauthError(c, 400, "invalid_grant", "The 'redirect_uri' is invalid.");
+      }
+      if (pending.codeChallenge) {
+        if (!codeVerifier) {
+          return oauthError(c, 400, "invalid_request", "The request is missing a required parameter 'code_verifier'.");
+        }
+        const expected = createHash("sha256").update(codeVerifier).digest("base64url");
+        if (expected !== pending.codeChallenge) {
+          return oauthError(c, 400, "invalid_grant", "PKCE verification failed.");
+        }
+      }
+      const user = aps.users.findOneBy("user_id", pending.userId);
+      if (!user) {
+        return oauthError(c, 400, "invalid_grant", "The authorization code is invalid or has expired.");
+      }
+      pendingCodes.delete(code);
+
+      const now = Math.floor(Date.now() / 1000);
+      const scope = pending.scope || "data:read";
+      const familyId = randomBytes(16).toString("hex");
+      const accessToken = await signAccessToken(store, {
+        clientId: client.client_id,
+        scope,
+        apsUserId: user.user_id,
+        now,
+      });
+      const refreshToken = generateRefreshToken();
+
+      getAccessTokens(store).set(accessToken, {
+        clientId: client.client_id,
+        scope,
+        issuedAt: now,
+        expiresAt: now + ACCESS_TOKEN_TTL_SECONDS,
+        apsUserId: user.user_id,
+        familyId,
+      });
+      getRefreshTokens(store).set(refreshToken, {
+        clientId: client.client_id,
+        scope,
+        apsUserId: user.user_id,
+        familyId,
+        expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
+      });
+      tokenMap?.set(accessToken, { login: user.email, id: user.id, scopes: parseScope(scope) });
+
+      debug("aps.oauth", `[token] issued 3-legged token for ${user.email}`);
+
+      const response: Record<string, unknown> = {
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: ACCESS_TOKEN_EXPIRES_IN,
+        refresh_token: refreshToken,
+      };
+      if (parseScope(scope).includes("openid")) {
+        response.id_token = await createIdToken(store, user, client.client_id, pending.nonce, baseUrl, now);
+      }
+      return c.json(response);
+    }
+
+    if (grantType === "refresh_token") {
+      const refreshToken = body.refresh_token ?? "";
+      if (!refreshToken) {
+        return oauthError(c, 400, "invalid_request", "The request is missing a required parameter 'refresh_token'.");
+      }
+
+      const consumed = getConsumedRefreshTokens(store);
+      const replayedFamily = consumed.get(refreshToken);
+      if (replayedFamily) {
+        invalidateGrantFamily(store, tokenMap, replayedFamily);
+        return oauthError(c, 400, "invalid_grant", "The refresh token is invalid or expired.");
+      }
+
+      const refreshTokens = getRefreshTokens(store);
+      const record = refreshTokens.get(refreshToken);
+      if (!record || record.expiresAt <= Date.now()) {
+        if (record) refreshTokens.delete(refreshToken);
+        return oauthError(c, 400, "invalid_grant", "The refresh token is invalid or expired.");
+      }
+      if (record.clientId !== client.client_id) {
+        return oauthError(c, 400, "invalid_grant", "The grant was issued to another client.");
+      }
+
+      let scope = record.scope;
+      const requestedScope = body.scope ?? "";
+      if (requestedScope) {
+        const granted = new Set(parseScope(record.scope));
+        const requested = parseScope(requestedScope);
+        if (requested.some((entry) => !granted.has(entry))) {
+          return oauthError(
+            c,
+            400,
+            "invalid_scope",
+            "The requested scope is invalid, unknown, malformed or exceeds the scope granted by the resource owner.",
+          );
+        }
+        scope = requested.join(" ");
+      }
+
+      const user = aps.users.findOneBy("user_id", record.apsUserId);
+      if (!user) {
+        return oauthError(c, 400, "invalid_grant", "The refresh token is invalid or expired.");
+      }
+
+      refreshTokens.delete(refreshToken);
+      consumed.set(refreshToken, record.familyId);
+
+      const now = Math.floor(Date.now() / 1000);
+      const accessToken = await signAccessToken(store, {
+        clientId: client.client_id,
+        scope,
+        apsUserId: user.user_id,
+        now,
+      });
+      const nextRefreshToken = generateRefreshToken();
+
+      getAccessTokens(store).set(accessToken, {
+        clientId: client.client_id,
+        scope,
+        issuedAt: now,
+        expiresAt: now + ACCESS_TOKEN_TTL_SECONDS,
+        apsUserId: user.user_id,
+        familyId: record.familyId,
+      });
+      refreshTokens.set(nextRefreshToken, {
+        clientId: client.client_id,
+        scope,
+        apsUserId: user.user_id,
+        familyId: record.familyId,
+        expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
+      });
+      tokenMap?.set(accessToken, { login: user.email, id: user.id, scopes: parseScope(scope) });
+
+      return c.json({
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: ACCESS_TOKEN_EXPIRES_IN,
+        refresh_token: nextRefreshToken,
+      });
+    }
+
+    if (grantType === "client_credentials") {
+      if (client.type !== "confidential") {
+        return invalidClient(c, "The client credentials are invalid.");
+      }
+      const scope = body.scope ?? "";
+      const scopes = parseScope(scope);
+      if (scopes.length === 0 || scopes.some((entry) => !isSupportedScope(entry))) {
+        return oauthError(
+          c,
+          400,
+          "invalid_scope",
+          "The requested scope is invalid, unknown, malformed or exceeds the scope granted by the resource owner.",
+        );
+      }
+
+      const now = Math.floor(Date.now() / 1000);
+      const accessToken = await signAccessToken(store, {
+        clientId: client.client_id,
+        scope,
+        apsUserId: null,
+        now,
+      });
+
+      getAccessTokens(store).set(accessToken, {
+        clientId: client.client_id,
+        scope,
+        issuedAt: now,
+        expiresAt: now + ACCESS_TOKEN_TTL_SECONDS,
+        apsUserId: null,
+        familyId: null,
+      });
+      tokenMap?.set(accessToken, { login: client.client_id, id: 0, scopes });
+
+      debug("aps.oauth", `[token] issued 2-legged token for ${client.client_id}`);
+
+      return c.json({
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: ACCESS_TOKEN_EXPIRES_IN,
+      });
+    }
+
+    return oauthError(c, 400, "invalid_request", "The token request must specify a valid 'grant_type'.");
+  });
+
+  app.post("/authentication/v2/revoke", async (c) => {
+    const body = await parseTokenLikeBody(c);
+    const auth = authenticateClient(c, aps, body);
+    if ("response" in auth) return auth.response;
+    const client = auth.client;
+
+    const token = body.token ?? "";
+    if (!token) {
+      return oauthError(c, 400, "invalid_request", "The request is missing a required parameter 'token'.");
+    }
+
+    const accessTokens = getAccessTokens(store);
+    const accessRecord = accessTokens.get(token);
+    if (accessRecord && accessRecord.clientId === client.client_id) {
+      accessTokens.delete(token);
+      tokenMap?.delete(token);
+    }
+    const refreshTokens = getRefreshTokens(store);
+    const refreshRecord = refreshTokens.get(token);
+    if (refreshRecord && refreshRecord.clientId === client.client_id) {
+      refreshTokens.delete(token);
+    }
+
+    return c.body(null, 200);
+  });
+
+  app.post("/authentication/v2/introspect", async (c) => {
+    const body = await parseTokenLikeBody(c);
+    const auth = authenticateClient(c, aps, body);
+    if ("response" in auth) return auth.response;
+
+    const token = body.token ?? "";
+    if (!token) {
+      return oauthError(c, 400, "invalid_request", "The request is missing a required parameter 'token'.");
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const access = getAccessTokens(store).get(token);
+    if (access && access.expiresAt > now) {
+      return c.json({
+        active: true,
+        scope: access.scope,
+        client_id: access.clientId,
+        exp: access.expiresAt,
+        ...(access.apsUserId ? { userid: access.apsUserId } : {}),
+      });
+    }
+
+    const refresh = getRefreshTokens(store).get(token);
+    if (refresh && refresh.expiresAt > Date.now()) {
+      return c.json({
+        active: true,
+        scope: refresh.scope,
+        client_id: refresh.clientId,
+        exp: Math.floor(refresh.expiresAt / 1000),
+        userid: refresh.apsUserId,
+      });
+    }
+
+    return c.json({ active: false });
+  });
+
+  app.get("/authentication/v2/logout", (c) => {
+    const postLogoutRedirectUri = c.req.query("post_logout_redirect_uri");
+    if (!postLogoutRedirectUri) {
+      return c.html(renderCardPage("Signed out", "Your Autodesk session has ended.", "", SERVICE_LABEL));
+    }
+
+    let allowed = false;
+    try {
+      const target = new URL(postLogoutRedirectUri);
+      allowed = aps.clients.all().some((client) =>
+        client.redirect_uris.some((uri) => {
+          try {
+            return new URL(uri).host === target.host;
+          } catch {
+            return false;
+          }
+        }),
+      );
+    } catch {
+      allowed = false;
+    }
+    if (!allowed) {
+      return c.html(
+        renderErrorPage(
+          "Redirect not allowed",
+          "The post_logout_redirect_uri domain is not in the allowed list.",
+          SERVICE_LABEL,
+        ),
+        400,
+      );
+    }
+    return c.redirect(postLogoutRedirectUri, 302);
+  });
+
+  app.get("/userinfo", (c) => {
+    const authHeader = c.req.header("Authorization") ?? "";
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    const record = token ? getAccessTokens(store).get(token) : undefined;
+    const now = Math.floor(Date.now() / 1000);
+    if (!record || record.expiresAt <= now || !record.apsUserId) {
+      return userProfileError(c);
+    }
+    const user = aps.users.findOneBy("user_id", record.apsUserId);
+    if (!user) return userProfileError(c);
+
+    const response: Record<string, unknown> = {
+      sub: user.user_id,
+      name: user.name,
+      given_name: user.first_name,
+      family_name: user.last_name,
+      preferred_username: userNameFor(user),
+      email: user.email,
+      email_verified: true,
+      locale: "en-US",
+      updated_at: Math.floor(new Date(user.updated_at).getTime() / 1000),
+      eidm_guid: user.user_id,
+    };
+    if (user.picture) {
+      response.picture = user.picture;
+      response.thumbnails = { sizeX200: user.picture };
+    }
+    return c.json(response);
+  });
+}

--- a/packages/@emulators/aps/src/store.ts
+++ b/packages/@emulators/aps/src/store.ts
@@ -1,0 +1,14 @@
+import { Store, type Collection } from "@emulators/core";
+import type { ApsClient, ApsUser } from "./entities.js";
+
+export interface ApsStore {
+  clients: Collection<ApsClient>;
+  users: Collection<ApsUser>;
+}
+
+export function getApsStore(store: Store): ApsStore {
+  return {
+    clients: store.collection<ApsClient>("aps.clients", ["client_id"]),
+    users: store.collection<ApsUser>("aps.users", ["user_id", "email"]),
+  };
+}

--- a/packages/@emulators/aps/tsconfig.json
+++ b/packages/@emulators/aps/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/aps/tsup.config.ts
+++ b/packages/@emulators/aps/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/@emulators/aps/vitest.config.ts
+++ b/packages/@emulators/aps/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -72,6 +72,7 @@
     "@emulators/clerk": "workspace:*",
     "@emulators/linear": "workspace:*",
     "@emulators/twilio": "workspace:*",
+    "@emulators/aps": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -40,6 +40,7 @@ const SERVICE_NAME_LIST = [
   "clerk",
   "linear",
   "twilio",
+  "aps",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -648,6 +649,33 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
         conversations: {
           services: [{ friendly_name: "Local Conversations" }],
         },
+      },
+    },
+  },
+
+  aps: {
+    label: "Autodesk Platform Services (APS) OAuth emulator",
+    endpoints:
+      "OAuth authorize, token exchange (authorization code, refresh token, client credentials), token revocation, introspection, JWKS, logout, userinfo, OIDC discovery",
+    async load() {
+      const mod = await import("@emulators/aps");
+      return { plugin: mod.apsPlugin, seedFromConfig: mod.seedFromConfig };
+    },
+    defaultFallback(cfg) {
+      const firstEmail = (cfg?.users as Array<{ email?: string }> | undefined)?.[0]?.email ?? "testuser@autodesk.local";
+      return { login: firstEmail, id: 1, scopes: ["user-profile:read", "data:read", "openid"] };
+    },
+    initConfig: {
+      aps: {
+        users: [{ email: "testuser@autodesk.local", name: "Test User" }],
+        clients: [
+          {
+            client_id: "aps-test-client",
+            client_secret: "aps-test-secret",
+            name: "My APS App",
+            redirect_uris: ["http://localhost:3000/api/auth/callback/aps"],
+          },
+        ],
       },
     },
   },

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -673,7 +673,10 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
             client_id: "aps-test-client",
             client_secret: "aps-test-secret",
             name: "My APS App",
-            redirect_uris: ["http://localhost:3000/api/auth/callback/aps"],
+            redirect_uris: [
+              "http://localhost:3000/api/auth/callback/aps",
+              "http://localhost:3000/api/auth/oauth2/callback/aps",
+            ],
           },
         ],
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,6 +575,25 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
+  packages/@emulators/aps:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+      jose:
+        specifier: ^6
+        version: 6.2.2
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/@emulators/aws:
     dependencies:
       '@emulators/core':
@@ -847,6 +866,9 @@ importers:
       '@emulators/apple':
         specifier: workspace:*
         version: link:../@emulators/apple
+      '@emulators/aps':
+        specifier: workspace:*
+        version: link:../@emulators/aps
       '@emulators/aws':
         specifier: workspace:*
         version: link:../@emulators/aws

--- a/skills/aps/SKILL.md
+++ b/skills/aps/SKILL.md
@@ -63,6 +63,7 @@ aps:
       name: My APS App
       redirect_uris:
         - http://localhost:3000/api/auth/callback/aps
+        - http://localhost:3000/api/auth/oauth2/callback/aps
     - client_id: aps-test-app
       type: public
       redirect_uris:

--- a/skills/aps/SKILL.md
+++ b/skills/aps/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: aps
+description: Emulated Autodesk Platform Services (APS) OAuth 2.0 for local development and testing. Use when the user needs to test Autodesk sign-in locally, emulate APS authentication v2, handle APS token exchange, configure APS OAuth clients, or work with Autodesk userinfo without hitting real Autodesk APIs. Triggers include "APS OAuth", "Autodesk Platform Services", "Forge OAuth", "Autodesk Forge", "emulate Autodesk login", "test APS 3-legged flow", "APS 2-legged token", "APS client credentials", "APS refresh token", "Autodesk userinfo", "mock Autodesk sign-in", or any task requiring a local APS authentication API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Autodesk Platform Services (APS) OAuth Emulator
+
+APS authentication v2 emulation with the 3-legged authorization code flow, PKCE support, the 2-legged client credentials flow, rotating single-use refresh tokens, RS256 access tokens, token introspection and revocation, and OIDC discovery.
+
+## Start
+
+```bash
+# APS only
+npx emulate --service aps
+
+# Default port when all services run
+# http://localhost:4014
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from "emulate";
+
+const aps = await createEmulator({ service: "aps", port: 4014 });
+// aps.url === 'http://localhost:4014'
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+APS_EMULATOR_URL=http://localhost:4014
+```
+
+### OAuth URL Mapping
+
+Real APS paths map 1:1 onto the emulator:
+
+| Real APS URL                                                          | Emulator URL                                         |
+| --------------------------------------------------------------------- | ---------------------------------------------------- |
+| `https://developer.api.autodesk.com/authentication/v2/authorize`      | `$APS_EMULATOR_URL/authentication/v2/authorize`      |
+| `https://developer.api.autodesk.com/authentication/v2/token`          | `$APS_EMULATOR_URL/authentication/v2/token`          |
+| `https://developer.api.autodesk.com/authentication/v2/revoke`         | `$APS_EMULATOR_URL/authentication/v2/revoke`         |
+| `https://developer.api.autodesk.com/authentication/v2/introspect`     | `$APS_EMULATOR_URL/authentication/v2/introspect`     |
+| `https://developer.api.autodesk.com/authentication/v2/keys`           | `$APS_EMULATOR_URL/authentication/v2/keys`           |
+| `https://developer.api.autodesk.com/authentication/v2/logout`         | `$APS_EMULATOR_URL/authentication/v2/logout`         |
+| `https://developer.api.autodesk.com/.well-known/openid-configuration` | `$APS_EMULATOR_URL/.well-known/openid-configuration` |
+| `https://api.userprofile.autodesk.com/userinfo`                       | `$APS_EMULATOR_URL/userinfo`                         |
+
+## Seed Config
+
+```yaml
+aps:
+  users:
+    - email: testuser@autodesk.local
+      name: Test User
+  clients:
+    - client_id: aps-test-client
+      client_secret: aps-test-secret
+      name: My APS App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/aps
+    - client_id: aps-test-app
+      type: public
+      redirect_uris:
+        - http://localhost:3000/callback
+```
+
+Client `type` is inferred when omitted: confidential when a `client_secret` is present, public otherwise. With no config, the emulator seeds a confidential client `aps-test-client` / `aps-test-secret`, a public client `aps-test-app`, and a user `testuser@autodesk.local`.
+
+## 3-Legged Authorization Code Flow
+
+```bash
+APS_URL="http://localhost:4014"
+CLIENT_ID="aps-test-client"
+CLIENT_SECRET="aps-test-secret"
+REDIRECT_URI="http://localhost:3000/api/auth/callback/aps"
+
+# 1. Open in browser (user picks a seeded Autodesk account)
+#    $APS_URL/authentication/v2/authorize?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&response_type=code&scope=data:read&state=abc
+
+# 2. After user selection, emulator redirects to:
+#    $REDIRECT_URI?code=<code>&state=abc
+
+# 3. Exchange code for tokens
+curl -X POST $APS_URL/authentication/v2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=authorization_code&code=<code>&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&redirect_uri=$REDIRECT_URI"
+```
+
+Client credentials can also be sent as an HTTP Basic `Authorization` header instead of body parameters. Do not send `client_id` in the body when an `Authorization` header is present; the emulator rejects that, matching real APS. Returns:
+
+```json
+{
+  "access_token": "<jwt>",
+  "token_type": "Bearer",
+  "expires_in": 3599,
+  "refresh_token": "..."
+}
+```
+
+When the requested scope includes `openid`, the response also contains an `id_token`. Authorization codes are single use and expire after 5 minutes.
+
+### PKCE
+
+The authorize endpoint accepts `code_challenge` with `code_challenge_method=S256` (`S256` only). PKCE is required for public clients, which omit `client_secret`:
+
+```bash
+# Verifier/challenge pair
+CODE_VERIFIER="test-code-verifier-string"
+CODE_CHALLENGE=$(printf %s "$CODE_VERIFIER" | openssl dgst -sha256 -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+
+# 1. Authorize with code_challenge=$CODE_CHALLENGE&code_challenge_method=S256
+
+# 2. Exchange with the verifier (public client, no secret)
+curl -X POST $APS_URL/authentication/v2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=authorization_code&code=<code>&client_id=aps-test-app&redirect_uri=http://localhost:3000/callback&code_verifier=$CODE_VERIFIER"
+```
+
+## 2-Legged Client Credentials Flow
+
+Confidential clients only. `scope` is required:
+
+```bash
+curl -X POST $APS_URL/authentication/v2/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&scope=data:read data:write"
+```
+
+Returns an `access_token` without a `refresh_token` or `id_token`.
+
+## Refresh Token Flow
+
+```bash
+curl -X POST $APS_URL/authentication/v2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=refresh_token&refresh_token=<refresh_token>&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET"
+```
+
+Refresh tokens live for 15 days and are single use. Every refresh returns a new `refresh_token`; always store the latest one. Replaying an already-used refresh token invalidates the whole grant family (all access and refresh tokens descended from the original authorization), matching real APS behavior. An optional `scope` parameter may downscope the grant but never widen it.
+
+## Other Endpoints
+
+### User Info
+
+```bash
+curl $APS_URL/userinfo \
+  -H "Authorization: Bearer <access_token>"
+```
+
+Requires a 3-legged token; 2-legged tokens carry no user context and return a 401 `AUTH-006` error.
+
+### Introspection
+
+```bash
+curl -X POST $APS_URL/authentication/v2/introspect \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "token=<access_or_refresh_token>"
+```
+
+### Revocation
+
+```bash
+curl -X POST $APS_URL/authentication/v2/revoke \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "token=<access_or_refresh_token>"
+```
+
+### OIDC Discovery and Logout
+
+```bash
+curl $APS_URL/.well-known/openid-configuration
+curl "$APS_URL/authentication/v2/logout?post_logout_redirect_uri=http://localhost:3000/"
+```
+
+The logout redirect is only followed when the target host matches a registered client redirect URI.
+
+## Verifying Access Tokens
+
+Access tokens are RS256 JWTs signed with the emulator's key pair and expire after one hour (`expires_in` 3599). Verify them against the JWKS endpoint:
+
+```bash
+curl $APS_URL/authentication/v2/keys
+```
+
+```typescript
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const jwks = createRemoteJWKSet(new URL(`${process.env.APS_EMULATOR_URL}/authentication/v2/keys`));
+const { payload } = await jwtVerify(accessToken, jwks, {
+  issuer: "https://developer.api.autodesk.com",
+  audience: "https://autodesk.com",
+});
+// payload.scope, payload.client_id, payload.userid (3-legged only)
+```
+
+## Current Limits
+
+Only authentication v2 and the user profile endpoint are emulated. Data APIs such as Data Management, Model Derivative, ACC/BIM 360, and APS webhooks are not included yet.

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -32,6 +32,7 @@ All services start with sensible defaults:
 | Clerk     | 4011        |
 | Linear    | 4012        |
 | Twilio    | 4013        |
+| APS       | 4014        |
 
 ## CLI
 
@@ -103,7 +104,7 @@ await vercel.close()
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, `'twilio'`, or `'aps'` |
 | `port` | `4000` | Port for the HTTP server |
 | `seed` | none | Inline seed data (same shape as YAML config) |
 | `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
@@ -403,6 +404,7 @@ packages/
     slack/           # Slack Web API, OAuth, incoming webhooks plugin
     linear/          # Linear GraphQL API, OAuth, webhooks plugin
     twilio/          # Twilio Messaging, Verify, Voice, webhooks plugin
+    aps/             # Autodesk Platform Services OAuth 2.0 / OIDC plugin
     apple/           # Sign in with Apple / OIDC plugin
     microsoft/       # Microsoft Entra ID OAuth 2.0 / OIDC plugin
     aws/             # AWS S3, SQS, IAM, STS plugin


### PR DESCRIPTION

Adds `@emulators/aps`, a stateful emulator for the Autodesk Platform Services OAuth v2 API (the authentication layer for Autodesk Construction Cloud, BIM 360, Fusion, and every other APS product). This is the first AEC (architecture, engineering, construction) service in emulate; the plan is to follow with the APS data APIs (Data Management, Model Derivative) based on interest, and a Procore emulator after that.

## What it emulates

All endpoints at their real `developer.api.autodesk.com` paths:

- `GET /authentication/v2/authorize` with the shared sign-in UI, PKCE (S256 only, required for public clients), and spec-accurate error redirects
- `POST /authentication/v2/token` for `authorization_code`, `client_credentials`, and `refresh_token`
- `POST /authentication/v2/revoke`, `POST /authentication/v2/introspect`
- `GET /authentication/v2/keys` (JWKS), `GET /authentication/v2/logout`
- `GET /userinfo` (real APS serves this from `api.userprofile.autodesk.com`; mapped onto the emulator base URL)
- `GET /.well-known/openid-configuration`

Access tokens are RS256 JWTs carrying the documented claims (`scope` as array, `client_id`, real APS `iss`/`aud`, `userid` on 3-legged) and verify against the JWKS endpoint. Lifetimes follow the docs: codes 5 minutes single-use, access tokens `expires_in: 3599`, refresh tokens 15 days.

## Fidelity note: single-use refresh tokens

APS rotates refresh tokens on every use and invalidates the previous one; replaying a consumed token kills the grant. This is the number-one production failure mode for APS integrations (two serverless instances refreshing concurrently brick the user's connection), and it is faithfully emulated including grant-family invalidation on replay, so integration tests can exercise the failure locally instead of discovering it in production.

## Implementation

- Built against the official APS OAuth v2 documentation (HTTP reference plus developer guide), with response bodies and error shapes matching the documented examples, including the platform error format (`developerMessage`, `errorCode`, `"more info"`).
- Follows the existing package patterns throughout: mirrors `@emulators/okta` for structure, `jose` for signing, the shared UI system from `@emulators/core` for the sign-in and error pages, seedable and resettable stores.
- Zero-config defaults (confidential client `aps-test-client`/`aps-test-secret`, public client `aps-test-app`, user `testuser@autodesk.local`) so `npx emulate --service aps` works immediately.
- 54 tests covering the three flows, PKCE enforcement, rotation and replay (family invalidation), introspection, revocation, JWKS verification of issued tokens, userinfo, discovery, and the documented error shapes.
- Docs updated per AGENTS.md: root README, config example, package README, `skills/aps`, and the web docs pages and navigation.

## Not included (yet)

APS data APIs (Data Management hubs/projects, Model Derivative) and rate-limit emulation. Kept out to keep this PR reviewable; happy to follow up based on interest.