### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 <!-- release:start -->
+## 0.10.0
+
+### New Features
+
+- **Expanded GitHub repository APIs** add stateful contents, README, commits, comparisons, raw file downloads, Git Data shapes, branch isolation, and commit-producing file writes (#191)
+- **Generated GitHub App keys** let `createEmulator` generate RSA private keys for GitHub Apps that omit `private_key`, expose generated material through `generatedSecrets`, and preserve it across resets (#200)
+
+### Bug Fixes
+
+- Fixed **Stripe webhook signatures** to send Stripe-compatible `Stripe-Signature` headers over the raw request body (#198)
+- Fixed **GitHub App JWT verification** for documented PKCS#1 keys and PKCS#8 keys by deriving public key material before verification (#199)
+
+### Contributors
+
+- @ctate
+- @EfeDurmaz16
+- @Railly
+- @sidpalas
+
+<!-- release:end -->
+
 ## 0.9.0
 
 ### New Features
@@ -15,8 +36,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.8.0
 

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-next",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/adapter-nuxt/package.json
+++ b/packages/@emulators/adapter-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-nuxt",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/apple/package.json
+++ b/packages/@emulators/apple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/apple",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/aws",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/clerk/package.json
+++ b/packages/@emulators/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/clerk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/core/package.json
+++ b/packages/@emulators/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/github/package.json
+++ b/packages/@emulators/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/github",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/google/package.json
+++ b/packages/@emulators/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/google",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/linear/package.json
+++ b/packages/@emulators/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/linear",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/microsoft/package.json
+++ b/packages/@emulators/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/microsoft",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/mongoatlas/package.json
+++ b/packages/@emulators/mongoatlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/mongoatlas",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/okta/package.json
+++ b/packages/@emulators/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/okta",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/resend/package.json
+++ b/packages/@emulators/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/resend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/slack/package.json
+++ b/packages/@emulators/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/slack",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/stripe/package.json
+++ b/packages/@emulators/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/stripe",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/twilio/package.json
+++ b/packages/@emulators/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/twilio",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/vercel/package.json
+++ b/packages/@emulators/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/vercel",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulate",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local drop-in replacement services for CI and no-network sandboxes",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump `emulate` and all `@emulators/*` packages to 0.10.0
- add release notes for expanded GitHub repository APIs, Stripe webhook signatures, GitHub App JWT verification, and generated GitHub App keys
- move the release markers from 0.9.0 to 0.10.0

## Included

- #191
- #198
- #199
- #200

## Verification

- `pnpm type-check` (34/34 tasks)
- `pnpm test` (33/33 tasks)
- `pnpm build` (26/26 tasks)
- `pnpm format:check`
- `node scripts/sync-versions.mjs --check`
- `git diff --check`
- packed all 18 publishable packages and verified every tarball reports 0.10.0
