### PR TITLE
feat(cli): deliver generated secrets securely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - run: sudo apt-get update && sudo apt-get install -y acl
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npx emulate list
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
 | `--base-url` | none | Override advertised base URL (supports `{service}` template) |
 | `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
-| `--generated-secrets-file` | none | Generate omitted service secrets and write them to a new owner-only JSON file (not supported on Windows) |
+| `--generated-secrets-file` | none | Generate omitted service secrets and write them to a new owner-only JSON file |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 
@@ -160,7 +160,7 @@ npx emulate start --service github --seed config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. emulate publishes complete JSON with owner-only `0600` permissions before opening listeners or configuring portless. Only generated secrets are included. Explicitly configured keys are never copied into the artifact. This flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files keep requiring `private_key`.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact so the command can be retried immediately. A hard termination such as `SIGKILL` can leave a complete published artifact that must be removed manually after confirming no invocation is using it. Only generated secrets are included. Explicitly configured keys are never copied into the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files keep requiring `private_key`.
 
 ### Vitest / Jest setup
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ npx emulate --port 3000
 # Use a seed config file
 npx emulate --seed config.yaml
 
+# Generate omitted service secrets into a private file
+npx emulate start --seed config.yaml --generated-secrets-file .emulate-secrets.json
+
 # Generate a starter config
 npx emulate init
 
@@ -61,6 +64,7 @@ npx emulate list
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
 | `--base-url` | none | Override advertised base URL (supports `{service}` template) |
 | `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
+| `--generated-secrets-file` | none | Generate omitted service secrets and write them to a new owner-only JSON file (not supported on Windows) |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 
@@ -148,6 +152,15 @@ const privateKey = github.generatedSecrets.find(
 ```
 
 Generated keys remain stable across `reset()` calls and appear only in `generatedSecrets`. Explicitly configured keys are never returned there. A new `createEmulator` call generates a new key.
+
+The CLI can also generate omitted GitHub App keys when a delivery file is requested:
+
+```bash
+npx emulate start --service github --seed config.yaml \
+  --generated-secrets-file .emulate-secrets.json
+```
+
+The destination must not exist. emulate publishes complete JSON with owner-only `0600` permissions before opening listeners or configuring portless. Only generated secrets are included. Explicitly configured keys are never copied into the artifact. This flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files keep requiring `private_key`.
 
 ### Vitest / Jest setup
 

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -146,7 +146,7 @@ npx emulate start --service github --seed emulate.config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. emulate publishes a complete owner-only JSON artifact before opening listeners or configuring portless. Explicit keys are excluded. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require an explicit private key.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Explicit keys are excluded. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require an explicit private key.
 
 ## Google Seed Config
 

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -137,7 +137,16 @@ github:
 
 JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's private key (RS256). The emulator verifies the signature and resolves the app.
 
-When using the programmatic `createEmulator` API, `private_key` may be omitted. The instance generates an RSA-2048 PKCS#1 key, exposes it through `generatedSecrets`, and keeps it stable across `reset()` calls. Seed files used by the CLI still require an explicit private key.
+When using the programmatic `createEmulator` API, `private_key` may be omitted. The instance generates an RSA-2048 PKCS#1 key, exposes it through `generatedSecrets`, and keeps it stable across `reset()` calls.
+
+The CLI can also generate omitted keys when a delivery file is requested:
+
+```bash
+npx emulate start --service github --seed emulate.config.yaml \
+  --generated-secrets-file .emulate-secrets.json
+```
+
+The destination must not exist. emulate publishes a complete owner-only JSON artifact before opening listeners or configuring portless. Explicit keys are excluded. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require an explicit private key.
 
 ## Google Seed Config
 

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -36,7 +36,7 @@ npx emulate start --service github --seed emulate.config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. emulate publishes complete JSON with `0600` permissions before opening listeners or configuring portless. Only generated keys appear in the artifact. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`. Direct `seedFromConfig` calls always require it.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Only generated keys appear in the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`. Direct `seedFromConfig` calls always require it.
 
 ## Users
 

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -27,7 +27,16 @@ const privateKey = github.generatedSecrets.find(
 )?.value
 ```
 
-The generated RSA-2048 PKCS#1 key remains stable across `reset()` calls. Explicit keys are never included in `generatedSecrets`. CLI seed files and direct `seedFromConfig` calls still require `private_key`.
+The generated RSA-2048 PKCS#1 key remains stable across `reset()` calls. Explicit keys are never included in `generatedSecrets`.
+
+The CLI can generate omitted keys when you request a private delivery file:
+
+```bash
+npx emulate start --service github --seed emulate.config.yaml \
+  --generated-secrets-file .emulate-secrets.json
+```
+
+The destination must not exist. emulate publishes complete JSON with `0600` permissions before opening listeners or configuring portless. Only generated keys appear in the artifact. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`. Direct `seedFromConfig` calls always require it.
 
 ## Users
 

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -39,6 +39,9 @@ npx emulate --port 3000
 # Use a seed config file
 npx emulate --seed config.yaml
 
+# Generate omitted service secrets into a private file
+npx emulate start --seed config.yaml --generated-secrets-file .emulate-secrets.json
+
 # Generate a starter config
 npx emulate init
 
@@ -75,8 +78,15 @@ npx emulate list
       <td>auto-detect</td>
       <td>Path to seed config (YAML or JSON)</td>
     </tr>
+    <tr>
+      <td><code>--generated-secrets-file</code></td>
+      <td>none</td>
+      <td>Generate omitted service secrets and write them to a new owner-only JSON file</td>
+    </tr>
   </tbody>
 </table>
+
+The generated-secrets destination must not exist. The file is published with owner-only permissions before startup. This flag is not supported on Windows.
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -86,7 +86,7 @@ npx emulate list
   </tbody>
 </table>
 
-The generated-secrets destination must not exist. The file is published with owner-only permissions before startup. This flag is not supported on Windows.
+The generated-secrets destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes the complete file before startup. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that requires manual recovery. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows.
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -195,7 +195,14 @@ seedFromConfig(store, baseUrl, materialized.config)
 const privateKey = materialized.generatedPrivateKeys[0]?.private_key
 ```
 
-The `emulate` package performs this materialization automatically in `createEmulator` and exposes generated keys through `generatedSecrets`.
+The `emulate` package performs this materialization automatically in `createEmulator` and exposes generated keys through `generatedSecrets`. The CLI can do the same when a private delivery file is requested:
+
+```bash
+npx emulate start --service github --seed emulate.config.yaml \
+  --generated-secrets-file .emulate-secrets.json
+```
+
+The destination must not exist. Explicit keys are excluded from the artifact. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files continue requiring `private_key`.
 
 ## Links
 

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -202,7 +202,7 @@ npx emulate start --service github --seed emulate.config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. Explicit keys are excluded from the artifact. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files continue requiring `private_key`.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Explicit keys are excluded from the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files continue requiring `private_key`.
 
 ## Links
 

--- a/packages/emulate/src/__tests__/generated-secrets-file-acl-unsupported.test.ts
+++ b/packages/emulate/src/__tests__/generated-secrets-file-acl-unsupported.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  spawnSync: vi.fn(() => ({
+    error: Object.assign(new Error("ACL tool unavailable"), { code: "ENOENT" }),
+    status: null,
+    stdout: "",
+    stderr: "",
+  })),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: mocks.spawnSync,
+}));
+
+const { preflightGeneratedSecretsFile } = await import("../generated-secrets-file.js");
+const directories: string[] = [];
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  for (const directory of directories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe("generated secrets ACL support", () => {
+  it("fails closed and removes probes when ACL tools are unavailable", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "emulate-generated-secrets-acl-unsupported-"));
+    directories.push(directory);
+
+    await expect(preflightGeneratedSecretsFile(join(directory, "secrets.json"))).rejects.toThrow(
+      "ACL command is unavailable",
+    );
+
+    expect(mocks.spawnSync).toHaveBeenCalledOnce();
+    expect(await readdir(directory)).toEqual([]);
+  });
+});

--- a/packages/emulate/src/__tests__/generated-secrets-file-unsupported.test.ts
+++ b/packages/emulate/src/__tests__/generated-secrets-file-unsupported.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  link: vi.fn(async () => {
+    const error = new Error("hard links unavailable") as NodeJS.ErrnoException;
+    error.code = "EOPNOTSUPP";
+    throw error;
+  }),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs/promises")>()),
+  link: mocks.link,
+}));
+
+const { preflightGeneratedSecretsFile } = await import("../generated-secrets-file.js");
+const directories: string[] = [];
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  for (const directory of directories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe("generated secrets filesystem support", () => {
+  it("fails closed and removes probes when hard links are unsupported", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "emulate-generated-secrets-unsupported-"));
+    directories.push(directory);
+
+    await expect(preflightGeneratedSecretsFile(join(directory, "secrets.json"))).rejects.toMatchObject({
+      code: "EOPNOTSUPP",
+    });
+
+    expect(mocks.link).toHaveBeenCalledOnce();
+    expect(await readdir(directory)).toEqual([]);
+  });
+});

--- a/packages/emulate/src/__tests__/generated-secrets-file.test.ts
+++ b/packages/emulate/src/__tests__/generated-secrets-file.test.ts
@@ -1,0 +1,170 @@
+import { access, chmod, lstat, mkdtemp, readFile, readdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  preflightGeneratedSecretsFile,
+  publishGeneratedSecretsFile,
+  type GeneratedSecretsArtifact,
+} from "../generated-secrets-file.js";
+
+const directories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "emulate-generated-secrets-"));
+  directories.push(directory);
+  return directory;
+}
+
+function artifact(value = "secret"): GeneratedSecretsArtifact {
+  return {
+    schemaVersion: 1,
+    generatedSecrets: [{ service: "github", kind: "github.app_private_key", id: "1", label: "App", value }],
+  };
+}
+
+afterEach(async () => {
+  for (const directory of directories.splice(0)) {
+    await import("node:fs/promises").then(({ rm }) => rm(directory, { recursive: true, force: true }));
+  }
+});
+
+describe("generated secrets file", () => {
+  it("publishes complete JSON with owner-only permissions", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const target = await preflightGeneratedSecretsFile(destination);
+    const payload = artifact();
+
+    await publishGeneratedSecretsFile(target, payload);
+
+    expect(JSON.parse(await readFile(destination, "utf8"))).toEqual(payload);
+    expect((await lstat(destination)).mode & 0o777).toBe(0o600);
+    expect(await readdir(directory)).toEqual(["secrets.json"]);
+  });
+
+  it("keeps 0600 permissions under a restrictive umask", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const previousUmask = process.umask(0o077);
+    try {
+      const target = await preflightGeneratedSecretsFile(destination);
+      await publishGeneratedSecretsFile(target, artifact());
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    expect((await lstat(destination)).mode & 0o777).toBe(0o600);
+  });
+
+  it("publishes a valid empty artifact", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const target = await preflightGeneratedSecretsFile(destination);
+
+    await publishGeneratedSecretsFile(target, { schemaVersion: 1, generatedSecrets: [] });
+
+    expect(JSON.parse(await readFile(destination, "utf8"))).toEqual({
+      schemaVersion: 1,
+      generatedSecrets: [],
+    });
+  });
+
+  it.each(["file", "directory", "symlink"] as const)("refuses an existing %s without changing it", async (kind) => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    if (kind === "file") await writeFile(destination, "keep");
+    if (kind === "directory") await import("node:fs/promises").then(({ mkdir }) => mkdir(destination));
+    if (kind === "symlink") {
+      await writeFile(join(directory, "target"), "keep");
+      await symlink(join(directory, "target"), destination);
+    }
+    const before = await lstat(destination);
+
+    await expect(preflightGeneratedSecretsFile(destination)).rejects.toThrow("already exists");
+
+    const after = await lstat(destination);
+    expect(after.isFile()).toBe(before.isFile());
+    expect(after.isDirectory()).toBe(before.isDirectory());
+    expect(after.isSymbolicLink()).toBe(before.isSymbolicLink());
+    if (kind !== "directory") expect(await readFile(destination, "utf8")).toBe("keep");
+  });
+
+  it("rejects a missing parent and Windows before creating files", async () => {
+    const directory = await temporaryDirectory();
+    const missingDestination = join(directory, "missing", "secrets.json");
+    const windowsDestination = join(directory, "windows.json");
+
+    await expect(preflightGeneratedSecretsFile(missingDestination)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(preflightGeneratedSecretsFile(windowsDestination, "win32")).rejects.toThrow(
+      "not supported on Windows",
+    );
+    await expect(access(windowsDestination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects an unwritable parent", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    await chmod(directory, 0o500);
+    try {
+      await expect(preflightGeneratedSecretsFile(destination)).rejects.toMatchObject({ code: "EACCES" });
+    } finally {
+      await chmod(directory, 0o700);
+    }
+  });
+
+  it("loses a destination race without overwriting and removes its temporary file", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const target = await preflightGeneratedSecretsFile(destination);
+    await writeFile(destination, "winner");
+
+    await expect(publishGeneratedSecretsFile(target, artifact())).rejects.toThrow("already exists");
+
+    expect(await readFile(destination, "utf8")).toBe("winner");
+    expect(await readdir(directory)).toEqual(["secrets.json"]);
+  });
+
+  it("removes its temporary file when serialization fails", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const target = await preflightGeneratedSecretsFile(destination);
+    const invalidArtifact = {
+      schemaVersion: 1,
+      generatedSecrets: [{ service: "github", kind: "test", id: "1", label: "Test", value: 1n }],
+    } as unknown as GeneratedSecretsArtifact;
+
+    await expect(publishGeneratedSecretsFile(target, invalidArtifact)).rejects.toThrow();
+
+    expect(await readdir(directory)).toEqual([]);
+  });
+
+  it("never exposes partial JSON at the destination", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const target = await preflightGeneratedSecretsFile(destination);
+    const payload = artifact("x".repeat(8 * 1024 * 1024));
+    let stopped = false;
+    const observations: string[] = [];
+    const observer = (async () => {
+      while (!stopped) {
+        try {
+          observations.push(await readFile(destination, "utf8"));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
+      }
+    })();
+
+    await publishGeneratedSecretsFile(target, payload);
+    stopped = true;
+    await observer;
+    observations.push(await readFile(destination, "utf8"));
+
+    expect(observations.length).toBeGreaterThan(0);
+    for (const observation of observations) {
+      expect(() => JSON.parse(observation)).not.toThrow();
+      expect(JSON.parse(observation)).toEqual(payload);
+    }
+  });
+});

--- a/packages/emulate/src/__tests__/generated-secrets-file.test.ts
+++ b/packages/emulate/src/__tests__/generated-secrets-file.test.ts
@@ -1,4 +1,5 @@
-import { access, chmod, lstat, mkdtemp, readFile, readdir, symlink, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { access, chmod, lstat, mkdtemp, readFile, readdir, rename, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -41,6 +42,19 @@ describe("generated secrets file", () => {
     expect(JSON.parse(await readFile(destination, "utf8"))).toEqual(payload);
     expect((await lstat(destination)).mode & 0o777).toBe(0o600);
     expect(await readdir(directory)).toEqual(["secrets.json"]);
+  });
+
+  it.runIf(process.platform === "darwin")("removes inherited ACLs before publishing", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    execFileSync("/bin/chmod", ["+a", "group:everyone allow read,file_inherit", directory]);
+
+    const target = await preflightGeneratedSecretsFile(destination);
+    await publishGeneratedSecretsFile(target, artifact());
+
+    const acl = execFileSync("/bin/ls", ["-le", destination], { encoding: "utf8" });
+    expect(acl).not.toMatch(/^\s+\d+:/m);
+    expect((await lstat(destination)).mode & 0o777).toBe(0o600);
   });
 
   it("keeps 0600 permissions under a restrictive umask", async () => {
@@ -166,5 +180,35 @@ describe("generated secrets file", () => {
       expect(() => JSON.parse(observation)).not.toThrow();
       expect(JSON.parse(observation)).toEqual(payload);
     }
+  });
+
+  it("rolls back only the exact published inode", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const replacement = join(directory, "replacement.json");
+    const target = await preflightGeneratedSecretsFile(destination);
+    const published = await publishGeneratedSecretsFile(target, artifact());
+
+    await rename(destination, join(directory, "published.json"));
+    await writeFile(replacement, "keep");
+    await rename(replacement, destination);
+    await published.rollback();
+
+    expect(await readFile(destination, "utf8")).toBe("keep");
+    expect(await readFile(join(directory, "published.json"), "utf8")).toContain("secret");
+  });
+
+  it("removes the owned artifact and permits immediate retry", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const target = await preflightGeneratedSecretsFile(destination);
+    const published = await publishGeneratedSecretsFile(target, artifact());
+
+    await published.rollback();
+
+    await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    const retryTarget = await preflightGeneratedSecretsFile(destination);
+    await publishGeneratedSecretsFile(retryTarget, artifact("retry"));
+    expect(await readFile(destination, "utf8")).toContain("retry");
   });
 });

--- a/packages/emulate/src/__tests__/start-generated-secrets.test.ts
+++ b/packages/emulate/src/__tests__/start-generated-secrets.test.ts
@@ -1,5 +1,6 @@
 import { generateKeyPairSync, sign } from "node:crypto";
-import { chmod, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createServer as createNodeServer } from "node:net";
+import { access, chmod, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -296,5 +297,214 @@ describe("CLI generated secrets", () => {
       "https://github.emulate.localhost",
       "https://vercel.emulate.localhost",
     ]);
+  });
+
+  it("removes a published artifact when Portless fails and permits immediate retry", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    const destination = join(directory, "secrets.json");
+    await writeFile(seedPath, "vercel:\n  users:\n    - username: developer\n");
+    const originalPath = process.env.PATH;
+    process.env.PATH = directory;
+    try {
+      await expect(
+        startCommand({
+          port: 15060,
+          service: "vercel",
+          seed: seedPath,
+          generatedSecretsFile: destination,
+          portless: true,
+        }),
+      ).rejects.toThrow("portless is required");
+    } finally {
+      process.env.PATH = originalPath;
+    }
+
+    await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    const beforeSigint = process.listeners("SIGINT");
+    const beforeSigterm = process.listeners("SIGTERM");
+    await startCommand({
+      port: 15060,
+      service: "vercel",
+      seed: seedPath,
+      generatedSecretsFile: destination,
+    });
+    const shutdown = process.listeners("SIGTERM").find((listener) => !beforeSigterm.includes(listener));
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("test shutdown");
+    }) as typeof process.exit);
+    expect(() => shutdown?.("SIGTERM")).toThrow("test shutdown");
+    exit.mockRestore();
+    for (const listener of process.listeners("SIGINT")) {
+      if (!beforeSigint.includes(listener)) process.removeListener("SIGINT", listener);
+    }
+    for (const listener of process.listeners("SIGTERM")) {
+      if (!beforeSigterm.includes(listener)) process.removeListener("SIGTERM", listener);
+    }
+  });
+
+  it("removes registered aliases and the artifact when a later alias fails", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    const destination = join(directory, "secrets.json");
+    const portlessPath = join(directory, "portless");
+    const logPath = join(directory, "portless.log");
+    await writeFile(seedPath, "vercel: {}\nresend: {}\n");
+    await writeFile(
+      portlessPath,
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "--version" ] || [ "$1" = "list" ]; then exit 0; fi',
+        'if [ "$1" = "alias" ] && [ "$2" = "resend.emulate" ]; then exit 1; fi',
+        'printf "%s\\n" "$*" >> "$PORTLESS_TEST_LOG"',
+      ].join("\n"),
+    );
+    await chmod(portlessPath, 0o700);
+    const originalPath = process.env.PATH;
+    const originalLog = process.env.PORTLESS_TEST_LOG;
+    process.env.PATH = `${directory}:${originalPath}`;
+    process.env.PORTLESS_TEST_LOG = logPath;
+    try {
+      await expect(
+        startCommand({
+          port: 15065,
+          service: "vercel,resend",
+          seed: seedPath,
+          generatedSecretsFile: destination,
+          portless: true,
+        }),
+      ).rejects.toThrow("Failed to register portless alias: resend.emulate");
+    } finally {
+      process.env.PATH = originalPath;
+      if (originalLog === undefined) delete process.env.PORTLESS_TEST_LOG;
+      else process.env.PORTLESS_TEST_LOG = originalLog;
+    }
+
+    expect(await readFile(logPath, "utf8")).toBe(
+      ["alias vercel.emulate 15065 --force", "alias --remove vercel.emulate", ""].join("\n"),
+    );
+    await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves the startup error and continues cleanup when alias removal fails", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    const destination = join(directory, "secrets.json");
+    const portlessPath = join(directory, "portless");
+    await writeFile(seedPath, "vercel: {}\nresend: {}\n");
+    await writeFile(
+      portlessPath,
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "--version" ] || [ "$1" = "list" ]; then exit 0; fi',
+        'if [ "$1" = "alias" ] && [ "$2" = "resend.emulate" ]; then exit 1; fi',
+        'if [ "$1" = "alias" ] && [ "$2" = "--remove" ]; then exit 1; fi',
+      ].join("\n"),
+    );
+    await chmod(portlessPath, 0o700);
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${directory}:${originalPath}`;
+    try {
+      await expect(
+        startCommand({
+          port: 15067,
+          service: "vercel,resend",
+          seed: seedPath,
+          generatedSecretsFile: destination,
+          portless: true,
+        }),
+      ).rejects.toThrow("Failed to register portless alias: resend.emulate");
+    } finally {
+      process.env.PATH = originalPath;
+    }
+
+    expect(stderr).toHaveBeenCalledWith(
+      "Warning: startup cleanup failed for portless alias: failed to remove portless alias: vercel.emulate",
+    );
+    await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the artifact when seeding fails after store creation", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    const destination = join(directory, "secrets.json");
+    await writeFile(seedPath, "vercel: {}\n");
+    const originalLoad = SERVICE_REGISTRY.vercel.load;
+    vi.spyOn(SERVICE_REGISTRY.vercel, "load").mockImplementation(async () => {
+      const loaded = await originalLoad();
+      return {
+        ...loaded,
+        seedFromConfig() {
+          throw new Error("forced seed failure");
+        },
+      };
+    });
+
+    await expect(
+      startCommand({
+        port: 15068,
+        service: "vercel",
+        seed: seedPath,
+        generatedSecretsFile: destination,
+      }),
+    ).rejects.toThrow("forced seed failure");
+
+    await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fetch("http://localhost:15068/v2/user")).rejects.toThrow();
+  });
+
+  it("closes an earlier listener and removes the artifact when a later listener cannot bind", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    const destination = join(directory, "secrets.json");
+    const basePort = 15070;
+    await writeFile(seedPath, "vercel: {}\nresend: {}\n");
+    const blocker = createNodeServer();
+    await new Promise<void>((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen(basePort + 1, resolve);
+    });
+
+    try {
+      await expect(
+        startCommand({
+          port: basePort,
+          service: "vercel,resend",
+          seed: seedPath,
+          generatedSecretsFile: destination,
+        }),
+      ).rejects.toMatchObject({ code: "EADDRINUSE" });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+
+    await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fetch(`http://localhost:${basePort}/v2/user`)).rejects.toThrow();
+    const beforeSigint = process.listeners("SIGINT");
+    const beforeSigterm = process.listeners("SIGTERM");
+    await startCommand({
+      port: basePort,
+      service: "vercel,resend",
+      seed: seedPath,
+      generatedSecretsFile: destination,
+    });
+    const shutdown = process.listeners("SIGTERM").find((listener) => !beforeSigterm.includes(listener));
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("test shutdown");
+    }) as typeof process.exit);
+    expect(() => shutdown?.("SIGTERM")).toThrow("test shutdown");
+    exit.mockRestore();
+    for (const listener of process.listeners("SIGINT")) {
+      if (!beforeSigint.includes(listener)) process.removeListener("SIGINT", listener);
+    }
+    for (const listener of process.listeners("SIGTERM")) {
+      if (!beforeSigterm.includes(listener)) process.removeListener("SIGTERM", listener);
+    }
   });
 });

--- a/packages/emulate/src/__tests__/start-generated-secrets.test.ts
+++ b/packages/emulate/src/__tests__/start-generated-secrets.test.ts
@@ -1,0 +1,300 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import { chmod, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prepareStartServices, startCommand } from "../commands/start.js";
+import { SERVICE_REGISTRY } from "../registry.js";
+
+const directories: string[] = [];
+
+function createAppJwt(appId: string, privateKey: string): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ iat: nowSeconds - 60, exp: nowSeconds + 9 * 60, iss: appId })).toString(
+    "base64url",
+  );
+  const unsigned = `${header}.${payload}`;
+  return `${unsigned}.${sign("RSA-SHA256", Buffer.from(unsigned), privateKey).toString("base64url")}`;
+}
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "emulate-start-secrets-"));
+  directories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const directory of directories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe("CLI generated secrets", () => {
+  it("delivers a usable key before startup without exposing it in output or HTTP", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    const destination = join(directory, "secrets.json");
+    await writeFile(
+      seedPath,
+      [
+        "github:",
+        "  users:",
+        "    - login: octocat",
+        "  apps:",
+        "    - app_id: 91",
+        "      slug: generated",
+        "      name: Generated",
+        "      installations:",
+        "        - installation_id: 92",
+        "          account: octocat",
+      ].join("\n"),
+    );
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const beforeSigint = process.listeners("SIGINT");
+    const beforeSigterm = process.listeners("SIGTERM");
+
+    await startCommand({
+      port: 14990,
+      service: "github",
+      seed: seedPath,
+      generatedSecretsFile: destination,
+    });
+
+    const artifact = JSON.parse(await readFile(destination, "utf8")) as {
+      schemaVersion: number;
+      generatedSecrets: Array<{ service: string; kind: string; id: string; label: string; value: string }>;
+    };
+    expect(artifact.schemaVersion).toBe(1);
+    expect(artifact.generatedSecrets).toHaveLength(1);
+    expect(artifact.generatedSecrets[0]).toMatchObject({
+      service: "github",
+      kind: "github.app_private_key",
+      id: "91",
+      label: "Generated",
+    });
+    const privateKey = artifact.generatedSecrets[0]!.value;
+    const response = await fetch("http://localhost:14990/app", {
+      headers: { Authorization: `Bearer ${createAppJwt("91", privateKey)}` },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).not.toContain(privateKey);
+    expect(stdout.mock.calls.flat().join("\n")).not.toContain(privateKey);
+    expect(stderr.mock.calls.flat().join("\n")).not.toContain(privateKey);
+
+    const shutdown = process.listeners("SIGTERM").find((listener) => !beforeSigterm.includes(listener));
+    expect(shutdown).toBeDefined();
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("test shutdown");
+    }) as typeof process.exit);
+    expect(() => shutdown?.("SIGTERM")).toThrow("test shutdown");
+    exit.mockRestore();
+    for (const listener of process.listeners("SIGINT")) {
+      if (!beforeSigint.includes(listener)) process.removeListener("SIGINT", listener);
+    }
+    for (const listener of process.listeners("SIGTERM")) {
+      if (!beforeSigterm.includes(listener)) process.removeListener("SIGTERM", listener);
+    }
+  });
+
+  it("materializes usable generated keys in service order and excludes explicit keys", async () => {
+    const { privateKey: explicitKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+      publicKeyEncoding: { type: "pkcs1", format: "pem" },
+    });
+    const seed = {
+      github: {
+        apps: [
+          { app_id: 101, slug: "first", name: "First" },
+          { app_id: 102, slug: "explicit", name: "Explicit", private_key: explicitKey },
+          { app_id: 103, slug: "third", name: "Third" },
+        ],
+      },
+      vercel: {},
+    };
+
+    const result = await prepareStartServices(["github", "vercel"], seed, { port: 15000 }, true);
+
+    expect(result.prepared.map(({ svc }) => svc)).toEqual(["github", "vercel"]);
+    expect(result.generatedSecrets.map(({ service, id }) => [service, id])).toEqual([
+      ["github", "101"],
+      ["github", "103"],
+    ]);
+    expect(result.generatedSecrets.some(({ value }) => value === explicitKey)).toBe(false);
+    for (const secret of result.generatedSecrets) {
+      expect(secret.value).toMatch(/^-----BEGIN RSA PRIVATE KEY-----/);
+      expect(() => sign("RSA-SHA256", Buffer.from("proof"), secret.value)).not.toThrow();
+    }
+  });
+
+  it("writes an empty artifact when selected services generate no secrets", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    const destination = join(directory, "secrets.json");
+    await writeFile(seedPath, "vercel:\n  users:\n    - username: developer\n");
+    const beforeSigint = process.listeners("SIGINT");
+    const beforeSigterm = process.listeners("SIGTERM");
+
+    await startCommand({
+      port: 15005,
+      service: "vercel",
+      seed: seedPath,
+      generatedSecretsFile: destination,
+    });
+
+    expect(JSON.parse(await readFile(destination, "utf8"))).toEqual({
+      schemaVersion: 1,
+      generatedSecrets: [],
+    });
+
+    const shutdown = process.listeners("SIGTERM").find((listener) => !beforeSigterm.includes(listener));
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("test shutdown");
+    }) as typeof process.exit);
+    expect(() => shutdown?.("SIGTERM")).toThrow("test shutdown");
+    exit.mockRestore();
+    for (const listener of process.listeners("SIGINT")) {
+      if (!beforeSigint.includes(listener)) process.removeListener("SIGINT", listener);
+    }
+    for (const listener of process.listeners("SIGTERM")) {
+      if (!beforeSigterm.includes(listener)) process.removeListener("SIGTERM", listener);
+    }
+  });
+
+  it("preserves missing private keys without the flag", async () => {
+    const seed = { github: { apps: [{ app_id: 201, slug: "missing", name: "Missing" }] } };
+
+    const result = await prepareStartServices(["github"], seed, { port: 15010 }, false);
+
+    expect(result.generatedSecrets).toEqual([]);
+    expect(result.prepared[0]?.svcSeedConfig).toEqual(seed.github);
+    expect((result.prepared[0]?.svcSeedConfig as typeof seed.github).apps).toEqual([
+      { app_id: 201, slug: "missing", name: "Missing" },
+    ]);
+  });
+
+  it("writes no secrets, output, listener, or portless state when delivery preflight fails", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const seedPath = join(directory, "seed.yaml");
+    await writeFile(destination, "keep");
+    await writeFile(seedPath, "github:\n  apps:\n    - app_id: 301\n      slug: blocked\n      name: Blocked\n");
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const loadService = vi.spyOn(SERVICE_REGISTRY.github, "load");
+    const sigintListeners = process.listenerCount("SIGINT");
+    const sigtermListeners = process.listenerCount("SIGTERM");
+
+    await expect(
+      startCommand({
+        port: 15020,
+        service: "github",
+        seed: seedPath,
+        generatedSecretsFile: destination,
+        portless: true,
+      }),
+    ).rejects.toThrow("already exists");
+
+    expect(await readFile(destination, "utf8")).toBe("keep");
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+    expect(loadService).not.toHaveBeenCalled();
+    expect(process.listenerCount("SIGINT")).toBe(sigintListeners);
+    expect(process.listenerCount("SIGTERM")).toBe(sigtermListeners);
+    await expect(fetch("http://localhost:15020/user")).rejects.toThrow();
+  });
+
+  it("stays silent and closed when another writer wins after key generation starts", async () => {
+    const directory = await temporaryDirectory();
+    const destination = join(directory, "secrets.json");
+    const seedPath = join(directory, "seed.yaml");
+    await writeFile(seedPath, "github:\n  apps:\n    - app_id: 302\n      slug: raced\n      name: Raced\n");
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const loadService = vi.spyOn(SERVICE_REGISTRY.github, "load");
+    let sawProbe = false;
+    const racer = (async () => {
+      while (true) {
+        const files = await readdir(directory);
+        const hasProbe = files.some((file) => file.endsWith(".probe") || file.endsWith(".probe-link"));
+        if (hasProbe) sawProbe = true;
+        if (sawProbe && !hasProbe) {
+          await writeFile(destination, "winner", { flag: "wx" });
+          return;
+        }
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+    })();
+
+    await expect(
+      startCommand({
+        port: 15025,
+        service: "github",
+        seed: seedPath,
+        generatedSecretsFile: destination,
+        portless: true,
+      }),
+    ).rejects.toThrow("already exists");
+    await racer;
+
+    expect(loadService).toHaveBeenCalledOnce();
+    expect(await readFile(destination, "utf8")).toBe("winner");
+    expect((await readdir(directory)).sort()).toEqual(["secrets.json", "seed.yaml"]);
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+    await expect(fetch("http://localhost:15025/user")).rejects.toThrow();
+  });
+
+  it("does not generate keys when the destination parent is unwritable", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    await writeFile(seedPath, "github:\n  apps:\n    - app_id: 301\n      slug: blocked\n      name: Blocked\n");
+    const outputDirectory = join(directory, "output");
+    await import("node:fs/promises").then(({ mkdir }) => mkdir(outputDirectory));
+    await chmod(outputDirectory, 0o500);
+    try {
+      await expect(
+        startCommand({
+          port: 15030,
+          service: "github",
+          seed: seedPath,
+          generatedSecretsFile: join(outputDirectory, "secrets.json"),
+        }),
+      ).rejects.toMatchObject({ code: "EACCES" });
+    } finally {
+      await chmod(outputDirectory, 0o700);
+    }
+  });
+
+  it("keeps the existing missing-key failure without the flag", async () => {
+    const directory = await temporaryDirectory();
+    const seedPath = join(directory, "seed.yaml");
+    await writeFile(seedPath, "github:\n  apps:\n    - app_id: 401\n      slug: missing\n      name: Missing\n");
+
+    await expect(startCommand({ port: 15040, service: "github", seed: seedPath })).rejects.toThrow(
+      'GitHub App "missing" requires private_key',
+    );
+    await expect(fetch("http://localhost:15040/user")).rejects.toThrow();
+  });
+
+  it("preserves portless aliases and URLs after preparation", async () => {
+    const result = await prepareStartServices(
+      ["github", "vercel"],
+      { github: {}, vercel: {} },
+      { port: 15050, portless: true },
+      true,
+    );
+
+    expect(result.portlessAliases).toEqual([
+      { name: "github.emulate", port: 15050 },
+      { name: "vercel.emulate", port: 15051 },
+    ]);
+    expect(result.prepared.map(({ baseUrl }) => baseUrl)).toEqual([
+      "https://github.emulate.localhost",
+      "https://vercel.emulate.localhost",
+    ]);
+  });
+});

--- a/packages/emulate/src/__tests__/start-generated-secrets.test.ts
+++ b/packages/emulate/src/__tests__/start-generated-secrets.test.ts
@@ -303,9 +303,15 @@ describe("CLI generated secrets", () => {
     const directory = await temporaryDirectory();
     const seedPath = join(directory, "seed.yaml");
     const destination = join(directory, "secrets.json");
+    const portlessPath = join(directory, "portless");
+    const logPath = join(directory, "portless.log");
     await writeFile(seedPath, "vercel:\n  users:\n    - username: developer\n");
+    await writeFile(portlessPath, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$PORTLESS_TEST_LOG"\nexit 1\n');
+    await chmod(portlessPath, 0o700);
     const originalPath = process.env.PATH;
-    process.env.PATH = directory;
+    const originalLog = process.env.PORTLESS_TEST_LOG;
+    process.env.PATH = `${directory}:${originalPath}`;
+    process.env.PORTLESS_TEST_LOG = logPath;
     try {
       await expect(
         startCommand({
@@ -318,8 +324,11 @@ describe("CLI generated secrets", () => {
       ).rejects.toThrow("portless is required");
     } finally {
       process.env.PATH = originalPath;
+      if (originalLog === undefined) delete process.env.PORTLESS_TEST_LOG;
+      else process.env.PORTLESS_TEST_LOG = originalLog;
     }
 
+    expect(await readFile(logPath, "utf8")).toBe("--version\n");
     await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
     const beforeSigint = process.listeners("SIGINT");
     const beforeSigterm = process.listeners("SIGTERM");

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -6,6 +6,12 @@ import { parse as parseYaml } from "yaml";
 import pc from "picocolors";
 import { ensurePortless, registerAliases, removeAliases, portlessBaseUrl, type PortlessAlias } from "../portless.js";
 import { resolveBaseUrl } from "../base-url.js";
+import {
+  preflightGeneratedSecretsFile,
+  publishGeneratedSecretsFile,
+  type GeneratedSecretRecord,
+  type GeneratedSecretsFileTarget,
+} from "../generated-secrets-file.js";
 
 declare const PKG_VERSION: string;
 const pkg = { version: PKG_VERSION };
@@ -16,6 +22,7 @@ export interface StartOptions {
   seed?: string;
   baseUrl?: string;
   portless?: boolean;
+  generatedSecretsFile?: string;
 }
 
 interface SeedConfig {
@@ -26,6 +33,15 @@ interface SeedConfig {
 interface LoadResult {
   config: SeedConfig;
   source: string;
+}
+
+interface PreparedService {
+  svc: ServiceName;
+  entry: (typeof SERVICE_REGISTRY)[ServiceName];
+  loadedSvc: Awaited<ReturnType<(typeof SERVICE_REGISTRY)[ServiceName]["load"]>>;
+  svcSeedConfig: Record<string, unknown> | undefined;
+  port: number;
+  baseUrl: string;
 }
 
 function loadSeedConfig(seedPath?: string): LoadResult | null {
@@ -76,6 +92,53 @@ function inferServicesFromConfig(config: SeedConfig): ServiceName[] | null {
   return found.length > 0 ? [...found] : null;
 }
 
+export async function prepareStartServices(
+  services: ServiceName[],
+  seedConfig: SeedConfig | null,
+  options: Pick<StartOptions, "port" | "baseUrl" | "portless">,
+  materializeGeneratedSecrets: boolean,
+): Promise<{
+  prepared: PreparedService[];
+  portlessAliases: PortlessAlias[];
+  generatedSecrets: GeneratedSecretRecord[];
+}> {
+  const portlessAliases: PortlessAlias[] = [];
+  const prepared: PreparedService[] = [];
+  const generatedSecrets: GeneratedSecretRecord[] = [];
+
+  for (let i = 0; i < services.length; i++) {
+    const svc = services[i];
+    const entry = SERVICE_REGISTRY[svc];
+    const loadedSvc = await entry.load();
+
+    const inputSvcSeedConfig = seedConfig?.[svc] as Record<string, unknown> | undefined;
+    const preparedSeed =
+      materializeGeneratedSecrets && inputSvcSeedConfig && loadedSvc.prepareSeed
+        ? await loadedSvc.prepareSeed(inputSvcSeedConfig)
+        : undefined;
+    const svcSeedConfig = preparedSeed?.config ?? inputSvcSeedConfig;
+    if (preparedSeed) {
+      generatedSecrets.push(...preparedSeed.generatedSecrets.map((secret) => ({ service: svc, ...secret })));
+    }
+    const port = (svcSeedConfig?.port as number | undefined) ?? options.port + i;
+
+    if (options.portless) {
+      portlessAliases.push({ name: `${svc}.emulate`, port });
+    }
+
+    const seedBaseUrl =
+      typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
+        ? svcSeedConfig.baseUrl
+        : undefined;
+    const effectiveBaseUrl = options.portless ? portlessBaseUrl(svc) : options.baseUrl;
+    const baseUrl = resolveBaseUrl({ service: svc, port, baseUrl: effectiveBaseUrl, seedBaseUrl });
+
+    prepared.push({ svc, entry, loadedSvc, svcSeedConfig, port, baseUrl });
+  }
+
+  return { prepared, portlessAliases, generatedSecrets };
+}
+
 export async function startCommand(options: StartOptions): Promise<void> {
   const { port: basePort } = options;
 
@@ -114,42 +177,31 @@ export async function startCommand(options: StartOptions): Promise<void> {
     tokens["test_token_admin"] = { login: "admin", id: 2, scopes: ["repo", "user", "admin:org", "admin:repo_hook"] };
   }
 
-  if (options.portless) {
+  let generatedSecretsTarget: GeneratedSecretsFileTarget | undefined;
+  if (options.generatedSecretsFile) {
+    generatedSecretsTarget = await preflightGeneratedSecretsFile(options.generatedSecretsFile);
+  }
+
+  if (options.portless && !generatedSecretsTarget) {
     await ensurePortless();
   }
 
-  interface PreparedService {
-    svc: ServiceName;
-    entry: (typeof SERVICE_REGISTRY)[ServiceName];
-    loadedSvc: Awaited<ReturnType<(typeof SERVICE_REGISTRY)[ServiceName]["load"]>>;
-    svcSeedConfig: Record<string, unknown> | undefined;
-    port: number;
-    baseUrl: string;
+  const { prepared, portlessAliases, generatedSecrets } = await prepareStartServices(
+    services,
+    seedConfig,
+    { port: basePort, baseUrl: options.baseUrl, portless: options.portless },
+    Boolean(generatedSecretsTarget),
+  );
+
+  if (generatedSecretsTarget) {
+    await publishGeneratedSecretsFile(generatedSecretsTarget, {
+      schemaVersion: 1,
+      generatedSecrets,
+    });
   }
 
-  const portlessAliases: PortlessAlias[] = [];
-  const prepared: PreparedService[] = [];
-
-  for (let i = 0; i < services.length; i++) {
-    const svc = services[i];
-    const entry = SERVICE_REGISTRY[svc];
-    const loadedSvc = await entry.load();
-
-    const svcSeedConfig = seedConfig?.[svc] as Record<string, unknown> | undefined;
-    const port = (svcSeedConfig?.port as number | undefined) ?? basePort + i;
-
-    if (options.portless) {
-      portlessAliases.push({ name: `${svc}.emulate`, port });
-    }
-
-    const seedBaseUrl =
-      typeof svcSeedConfig?.baseUrl === "string" && svcSeedConfig.baseUrl.length > 0
-        ? svcSeedConfig.baseUrl
-        : undefined;
-    const effectiveBaseUrl = options.portless ? portlessBaseUrl(svc) : options.baseUrl;
-    const baseUrl = resolveBaseUrl({ service: svc, port, baseUrl: effectiveBaseUrl, seedBaseUrl });
-
-    prepared.push({ svc, entry, loadedSvc, svcSeedConfig, port, baseUrl });
+  if (options.portless && generatedSecretsTarget) {
+    await ensurePortless();
   }
 
   if (portlessAliases.length > 0) {

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -4,13 +4,22 @@ import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import { parse as parseYaml } from "yaml";
 import pc from "picocolors";
-import { ensurePortless, registerAliases, removeAliases, portlessBaseUrl, type PortlessAlias } from "../portless.js";
+import {
+  ensurePortless,
+  registerAlias,
+  registerAliases,
+  removeAlias,
+  removeAliases,
+  portlessBaseUrl,
+  type PortlessAlias,
+} from "../portless.js";
 import { resolveBaseUrl } from "../base-url.js";
 import {
   preflightGeneratedSecretsFile,
   publishGeneratedSecretsFile,
   type GeneratedSecretRecord,
   type GeneratedSecretsFileTarget,
+  type PublishedGeneratedSecretsFile,
 } from "../generated-secrets-file.js";
 
 declare const PKG_VERSION: string;
@@ -43,6 +52,8 @@ interface PreparedService {
   port: number;
   baseUrl: string;
 }
+
+type Tokens = Record<string, { login: string; id: number; scopes?: string[] }>;
 
 function loadSeedConfig(seedPath?: string): LoadResult | null {
   if (seedPath) {
@@ -139,6 +150,124 @@ export async function prepareStartServices(
   return { prepared, portlessAliases, generatedSecrets };
 }
 
+type HttpServer = ReturnType<typeof serve>;
+
+function createPreparedServiceServer(preparedService: PreparedService, tokens: Tokens) {
+  const { entry, loadedSvc, svcSeedConfig, port, baseUrl } = preparedService;
+  let cachedResolver: AppKeyResolver | undefined = undefined;
+  const appKeyResolver: AppKeyResolver | undefined = loadedSvc.createAppKeyResolver
+    ? (appId) => cachedResolver!(appId)
+    : undefined;
+  const fallbackUser = entry.defaultFallback(svcSeedConfig);
+  const server = createServer(loadedSvc.plugin, {
+    port,
+    baseUrl,
+    tokens,
+    appKeyResolver,
+    fallbackUser,
+  });
+  cachedResolver = loadedSvc.createAppKeyResolver?.(server.store);
+  return server;
+}
+
+function seedPreparedService(
+  preparedService: PreparedService,
+  store: Store,
+  webhooks: ReturnType<typeof createServer>["webhooks"],
+): void {
+  const { loadedSvc, svcSeedConfig, baseUrl } = preparedService;
+  loadedSvc.plugin.seed?.(store, baseUrl);
+  if (svcSeedConfig && loadedSvc.seedFromConfig) {
+    loadedSvc.seedFromConfig(store, baseUrl, svcSeedConfig, webhooks);
+  }
+}
+
+function waitForServerListening(server: HttpServer): Promise<void> {
+  if (server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    server.once("listening", onListening);
+    server.once("error", onError);
+  });
+}
+
+function closeServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (!error || (error as NodeJS.ErrnoException).code === "ERR_SERVER_NOT_RUNNING") {
+        resolve();
+        return;
+      }
+      reject(error);
+    });
+    server.closeAllConnections();
+  });
+}
+
+function reportCleanupError(stage: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Warning: startup cleanup failed for ${stage}: ${message}`);
+}
+
+async function rollbackStartup(
+  httpServers: HttpServer[],
+  stores: Store[],
+  registeredAliases: PortlessAlias[],
+  generatedSecretsFile: PublishedGeneratedSecretsFile,
+): Promise<void> {
+  for (const server of [...httpServers].reverse()) {
+    try {
+      await closeServer(server);
+    } catch (error) {
+      reportCleanupError("listener", error);
+    }
+  }
+  for (const store of [...stores].reverse()) {
+    try {
+      store.reset();
+    } catch (error) {
+      reportCleanupError("store", error);
+    }
+  }
+  for (const alias of [...registeredAliases].reverse()) {
+    try {
+      removeAlias(alias);
+    } catch (error) {
+      reportCleanupError("portless alias", error);
+    }
+  }
+  try {
+    await generatedSecretsFile.rollback();
+  } catch (error) {
+    reportCleanupError("generated secrets file", error);
+  }
+}
+
+function installShutdown(portlessAliases: PortlessAlias[], stores: Store[], httpServers: HttpServer[]): void {
+  const shutdown = () => {
+    console.log(`\n${pc.dim("Shutting down...")}`);
+    if (portlessAliases.length > 0) {
+      removeAliases(portlessAliases);
+    }
+    for (const store of stores) {
+      store.reset();
+    }
+    for (const server of httpServers) {
+      server.close();
+    }
+    process.exit(0);
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+}
+
 export async function startCommand(options: StartOptions): Promise<void> {
   const { port: basePort } = options;
 
@@ -167,7 +296,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
     }
   }
 
-  const tokens: Record<string, { login: string; id: number; scopes?: string[] }> = {};
+  const tokens: Tokens = {};
   if (seedConfig?.tokens) {
     let tokenId = 100;
     for (const [token, user] of Object.entries(seedConfig.tokens)) {
@@ -193,73 +322,63 @@ export async function startCommand(options: StartOptions): Promise<void> {
     Boolean(generatedSecretsTarget),
   );
 
-  if (generatedSecretsTarget) {
-    await publishGeneratedSecretsFile(generatedSecretsTarget, {
-      schemaVersion: 1,
-      generatedSecrets,
-    });
-  }
-
-  if (options.portless && generatedSecretsTarget) {
-    await ensurePortless();
-  }
-
-  if (portlessAliases.length > 0) {
-    registerAliases(portlessAliases);
-  }
-
   const serviceUrls: Array<{ name: string; url: string }> = [];
   const stores: Store[] = [];
-  const httpServers: ReturnType<typeof serve>[] = [];
+  const httpServers: HttpServer[] = [];
 
-  for (const { svc, entry, loadedSvc, svcSeedConfig, port, baseUrl } of prepared) {
-    serviceUrls.push({ name: svc, url: baseUrl });
-
-    // eslint-disable-next-line prefer-const -- reassigned after closure captures it
-    let cachedResolver: AppKeyResolver | undefined;
-    const appKeyResolver: AppKeyResolver | undefined = loadedSvc.createAppKeyResolver
-      ? (appId) => cachedResolver!(appId)
-      : undefined;
-
-    const fallbackUser = entry.defaultFallback(svcSeedConfig);
-
-    const { app, store, webhooks } = createServer(loadedSvc.plugin, {
-      port,
-      baseUrl,
-      tokens,
-      appKeyResolver,
-      fallbackUser,
-    });
-    cachedResolver = loadedSvc.createAppKeyResolver?.(store);
-    stores.push(store);
-
-    loadedSvc.plugin.seed?.(store, baseUrl);
-
-    if (svcSeedConfig && loadedSvc.seedFromConfig) {
-      loadedSvc.seedFromConfig(store, baseUrl, svcSeedConfig, webhooks);
+  if (!generatedSecretsTarget) {
+    if (portlessAliases.length > 0) {
+      registerAliases(portlessAliases);
     }
 
-    const httpServer = serve({ fetch: app.fetch, port });
-    httpServers.push(httpServer);
+    for (const preparedService of prepared) {
+      const { svc, port, baseUrl } = preparedService;
+      serviceUrls.push({ name: svc, url: baseUrl });
+      const { app, store, webhooks } = createPreparedServiceServer(preparedService, tokens);
+      stores.push(store);
+      seedPreparedService(preparedService, store, webhooks);
+      const httpServer = serve({ fetch: app.fetch, port });
+      httpServers.push(httpServer);
+    }
+
+    printBanner(serviceUrls, tokens, configSource);
+    installShutdown(portlessAliases, stores, httpServers);
+    return;
   }
 
-  printBanner(serviceUrls, tokens, configSource);
+  const publishedSecretsFile = await publishGeneratedSecretsFile(generatedSecretsTarget, {
+    schemaVersion: 1,
+    generatedSecrets,
+  });
+  const registeredAliases: PortlessAlias[] = [];
 
-  const shutdown = () => {
-    console.log(`\n${pc.dim("Shutting down...")}`);
-    if (portlessAliases.length > 0) {
-      removeAliases(portlessAliases);
+  try {
+    if (options.portless) {
+      await ensurePortless({ throwOnFailure: true });
     }
-    for (const store of stores) {
-      store.reset();
+    for (const alias of portlessAliases) {
+      registerAlias(alias);
+      registeredAliases.push(alias);
     }
-    for (const srv of httpServers) {
-      srv.close();
+
+    for (const preparedService of prepared) {
+      const { svc, port, baseUrl } = preparedService;
+      serviceUrls.push({ name: svc, url: baseUrl });
+      const { app, store, webhooks } = createPreparedServiceServer(preparedService, tokens);
+      stores.push(store);
+      seedPreparedService(preparedService, store, webhooks);
+      const httpServer = serve({ fetch: app.fetch, port });
+      httpServers.push(httpServer);
+      await waitForServerListening(httpServer);
     }
-    process.exit(0);
-  };
-  process.once("SIGINT", shutdown);
-  process.once("SIGTERM", shutdown);
+
+    printBanner(serviceUrls, tokens, configSource);
+  } catch (error) {
+    await rollbackStartup(httpServers, stores, registeredAliases, publishedSecretsFile);
+    throw error;
+  }
+
+  installShutdown(registeredAliases, stores, httpServers);
 }
 
 function printBanner(

--- a/packages/emulate/src/generated-secrets-file.ts
+++ b/packages/emulate/src/generated-secrets-file.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { constants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
 import { link, lstat, open, realpath, stat, unlink } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 import type { ServiceName } from "./registry.js";
@@ -20,11 +22,18 @@ export interface GeneratedSecretsArtifact {
 export interface GeneratedSecretsFileTarget {
   path: string;
   parent: string;
+  platform: NodeJS.Platform;
 }
 
-interface FileIdentity {
+export interface FileIdentity {
   dev: bigint;
   ino: bigint;
+}
+
+export interface PublishedGeneratedSecretsFile {
+  path: string;
+  identity: FileIdentity;
+  rollback(): Promise<void>;
 }
 
 function temporaryPath(target: GeneratedSecretsFileTarget, purpose: string): string {
@@ -50,6 +59,65 @@ async function removeCreatedPathIfOwned(path: string, identity: FileIdentity): P
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
+}
+
+function runAclCommand(command: string, args: string[], file: FileHandle): string {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe", file.fd],
+  });
+  if (result.error) {
+    throw new Error(`Generated secrets ACL command is unavailable: ${command}`, { cause: result.error });
+  }
+  if (result.status !== 0) {
+    throw new Error(`Generated secrets ACL command failed: ${command}: ${result.stderr.trim()}`);
+  }
+  return result.stdout;
+}
+
+function verifyDarwinAcl(output: string): void {
+  if (output.split("\n").some((line) => /^\s+\d+:/.test(line))) {
+    throw new Error("Generated secrets file retains an access control list after sanitization");
+  }
+}
+
+function verifyLinuxAcl(output: string): void {
+  const entries = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+  if (
+    entries.length !== 3 ||
+    entries[0] !== "user::rw-" ||
+    entries[1] !== "group::---" ||
+    entries[2] !== "other::---"
+  ) {
+    throw new Error("Generated secrets file retains non-owner access after ACL sanitization");
+  }
+}
+
+async function sanitizeAndVerifyPrivateFile(file: FileHandle, platform: NodeJS.Platform): Promise<FileIdentity> {
+  await file.chmod(0o600);
+  const getuid = process.getuid;
+  if (!getuid) {
+    throw new Error("--generated-secrets-file requires owner identity verification");
+  }
+
+  if (platform === "darwin") {
+    runAclCommand("/bin/chmod", ["-N", "/dev/fd/3"], file);
+    verifyDarwinAcl(runAclCommand("/bin/ls", ["-le", "/dev/fd/3"], file));
+  } else if (platform === "linux") {
+    runAclCommand("setfacl", ["-b", "/proc/self/fd/3"], file);
+    verifyLinuxAcl(runAclCommand("getfacl", ["-c", "/proc/self/fd/3"], file));
+  } else {
+    throw new Error(`--generated-secrets-file is not supported on ${platform}`);
+  }
+
+  const stats = await file.stat({ bigint: true });
+  if (!stats.isFile() || (stats.mode & 0o777n) !== 0o600n || stats.uid !== BigInt(getuid())) {
+    throw new Error("Generated secrets file could not be verified as an owner-only regular file");
+  }
+  return { dev: stats.dev, ino: stats.ino };
 }
 
 async function verifyPathIdentity(path: string, identity: FileIdentity): Promise<void> {
@@ -111,6 +179,9 @@ export async function preflightGeneratedSecretsFile(
   if (platform === "win32") {
     throw new Error("--generated-secrets-file is not supported on Windows");
   }
+  if (platform !== "darwin" && platform !== "linux") {
+    throw new Error(`--generated-secrets-file is not supported on ${platform}`);
+  }
 
   const requestedPath = resolve(destination);
   const parent = await realpath(dirname(requestedPath));
@@ -123,7 +194,7 @@ export async function preflightGeneratedSecretsFile(
     throw new Error(`Generated secrets path already exists: ${path}`);
   }
 
-  const target = { path, parent };
+  const target = { path, parent, platform };
   const probeSource = temporaryPath(target, "probe");
   const probeLink = temporaryPath(target, "probe-link");
   let probeIdentity: FileIdentity | undefined;
@@ -134,7 +205,7 @@ export async function preflightGeneratedSecretsFile(
     try {
       const initialStats = await file.stat({ bigint: true });
       probeIdentity = { dev: initialStats.dev, ino: initialStats.ino };
-      await file.chmod(0o600);
+      await sanitizeAndVerifyPrivateFile(file, platform);
       await file.sync();
     } finally {
       await file.close();
@@ -156,7 +227,7 @@ export async function preflightGeneratedSecretsFile(
 export async function publishGeneratedSecretsFile(
   target: GeneratedSecretsFileTarget,
   artifact: GeneratedSecretsArtifact,
-): Promise<void> {
+): Promise<PublishedGeneratedSecretsFile> {
   const temporary = temporaryPath(target, "tmp");
   let temporaryIdentity: FileIdentity | undefined;
   let published = false;
@@ -166,11 +237,7 @@ export async function publishGeneratedSecretsFile(
     try {
       const initialStats = await file.stat({ bigint: true });
       temporaryIdentity = { dev: initialStats.dev, ino: initialStats.ino };
-      await file.chmod(0o600);
-      const privateStats = await file.stat({ bigint: true });
-      if (!privateStats.isFile() || (privateStats.mode & 0o777n) !== 0o600n) {
-        throw new Error(`Generated secrets file permissions could not be restricted to 0600: ${temporary}`);
-      }
+      await sanitizeAndVerifyPrivateFile(file, target.platform);
       await file.writeFile(`${JSON.stringify(artifact, null, 2)}\n`, "utf8");
       await file.sync();
     } finally {
@@ -185,6 +252,19 @@ export async function publishGeneratedSecretsFile(
     await syncDirectory(target.parent);
     await verifyPathIdentity(target.path, temporaryIdentity);
     await verifyPrivateRegularFile(target.path);
+    const identity = temporaryIdentity;
+    return {
+      path: target.path,
+      identity,
+      async rollback() {
+        const existed = await pathExists(target.path);
+        if (!existed) return;
+        const current = await lstat(target.path, { bigint: true });
+        if (current.dev !== identity.dev || current.ino !== identity.ino) return;
+        await unlink(target.path);
+        await syncDirectory(target.parent);
+      },
+    };
   } catch (error) {
     if (temporaryIdentity) await removeCreatedPathIfOwned(temporary, temporaryIdentity);
     if (published && temporaryIdentity) {

--- a/packages/emulate/src/generated-secrets-file.ts
+++ b/packages/emulate/src/generated-secrets-file.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { link, lstat, open, realpath, stat, unlink } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import type { ServiceName } from "./registry.js";
+
+export interface GeneratedSecretRecord {
+  service: ServiceName;
+  kind: string;
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface GeneratedSecretsArtifact {
+  schemaVersion: 1;
+  generatedSecrets: GeneratedSecretRecord[];
+}
+
+export interface GeneratedSecretsFileTarget {
+  path: string;
+  parent: string;
+}
+
+interface FileIdentity {
+  dev: bigint;
+  ino: bigint;
+}
+
+function temporaryPath(target: GeneratedSecretsFileTarget, purpose: string): string {
+  return resolve(target.parent, `.${basename(target.path)}.${process.pid}.${randomUUID()}.${purpose}`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function removeCreatedPathIfOwned(path: string, identity: FileIdentity): Promise<void> {
+  try {
+    const stats = await lstat(path, { bigint: true });
+    if (stats.dev === identity.dev && stats.ino === identity.ino) {
+      await unlink(path);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+async function verifyPathIdentity(path: string, identity: FileIdentity): Promise<void> {
+  const stats = await lstat(path, { bigint: true });
+  if (stats.dev !== identity.dev || stats.ino !== identity.ino) {
+    throw new Error(`Generated secrets path identity changed during publication: ${path}`);
+  }
+}
+
+async function verifyPrivateRegularFile(path: string): Promise<void> {
+  const stats = await lstat(path);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new Error(`Generated secrets path is not a regular file: ${path}`);
+  }
+  if ((stats.mode & 0o777) !== 0o600) {
+    throw new Error(`Generated secrets file permissions could not be restricted to 0600: ${path}`);
+  }
+}
+
+async function verifyHardLink(
+  source: string,
+  destination: string,
+  expectedIdentity?: FileIdentity,
+): Promise<FileIdentity> {
+  const [sourceStats, destinationStats] = await Promise.all([
+    lstat(source, { bigint: true }),
+    lstat(destination, { bigint: true }),
+  ]);
+  if (
+    sourceStats.dev !== destinationStats.dev ||
+    sourceStats.ino !== destinationStats.ino ||
+    sourceStats.nlink < 2 ||
+    destinationStats.nlink < 2
+  ) {
+    throw new Error(`Generated secrets filesystem does not provide verifiable hard links: ${destination}`);
+  }
+  if (
+    expectedIdentity &&
+    (destinationStats.dev !== expectedIdentity.dev || destinationStats.ino !== expectedIdentity.ino)
+  ) {
+    throw new Error(`Generated secrets temporary file identity changed before publication: ${source}`);
+  }
+  return { dev: destinationStats.dev, ino: destinationStats.ino };
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, constants.O_RDONLY);
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}
+
+export async function preflightGeneratedSecretsFile(
+  destination: string,
+  platform = process.platform,
+): Promise<GeneratedSecretsFileTarget> {
+  if (platform === "win32") {
+    throw new Error("--generated-secrets-file is not supported on Windows");
+  }
+
+  const requestedPath = resolve(destination);
+  const parent = await realpath(dirname(requestedPath));
+  const path = resolve(parent, basename(requestedPath));
+  const parentStats = await stat(parent);
+  if (!parentStats.isDirectory()) {
+    throw new Error(`Generated secrets parent is not a directory: ${parent}`);
+  }
+  if (await pathExists(path)) {
+    throw new Error(`Generated secrets path already exists: ${path}`);
+  }
+
+  const target = { path, parent };
+  const probeSource = temporaryPath(target, "probe");
+  const probeLink = temporaryPath(target, "probe-link");
+  let probeIdentity: FileIdentity | undefined;
+  let linkCreated = false;
+
+  try {
+    const file = await open(probeSource, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+    try {
+      const initialStats = await file.stat({ bigint: true });
+      probeIdentity = { dev: initialStats.dev, ino: initialStats.ino };
+      await file.chmod(0o600);
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+    await verifyPrivateRegularFile(probeSource);
+    await link(probeSource, probeLink);
+    linkCreated = true;
+    await verifyPrivateRegularFile(probeLink);
+    await verifyHardLink(probeSource, probeLink, probeIdentity);
+    await syncDirectory(parent);
+  } finally {
+    if (linkCreated && probeIdentity) await removeCreatedPathIfOwned(probeLink, probeIdentity);
+    if (probeIdentity) await removeCreatedPathIfOwned(probeSource, probeIdentity);
+  }
+
+  return target;
+}
+
+export async function publishGeneratedSecretsFile(
+  target: GeneratedSecretsFileTarget,
+  artifact: GeneratedSecretsArtifact,
+): Promise<void> {
+  const temporary = temporaryPath(target, "tmp");
+  let temporaryIdentity: FileIdentity | undefined;
+  let published = false;
+
+  try {
+    const file = await open(temporary, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+    try {
+      const initialStats = await file.stat({ bigint: true });
+      temporaryIdentity = { dev: initialStats.dev, ino: initialStats.ino };
+      await file.chmod(0o600);
+      const privateStats = await file.stat({ bigint: true });
+      if (!privateStats.isFile() || (privateStats.mode & 0o777n) !== 0o600n) {
+        throw new Error(`Generated secrets file permissions could not be restricted to 0600: ${temporary}`);
+      }
+      await file.writeFile(`${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+
+    await link(temporary, target.path);
+    published = true;
+    await verifyPrivateRegularFile(target.path);
+    await verifyHardLink(temporary, target.path, temporaryIdentity);
+    await removeCreatedPathIfOwned(temporary, temporaryIdentity);
+    await syncDirectory(target.parent);
+    await verifyPathIdentity(target.path, temporaryIdentity);
+    await verifyPrivateRegularFile(target.path);
+  } catch (error) {
+    if (temporaryIdentity) await removeCreatedPathIfOwned(temporary, temporaryIdentity);
+    if (published && temporaryIdentity) {
+      await removeCreatedPathIfOwned(target.path, temporaryIdentity);
+      await syncDirectory(target.parent);
+    }
+    if ((error as NodeJS.ErrnoException).code === "EEXIST" && !published) {
+      throw new Error(`Generated secrets path already exists: ${target.path}`, { cause: error });
+    }
+    throw error;
+  }
+}

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -39,7 +39,7 @@ program
   .option("--portless", "Serve over HTTPS via portless (auto-registers aliases)")
   .option(
     "--generated-secrets-file <path>",
-    "Write service-generated secrets to a new owner-only JSON file (not supported on Windows)",
+    "Write service-generated secrets to a new owner-only JSON file (Linux requires setfacl and getfacl)",
   )
   .action(async (opts) => {
     const port = parseInt(opts.port, 10);

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -37,19 +37,34 @@ program
   .option("--seed <file>", "Path to seed config file")
   .option("--base-url <url>", "Override advertised base URL (supports {service} template)")
   .option("--portless", "Serve over HTTPS via portless (auto-registers aliases)")
+  .option(
+    "--generated-secrets-file <path>",
+    "Write service-generated secrets to a new owner-only JSON file (not supported on Windows)",
+  )
   .action(async (opts) => {
     const port = parseInt(opts.port, 10);
     if (Number.isNaN(port) || port < 1 || port > 65535) {
       console.error(`Invalid port: ${opts.port}`);
       process.exit(1);
     }
-    await startCommand({
+    const options = {
       port,
       service: opts.service,
       seed: opts.seed,
       baseUrl: opts.baseUrl,
       portless: opts.portless,
-    });
+      generatedSecretsFile: opts.generatedSecretsFile,
+    };
+    if (!opts.generatedSecretsFile) {
+      await startCommand(options);
+      return;
+    }
+    try {
+      await startCommand(options);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
   });
 
 program

--- a/packages/emulate/src/portless.ts
+++ b/packages/emulate/src/portless.ts
@@ -26,35 +26,39 @@ function isProxyRunning(): boolean {
   return result.status === 0;
 }
 
-export async function ensurePortless(): Promise<void> {
+function failPortless(message: string, throwOnFailure: boolean): never {
+  if (throwOnFailure) {
+    throw new Error(message);
+  }
+  console.error(message);
+  process.exit(1);
+}
+
+export async function ensurePortless(options: { throwOnFailure?: boolean } = {}): Promise<void> {
+  const throwOnFailure = options.throwOnFailure ?? false;
   if (!hasPortless()) {
     if (!isInteractive()) {
-      console.error("portless is required but not installed. Run: npm i -g portless");
-      process.exit(1);
+      failPortless("portless is required but not installed. Run: npm i -g portless", throwOnFailure);
     }
 
     const yes = await promptYesNo("portless is not installed. Install it now? (npm i -g portless) [Y/n] ");
     if (!yes) {
-      console.error("Cannot continue without portless.");
-      process.exit(1);
+      failPortless("Cannot continue without portless.", throwOnFailure);
     }
 
     try {
       execSync("npm i -g portless", { stdio: "inherit" });
     } catch {
-      console.error("Failed to install portless.");
-      process.exit(1);
+      failPortless("Failed to install portless.", throwOnFailure);
     }
 
     if (!hasPortless()) {
-      console.error("portless was installed but could not be found on PATH.");
-      process.exit(1);
+      failPortless("portless was installed but could not be found on PATH.", throwOnFailure);
     }
   }
 
   if (!isProxyRunning()) {
-    console.error("portless proxy is not running. Start it with: portless proxy start");
-    process.exit(1);
+    failPortless("portless proxy is not running. Start it with: portless proxy start", throwOnFailure);
   }
 }
 
@@ -63,27 +67,43 @@ export interface PortlessAlias {
   port: number;
 }
 
+export function registerAlias({ name, port }: PortlessAlias): void {
+  const result = spawnSync("portless", ["alias", name, String(port), "--force"], {
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error(`Failed to register portless alias: ${name} -> ${port}`);
+  }
+}
+
 export function registerAliases(aliases: PortlessAlias[]): void {
   const registered: PortlessAlias[] = [];
-  for (const { name, port } of aliases) {
-    const result = spawnSync("portless", ["alias", name, String(port), "--force"], {
-      stdio: "inherit",
-    });
-    if (result.status !== 0) {
+  for (const alias of aliases) {
+    try {
+      registerAlias(alias);
+    } catch (error) {
       if (registered.length > 0) {
         removeAliases(registered);
       }
-      throw new Error(`Failed to register portless alias: ${name} -> ${port}`);
+      throw error;
     }
-    registered.push({ name, port });
+    registered.push(alias);
+  }
+}
+
+export function removeAlias({ name }: PortlessAlias): void {
+  const result = spawnSync("portless", ["alias", "--remove", name], { stdio: "ignore" });
+  if (result.status !== 0) {
+    throw new Error(`failed to remove portless alias: ${name}`);
   }
 }
 
 export function removeAliases(aliases: PortlessAlias[]): void {
-  for (const { name } of aliases) {
-    const result = spawnSync("portless", ["alias", "--remove", name], { stdio: "ignore" });
-    if (result.status !== 0) {
-      console.error(`Warning: failed to remove portless alias: ${name}`);
+  for (const alias of aliases) {
+    try {
+      removeAlias(alias);
+    } catch (error) {
+      console.error(`Warning: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 }

--- a/packages/emulate/vitest.config.ts
+++ b/packages/emulate/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  define: {
+    PKG_VERSION: JSON.stringify("0.0.0-test"),
+  },
   test: {
     globals: true,
   },

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -70,11 +70,11 @@ npx emulate list
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
 | `--base-url` | none | Override advertised base URL (supports `{service}` template) |
 | `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
-| `--generated-secrets-file` | none | Generate omitted service secrets and write them to a new owner-only JSON file (not supported on Windows) |
+| `--generated-secrets-file` | none | Generate omitted service secrets and write them to a new owner-only JSON file |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 
-The generated-secrets destination must not exist. emulate publishes complete JSON with `0600` permissions before opening listeners or configuring portless. Only service-generated values appear in the artifact. The flag is not supported on Windows.
+The generated-secrets destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Only service-generated values appear in the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows.
 
 The advertised base URL (used in OAuth redirects, webhook URLs, etc.) can be overridden via `--base-url`, the `EMULATE_BASE_URL` env var (supports `{service}` template), or per-service `baseUrl` in the seed config. When running under portless, the `PORTLESS_URL` env var is also detected automatically.
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -48,6 +48,9 @@ npx emulate --port 3000
 # Use a seed config file
 npx emulate --seed config.yaml
 
+# Generate omitted service secrets into a private file
+npx emulate start --seed config.yaml --generated-secrets-file .emulate-secrets.json
+
 # Generate a starter config
 npx emulate init
 
@@ -67,8 +70,11 @@ npx emulate list
 | `--seed` | auto-detect | Path to seed config (YAML or JSON) |
 | `--base-url` | none | Override advertised base URL (supports `{service}` template) |
 | `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
+| `--generated-secrets-file` | none | Generate omitted service secrets and write them to a new owner-only JSON file (not supported on Windows) |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+
+The generated-secrets destination must not exist. emulate publishes complete JSON with `0600` permissions before opening listeners or configuring portless. Only service-generated values appear in the artifact. The flag is not supported on Windows.
 
 The advertised base URL (used in OAuth redirects, webhook URLs, etc.) can be overridden via `--base-url`, the `EMULATE_BASE_URL` env var (supports `{service}` template), or per-service `baseUrl` in the seed config. When running under portless, the `PORTLESS_URL` env var is also detected automatically.
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -60,7 +60,7 @@ npx emulate start --service github --seed emulate.config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. It is published as complete JSON with `0600` permissions before any listener or portless alias starts. Read `generatedSecrets` from the artifact, then keep the file out of source control. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before any listener or portless alias starts. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Read `generatedSecrets` from the artifact, then keep the file out of source control. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`.
 
 ## Auth
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -51,7 +51,16 @@ const privateKey = github.generatedSecrets.find(
 )?.value
 ```
 
-The key remains stable across `github.reset()`. Explicit keys are not included in `generatedSecrets`. CLI seed files still require `private_key`.
+The key remains stable across `github.reset()`. Explicit keys are not included in `generatedSecrets`.
+
+For the CLI, omit `private_key` only when requesting a private delivery file:
+
+```bash
+npx emulate start --service github --seed emulate.config.yaml \
+  --generated-secrets-file .emulate-secrets.json
+```
+
+The destination must not exist. It is published as complete JSON with `0600` permissions before any listener or portless alias starts. Read `generatedSecrets` from the artifact, then keep the file out of source control. The flag is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`.
 
 ## Auth
 


### PR DESCRIPTION
## Summary

- add `--generated-secrets-file <path>` for opt-in schema v1 secret delivery
- publish complete owner-only JSON before Portless, aliases, listeners, or output
- verify effective ACL access on macOS and Linux, failing closed when unavailable
- roll back aliases, stores, listeners, and the invocation-owned artifact after failed startup
- preserve existing behavior without the flag

## Verification

- full build, test, type-check, lint, format, and diff checks
- built CLI dogfood for inherited ACL removal and immediate retry after failed startup
- regression and mutation coverage for ACLs, inode-safe rollback, cleanup, and listener failures

Part of #203. This is slice 2 and does not close the tracker.
