### PR TITLE
feat(github): seed org membership via orgs[].members

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ github:
   orgs:
     - login: my-org
       name: My Organization
+      # Optional. Team-backed membership; seed at least one admin or a
+      # private org repo is unreachable by every seeded user token.
+      members:
+        - login: octocat
+          role: admin
   repos:
     - owner: octocat
       name: hello-world

--- a/packages/@emulators/github/src/__tests__/org-members.test.ts
+++ b/packages/@emulators/github/src/__tests__/org-members.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "@emulators/core";
+import { Store, WebhookDispatcher } from "@emulators/core";
+import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
+import { githubPlugin, seedFromConfig, getGitHubStore } from "../index.js";
+
+const base = "http://localhost:4000";
+
+function createTestApp(seedConfig: Parameters<typeof seedFromConfig>[2]) {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  const scopes = ["repo", "user", "admin:org", "admin:repo_hook"];
+  tokenMap.set("octocat-token", { login: "octocat", id: 1, scopes });
+  tokenMap.set("hubot-token", { login: "hubot", id: 2, scopes });
+  tokenMap.set("outsider-token", { login: "outsider", id: 3, scopes });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use(
+    "*",
+    authMiddleware(tokenMap, () => null),
+  );
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, seedConfig);
+  return { app, store };
+}
+
+const SEED = {
+  users: [{ login: "octocat" }, { login: "hubot" }, { login: "outsider" }],
+  orgs: [
+    {
+      login: "my-org",
+      name: "My Organization",
+      members: [{ login: "octocat", role: "admin" as const }, { login: "hubot" }],
+    },
+  ],
+  repos: [{ owner: "my-org", name: "secret", private: true }],
+};
+
+async function get(app: Hono, path: string, token: string) {
+  return app.request(`${base}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+}
+
+describe("seeded org membership", () => {
+  it("lists seeded members with their org roles", async () => {
+    const { app, store } = createTestApp(SEED);
+    const gh = getGitHubStore(store);
+    const org = gh.orgs.findOneBy("login", "my-org")!;
+    const members = gh.teams.findBy("org_id", org.id).find((t) => t.slug === "members")!;
+    expect(members.members_count).toBe(2);
+
+    const list = await get(app, "/orgs/my-org/members", "octocat-token");
+    expect(list.status).toBe(200);
+    const logins = ((await list.json()) as Array<{ login: string }>).map((m) => m.login).sort();
+    expect(logins).toEqual(["hubot", "octocat"]);
+
+    const admin = await get(app, "/orgs/my-org/memberships/octocat", "octocat-token");
+    expect(admin.status).toBe(200);
+    expect(((await admin.json()) as { role: string }).role).toBe("admin");
+
+    const member = await get(app, "/orgs/my-org/memberships/hubot", "octocat-token");
+    expect(member.status).toBe(200);
+    expect(((await member.json()) as { role: string }).role).toBe("member");
+  });
+
+  it("lets seeded members read a private org repo and keeps outsiders out", async () => {
+    const { app } = createTestApp(SEED);
+    expect((await get(app, "/repos/my-org/secret", "octocat-token")).status).toBe(200);
+    expect((await get(app, "/repos/my-org/secret", "hubot-token")).status).toBe(200);
+    expect((await get(app, "/repos/my-org/secret", "outsider-token")).status).toBe(403);
+  });
+
+  it("lets a seeded admin use the org-admin endpoints (membership grant)", async () => {
+    const { app } = createTestApp(SEED);
+    const res = await app.request(`${base}/orgs/my-org/memberships/outsider`, {
+      method: "PUT",
+      headers: { Authorization: "Bearer octocat-token", "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "member" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await get(app, "/repos/my-org/secret", "outsider-token")).status).toBe(200);
+  });
+
+  it("rejects a member login that is not a seeded user", () => {
+    expect(() =>
+      createTestApp({
+        users: [{ login: "octocat" }],
+        orgs: [{ login: "my-org", members: [{ login: "nobody-here" }] }],
+      }),
+    ).toThrow(/member "nobody-here" is not a seeded user/);
+  });
+});

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -3,7 +3,7 @@ import type { Hono } from "@emulators/core";
 import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@emulators/core";
 import { getGitHubStore } from "./store.js";
 import type { GitHubStore } from "./store.js";
-import type { GitHubAppInstallation } from "./entities.js";
+import type { GitHubAppInstallation, GitHubOrg } from "./entities.js";
 import { generateNodeId } from "./helpers.js";
 import { usersRoutes } from "./routes/users.js";
 import { reposRoutes } from "./routes/repos.js";
@@ -48,6 +48,14 @@ export interface GitHubSeedConfig {
     name?: string;
     description?: string;
     email?: string;
+    /**
+     * Seed org membership. Team-backed, the same representation
+     * `PUT /orgs/:org/memberships/:username` writes at runtime. Logins must be
+     * seeded in `users`. Without at least one `admin`, a private org repo is
+     * unreachable by every seeded user token and nothing at runtime can grant
+     * membership (the membership endpoint itself requires an org admin).
+     */
+    members?: Array<{ login: string; role?: "admin" | "member" }>;
   }>;
   tokens?: Record<string, { login: string; scopes?: string[] }>;
   repos?: Array<{
@@ -205,6 +213,42 @@ function seedDefaults(store: Store, baseUrl: string): void {
   gh.users.update(admin.id, { node_id: generateNodeId("User", admin.id) });
 }
 
+type SeededOrgMember = { login: string; role?: "admin" | "member" };
+
+// Same slug as routes/orgs.ts getOrCreateMembersTeam: org membership is a
+// synthetic "members" team, and an `admin` is a `maintainer` of that team.
+const SEED_MEMBERS_TEAM_SLUG = "members";
+
+function seedOrgMembers(gh: GitHubStore, org: GitHubOrg, members: SeededOrgMember[]): void {
+  let team = gh.teams.findBy("org_id", org.id).find((t) => t.slug === SEED_MEMBERS_TEAM_SLUG);
+  if (!team) {
+    const inserted = gh.teams.insert({
+      node_id: "",
+      name: "Members",
+      slug: SEED_MEMBERS_TEAM_SLUG,
+      description: null,
+      privacy: "closed",
+      permission: "pull",
+      org_id: org.id,
+      parent_id: null,
+      members_count: 0,
+      repos_count: 0,
+    });
+    team = gh.teams.update(inserted.id, { node_id: generateNodeId("Team", inserted.id) }) ?? inserted;
+  }
+  for (const m of members) {
+    const user = gh.users.findOneBy("login", m.login);
+    if (!user) {
+      throw new Error(`GitHub org "${org.login}" member "${m.login}" is not a seeded user`);
+    }
+    const role = m.role === "admin" ? "maintainer" : "member";
+    const existing = gh.teamMembers.findBy("team_id", team.id).find((x) => x.user_id === user.id);
+    if (existing) gh.teamMembers.update(existing.id, { role });
+    else gh.teamMembers.insert({ team_id: team.id, user_id: user.id, role });
+  }
+  gh.teams.update(team.id, { members_count: gh.teamMembers.findBy("team_id", team.id).length });
+}
+
 export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeedConfig): void {
   for (const app of config.apps ?? []) {
     if (!app.private_key) {
@@ -270,6 +314,7 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
         billing_email: null,
       });
       gh.orgs.update(org.id, { node_id: generateNodeId("Org", org.id) });
+      if (o.members?.length) seedOrgMembers(gh, org, o.members);
     }
   }
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -175,6 +175,14 @@ github:
       name: My Organization
       description: A test organization
       email: org@example.com
+      # Optional membership (logins must be seeded users). `admin` maps to a
+      # maintainer of the synthetic "members" team, exactly what
+      # PUT /orgs/:org/memberships/:username writes. Seed one admin when the
+      # org owns private repos: no seeded user can read them otherwise, and
+      # the membership endpoint itself requires an org admin.
+      members:
+        - login: octocat
+          role: admin
   repos:
     - owner: octocat
       name: hello-world


### PR DESCRIPTION
## Summary

- Add an optional `members` array to `github.orgs[]` seed entries: `{ login, role?: "admin" | "member" }`
- Membership is stored as the synthetic `members` team, the same representation `PUT /orgs/:org/memberships/:username` writes at runtime, so `admin` = maintainer of that team and every existing org-role check applies unchanged
- Unknown member logins throw at seed time (they must be seeded `users`), matching the strict seed validation added for apps in 0.10.0

## Why

A seeded org has no members and no admin. Every private repo it owns is therefore unreachable by every seeded user token (403), and nothing at runtime can repair that: the membership endpoint itself requires an org admin. Seeding one admin closes the loop. Hit this in [Yonatan-HQ/platform](https://github.com/Yonatan-HQ/platform) when moving the seed from a user owner to the real org owner.

## Changes

| File | Change |
|------|--------|
| `index.ts` | `members?` on the `orgs[]` seed type; `seedOrgMembers()` (team-backed, idempotent per login) |
| `__tests__/org-members.test.ts` | roles listed, members read a private org repo / outsiders 403, seeded admin can grant membership at runtime, unknown login throws |
| `README.md`, `skills/github/SKILL.md` | document the field and the "seed one admin" rule |

## Test plan

- [x] `pnpm --filter @emulators/github test` (5 files pass, incl. the 4 new cases)
- [x] `pnpm -r build`
- [x] `pnpm --filter @emulators/github lint` (0 errors, no new warnings)