### PR TITLE
fix(github): resolve write actors for org-installed App tokens

### DIFF
--- a/packages/@emulators/github/src/__tests__/installation-writes.test.ts
+++ b/packages/@emulators/github/src/__tests__/installation-writes.test.ts
@@ -1,0 +1,134 @@
+import { generateKeyPairSync, sign } from "crypto";
+import { describe, it, expect } from "vitest";
+import { Hono } from "@emulators/core";
+import { Store, WebhookDispatcher } from "@emulators/core";
+import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
+import { githubPlugin, seedFromConfig, getGitHubStore } from "../index.js";
+
+const base = "http://localhost:4000";
+const APP_ID = 4242;
+
+function createTestApp() {
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use(
+    "*",
+    authMiddleware(tokenMap, (appId) => {
+      const gh = getGitHubStore(store);
+      const ghApp = gh.apps.all().find((a) => a.app_id === appId);
+      if (!ghApp) return null;
+      return { privateKey: ghApp.private_key, slug: ghApp.slug, name: ghApp.name };
+    }),
+  );
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ login: "octocat" }],
+    orgs: [{ login: "my-org", name: "My Organization" }],
+    repos: [{ owner: "my-org", name: "secret", private: true, auto_init: true }],
+    apps: [
+      {
+        app_id: APP_ID,
+        slug: "my-app",
+        name: "My App",
+        private_key: privateKey,
+        permissions: { contents: "write", issues: "write", pull_requests: "write" },
+        installations: [{ installation_id: 100, account: "my-org", repository_selection: "all" }],
+      },
+    ],
+  });
+  return { app, store, privateKey };
+}
+
+function appJwt(privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const b64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString("base64url");
+  const unsigned = `${b64({ alg: "RS256", typ: "JWT" })}.${b64({ iat: now - 60, exp: now + 540, iss: String(APP_ID) })}`;
+  return `${unsigned}.${sign("RSA-SHA256", Buffer.from(unsigned), privateKey).toString("base64url")}`;
+}
+
+async function installationToken(app: Hono, privateKey: string): Promise<string> {
+  const res = await app.request(`${base}/app/installations/100/access_tokens`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${appJwt(privateKey)}` },
+  });
+  expect(res.status).toBe(201);
+  return ((await res.json()) as { token: string }).token;
+}
+
+function json(method: string, token: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+describe("writes with an org-installed App token", () => {
+  it("creates issues, milestones, labels and comments as the app bot", async () => {
+    const { app, privateKey } = createTestApp();
+    const token = await installationToken(app, privateKey);
+
+    const issue = await app.request(`${base}/repos/my-org/secret/issues`, json("POST", token, { title: "hello" }));
+    expect(issue.status).toBe(201);
+    const created = (await issue.json()) as { number: number; user: { login: string; type: string } };
+    expect(created.user.login).toBe("my-app[bot]");
+    expect(created.user.type).toBe("Bot");
+
+    const milestone = await app.request(`${base}/repos/my-org/secret/milestones`, json("POST", token, { title: "m1" }));
+    expect(milestone.status).toBe(201);
+
+    const labels = await app.request(
+      `${base}/repos/my-org/secret/issues/${created.number}/labels`,
+      json("POST", token, { labels: ["bug"] }),
+    );
+    expect(labels.status).toBe(200);
+
+    const comment = await app.request(
+      `${base}/repos/my-org/secret/issues/${created.number}/comments`,
+      json("POST", token, { body: "from the bot" }),
+    );
+    expect(comment.status).toBe(201);
+    expect(((await comment.json()) as { user: { login: string } }).user.login).toBe("my-app[bot]");
+  });
+
+  it("opens a pull request from a branch it pushed", async () => {
+    const { app, privateKey } = createTestApp();
+    const token = await installationToken(app, privateKey);
+    const head = await app.request(`${base}/repos/my-org/secret/git/ref/heads/main`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(head.status).toBe(200);
+    const sha = ((await head.json()) as { object: { sha: string } }).object.sha;
+    const ref = await app.request(
+      `${base}/repos/my-org/secret/git/refs`,
+      json("POST", token, { ref: "refs/heads/feat", sha }),
+    );
+    expect(ref.status).toBe(201);
+    const pr = await app.request(
+      `${base}/repos/my-org/secret/pulls`,
+      json("POST", token, { title: "feat", head: "feat", base: "main" }),
+    );
+    expect(pr.status).toBe(201);
+    expect(((await pr.json()) as { user: { login: string } }).user.login).toBe("my-app[bot]");
+  });
+
+  it("still rejects writes without a token", async () => {
+    const { app } = createTestApp();
+    const res = await app.request(`${base}/repos/my-org/secret/issues`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "nope" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -307,16 +307,24 @@ export function assertRepoAdmin(gh: GitHubStore, authUser: AuthUser | undefined,
   throw forbidden();
 }
 
+// Write helpers resolve the ACTOR, not a user: an installation token's
+// `login` is the installation account (a user or an org), and an org is not a
+// row in `users`, so the user-only assert answered 401 for every write made
+// with an org-installed App. The actor for an installation is `<slug>[bot]`
+// (installationActor), exactly what GitHub attributes such writes to.
 export function assertRepoWrite(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {
-  const user = assertAuthenticatedUser(gh, authUser);
+  const user = assertAuthenticatedActor(gh, authUser);
   if (!repo.private) return user;
   if (!canAccessRepo(gh, authUser, repo)) throw forbidden();
   return user;
 }
 
 export function assertIssueWrite(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {
-  const user = assertAuthenticatedUser(gh, authUser);
+  const user = assertAuthenticatedActor(gh, authUser);
   if (!repo.private) return user;
   if (!canAccessRepo(gh, authUser, repo)) throw forbidden();
+  if (authUser?.installation && !hasInstallationPermission(authUser, ["issues", "pull_requests"], "write")) {
+    throw forbidden();
+  }
   return user;
 }


### PR DESCRIPTION
## Summary

- `assertRepoWrite` / `assertIssueWrite` now resolve the **actor** (`assertAuthenticatedActor`: `<slug>[bot]` for installation tokens, the user otherwise) instead of the user-only `assertAuthenticatedUser`
- Issue writes additionally check the installation's `issues` / `pull_requests` write permission, like GitHub

## Why

An installation token's `AuthUser.login` is the installation **account** login. For an App installed on an **organization** that login is the org, which is not a row in `users`, so every issue, milestone, label, comment and pull-request write with an org-installed App token answered **401 "Requires authentication"** while reads worked. User-account installs only worked by accident: the write was attributed to the account user rather than the app's `[bot]` actor that `installationActor()` already builds.

Found while running [Yonatan-HQ/platform](https://github.com/Yonatan-HQ/platform)'s emulate tier with the seed's App installed on the org (the prod shape: promote auto-merge writes with an org-installed App).

## Changes

| File | Change |
|------|--------|
| `route-helpers.ts` | `assertRepoWrite` / `assertIssueWrite` via `assertAuthenticatedActor`; installation permission gate on issue writes |
| `__tests__/installation-writes.test.ts` | org-installed App mints a token, creates issue / milestone / labels / comment / branch / PR as `my-app[bot]`; no-token write still 401 |

Not touched: `pulls.ts` update-branch still uses `assertAuthenticatedUser`; same class, left for a separate change to keep this one small.

## Test plan

- [x] `pnpm --filter @emulators/github test` (5 files pass, 3 new cases)
- [x] `pnpm -r build`
- [x] `pnpm --filter @emulators/github lint` (0 errors, no new warnings)