### PR TITLE
feat(github): honor the raw media type on GET /repos/:owner/:repo/contents/:path

### DIFF
--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -2259,3 +2259,28 @@ describe("search result URLs resolve against the contents API", () => {
     expect((await search("feature-search-needle")).total_count).toBe(0);
   });
 });
+
+describe("contents raw media type", () => {
+  it("returns file bytes for Accept: application/vnd.github.raw+json", async () => {
+    const { app } = createTestApp();
+    const put = await app.request(`${base}/repos/octocat/hello-world/contents/docs/raw.md`, {
+      method: "PUT",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "docs: raw", content: Buffer.from("# raw\n").toString("base64") }),
+    });
+    expect(put.status).toBe(201);
+
+    const raw = await app.request(`${base}/repos/octocat/hello-world/contents/docs/raw.md`, {
+      headers: { ...authHeaders(), Accept: "application/vnd.github.raw+json" },
+    });
+    expect(raw.status).toBe(200);
+    expect(raw.headers.get("content-type")).toBe("application/vnd.github.raw");
+    expect(await raw.text()).toBe("# raw\n");
+
+    const json = await app.request(`${base}/repos/octocat/hello-world/contents/docs/raw.md`, {
+      headers: authHeaders(),
+    });
+    expect(json.status).toBe(200);
+    expect(((await json.json()) as { encoding: string }).encoding).toBe("base64");
+  });
+});

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -460,6 +460,19 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     }
     const entry = flat.blobs.get(path);
     if (entry) {
+      // Raw media type (`application/vnd.github.raw` / `.raw+json`): return the
+      // file bytes, as GitHub does, instead of the JSON envelope.
+      const accept = c.req.header("Accept") ?? "";
+      if (/application\/vnd\.github\.raw(\+json)?/i.test(accept)) {
+        const resolved = resolveSymlinkEntry(gh, repo.id, path, entry, flat);
+        const blob = findBlob(gh, repo.id, resolved?.sha ?? entry.sha);
+        if (!blob) throw notFoundResponse();
+        const content = blobBytes(blob);
+        return c.body(content, 200, {
+          "Content-Type": "application/vnd.github.raw",
+          "Content-Length": String(content.byteLength),
+        });
+      }
       return c.json(formatFileContent(gh, repo, baseUrl, path, ref, entry, true, flat));
     }
     const prefix = `${path}/`;


### PR DESCRIPTION
## Summary

- `GET /repos/:owner/:repo/contents/:path` returns the file **bytes** with `Content-Type: application/vnd.github.raw` when the request accepts `application/vnd.github.raw` or `application/vnd.github.raw+json`, as GitHub does; the JSON envelope is unchanged for every other `Accept`
- Symlinks resolve like the existing `/:owner/:repo/raw/:ref/:path` route

## Why

Clients that read files this way (a `get_file_content()` sending the raw media type, the documented GitHub pattern) got the base64 JSON envelope from the emulator where production returns text. Found by [Yonatan-HQ/platform](https://github.com/Yonatan-HQ/platform)'s emulate tier driving its real GitHub service against 0.10.0's stateful contents API.

## Changes

| File | Change |
|------|--------|
| `routes/contents.ts` | raw media-type branch in `getContents` |
| `__tests__/contents-commits.test.ts` | PUT a file, GET with `.raw+json` → bytes + `application/vnd.github.raw`; default Accept still returns `encoding: base64` |

## Test plan

- [x] `pnpm --filter @emulators/github test` (6 files pass)
- [x] `pnpm -r build`
- [x] `pnpm --filter @emulators/github lint` (0 errors, no new warnings)