### PR TITLE
Honor GitHub raw media types for repository contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 
 ### Contents & Commit History
 - `GET /repos/:owner/:repo/readme` - get the repository README
-- `GET /repos/:owner/:repo/contents/:path` - get a file or list a directory at a ref
+- `GET /repos/:owner/:repo/contents/:path` - get a file as JSON or raw bytes with a GitHub raw media type, or list a directory at a ref
 - `GET /:owner/:repo/raw/:ref/:path` - download file content from advertised raw URLs
 - `PUT/DELETE /repos/:owner/:repo/contents/:path` - create, update, or delete a file and commit the change
 - `GET /repos/:owner/:repo/commits` - list commits with ref, path, author, and date filters

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -72,12 +72,19 @@ The destination must not exist. emulate removes inherited ACLs, verifies effecti
 ## Contents & Commit History
 
 - `GET /repos/:owner/:repo/readme` - get the repository README
-- `GET /repos/:owner/:repo/contents/:path` - get a file or list a directory at a ref
+- `GET /repos/:owner/:repo/contents/:path` - get a file as JSON or raw bytes with a GitHub raw media type, or list a directory at a ref
 - `GET /:owner/:repo/raw/:ref/:path` - download file content from advertised raw URLs
 - `PUT/DELETE /repos/:owner/:repo/contents/:path` - create, update, or delete a file and commit the change
 - `GET /repos/:owner/:repo/commits` - list commits with ref, path, author, and date filters
 - `GET /repos/:owner/:repo/commits/:ref` - get a commit with file diffs and stats
 - `GET /repos/:owner/:repo/compare/:base...:head` - compare two refs
+
+Files use the normal JSON envelope unless the request accepts a GitHub raw media type. To read the exact stored bytes from the Contents API:
+
+```bash
+curl "http://localhost:4001/repos/octocat/hello-world/contents/README.md?ref=main" \
+  -H "Accept: application/vnd.github.raw+json"
+```
 
 ## Issues
 

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -41,7 +41,7 @@ npm install @emulators/github
 
 ### Contents & Commit History
 - `GET /repos/:owner/:repo/readme` — get the repository README
-- `GET /repos/:owner/:repo/contents/:path` — get a file or list a directory at a ref
+- `GET /repos/:owner/:repo/contents/:path` — get a file as JSON or raw bytes with a GitHub raw media type, or list a directory at a ref
 - `GET /:owner/:repo/raw/:ref/:path` — download file content from advertised raw URLs
 - `PUT/DELETE /repos/:owner/:repo/contents/:path` — create, update, or delete a file and commit the change
 - `GET /repos/:owner/:repo/commits` — list commits with ref, path, author, and date filters

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -207,6 +207,7 @@ describe("GitHub contents routes", () => {
       "application/vnd.github.v3.raw",
       "application/vnd.github.v3.raw+json",
       "application/json, application/vnd.github.raw+json; q=0.9",
+      'application/json; profile="one,two", application/vnd.github.raw+json',
     ];
     for (const accept of rawMediaTypes) {
       const response = await app.request(`${base}/repos/octocat/hello-world/contents/binary.dat`, {
@@ -225,6 +226,7 @@ describe("GitHub contents routes", () => {
       "application/json",
       "application/vnd.github+json",
       "application/vnd.github.rawfoo",
+      'application/json; profile="one, application/vnd.github.raw+json; q=0.9"',
     ]) {
       const response = await app.request(`${base}/repos/octocat/hello-world/contents/binary.dat`, {
         headers: { ...authHeaders(), ...(accept ? { Accept: accept } : {}) },

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -189,6 +189,52 @@ describe("GitHub contents routes", () => {
     expect(await download.text()).toBe("# hello-world\n");
   });
 
+  it("returns raw file bytes for GitHub raw media types and JSON otherwise", async () => {
+    const content = Buffer.from([0, 1, 2, 127, 128, 255, 10]);
+    const created = await app.request(`${base}/repos/octocat/hello-world/contents/binary.dat`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        message: "Add binary file",
+        content: content.toString("base64"),
+      }),
+    });
+    expect(created.status).toBe(201);
+
+    const rawMediaTypes = [
+      "application/vnd.github.raw+json",
+      "application/vnd.github.raw",
+      "application/vnd.github.v3.raw",
+      "application/vnd.github.v3.raw+json",
+      "application/json, application/vnd.github.raw+json; q=0.9",
+    ];
+    for (const accept of rawMediaTypes) {
+      const response = await app.request(`${base}/repos/octocat/hello-world/contents/binary.dat`, {
+        headers: { ...authHeaders(), Accept: accept },
+      });
+      expect(response.status, accept).toBe(200);
+      expect(response.headers.get("Content-Type"), accept).toBe("application/vnd.github.raw");
+      expect(response.headers.get("Content-Length"), accept).toBe(String(content.byteLength));
+      expect(Buffer.from(await response.arrayBuffer()), accept).toEqual(content);
+    }
+
+    for (const accept of [
+      undefined,
+      "*/*",
+      "application/json",
+      "application/vnd.github+json",
+      "application/vnd.github.rawfoo",
+    ]) {
+      const response = await app.request(`${base}/repos/octocat/hello-world/contents/binary.dat`, {
+        headers: { ...authHeaders(), ...(accept ? { Accept: accept } : {}) },
+      });
+      expect(response.status, accept).toBe(200);
+      const body = (await response.json()) as { encoding: string; content: string };
+      expect(body.encoding, accept).toBe("base64");
+      expect(Buffer.from(body.content, "base64"), accept).toEqual(content);
+    }
+  });
+
   it("serves the URL shape that code search results advertise (?ref=HEAD)", async () => {
     const res = await app.request(`${base}/repos/octocat/hello-world/contents/README.md?ref=HEAD`, {
       headers: authHeaders(),
@@ -254,8 +300,11 @@ describe("GitHub contents routes", () => {
     const treeBody = (await tree.json()) as { tree: Array<{ path: string; type: string }> };
     expect(treeBody.tree).toContainEqual(expect.objectContaining({ path: "index.ts", type: "blob" }));
 
-    const dir = await app.request(`${base}/repos/octocat/hello-world/contents/src`, { headers: authHeaders() });
+    const dir = await app.request(`${base}/repos/octocat/hello-world/contents/src`, {
+      headers: { ...authHeaders(), Accept: "application/vnd.github.raw+json" },
+    });
     expect(dir.status).toBe(200);
+    expect(dir.headers.get("Content-Type")).toContain("application/json");
     const dirBody = (await dir.json()) as Array<{ path: string; type: string }>;
     expect(dirBody).toHaveLength(1);
     expect(dirBody[0].path).toBe("src/index.ts");
@@ -1240,6 +1289,11 @@ describe("GitHub contents routes", () => {
     const rawLink = await app.request(`${base}/octocat/hello-world/raw/main/link.txt`, { headers: authHeaders() });
     expect(rawLink.status).toBe(200);
     expect(await rawLink.text()).toBe("target\n");
+    const contentsRawLink = await app.request(`${base}/repos/octocat/hello-world/contents/link.txt`, {
+      headers: { ...authHeaders(), Accept: "application/vnd.github.raw+json" },
+    });
+    expect(contentsRawLink.status).toBe(200);
+    expect(await contentsRawLink.text()).toBe("target\n");
 
     const broken = await app.request(`${base}/repos/octocat/hello-world/contents/broken-link`, {
       headers: authHeaders(),

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -215,6 +215,7 @@ describe("GitHub contents routes", () => {
       expect(response.status, accept).toBe(200);
       expect(response.headers.get("Content-Type"), accept).toBe("application/vnd.github.raw");
       expect(response.headers.get("Content-Length"), accept).toBe(String(content.byteLength));
+      expect(response.headers.get("Vary"), accept).toBe("Accept");
       expect(Buffer.from(await response.arrayBuffer()), accept).toEqual(content);
     }
 
@@ -229,6 +230,7 @@ describe("GitHub contents routes", () => {
         headers: { ...authHeaders(), ...(accept ? { Accept: accept } : {}) },
       });
       expect(response.status, accept).toBe(200);
+      expect(response.headers.get("Vary"), accept).toBe("Accept");
       const body = (await response.json()) as { encoding: string; content: string };
       expect(body.encoding, accept).toBe("base64");
       expect(Buffer.from(body.content, "base64"), accept).toEqual(content);

--- a/packages/@emulators/github/src/__tests__/contents-commits.test.ts
+++ b/packages/@emulators/github/src/__tests__/contents-commits.test.ts
@@ -1304,9 +1304,10 @@ describe("GitHub contents routes", () => {
     );
 
     const submodule = await app.request(`${base}/repos/octocat/hello-world/contents/vendor/mod`, {
-      headers: authHeaders(),
+      headers: { ...authHeaders(), Accept: "application/vnd.github.raw+json" },
     });
     expect(submodule.status).toBe(200);
+    expect(submodule.headers.get("Content-Type")).toContain("application/json");
     expect(await submodule.json()).toEqual(
       expect.objectContaining({
         type: "submodule",

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -61,12 +61,40 @@ const rawContentMediaTypes = new Set([
 ]);
 
 function acceptsRawContent(accept: string | undefined): boolean {
-  return (
-    accept?.split(",").some((range) => {
-      const [mediaType] = range.split(";", 1);
-      return rawContentMediaTypes.has(mediaType.trim().toLowerCase());
-    }) ?? false
-  );
+  if (!accept) return false;
+
+  let rangeStart = 0;
+  let inQuotes = false;
+  let escaped = false;
+  const isRawRange = (rangeEnd: number) => {
+    const range = accept.slice(rangeStart, rangeEnd);
+    const parameterStart = range.indexOf(";");
+    const mediaType = range
+      .slice(0, parameterStart === -1 ? undefined : parameterStart)
+      .trim()
+      .toLowerCase();
+    return rawContentMediaTypes.has(mediaType);
+  };
+
+  for (let index = 0; index < accept.length; index++) {
+    const character = accept[index];
+    if (inQuotes) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inQuotes = false;
+      }
+    } else if (character === '"') {
+      inQuotes = true;
+    } else if (character === ",") {
+      if (isRawRange(index)) return true;
+      rangeStart = index + 1;
+    }
+  }
+
+  return isRawRange(accept.length);
 }
 
 function blobBase64(blob: ReturnType<typeof findBlob>): string {

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -53,6 +53,22 @@ function findBlob(gh: GitHubStore, repoId: number, sha: string) {
   return gh.blobs.findBy("repo_id", repoId).find((blob) => blob.sha === sha);
 }
 
+const rawContentMediaTypes = new Set([
+  "application/vnd.github.raw",
+  "application/vnd.github.raw+json",
+  "application/vnd.github.v3.raw",
+  "application/vnd.github.v3.raw+json",
+]);
+
+function acceptsRawContent(accept: string | undefined): boolean {
+  return (
+    accept?.split(",").some((range) => {
+      const [mediaType] = range.split(";", 1);
+      return rawContentMediaTypes.has(mediaType.trim().toLowerCase());
+    }) ?? false
+  );
+}
+
 function blobBase64(blob: ReturnType<typeof findBlob>): string {
   if (!blob) return "";
   return blob.encoding === "base64" ? blob.content : Buffer.from(blob.content, "utf8").toString("base64");
@@ -87,6 +103,11 @@ function resolveSymlinkEntry(
   if (!targetPath) return undefined;
   const target = flat.blobs.get(targetPath);
   return target?.type === "blob" && (target.mode === "100644" || target.mode === "100755") ? target : undefined;
+}
+
+function resolveRawBlob(gh: GitHubStore, repoId: number, path: string, entry: FileTreeEntry, flat: FlatTree) {
+  const resolved = resolveSymlinkEntry(gh, repoId, path, entry, flat);
+  return findBlob(gh, repoId, resolved?.sha ?? entry.sha);
 }
 
 function submoduleUrls(gh: GitHubStore, repoId: number, flat: FlatTree): Map<string, string> {
@@ -460,6 +481,15 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     }
     const entry = flat.blobs.get(path);
     if (entry) {
+      if (acceptsRawContent(c.req.header("Accept"))) {
+        const blob = resolveRawBlob(gh, repo.id, path, entry, flat);
+        if (!blob) throw notFoundResponse();
+        const content = blobBytes(blob);
+        return c.body(content, 200, {
+          "Content-Type": "application/vnd.github.raw",
+          "Content-Length": String(content.byteLength),
+        });
+      }
       return c.json(formatFileContent(gh, repo, baseUrl, path, ref, entry, true, flat));
     }
     const prefix = `${path}/`;
@@ -483,8 +513,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     const flat = flattenTree(gh, repo.id, commit.tree_sha);
     const entry = flat.blobs.get(path);
     if (!entry) throw notFoundResponse();
-    const resolved = resolveSymlinkEntry(gh, repo.id, path, entry, flat);
-    const blob = findBlob(gh, repo.id, resolved?.sha ?? entry.sha);
+    const blob = resolveRawBlob(gh, repo.id, path, entry, flat);
     if (!blob) throw notFoundResponse();
     const content = blobBytes(blob);
     return c.body(content, 200, {

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -481,6 +481,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     }
     const entry = flat.blobs.get(path);
     if (entry) {
+      c.header("Vary", "Accept");
       if (entry.type === "blob" && acceptsRawContent(c.req.header("Accept"))) {
         const blob = resolveRawBlob(gh, repo.id, path, entry, flat);
         if (!blob) throw notFoundResponse();

--- a/packages/@emulators/github/src/routes/contents.ts
+++ b/packages/@emulators/github/src/routes/contents.ts
@@ -481,7 +481,7 @@ export function contentsRoutes({ app, store, webhooks, baseUrl }: RouteContext):
     }
     const entry = flat.blobs.get(path);
     if (entry) {
-      if (acceptsRawContent(c.req.header("Accept"))) {
+      if (entry.type === "blob" && acceptsRawContent(c.req.header("Accept"))) {
         const blob = resolveRawBlob(gh, repo.id, path, entry, flat);
         if (!blob) throw notFoundResponse();
         const content = blobBytes(blob);

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -22,7 +22,8 @@ Framework adapters:
   Docs: https://emulate.dev/docs/nextjs and https://emulate.dev/docs/nuxt
 
 GitHub API coverage:
-  Includes repository contents, raw downloads, commit history, commit details, and ref comparisons.
+  Includes repository contents with raw media type responses, raw downloads, commit history,
+  commit details, and ref comparisons.
 
 Linear API coverage:
   Issue queries and mutations include numeric priority and derived priorityLabel fields.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -281,6 +281,10 @@ curl -X DELETE http://localhost:4001/repos/octocat/hello-world \
 # Read a file or list a directory at a branch, tag, or commit
 curl "http://localhost:4001/repos/octocat/hello-world/contents/README.md?ref=main"
 
+# Read raw bytes from the Contents API
+curl "http://localhost:4001/repos/octocat/hello-world/contents/README.md?ref=main" \
+  -H "Accept: application/vnd.github.raw+json"
+
 # Download raw file content from the URL advertised by contents and commit responses
 curl http://localhost:4001/octocat/hello-world/raw/main/README.md
 


### PR DESCRIPTION
## Summary

- Return exact file bytes from the GitHub Contents API when `Accept` includes a supported GitHub raw media type, while preserving the existing JSON representation for ordinary requests, directories, and submodules.
- Reuse symlink-aware blob resolution so raw Contents API responses and advertised raw download URLs resolve file links consistently.
- Set raw response metadata and `Vary: Accept` so binary payloads are represented correctly and content-negotiated responses remain cache safe.
- Document how to request raw repository contents across the README, GitHub package guide, docs site, CLI help, and GitHub skill.