### PR TITLE
Add Google Calendar API discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,8 +800,33 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `GET /gmail/v1/users/:userId/history`, `POST /gmail/v1/users/:userId/watch`, `POST /gmail/v1/users/:userId/stop`
 - `GET /gmail/v1/users/:userId/settings/filters`, `POST /gmail/v1/users/:userId/settings/filters`, `DELETE /gmail/v1/users/:userId/settings/filters/:id`
 - `GET /gmail/v1/users/:userId/settings/forwardingAddresses`, `GET /gmail/v1/users/:userId/settings/sendAs`
+- `GET /discovery/v1/apis/calendar/v3/rest` - Google API Discovery v1 document for the emulated Calendar methods
 - `GET /calendar/v3/users/:userId/calendarList`, `GET /calendar/v3/calendars/:calendarId/events`, `POST /calendar/v3/calendars/:calendarId/events`, `DELETE /calendar/v3/calendars/:calendarId/events/:eventId`, `POST /calendar/v3/freeBusy`
 - `GET /drive/v3/files`, `GET /drive/v3/files/:fileId`, `POST /drive/v3/files`, `PATCH /drive/v3/files/:fileId`, `PUT /drive/v3/files/:fileId`, `POST /upload/drive/v3/files`
+
+### Google Calendar API Discovery
+
+Discovery-based clients must use the emulator's discovery template explicitly. The document is public and advertises the running emulator's configured base URL. Calendar method calls still require a bearer token.
+
+```python
+import os
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+emulator_url = os.environ.get("GOOGLE_EMULATOR_URL", "http://localhost:4002")
+calendar = build(
+    "calendar",
+    "v3",
+    discoveryServiceUrl=f"{emulator_url}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest",
+    credentials=Credentials(token="local-test-token"),
+    cache_discovery=False,
+)
+
+events = calendar.events().list(calendarId="primary", maxResults=10).execute()
+```
+
+Calling `build("calendar", "v3")` without `discoveryServiceUrl` uses Google's default discovery source and does not find the emulator automatically.
 
 ## Slack API
 

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -67,6 +67,32 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `DELETE /calendar/v3/calendars/:calendarId/events/:eventId` - delete event
 - `POST /calendar/v3/freeBusy` - query free/busy
 
+## Google API Discovery
+
+`GET /discovery/v1/apis/calendar/v3/rest` returns a public Google API Discovery v1 document for the emulated Calendar methods. This is separate from OIDC discovery. The document advertises the base URL configured for the running emulator, including any adapter mount path.
+
+Discovery-based clients must use the emulator template explicitly. Calendar method execution still requires a bearer token.
+
+```python
+import os
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+emulator_url = os.environ.get("GOOGLE_EMULATOR_URL", "http://localhost:4002")
+calendar = build(
+    "calendar",
+    "v3",
+    discoveryServiceUrl=f"{emulator_url}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest",
+    credentials=Credentials(token="local-test-token"),
+    cache_discovery=False,
+)
+
+calendars = calendar.calendarList().list().execute()
+```
+
+Plain `build("calendar", "v3")` uses Google's default discovery source and does not find the emulator automatically.
+
 ## Drive
 
 - `GET /drive/v3/files` - list files

--- a/packages/@emulators/google/README.md
+++ b/packages/@emulators/google/README.md
@@ -61,11 +61,32 @@ npm install @emulators/google
 - `GET /gmail/v1/users/:userId/settings/sendAs` — list send-as aliases
 
 ### Calendar
+- `GET /discovery/v1/apis/calendar/v3/rest` — Google API Discovery v1 document for the emulated Calendar methods
 - `GET /calendar/v3/users/:userId/calendarList` — list calendars
 - `GET /calendar/v3/calendars/:calendarId/events` — list events
 - `POST /calendar/v3/calendars/:calendarId/events` — create event
 - `DELETE /calendar/v3/calendars/:calendarId/events/:eventId` — delete event
 - `POST /calendar/v3/freeBusy` — free/busy query
+
+The discovery endpoint is public and its document advertises the `baseUrl` passed when registering the plugin. Calendar method calls still require a bearer token. Discovery-based clients must use the emulator template explicitly:
+
+```python
+import os
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+emulator_url = os.environ.get("GOOGLE_EMULATOR_URL", "http://localhost:4002")
+calendar = build(
+    "calendar",
+    "v3",
+    discoveryServiceUrl=f"{emulator_url}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest",
+    credentials=Credentials(token="local-test-token"),
+    cache_discovery=False,
+)
+```
+
+Plain `build("calendar", "v3")` uses Google's default discovery source and does not find the emulator automatically.
 
 ### Drive
 - `GET /drive/v3/files` — list files

--- a/packages/@emulators/google/src/__tests__/google.test.ts
+++ b/packages/@emulators/google/src/__tests__/google.test.ts
@@ -14,7 +14,7 @@ import { buildRawMessage } from "../helpers.js";
 
 const base = "http://localhost:4000";
 
-function createTestApp() {
+function createTestApp(advertisedBaseUrl = base) {
   const store = new Store();
   const webhooks = new WebhookDispatcher();
   const tokenMap: TokenMap = new Map();
@@ -28,9 +28,9 @@ function createTestApp() {
   app.onError(createApiErrorHandler());
   app.use("*", createErrorHandler());
   app.use("*", authMiddleware(tokenMap));
-  googlePlugin.register(app as any, store, webhooks, base, tokenMap);
-  googlePlugin.seed?.(store, base);
-  seedFromConfig(store, base, {
+  googlePlugin.register(app as any, store, webhooks, advertisedBaseUrl, tokenMap);
+  googlePlugin.seed?.(store, advertisedBaseUrl);
+  seedFromConfig(store, advertisedBaseUrl, {
     users: [
       { email: "testuser@example.com", name: "Test User" },
       { email: "consumer@gmail.com", name: "Consumer User" },
@@ -177,6 +177,41 @@ function createTestApp() {
 
 function authHeaders(extra?: Record<string, string>): Record<string, string> {
   return { Authorization: "Bearer test-token", ...extra };
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function recordProperty(record: Record<string, unknown>, key: string): Record<string, unknown> {
+  return asRecord(record[key], key);
+}
+
+function discoveryMethod(
+  document: Record<string, unknown>,
+  resourceName: string,
+  methodName: string,
+): Record<string, unknown> {
+  const resources = recordProperty(document, "resources");
+  const resource = recordProperty(resources, resourceName);
+  const methods = recordProperty(resource, "methods");
+  return recordProperty(methods, methodName);
+}
+
+function collectSchemaRefs(value: unknown, refs = new Set<string>()): Set<string> {
+  if (Array.isArray(value)) {
+    for (const item of value) collectSchemaRefs(item, refs);
+    return refs;
+  }
+  if (typeof value !== "object" || value === null) return refs;
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.$ref === "string") refs.add(record.$ref);
+  for (const nested of Object.values(record)) collectSchemaRefs(nested, refs);
+  return refs;
 }
 
 async function jsonRequest(
@@ -931,6 +966,281 @@ describe("Google plugin integration", () => {
     });
     expect(userinfoRes.status).toBe(200);
     expect(((await userinfoRes.json()) as { hd?: string }).hd).toBe("override.io");
+  });
+
+  it("serves the public Calendar discovery document with the implemented method contract", async () => {
+    const res = await app.request(`${base}/discovery/v1/apis/calendar/v3/rest`);
+    expect(res.status).toBe(200);
+
+    const document = asRecord(await res.json(), "discovery document");
+    expect({
+      kind: document.kind,
+      discoveryVersion: document.discoveryVersion,
+      id: document.id,
+      name: document.name,
+      version: document.version,
+      title: document.title,
+      protocol: document.protocol,
+    }).toEqual({
+      kind: "discovery#restDescription",
+      discoveryVersion: "v1",
+      id: "calendar:v3",
+      name: "calendar",
+      version: "v3",
+      title: "Calendar API",
+      protocol: "rest",
+    });
+    expect(document.parameters).toEqual({});
+
+    const resources = recordProperty(document, "resources");
+    expect(Object.keys(resources)).toEqual(["calendarList", "events", "freebusy"]);
+    expect(Object.keys(recordProperty(recordProperty(resources, "calendarList"), "methods"))).toEqual(["list"]);
+    expect(Object.keys(recordProperty(recordProperty(resources, "events"), "methods"))).toEqual([
+      "list",
+      "insert",
+      "delete",
+    ]);
+    expect(Object.keys(recordProperty(recordProperty(resources, "freebusy"), "methods"))).toEqual(["query"]);
+
+    const calendarList = discoveryMethod(document, "calendarList", "list");
+    expect({
+      id: calendarList.id,
+      path: calendarList.path,
+      httpMethod: calendarList.httpMethod,
+      parameterOrder: calendarList.parameterOrder,
+      response: calendarList.response,
+    }).toEqual({
+      id: "calendar.calendarList.list",
+      path: "users/me/calendarList",
+      httpMethod: "GET",
+      parameterOrder: [],
+      response: { $ref: "CalendarList" },
+    });
+
+    const eventsList = discoveryMethod(document, "events", "list");
+    expect({
+      id: eventsList.id,
+      path: eventsList.path,
+      httpMethod: eventsList.httpMethod,
+      parameterOrder: eventsList.parameterOrder,
+      response: eventsList.response,
+    }).toEqual({
+      id: "calendar.events.list",
+      path: "calendars/{calendarId}/events",
+      httpMethod: "GET",
+      parameterOrder: ["calendarId"],
+      response: { $ref: "Events" },
+    });
+    const listParameters = recordProperty(eventsList, "parameters");
+    expect(Object.keys(listParameters)).toEqual([
+      "calendarId",
+      "timeMin",
+      "timeMax",
+      "maxResults",
+      "pageToken",
+      "q",
+      "orderBy",
+      "singleEvents",
+    ]);
+    expect(recordProperty(listParameters, "calendarId")).toMatchObject({
+      type: "string",
+      location: "path",
+      required: true,
+    });
+    expect(recordProperty(listParameters, "timeMin")).toMatchObject({
+      type: "string",
+      format: "date-time",
+      location: "query",
+    });
+    expect(recordProperty(listParameters, "timeMax")).toMatchObject({
+      type: "string",
+      format: "date-time",
+      location: "query",
+    });
+    expect(recordProperty(listParameters, "maxResults")).toMatchObject({
+      type: "integer",
+      format: "int32",
+      location: "query",
+    });
+    expect(recordProperty(listParameters, "orderBy").enum).toEqual(["startTime"]);
+    expect(listParameters.showDeleted).toBeUndefined();
+
+    const eventsInsert = discoveryMethod(document, "events", "insert");
+    expect({
+      id: eventsInsert.id,
+      path: eventsInsert.path,
+      httpMethod: eventsInsert.httpMethod,
+      parameterOrder: eventsInsert.parameterOrder,
+      request: eventsInsert.request,
+      response: eventsInsert.response,
+    }).toEqual({
+      id: "calendar.events.insert",
+      path: "calendars/{calendarId}/events",
+      httpMethod: "POST",
+      parameterOrder: ["calendarId"],
+      request: { $ref: "Event" },
+      response: { $ref: "Event" },
+    });
+    expect(recordProperty(recordProperty(eventsInsert, "parameters"), "calendarId")).toMatchObject({
+      location: "path",
+      required: true,
+    });
+
+    const eventsDelete = discoveryMethod(document, "events", "delete");
+    expect({
+      id: eventsDelete.id,
+      path: eventsDelete.path,
+      httpMethod: eventsDelete.httpMethod,
+      parameterOrder: eventsDelete.parameterOrder,
+      response: eventsDelete.response,
+    }).toEqual({
+      id: "calendar.events.delete",
+      path: "calendars/{calendarId}/events/{eventId}",
+      httpMethod: "DELETE",
+      parameterOrder: ["calendarId", "eventId"],
+      response: undefined,
+    });
+    const deleteParameters = recordProperty(eventsDelete, "parameters");
+    for (const parameterName of ["calendarId", "eventId"]) {
+      expect(recordProperty(deleteParameters, parameterName)).toMatchObject({
+        type: "string",
+        location: "path",
+        required: true,
+      });
+    }
+
+    const freebusyQuery = discoveryMethod(document, "freebusy", "query");
+    expect({
+      id: freebusyQuery.id,
+      path: freebusyQuery.path,
+      httpMethod: freebusyQuery.httpMethod,
+      parameterOrder: freebusyQuery.parameterOrder,
+      request: freebusyQuery.request,
+      response: freebusyQuery.response,
+    }).toEqual({
+      id: "calendar.freebusy.query",
+      path: "freeBusy",
+      httpMethod: "POST",
+      parameterOrder: [],
+      request: { $ref: "FreeBusyRequest" },
+      response: { $ref: "FreeBusyResponse" },
+    });
+
+    const unauthenticatedCalendarRes = await app.request(`${base}/calendar/v3/users/me/calendarList`);
+    expect(unauthenticatedCalendarRes.status).toBe(401);
+  });
+
+  it("provides a closed Calendar discovery schema graph matching emulator payloads", async () => {
+    const res = await app.request(`${base}/discovery/v1/apis/calendar/v3/rest`);
+    const document = asRecord(await res.json(), "discovery document");
+    const resources = recordProperty(document, "resources");
+    const schemas = recordProperty(document, "schemas");
+    const refs = collectSchemaRefs({ resources, schemas });
+
+    expect([...refs].filter((ref) => schemas[ref] === undefined)).toEqual([]);
+    expect(Object.keys(schemas)).toEqual([
+      "CalendarList",
+      "CalendarListEntry",
+      "Events",
+      "Event",
+      "EventDateTime",
+      "EventAttendee",
+      "ConferenceData",
+      "EntryPoint",
+      "FreeBusyRequest",
+      "FreeBusyRequestItem",
+      "FreeBusyResponse",
+      "FreeBusyCalendar",
+      "TimePeriod",
+    ]);
+
+    const calendarListProperties = recordProperty(recordProperty(schemas, "CalendarList"), "properties");
+    expect(recordProperty(recordProperty(calendarListProperties, "items"), "items").$ref).toBe("CalendarListEntry");
+    const calendarEntryProperties = recordProperty(recordProperty(schemas, "CalendarListEntry"), "properties");
+    expect(Object.keys(calendarEntryProperties)).toEqual([
+      "kind",
+      "etag",
+      "id",
+      "summary",
+      "description",
+      "timeZone",
+      "selected",
+      "primary",
+      "accessRole",
+      "backgroundColor",
+      "foregroundColor",
+    ]);
+
+    const eventsProperties = recordProperty(recordProperty(schemas, "Events"), "properties");
+    expect(recordProperty(recordProperty(eventsProperties, "items"), "items").$ref).toBe("Event");
+    expect(recordProperty(eventsProperties, "nextPageToken").type).toBe("string");
+
+    const eventProperties = recordProperty(recordProperty(schemas, "Event"), "properties");
+    expect(recordProperty(eventProperties, "start").$ref).toBe("EventDateTime");
+    expect(recordProperty(eventProperties, "end").$ref).toBe("EventDateTime");
+    expect(recordProperty(recordProperty(eventProperties, "attendees"), "items").$ref).toBe("EventAttendee");
+    expect(recordProperty(eventProperties, "conferenceData").$ref).toBe("ConferenceData");
+    expect(Object.keys(eventProperties)).toEqual([
+      "kind",
+      "etag",
+      "id",
+      "status",
+      "htmlLink",
+      "hangoutLink",
+      "summary",
+      "description",
+      "location",
+      "created",
+      "updated",
+      "start",
+      "end",
+      "attendees",
+      "conferenceData",
+      "transparency",
+    ]);
+
+    const eventDateTimeProperties = recordProperty(recordProperty(schemas, "EventDateTime"), "properties");
+    expect(recordProperty(eventDateTimeProperties, "date")).toMatchObject({ type: "string", format: "date" });
+    expect(recordProperty(eventDateTimeProperties, "dateTime")).toMatchObject({
+      type: "string",
+      format: "date-time",
+    });
+    expect(recordProperty(eventDateTimeProperties, "timeZone").type).toBe("string");
+
+    const conferenceProperties = recordProperty(recordProperty(schemas, "ConferenceData"), "properties");
+    expect(recordProperty(recordProperty(conferenceProperties, "entryPoints"), "items").$ref).toBe("EntryPoint");
+
+    const requestProperties = recordProperty(recordProperty(schemas, "FreeBusyRequest"), "properties");
+    expect(recordProperty(requestProperties, "timeMin")).toMatchObject({ format: "date-time", required: true });
+    expect(recordProperty(requestProperties, "timeMax")).toMatchObject({ format: "date-time", required: true });
+    expect(recordProperty(recordProperty(requestProperties, "items"), "items").$ref).toBe("FreeBusyRequestItem");
+
+    const responseProperties = recordProperty(recordProperty(schemas, "FreeBusyResponse"), "properties");
+    expect(recordProperty(recordProperty(responseProperties, "calendars"), "additionalProperties").$ref).toBe(
+      "FreeBusyCalendar",
+    );
+    const freeBusyCalendarProperties = recordProperty(recordProperty(schemas, "FreeBusyCalendar"), "properties");
+    expect(recordProperty(recordProperty(freeBusyCalendarProperties, "busy"), "items").$ref).toBe("TimePeriod");
+  });
+
+  it("advertises the configured prefix in Calendar discovery URLs", async () => {
+    const prefixedApp = createTestApp("https://example.test/emulate/google/").app;
+    const res = await prefixedApp.request(`${base}/discovery/v1/apis/calendar/v3/rest`);
+    expect(res.status).toBe(200);
+
+    const document = asRecord(await res.json(), "discovery document");
+    expect({
+      rootUrl: document.rootUrl,
+      servicePath: document.servicePath,
+      baseUrl: document.baseUrl,
+      basePath: document.basePath,
+    }).toEqual({
+      rootUrl: "https://example.test/emulate/google/",
+      servicePath: "calendar/v3/",
+      baseUrl: "https://example.test/emulate/google/calendar/v3/",
+      basePath: "/emulate/google/calendar/v3/",
+    });
+    expect(String(document.baseUrl)).not.toContain("google//calendar");
   });
 
   it("lists calendar resources, creates events, queries freebusy, and deletes events", async () => {

--- a/packages/@emulators/google/src/calendar-discovery.ts
+++ b/packages/@emulators/google/src/calendar-discovery.ts
@@ -1,0 +1,337 @@
+export function buildCalendarDiscoveryDocument(baseUrl: string) {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+  const rootUrl = `${normalizedBaseUrl}/`;
+  const calendarBaseUrl = `${normalizedBaseUrl}/calendar/v3/`;
+
+  return {
+    kind: "discovery#restDescription",
+    discoveryVersion: "v1",
+    id: "calendar:v3",
+    name: "calendar",
+    version: "v3",
+    title: "Calendar API",
+    description: "Emulated Google Calendar API for local development and testing.",
+    protocol: "rest",
+    rootUrl,
+    servicePath: "calendar/v3/",
+    basePath: new URL(calendarBaseUrl).pathname,
+    baseUrl: calendarBaseUrl,
+    batchPath: "batch/calendar/v3",
+    parameters: {},
+    schemas: {
+      CalendarList: {
+        id: "CalendarList",
+        type: "object",
+        description: "A collection of calendars in the authenticated user's calendar list.",
+        properties: {
+          kind: { type: "string", description: "Identifies this as a calendar list." },
+          items: {
+            type: "array",
+            description: "Calendars in the list.",
+            items: { $ref: "CalendarListEntry" },
+          },
+        },
+      },
+      CalendarListEntry: {
+        id: "CalendarListEntry",
+        type: "object",
+        description: "A calendar in the authenticated user's calendar list.",
+        properties: {
+          kind: { type: "string", description: "Identifies this as a calendar list entry." },
+          etag: { type: "string", description: "ETag of the entry." },
+          id: { type: "string", description: "Calendar identifier." },
+          summary: { type: "string", description: "Calendar title." },
+          description: { type: "string", description: "Calendar description." },
+          timeZone: { type: "string", description: "Calendar time zone." },
+          selected: { type: "boolean", description: "Whether the calendar is selected in the UI." },
+          primary: { type: "boolean", description: "Whether this is the authenticated user's primary calendar." },
+          accessRole: { type: "string", description: "Authenticated user's access role for the calendar." },
+          backgroundColor: { type: "string", description: "Calendar background color." },
+          foregroundColor: { type: "string", description: "Calendar foreground color." },
+        },
+      },
+      Events: {
+        id: "Events",
+        type: "object",
+        description: "Events returned from a calendar.",
+        properties: {
+          kind: { type: "string", description: "Identifies this as an events collection." },
+          nextPageToken: { type: "string", description: "Token for the next page of results." },
+          items: {
+            type: "array",
+            description: "Events on the calendar.",
+            items: { $ref: "Event" },
+          },
+        },
+      },
+      Event: {
+        id: "Event",
+        type: "object",
+        description: "A Google Calendar event.",
+        properties: {
+          kind: { type: "string", description: "Identifies this as an event." },
+          etag: { type: "string", description: "ETag of the event." },
+          id: { type: "string", description: "Event identifier." },
+          status: { type: "string", description: "Event status." },
+          htmlLink: { type: "string", description: "Absolute link to the event in Google Calendar." },
+          hangoutLink: { type: "string", description: "Absolute link to the associated video conference." },
+          summary: { type: "string", description: "Event title." },
+          description: { type: "string", description: "Event description." },
+          location: { type: "string", description: "Geographic location of the event." },
+          created: { type: "string", format: "date-time", description: "Creation time." },
+          updated: { type: "string", format: "date-time", description: "Last modification time." },
+          start: { $ref: "EventDateTime", description: "Event start time." },
+          end: { $ref: "EventDateTime", description: "Event end time." },
+          attendees: {
+            type: "array",
+            description: "Event attendees.",
+            items: { $ref: "EventAttendee" },
+          },
+          conferenceData: { $ref: "ConferenceData", description: "Conference details for the event." },
+          transparency: { type: "string", description: "Whether the event blocks time on the calendar." },
+        },
+      },
+      EventDateTime: {
+        id: "EventDateTime",
+        type: "object",
+        description: "An event date or date and time.",
+        properties: {
+          date: { type: "string", format: "date", description: "Date for an all-day event." },
+          dateTime: { type: "string", format: "date-time", description: "Date and time for a timed event." },
+          timeZone: { type: "string", description: "Time zone for the value." },
+        },
+      },
+      EventAttendee: {
+        id: "EventAttendee",
+        type: "object",
+        description: "An attendee of an event.",
+        properties: {
+          email: { type: "string", description: "Attendee email address." },
+          displayName: { type: "string", description: "Attendee display name." },
+          responseStatus: { type: "string", description: "Attendee response status." },
+          organizer: { type: "boolean", description: "Whether the attendee is the organizer." },
+          self: { type: "boolean", description: "Whether this attendee represents the authenticated user." },
+        },
+      },
+      ConferenceData: {
+        id: "ConferenceData",
+        type: "object",
+        description: "Conference information attached to an event.",
+        properties: {
+          entryPoints: {
+            type: "array",
+            description: "Ways to join the conference.",
+            items: { $ref: "EntryPoint" },
+          },
+        },
+      },
+      EntryPoint: {
+        id: "EntryPoint",
+        type: "object",
+        description: "A way to join an event conference.",
+        properties: {
+          entryPointType: { type: "string", description: "Type of conference entry point." },
+          uri: { type: "string", description: "URI for joining the conference." },
+          label: { type: "string", description: "User-visible entry point label." },
+        },
+      },
+      FreeBusyRequest: {
+        id: "FreeBusyRequest",
+        type: "object",
+        description: "A free and busy query.",
+        properties: {
+          timeMin: {
+            type: "string",
+            format: "date-time",
+            description: "Start of the query interval.",
+            required: true,
+          },
+          timeMax: {
+            type: "string",
+            format: "date-time",
+            description: "End of the query interval.",
+            required: true,
+          },
+          items: {
+            type: "array",
+            description: "Calendars to query.",
+            required: true,
+            items: { $ref: "FreeBusyRequestItem" },
+          },
+        },
+      },
+      FreeBusyRequestItem: {
+        id: "FreeBusyRequestItem",
+        type: "object",
+        description: "A calendar requested in a free and busy query.",
+        properties: {
+          id: { type: "string", description: "Calendar identifier.", required: true },
+        },
+      },
+      FreeBusyResponse: {
+        id: "FreeBusyResponse",
+        type: "object",
+        description: "Free and busy information for requested calendars.",
+        properties: {
+          kind: { type: "string", description: "Identifies this as a free and busy response." },
+          timeMin: { type: "string", format: "date-time", description: "Start of the query interval." },
+          timeMax: { type: "string", format: "date-time", description: "End of the query interval." },
+          calendars: {
+            type: "object",
+            description: "Free and busy results keyed by calendar identifier.",
+            additionalProperties: { $ref: "FreeBusyCalendar" },
+          },
+        },
+      },
+      FreeBusyCalendar: {
+        id: "FreeBusyCalendar",
+        type: "object",
+        description: "Free and busy intervals for one calendar.",
+        properties: {
+          busy: {
+            type: "array",
+            description: "Intervals during which the calendar is busy.",
+            items: { $ref: "TimePeriod" },
+          },
+        },
+      },
+      TimePeriod: {
+        id: "TimePeriod",
+        type: "object",
+        description: "A time interval.",
+        properties: {
+          start: { type: "string", format: "date-time", description: "Start of the interval." },
+          end: { type: "string", format: "date-time", description: "End of the interval." },
+        },
+      },
+    },
+    resources: {
+      calendarList: {
+        methods: {
+          list: {
+            id: "calendar.calendarList.list",
+            path: "users/me/calendarList",
+            httpMethod: "GET",
+            description: "Returns the calendars in the authenticated user's calendar list.",
+            parameterOrder: [],
+            parameters: {},
+            response: { $ref: "CalendarList" },
+          },
+        },
+      },
+      events: {
+        methods: {
+          list: {
+            id: "calendar.events.list",
+            path: "calendars/{calendarId}/events",
+            httpMethod: "GET",
+            description: "Returns events on the specified calendar.",
+            parameterOrder: ["calendarId"],
+            parameters: {
+              calendarId: {
+                type: "string",
+                description: "Calendar identifier. Use primary for the authenticated user's primary calendar.",
+                location: "path",
+                required: true,
+              },
+              timeMin: {
+                type: "string",
+                format: "date-time",
+                description: "Lower bound for event end times.",
+                location: "query",
+              },
+              timeMax: {
+                type: "string",
+                format: "date-time",
+                description: "Upper bound for event start times.",
+                location: "query",
+              },
+              maxResults: {
+                type: "integer",
+                format: "int32",
+                description: "Maximum number of events returned on one page.",
+                location: "query",
+                minimum: "1",
+                maximum: "250",
+              },
+              pageToken: {
+                type: "string",
+                description: "Token specifying the result page to return.",
+                location: "query",
+              },
+              q: {
+                type: "string",
+                description: "Free text search terms.",
+                location: "query",
+              },
+              orderBy: {
+                type: "string",
+                description: "Order of events in the result.",
+                location: "query",
+                enum: ["startTime"],
+              },
+              singleEvents: {
+                type: "boolean",
+                description: "Whether recurring events should be expanded into instances.",
+                location: "query",
+              },
+            },
+            response: { $ref: "Events" },
+          },
+          insert: {
+            id: "calendar.events.insert",
+            path: "calendars/{calendarId}/events",
+            httpMethod: "POST",
+            description: "Creates an event on the specified calendar.",
+            parameterOrder: ["calendarId"],
+            parameters: {
+              calendarId: {
+                type: "string",
+                description: "Calendar identifier. Use primary for the authenticated user's primary calendar.",
+                location: "path",
+                required: true,
+              },
+            },
+            request: { $ref: "Event" },
+            response: { $ref: "Event" },
+          },
+          delete: {
+            id: "calendar.events.delete",
+            path: "calendars/{calendarId}/events/{eventId}",
+            httpMethod: "DELETE",
+            description: "Deletes an event.",
+            parameterOrder: ["calendarId", "eventId"],
+            parameters: {
+              calendarId: {
+                type: "string",
+                description: "Calendar identifier. Use primary for the authenticated user's primary calendar.",
+                location: "path",
+                required: true,
+              },
+              eventId: {
+                type: "string",
+                description: "Event identifier.",
+                location: "path",
+                required: true,
+              },
+            },
+          },
+        },
+      },
+      freebusy: {
+        methods: {
+          query: {
+            id: "calendar.freebusy.query",
+            path: "freeBusy",
+            httpMethod: "POST",
+            description: "Returns free and busy information for a set of calendars.",
+            parameterOrder: [],
+            parameters: {},
+            request: { $ref: "FreeBusyRequest" },
+            response: { $ref: "FreeBusyResponse" },
+          },
+        },
+      },
+    },
+  };
+}

--- a/packages/@emulators/google/src/routes/calendar.ts
+++ b/packages/@emulators/google/src/routes/calendar.ts
@@ -1,4 +1,5 @@
 import type { RouteContext } from "@emulators/core";
+import { buildCalendarDiscoveryDocument } from "../calendar-discovery.js";
 import {
   buildFreeBusyResponse,
   createCalendarEventRecord,
@@ -21,8 +22,12 @@ import {
 } from "../route-helpers.js";
 import { getGoogleStore } from "../store.js";
 
-export function calendarRoutes({ app, store }: RouteContext): void {
+export function calendarRoutes({ app, store, baseUrl }: RouteContext): void {
   const gs = getGoogleStore(store);
+
+  app.get("/discovery/v1/apis/calendar/v3/rest", (c) => {
+    return c.json(buildCalendarDiscoveryDocument(baseUrl));
+  });
 
   app.get("/calendar/v3/users/:userId/calendarList", (c) => {
     const authEmail = requireGmailUser(c);

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -24,6 +24,9 @@ Framework adapters:
 GitHub API coverage:
   Includes repository contents, raw downloads, commit history, commit details, and ref comparisons.
 
+Google Calendar discovery:
+  Use /discovery/v1/apis/calendar/v3/rest to configure discovery-based clients against the emulator.
+
 Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.
 `,

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -157,7 +157,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   google: {
     label: "Google OAuth 2.0 / OpenID Connect + Gmail, Calendar, and Drive emulator",
     endpoints:
-      "OAuth authorize, token exchange, userinfo, OIDC discovery, token revocation, Gmail messages/drafts/threads/labels/history/settings, Calendar lists/events/freebusy, Drive files/uploads",
+      "OAuth authorize, token exchange, userinfo, OIDC discovery, token revocation, Gmail messages/drafts/threads/labels/history/settings, Calendar discovery/lists/events/freebusy, Drive files/uploads",
     async load() {
       const mod = await import("@emulators/google");
       return { plugin: mod.googlePlugin, seedFromConfig: mod.seedFromConfig };

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -45,6 +45,7 @@ GOOGLE_EMULATOR_URL=http://localhost:4002
 | `https://accounts.google.com/.well-known/openid-configuration` | `$GOOGLE_EMULATOR_URL/.well-known/openid-configuration` |
 | `https://www.googleapis.com/oauth2/v3/certs` | `$GOOGLE_EMULATOR_URL/oauth2/v3/certs` |
 | `https://gmail.googleapis.com/gmail/v1/...` | `$GOOGLE_EMULATOR_URL/gmail/v1/...` |
+| `https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest` | `$GOOGLE_EMULATOR_URL/discovery/v1/apis/calendar/v3/rest` |
 | `https://www.googleapis.com/calendar/v3/...` | `$GOOGLE_EMULATOR_URL/calendar/v3/...` |
 | `https://www.googleapis.com/drive/v3/...` | `$GOOGLE_EMULATOR_URL/drive/v3/...` |
 
@@ -468,6 +469,34 @@ curl http://localhost:4002/gmail/v1/users/me/settings/sendAs \
 ```
 
 ## Google Calendar API
+
+### Google API Discovery
+
+The Calendar discovery document is public. It advertises the configured emulator base URL, including any adapter mount path. Calendar method calls still require a bearer token.
+
+```bash
+curl "$GOOGLE_EMULATOR_URL/discovery/v1/apis/calendar/v3/rest"
+```
+
+Pass the emulator discovery template explicitly when constructing `google-api-python-client`. Plain `build("calendar", "v3")` uses Google's default discovery source.
+
+```python
+import os
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+emulator_url = os.environ.get("GOOGLE_EMULATOR_URL", "http://localhost:4002")
+calendar = build(
+    "calendar",
+    "v3",
+    discoveryServiceUrl=f"{emulator_url}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest",
+    credentials=Credentials(token="local-test-token"),
+    cache_discovery=False,
+)
+
+events = calendar.events().list(calendarId="primary", maxResults=10).execute()
+```
 
 ### Calendar List
 


### PR DESCRIPTION
## Summary

Add a public `GET /discovery/v1/apis/calendar/v3/rest` endpoint that describes the five Calendar v3 methods supported by the Google emulator: calendar list, event listing, event creation, event deletion, and free/busy queries. The minimal Discovery v1 document includes the request and response schema graph needed to construct those calls without advertising unsupported Calendar operations.

Build the document's root and base URLs from the configured emulator URL so discovery-generated clients preserve adapter mount prefixes. Discovery remains public, while calls to the advertised Calendar methods continue to require bearer authentication.

Document how to configure discovery-based clients explicitly against the emulator, and surface the new endpoint in the CLI help and Google service registry. This closes the compatibility gap for clients such as `google-api-python-client` that construct Calendar services from discovery metadata.