### PR TITLE
feat(sepay): SePay emulator + fix(resend): Svix webhook delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ All services start with sensible defaults. No config file needed:
 
 Stripe webhooks configured with a secret include a `Stripe-Signature` header signed over the timestamp and raw request body.
 
+Resend webhooks configured via `resend.webhook_targets` deliver `email.*`/`domain.*`/`contact.*` events with Svix-style headers (`svix-id`, `svix-timestamp`, `svix-signature: v1,<base64 HMAC-SHA256>`). Omitted `signing_secret` values auto-generate as Svix-format secrets (`whsec_<base64>`) and surface in `generatedSecrets`.
+
 ## CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All services start with sensible defaults. No config file needed:
 - **Clerk** on `http://localhost:4011`
 - **Linear** on `http://localhost:4012`
 - **Twilio** on `http://localhost:4013`
+- **SePay** on `http://localhost:4014`
 
 Stripe webhooks configured with a secret include a `Stripe-Signature` header signed over the timestamp and raw request body.
 
@@ -57,14 +58,14 @@ npx emulate list
 
 ### Options
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `-p, --port` | `4000` | Base port (auto-increments per service) |
-| `-s, --service` | all | Comma-separated services to enable |
-| `--seed` | auto-detect | Path to seed config (YAML or JSON) |
-| `--base-url` | none | Override advertised base URL (supports `{service}` template) |
-| `--portless` | off | Serve over HTTPS via portless (auto-registers aliases) |
-| `--generated-secrets-file` | none | Generate omitted service secrets and write them to a new owner-only JSON file |
+| Flag                       | Default     | Description                                                                   |
+| -------------------------- | ----------- | ----------------------------------------------------------------------------- |
+| `-p, --port`               | `4000`      | Base port (auto-increments per service)                                       |
+| `-s, --service`            | all         | Comma-separated services to enable                                            |
+| `--seed`                   | auto-detect | Path to seed config (YAML or JSON)                                            |
+| `--base-url`               | none        | Override advertised base URL (supports `{service}` template)                  |
+| `--portless`               | off         | Serve over HTTPS via portless (auto-registers aliases)                        |
+| `--generated-secrets-file` | none        | Generate omitted service secrets and write them to a new owner-only JSON file |
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 
@@ -116,39 +117,41 @@ npm install emulate
 Each call to `createEmulator` starts a single service:
 
 ```typescript
-import { createEmulator } from 'emulate'
+import { createEmulator } from "emulate";
 
-const github = await createEmulator({ service: 'github', port: 4001 })
-const vercel = await createEmulator({ service: 'vercel', port: 4002 })
+const github = await createEmulator({ service: "github", port: 4001 });
+const vercel = await createEmulator({ service: "vercel", port: 4002 });
 
-github.url   // 'http://localhost:4001'
-vercel.url   // 'http://localhost:4002'
+github.url; // 'http://localhost:4001'
+vercel.url; // 'http://localhost:4002'
 
-await github.close()
-await vercel.close()
+await github.close();
+await vercel.close();
 ```
 
 When a GitHub App omits `private_key`, `createEmulator` generates an RSA-2048 PKCS#1 key for that emulator instance:
 
 ```typescript
 const github = await createEmulator({
-  service: 'github',
+  service: "github",
   seed: {
     github: {
-      users: [{ login: 'octocat' }],
-      apps: [{
-        app_id: 12345,
-        slug: 'my-github-app',
-        name: 'My GitHub App',
-        installations: [{ installation_id: 100, account: 'octocat' }],
-      }],
+      users: [{ login: "octocat" }],
+      apps: [
+        {
+          app_id: 12345,
+          slug: "my-github-app",
+          name: "My GitHub App",
+          installations: [{ installation_id: 100, account: "octocat" }],
+        },
+      ],
     },
   },
-})
+});
 
 const privateKey = github.generatedSecrets.find(
-  secret => secret.kind === 'github.app_private_key' && secret.id === '12345',
-)?.value
+  (secret) => secret.kind === "github.app_private_key" && secret.id === "12345",
+)?.value;
 ```
 
 Generated keys remain stable across `reset()` calls and appear only in `generatedSecrets`. Explicitly configured keys are never returned there. A new `createEmulator` call generates a new key.
@@ -166,41 +169,44 @@ The destination must not exist. emulate removes inherited ACLs, verifies effecti
 
 ```typescript
 // vitest.setup.ts
-import { createEmulator, type Emulator } from 'emulate'
+import { createEmulator, type Emulator } from "emulate";
 
-let github: Emulator
-let vercel: Emulator
+let github: Emulator;
+let vercel: Emulator;
 
 beforeAll(async () => {
-  ;[github, vercel] = await Promise.all([
-    createEmulator({ service: 'github', port: 4001 }),
-    createEmulator({ service: 'vercel', port: 4002 }),
-  ])
-  process.env.GITHUB_EMULATOR_URL = github.url
-  process.env.VERCEL_EMULATOR_URL = vercel.url
-})
+  [github, vercel] = await Promise.all([
+    createEmulator({ service: "github", port: 4001 }),
+    createEmulator({ service: "vercel", port: 4002 }),
+  ]);
+  process.env.GITHUB_EMULATOR_URL = github.url;
+  process.env.VERCEL_EMULATOR_URL = vercel.url;
+});
 
-afterEach(() => { github.reset(); vercel.reset() })
-afterAll(() => Promise.all([github.close(), vercel.close()]))
+afterEach(() => {
+  github.reset();
+  vercel.reset();
+});
+afterAll(() => Promise.all([github.close(), vercel.close()]));
 ```
 
 ### Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `service` | *(required)* | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, or `'twilio'` |
-| `port` | `4000` | Port for the HTTP server |
-| `seed` | none | Inline seed data (same shape as YAML config) |
-| `baseUrl` | none | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
+| Option    | Default      | Description                                                                                                                                                                                                                                                                                       |
+| --------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `service` | _(required)_ | Service name: `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, `'okta'`, `'aws'`, `'resend'`, `'stripe'`, `'mongoatlas'`, `'clerk'`, `'linear'`, `'twilio'`, or `'sepay'`                                                                                                 |
+| `port`    | `4000`       | Port for the HTTP server                                                                                                                                                                                                                                                                          |
+| `seed`    | none         | Inline seed data (same shape as YAML config)                                                                                                                                                                                                                                                      |
+| `baseUrl` | none         | Override advertised base URL. Per-service `baseUrl` in seed config takes highest priority, then this option, then `EMULATE_BASE_URL` env var (supports `{service}`), then `PORTLESS_URL` (supports `{service}`, automatically set by the `portless` CLI wrapper), then `http://localhost:<port>`. |
 
 ### Instance methods
 
-| Method | Description |
-|--------|-------------|
-| `url` | Base URL of the running server |
+| Method             | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| `url`              | Base URL of the running server                       |
 | `generatedSecrets` | Readonly secrets generated while preparing seed data |
-| `reset()` | Wipe the store and replay seed data |
-| `close()` | Shut down the HTTP server, returns a Promise |
+| `reset()`          | Wipe the store and replay seed data                  |
+| `close()`          | Shut down the HTTP server, returns a Promise         |
 
 ## Configuration
 
@@ -525,6 +531,7 @@ github:
 JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's private key (RS256). The emulator verifies the signature and resolves the app.
 
 **App webhook delivery**: When events occur on repos where a GitHub App is installed, the emulator mirrors real GitHub behavior:
+
 - All webhook payloads (including repo and org hooks) include an `installation` field with `{ id, node_id }`.
 - If the app has a `webhook_url`, the emulator delivers the event there with the `installation` field and (if configured) an `X-Hub-Signature-256` header signed with `webhook_secret`.
 
@@ -583,6 +590,7 @@ microsoft:
 Every endpoint below is fully stateful with Vercel-style JSON responses and cursor-based pagination.
 
 ### User & Teams
+
 - `GET /v2/user` - authenticated user
 - `PATCH /v2/user` - update user
 - `GET /v2/teams` - list teams (cursor paginated)
@@ -593,6 +601,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `POST /v2/teams/:teamId/members` - add member
 
 ### Projects
+
 - `POST /v11/projects` - create project (with optional env vars and git integration)
 - `GET /v10/projects` - list projects (search, cursor pagination)
 - `GET /v9/projects/:idOrName` - get project (includes env vars)
@@ -602,6 +611,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `PATCH /v1/projects/:idOrName/protection-bypass` - manage bypass secrets
 
 ### Deployments
+
 - `POST /v13/deployments` - create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` - get deployment (by ID or URL)
 - `GET /v6/deployments` - list deployments (filter by project, target, state)
@@ -613,6 +623,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `POST /v2/files` - upload file (by SHA digest)
 
 ### Domains
+
 - `POST /v10/projects/:idOrName/domains` - add domain (with verification challenge)
 - `GET /v9/projects/:idOrName/domains` - list domains
 - `GET /v9/projects/:idOrName/domains/:domain` - get domain
@@ -621,6 +632,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `POST /v9/projects/:idOrName/domains/:domain/verify` - verify domain
 
 ### Environment Variables
+
 - `GET /v10/projects/:idOrName/env` - list env vars (with decrypt option)
 - `POST /v10/projects/:idOrName/env` - create env vars (single, batch, upsert)
 - `GET /v10/projects/:idOrName/env/:id` - get env var
@@ -628,6 +640,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `DELETE /v9/projects/:idOrName/env/:id` - delete env var
 
 ### Blob
+
 Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`).
 
 - `PUT /api/blob?pathname=<path>` - upload a blob (honors `x-add-random-suffix`, `x-allow-overwrite`, `x-content-type`, `x-cache-control-max-age`, `x-if-match` headers)
@@ -650,6 +663,7 @@ Any token of the form `vercel_blob_rw_<storeId>_<secret>` is accepted; the store
 Every endpoint below is fully stateful. Creates, updates, and deletes persist in memory and affect related entities.
 
 ### Users
+
 - `GET /user` - authenticated user
 - `PATCH /user` - update profile
 - `GET /users/:username` - get user
@@ -660,6 +674,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /users/:username/following` - list following
 
 ### Repositories
+
 - `GET /repos/:owner/:repo` - get repo
 - `GET /repositories/:id` - get repo by numeric ID
 - `POST /user/repos` - create user repo
@@ -677,6 +692,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /repos/:owner/:repo/tags` - list tags
 
 ### Contents & Commit History
+
 - `GET /repos/:owner/:repo/readme` - get the repository README
 - `GET /repos/:owner/:repo/contents/:path` - get a file or list a directory at a ref
 - `GET /:owner/:repo/raw/:ref/:path` - download file content from advertised raw URLs
@@ -686,6 +702,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /repos/:owner/:repo/compare/:base...:head` - compare two refs
 
 ### Issues
+
 - `GET /repos/:owner/:repo/issues` - list (filter by state, labels, assignee, milestone, creator, since)
 - `POST /repos/:owner/:repo/issues` - create
 - `GET /repos/:owner/:repo/issues/:number` - get
@@ -696,6 +713,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `POST/DELETE /repos/:owner/:repo/issues/:number/assignees` - manage assignees
 
 ### Pull Requests
+
 - `GET /repos/:owner/:repo/pulls` - list (filter by state, head, base)
 - `POST /repos/:owner/:repo/pulls` - create
 - `GET /repos/:owner/:repo/pulls/:number` - get
@@ -707,12 +725,14 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `PUT /repos/:owner/:repo/pulls/:number/update-branch` - update branch
 
 ### Comments
+
 - Issue comments: full CRUD on `/repos/:owner/:repo/issues/:number/comments`
 - Review comments: full CRUD on `/repos/:owner/:repo/pulls/:number/comments`
 - Commit comments: full CRUD on `/repos/:owner/:repo/commits/:sha/comments`
 - Repo-wide listings for each type
 
 ### Reviews
+
 - `GET /repos/:owner/:repo/pulls/:number/reviews` - list
 - `POST /repos/:owner/:repo/pulls/:number/reviews` - create (with inline comments)
 - `GET/PUT /repos/:owner/:repo/pulls/:number/reviews/:id` - get/update
@@ -720,10 +740,12 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `PUT /repos/:owner/:repo/pulls/:number/reviews/:id/dismissals` - dismiss
 
 ### Labels & Milestones
+
 - Labels: full CRUD, add/remove from issues, replace all
 - Milestones: full CRUD, state transitions, issue counts
 
 ### Branches & Git Data
+
 - Branches: list, get, protection CRUD (status checks, PR reviews, enforce admins)
 - Refs: get, match, create, update, delete
 - Commits: get, create
@@ -732,21 +754,25 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - Tags: get, create
 
 ### Organizations & Teams
+
 - Orgs: get, update, list
 - Org members: list, check, remove, get/set membership
 - Teams: full CRUD, members, repos
 
 ### Releases
+
 - Releases: full CRUD, latest, by tag
 - Release assets: full CRUD, upload
 - Generate release notes
 
 ### Webhooks
+
 - Repo webhooks: full CRUD, ping, test, deliveries
 - Org webhooks: full CRUD, ping
 - Real HTTP delivery to registered URLs on all state changes
 
 ### Search
+
 - `GET /search/repositories` - full query syntax (user, org, language, topic, stars, forks, etc.)
 - `GET /search/issues` - issues + PRs (repo, is, author, label, milestone, state, etc.)
 - `GET /search/users` - users + orgs
@@ -756,6 +782,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /search/labels` - label search
 
 ### Actions
+
 - Workflows: list, get, enable/disable, dispatch
 - Workflow runs: list, get, cancel, rerun, delete, logs
 - Jobs: list, get, logs
@@ -763,11 +790,13 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - Secrets: repo + org CRUD
 
 ### Checks
+
 - Check runs: create, update, get, annotations, rerequest, list by ref/suite
 - Check suites: create, get, preferences, rerequest, list by ref
 - Automatic suite status rollup from check run results
 
 ### Misc
+
 - `GET /rate_limit` - rate limit status
 - `GET /meta` - server metadata
 - `GET /octocat` - ASCII art
@@ -808,6 +837,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, user profiles, presence, modern file uploads, pins, bookmarks, views, OAuth v2, and incoming webhooks. Chat writes preserve common rich message fields such as `blocks`, `attachments`, `metadata`, formatting flags, unfurl flags, and client message ids. Conversation writes update archive state, names, topics, purposes, membership, DMs, MPIMs, and read cursors. User writes update profile fields, status, custom fields, and deterministic active or away presence. File writes support the current external upload flow with local upload URLs, file share messages, reads, lists, downloads, and deletes. Pin and bookmark writes support channel message pins and link bookmarks. View writes support App Home publishing and modal stacks. Seeded OAuth apps and OAuth installs create bot users and installation records. OAuth exchanges and explicit token seeds create scoped token records. Supported write state changes dispatch Slack `event_callback` payloads to configured webhook URLs.
 
 ### Auth & Chat
+
 - `POST /api/auth.test` - test authentication
 - `POST /api/chat.postMessage` - post message with text or rich payload fields (supports threads via `thread_ts` and DM user IDs)
 - `POST /api/chat.postEphemeral` - post ephemeral message outside channel history
@@ -820,6 +850,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/chat.meMessage` - /me message
 
 ### Conversations
+
 - `POST /api/conversations.list` - list conversations (cursor pagination, `types`, `exclude_archived`)
 - `POST /api/conversations.info` - get channel info
 - `POST /api/conversations.create` - create channel
@@ -835,6 +866,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/conversations.members` - list members
 
 ### Users & Reactions
+
 - `POST /api/users.list` - list users (cursor pagination)
 - `POST /api/users.info` - get user info
 - `POST /api/users.lookupByEmail` - lookup by email
@@ -845,6 +877,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/reactions.add` / `reactions.remove` / `reactions.get` - manage reactions
 
 ### Files
+
 - `POST /api/files.getUploadURLExternal` - create a local external upload session
 - `POST /upload/v1/:fileId` - receive raw uploaded file bytes
 - `POST /api/files.completeUploadExternal` - complete uploads and optionally share file messages
@@ -854,6 +887,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/files.delete` - delete a completed file
 
 ### Pins & Bookmarks
+
 - `POST /api/pins.add` - pin a message to a channel
 - `GET /api/pins.list` / `POST /api/pins.list` - list pinned message items for a channel
 - `POST /api/pins.remove` - remove a message pin from a channel
@@ -863,6 +897,7 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 - `POST /api/bookmarks.remove` - remove a bookmark from a channel
 
 ### Views
+
 - `POST /api/views.publish` - publish or update an App Home view for a user
 - `POST /api/views.open` - open a modal view
 - `POST /api/views.update` - update a view by `view_id` or `external_id`
@@ -872,16 +907,19 @@ Fully stateful Slack Web API emulation with channels, messages, threads, reactio
 Modal opens and pushes require values from `/api/views.generateTriggerId`. Pass the returned value as `trigger_id` or `interactivity_pointer`; generate push values with an existing `view_id` and use them within 3 seconds.
 
 ### Team, Bots & Webhooks
+
 - `POST /api/team.info` - workspace info
 - `POST /api/bots.info` - bot info
 - `POST /services/:teamId/:botId/:webhookId` - incoming webhook with text or rich payload fields
 
 ### OAuth
+
 - `GET /oauth/v2/authorize` - authorization (shows user picker)
 - `POST /oauth/v2/authorize/callback` - local user picker callback that creates the auth code
 - `POST /api/oauth.v2.access` - token exchange
 
 ### Inspector
+
 - `GET /` - tabbed local inspector for conversations, messages, files, views, auth records, incoming webhooks, event subscriptions, and event deliveries
 
 Slack scope checks are relaxed by default so local tests can use simple bearer tokens. Set `slack.strict_scopes: true` in seed config to make supported Web API methods return Slack-style `missing_scope` errors with `needed` and `provided` fields. Strict mode checks `chat:write`, `channels:read`, `channels:history`, `channels:join`, `channels:manage`, `channels:write`, `groups:read`, `groups:history`, `groups:write`, `im:read`, `im:history`, `im:write`, `mpim:read`, `mpim:history`, `mpim:write`, `users:read`, `users:read.email`, `users.profile:read`, `users.profile:write`, `users:write`, `files:read`, `files:write`, `pins:read`, `pins:write`, `bookmarks:read`, `bookmarks:write`, `reactions:read`, `reactions:write`, and `team:read`. Slack lists no method-specific scopes for `views.publish`, `views.open`, `views.update`, or `views.push`, so the emulator requires auth but does not add strict-scope checks for those methods.
@@ -974,6 +1012,29 @@ To test inbound SMS webhooks, configure a seeded phone number `sms_url`, then ca
 
 Current Twilio limits: no carrier delivery, A2P 10DLC, toll-free verification, real phone number purchasing, exact rate limits, Studio, Flex, TaskRouter, Video, Sync, Segment, SendGrid, Conversations SDK websocket behavior, or complete TwiML interpreter.
 
+## SePay API
+
+SePay VietQR payment gateway emulation: the v1 transaction query API (`my.sepay.vn/userapi`), inbound-to-merchant webhook delivery with bearer webhook keys, VietQR image generation, and a local simulator for creating bank transactions. No real bank traffic is performed.
+
+Default local credentials:
+
+```text
+SEPAY_API_KEY=sepay_test_api_key
+SEPAY_WEBHOOK_API_KEY=sepay_test_webhook_key
+```
+
+### REST Routes
+
+- `GET /userapi/transactions/list` - list transactions (filters: `account_number`, `reference_number`, `since_id`, `amount_in`, `amount_out`, `limit`, `offset`)
+- `GET /userapi/transactions/details/{id}` - get transaction details
+- `GET /img?acc=&bank=&amount=&des=` - generate a VietQR PNG encoding an EMVCo payload (also at `/qr/img`)
+
+All `/userapi/*` routes require `Authorization: Bearer <API_KEY>` and return 401 otherwise, matching the real gateway.
+
+### Simulator And Webhooks
+
+- `POST /userapi/simulate/transaction` - create a transaction in the store and POST the SePay webhook payload (`id`, `gateway`, `transactionDate`, `accountNumber`, `subAccount`, `amountIn`, `amountOut`, `accumulated`, `code`, `transactionContent`, `referenceNumber`, `body`) to every seeded webhook target with header `Authorization: Bearer <target webhook api key>`. Each attempt is recorded in the store with target URL, request body, status code, and timestamp for assertions.
+
 ## Apple Sign In
 
 Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
@@ -1018,19 +1079,25 @@ S3 routes use root paths matching the real AWS S3 wire format, so the official A
 - `DELETE /:bucket/:key` - delete object
 
 ### SQS
+
 All operations via `POST /sqs/` with `Action` parameter:
+
 - `CreateQueue`, `ListQueues`, `GetQueueUrl`, `GetQueueAttributes`
 - `SendMessage`, `ReceiveMessage`, `DeleteMessage`
 - `PurgeQueue`, `DeleteQueue`
 
 ### IAM
+
 All operations via `POST /iam/` with `Action` parameter:
+
 - `CreateUser`, `GetUser`, `ListUsers`, `DeleteUser`
 - `CreateAccessKey`, `ListAccessKeys`, `DeleteAccessKey`
 - `CreateRole`, `GetRole`, `ListRoles`, `DeleteRole`
 
 ### STS
+
 All operations via `POST /sts/` with `Action` parameter:
+
 - `GetCallerIdentity`, `AssumeRole`
 
 ## Next.js Integration
@@ -1051,27 +1118,27 @@ Create a catch-all route that serves emulator traffic:
 
 ```typescript
 // app/emulate/[...path]/route.ts
-import { createEmulateHandler } from '@emulators/adapter-next'
-import * as github from '@emulators/github'
-import * as google from '@emulators/google'
+import { createEmulateHandler } from "@emulators/adapter-next";
+import * as github from "@emulators/github";
+import * as google from "@emulators/google";
 
 export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
   services: {
     github: {
       emulator: github,
       seed: {
-        users: [{ login: 'octocat', name: 'The Octocat' }],
-        repos: [{ owner: 'octocat', name: 'hello-world', auto_init: true }],
+        users: [{ login: "octocat", name: "The Octocat" }],
+        repos: [{ owner: "octocat", name: "hello-world", auto_init: true }],
       },
     },
     google: {
       emulator: google,
       seed: {
-        users: [{ email: 'test@example.com', name: 'Test User' }],
+        users: [{ email: "test@example.com", name: "Test User" }],
       },
     },
   },
-})
+});
 ```
 
 ### Auth.js / NextAuth configuration
@@ -1079,19 +1146,17 @@ export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
 Point your provider at the emulator paths on the same origin:
 
 ```typescript
-import GitHub from 'next-auth/providers/github'
+import GitHub from "next-auth/providers/github";
 
-const baseUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : 'http://localhost:3000'
+const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000";
 
 GitHub({
-  clientId: 'any-value',
-  clientSecret: 'any-value',
+  clientId: "any-value",
+  clientSecret: "any-value",
   authorization: { url: `${baseUrl}/emulate/github/login/oauth/authorize` },
   token: { url: `${baseUrl}/emulate/github/login/oauth/access_token` },
   userinfo: { url: `${baseUrl}/emulate/github/user` },
-})
+});
 ```
 
 No `oauth_apps` need to be seeded. When none are configured, the emulator skips `client_id`, `client_secret`, and `redirect_uri` validation.
@@ -1102,17 +1167,17 @@ Emulator UI pages use bundled fonts. Wrap your Next.js config to include them in
 
 ```typescript
 // next.config.mjs
-import { withEmulate } from '@emulators/adapter-next'
+import { withEmulate } from "@emulators/adapter-next";
 
 export default withEmulate({
   // your normal Next.js config
-})
+});
 ```
 
 If you mount the catch-all at a custom path, pass the matching prefix:
 
 ```typescript
-export default withEmulate(nextConfig, { routePrefix: '/api/emulate' })
+export default withEmulate(nextConfig, { routePrefix: "/api/emulate" });
 ```
 
 ### Persistence
@@ -1120,18 +1185,22 @@ export default withEmulate(nextConfig, { routePrefix: '/api/emulate' })
 By default, emulator state is in-memory and resets on every cold start. To persist state across restarts, pass a `persistence` adapter:
 
 ```typescript
-import { createEmulateHandler } from '@emulators/adapter-next'
-import * as github from '@emulators/github'
+import { createEmulateHandler } from "@emulators/adapter-next";
+import * as github from "@emulators/github";
 
 const kvAdapter = {
-  async load() { return await kv.get('emulate-state') },
-  async save(data: string) { await kv.set('emulate-state', data) },
-}
+  async load() {
+    return await kv.get("emulate-state");
+  },
+  async save(data: string) {
+    await kv.set("emulate-state", data);
+  },
+};
 
 export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
   services: { github: { emulator: github } },
   persistence: kvAdapter,
-})
+});
 ```
 
 For local development, `@emulators/core` ships `filePersistence`:
@@ -1163,27 +1232,29 @@ Create a named catch-all route that serves emulator traffic:
 
 ```typescript
 // server/routes/emulate/[...path].ts
-import { createEmulateHandler } from '@emulators/adapter-nuxt'
-import * as github from '@emulators/github'
-import * as google from '@emulators/google'
+import { createEmulateHandler } from "@emulators/adapter-nuxt";
+import * as github from "@emulators/github";
+import * as google from "@emulators/google";
 
-export default defineEventHandler(createEmulateHandler({
-  services: {
-    github: {
-      emulator: github,
-      seed: {
-        users: [{ login: 'octocat', name: 'The Octocat' }],
-        repos: [{ owner: 'octocat', name: 'hello-world', auto_init: true }],
+export default defineEventHandler(
+  createEmulateHandler({
+    services: {
+      github: {
+        emulator: github,
+        seed: {
+          users: [{ login: "octocat", name: "The Octocat" }],
+          repos: [{ owner: "octocat", name: "hello-world", auto_init: true }],
+        },
+      },
+      google: {
+        emulator: google,
+        seed: {
+          users: [{ email: "test@example.com", name: "Test User" }],
+        },
       },
     },
-    google: {
-      emulator: google,
-      seed: {
-        users: [{ email: 'test@example.com', name: 'Test User' }],
-      },
-    },
-  },
-}))
+  }),
+);
 ```
 
 ### Nuxt config
@@ -1192,11 +1263,13 @@ Emulator UI pages use bundled fonts. Wrap your Nuxt config so Nitro traces the c
 
 ```typescript
 // nuxt.config.ts
-import { withEmulate } from '@emulators/adapter-nuxt'
+import { withEmulate } from "@emulators/adapter-nuxt";
 
-export default defineNuxtConfig(withEmulate({
-  // your normal Nuxt config
-}))
+export default defineNuxtConfig(
+  withEmulate({
+    // your normal Nuxt config
+  }),
+);
 ```
 
 ### OAuth configuration
@@ -1204,15 +1277,15 @@ export default defineNuxtConfig(withEmulate({
 Point your OAuth provider at the emulator paths on the same origin:
 
 ```typescript
-const baseUrl = process.env.NUXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+const baseUrl = process.env.NUXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 
 export const githubOAuth = {
-  clientId: 'any-value',
-  clientSecret: 'any-value',
+  clientId: "any-value",
+  clientSecret: "any-value",
   authorizationUrl: `${baseUrl}/emulate/github/login/oauth/authorize`,
   tokenUrl: `${baseUrl}/emulate/github/login/oauth/access_token`,
   userInfoUrl: `${baseUrl}/emulate/github/user`,
-}
+};
 ```
 
 No `oauth_apps` need to be seeded. When none are configured, the emulator skips `client_id`, `client_secret`, and `redirect_uri` validation.
@@ -1222,18 +1295,24 @@ No `oauth_apps` need to be seeded. When none are configured, the emulator skips 
 By default, emulator state is in-memory and resets on every cold start. To persist state across restarts, pass a `persistence` adapter:
 
 ```typescript
-import { createEmulateHandler } from '@emulators/adapter-nuxt'
-import * as github from '@emulators/github'
+import { createEmulateHandler } from "@emulators/adapter-nuxt";
+import * as github from "@emulators/github";
 
 const storageAdapter = {
-  async load() { return await useStorage('emulate').getItem<string>('state') },
-  async save(data: string) { await useStorage('emulate').setItem('state', data) },
-}
+  async load() {
+    return await useStorage("emulate").getItem<string>("state");
+  },
+  async save(data: string) {
+    await useStorage("emulate").setItem("state", data);
+  },
+};
 
-export default defineEventHandler(createEmulateHandler({
-  services: { github: { emulator: github } },
-  persistence: storageAdapter,
-}))
+export default defineEventHandler(
+  createEmulateHandler({
+    services: { github: { emulator: github } },
+    persistence: storageAdapter,
+  }),
+);
 ```
 
 The persistence adapter is called on cold start (load) and after every mutating request (save). Saves are serialized via an internal queue to prevent race conditions.
@@ -1253,6 +1332,7 @@ packages/
     slack/          # Slack Web API, OAuth v2, incoming webhooks
     linear/         # Linear GraphQL API, OAuth, webhooks
     twilio/         # Twilio Messaging, Verify, Voice, webhooks
+    sepay/          # SePay VietQR payments, transactions, webhooks
     apple/          # Apple Sign In / OIDC
     microsoft/      # Microsoft Entra ID OAuth 2.0 / OIDC + Graph /me
     aws/            # AWS S3, SQS, IAM, STS
@@ -1277,6 +1357,8 @@ Tokens are configured in the seed config and map to users. Pass them as `Authori
 **Linear**: GraphQL accepts `Authorization: Bearer <token>` or a bare personal API key value. Seeded Linear tokens map to users or app actors, OAuth apps support local authorization code and client credentials flows, and optional strict scope mode checks supported GraphQL operations.
 
 **Twilio**: HTTP Basic auth accepts the seeded Account SID/Auth Token pair or API Key/API Secret pair. Product-host APIs are exposed under local prefixes such as `/messaging/v1` and `/verify/v2`; the 2010 API lives at `/2010-04-01`.
+
+**SePay**: `/userapi/*` routes require `Authorization: Bearer <api key>` validated against the seeded API keys (401 otherwise). Webhook deliveries to seeded targets carry `Authorization: Bearer <webhook api key>` per target.
 
 **Apple**: OIDC authorization code flow with RS256 ID tokens. On first auth per user/client pair, a `user` JSON blob is included.
 

--- a/apps/web/app/docs/sepay/layout.tsx
+++ b/apps/web/app/docs/sepay/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("sepay");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/app/docs/sepay/page.mdx
+++ b/apps/web/app/docs/sepay/page.mdx
@@ -1,0 +1,97 @@
+# SePay
+
+SePay VietQR payment gateway emulation: the v1 transaction query API, inbound-to-merchant webhook delivery, VietQR image generation, and a local transaction simulator.
+
+## Auth
+
+All `/userapi/*` routes require `Authorization: Bearer <API_KEY>` matching a seeded API key. Missing or invalid keys return 401.
+
+Default credentials:
+
+- API key: `sepay_test_api_key`
+- Webhook API key (fallback for targets without an explicit key): `sepay_test_webhook_key`
+
+## Transactions
+
+- `GET /userapi/transactions/list` — list transactions (newest first)
+  - Filters: `account_number`, `reference_number`, `since_id`, `amount_in`, `amount_out`, `limit` (max 5000), `offset`
+- `GET /userapi/transactions/details/:id` — get transaction details
+- `GET /userapi/transactions/:id` — alias of details
+
+Response shape matches the real v1 API:
+
+```json
+{
+  "status": 200,
+  "error": null,
+  "messages": { "success": true },
+  "transactions": [
+    {
+      "id": "100001",
+      "gateway": "Vietcombank",
+      "bank_brand_name": "Vietcombank",
+      "account_number": "0071000888888",
+      "sub_account": null,
+      "transaction_date": "2026-01-15 09:30:00",
+      "transfer_type": "in",
+      "amount_in": "250000.00",
+      "amount_out": "0.00",
+      "accumulated": "0.00",
+      "code": "ORD1001",
+      "transaction_content": "ORD1001 thanh toan don hang",
+      "reference_number": "FT26011509300001"
+    }
+  ]
+}
+```
+
+## Transaction Simulator
+
+`POST /userapi/simulate/transaction` creates a transaction in the store and fires the SePay webhook payload to every seeded webhook target. Body fields are camelCase:
+
+```json
+{
+  "id": "optional-id",
+  "gateway": "Vietcombank",
+  "accountNumber": "0071000888888",
+  "amountIn": 250000,
+  "code": "ORDER123",
+  "content": "payment content",
+  "referenceNumber": "FT260115..."
+}
+```
+
+Webhook deliveries POST JSON with header `Authorization: Bearer <target webhook api key>` and payload `{ id, gateway, transactionDate, accountNumber, subAccount, amountIn, amountOut, accumulated, code, transactionContent, referenceNumber, body }`. Each attempt is recorded in the store with target URL, request body, status code, success flag, error, and timestamp.
+
+## VietQR Image
+
+- `GET /img?acc=<account>&bank=<bin>&amount=<vnd>&des=<description>` — PNG QR encoding an EMVCo VietQR payload with CRC16 checksum (also available at `/qr/img`)
+
+## Seed Config
+
+```yaml
+sepay:
+  api_keys:
+    - token: sepay_test_api_key
+      label: Local API Key
+  webhook_targets:
+    - url: http://localhost:3000/api/payments/sepay/webhook
+      api_key: sepay_test_webhook_key
+  bank_accounts:
+    - bin: "970436"
+      account_number: "0071000888888"
+      name: NGUYEN VAN A
+  transactions:
+    - id: 100001
+      transferType: in
+      amount: 250000
+      code: ORD1001
+      content: "ORD1001 thanh toan don hang"
+      referenceNumber: FT26011509300001
+```
+
+Omitted API keys and target keys are generated automatically and reported through `generatedSecrets` when using the programmatic API or `--generated-secrets-file`.
+
+## Current Limits
+
+No real bank connections, API v2 endpoints, virtual accounts, bank account listing endpoints, transaction count endpoint, rate limiting, or webhook retries.

--- a/apps/web/components/docs-mobile-nav.tsx
+++ b/apps/web/components/docs-mobile-nav.tsx
@@ -35,6 +35,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/sepay", label: "SePay" },
     ],
   },
   {

--- a/apps/web/components/docs-nav.tsx
+++ b/apps/web/components/docs-nav.tsx
@@ -33,6 +33,7 @@ const sections: NavSection[] = [
       { href: "/docs/mongoatlas", label: "MongoDB Atlas" },
       { href: "/docs/resend", label: "Resend" },
       { href: "/docs/stripe", label: "Stripe" },
+      { href: "/docs/sepay", label: "SePay" },
     ],
   },
   {

--- a/apps/web/components/hero-terminal.tsx
+++ b/apps/web/components/hero-terminal.tsx
@@ -14,6 +14,7 @@ const services = [
   { name: "MongoDB Atlas", port: 4008, slug: "mongoatlas" },
   { name: "Resend", port: 4009, slug: "resend" },
   { name: "Stripe", port: 4010, slug: "stripe" },
+  { name: "SePay", port: 4011, slug: "sepay" },
 ];
 
 export function HeroTerminal({ pixelFont }: { pixelFont: string }) {

--- a/apps/web/lib/docs-navigation.ts
+++ b/apps/web/lib/docs-navigation.ts
@@ -22,6 +22,7 @@ export const allDocsPages: NavItem[] = [
   { name: "MongoDB Atlas", href: "/docs/mongoatlas" },
   { name: "Resend", href: "/docs/resend" },
   { name: "Stripe", href: "/docs/stripe" },
+  { name: "SePay", href: "/docs/sepay" },
   { name: "Authentication", href: "/docs/authentication" },
   { name: "Architecture", href: "/docs/architecture" },
 ];

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -17,6 +17,7 @@ export const PAGE_TITLES: Record<string, string> = {
   mongoatlas: "MongoDB Atlas",
   resend: "Resend",
   stripe: "Stripe",
+  sepay: "SePay",
   authentication: "Authentication",
   architecture: "Architecture",
 };

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -128,3 +128,25 @@ google:
       mime_type: application/vnd.google-apps.folder
       parent_ids:
         - root
+
+sepay:
+  api_keys:
+    - token: sepay_test_api_key
+      label: Local API Key
+  webhook_targets:
+    - url: http://localhost:3000/api/payments/sepay/webhook
+      api_key: sepay_test_webhook_key
+  bank_accounts:
+    - bin: "970436"
+      account_number: "0071000888888"
+      name: NGUYEN VAN A
+  transactions:
+    - id: 100001
+      gateway: Vietcombank
+      transactionDate: "2026-01-15 09:30:00"
+      accountNumber: "0071000888888"
+      transferType: in
+      amount: 250000
+      code: ORD1001
+      content: "ORD1001 thanh toan don hang"
+      referenceNumber: FT26011509300001

--- a/packages/@emulators/resend/src/__tests__/resend.test.ts
+++ b/packages/@emulators/resend/src/__tests__/resend.test.ts
@@ -1,3 +1,5 @@
+import { createHmac, randomBytes } from "crypto";
+import { createServer, type AddressInfo, type IncomingHttpHeaders } from "node:http";
 import { describe, it, expect, beforeEach } from "vitest";
 import { Hono } from "@emulators/core";
 import {
@@ -8,13 +10,13 @@ import {
   createErrorHandler,
   type TokenMap,
 } from "@emulators/core";
-import { resendPlugin, seedFromConfig, getResendStore } from "../index.js";
+import { resendPlugin, seedFromConfig, materializeResendSeedConfig, getResendStore } from "../index.js";
 
 const base = "http://localhost:4000";
 
-function createTestApp() {
+function createTestApp(webhooksOverride?: WebhookDispatcher) {
   const store = new Store();
-  const webhooks = new WebhookDispatcher();
+  const webhooks = webhooksOverride ?? new WebhookDispatcher();
   const tokenMap: TokenMap = new Map();
   tokenMap.set("re_test_token", {
     login: "testuser@example.com",
@@ -456,5 +458,87 @@ describe("Resend plugin - seedFromConfig", () => {
     const contacts = rs.contacts.all();
     expect(contacts.length).toBe(1);
     expect(contacts[0].email).toBe("user@example.com");
+  });
+});
+
+describe("Resend plugin - webhook delivery", () => {
+  it("delivers email.sent and email.delivered with verifiable Svix signatures", async () => {
+    const received: Array<{ headers: IncomingHttpHeaders; body: string }> = [];
+    const server = createServer((req, res) => {
+      let raw = "";
+      req.on("data", (chunk) => (raw += chunk));
+      req.on("end", () => {
+        received.push({ headers: req.headers, body: raw });
+        res.writeHead(200);
+        res.end("ok");
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    const targetUrl = `http://127.0.0.1:${port}/webhook`;
+
+    try {
+      const signingSecret = `whsec_${randomBytes(32).toString("base64")}`;
+      const webhooks = new WebhookDispatcher();
+      const { app, store } = createTestApp(webhooks);
+      seedFromConfig(store, base, { webhook_targets: [{ url: targetUrl, signing_secret: signingSecret }] }, webhooks);
+
+      const sendRes = await app.request(`${base}/emails`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ from: "noreply@example.com", to: "user@example.com", subject: "Hooked" }),
+      });
+      expect(sendRes.status).toBe(200);
+
+      expect(received.length).toBe(2);
+      const events = received.map((r) => JSON.parse(r.body).type);
+      expect(events).toEqual(["email.sent", "email.delivered"]);
+
+      for (const r of received) {
+        const svixId = r.headers["svix-id"];
+        const timestamp = r.headers["svix-timestamp"];
+        const signature = r.headers["svix-signature"];
+        expect(svixId).toBeDefined();
+        expect(timestamp).toMatch(/^\d+$/);
+        expect(signature).toMatch(/^v1,[A-Za-z0-9+/=]+$/);
+
+        const key = Buffer.from(signingSecret.replace(/^whsec_/, ""), "base64");
+        const expected = createHmac("sha256", key).update(`${svixId}.${timestamp}.${r.body}`).digest("base64");
+        expect(signature).toBe(`v1,${expected}`);
+      }
+
+      const svixIds = new Set(received.map((r) => r.headers["svix-id"]));
+      expect(svixIds.size).toBe(2);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("materializes omitted signing secrets and keeps explicit ones verbatim", () => {
+    const explicitSecret = "whsec_explicit_secret_value";
+    const { config, generatedSecrets } = materializeResendSeedConfig({
+      webhook_targets: [
+        { url: "http://localhost:9001/generated" },
+        { url: "http://localhost:9001/explicit", signing_secret: explicitSecret },
+      ],
+    });
+
+    const targets = config.webhook_targets!;
+    expect(targets[0].signing_secret).toMatch(/^whsec_[A-Za-z0-9+/=]{32,}$/);
+    expect(targets[1].signing_secret).toBe(explicitSecret);
+
+    expect(generatedSecrets).toHaveLength(1);
+    expect(generatedSecrets[0]).toMatchObject({
+      kind: "resend.webhook_signing_secret",
+      id: "http://localhost:9001/generated",
+      value: targets[0].signing_secret,
+    });
+
+    const store = new Store();
+    const webhooks = new WebhookDispatcher();
+    seedFromConfig(store, base, config, webhooks);
+    seedFromConfig(store, base, config, webhooks);
+    expect(webhooks.getSubscriptions("resend")).toHaveLength(2);
+    expect(webhooks.getSubscriptions("resend")[0].events).toEqual(["*"]);
   });
 });

--- a/packages/@emulators/resend/src/index.ts
+++ b/packages/@emulators/resend/src/index.ts
@@ -1,5 +1,14 @@
+import { createHmac, randomBytes } from "crypto";
 import type { Hono } from "@emulators/core";
-import type { ServicePlugin, Store, WebhookDispatcher, TokenMap, AppEnv, RouteContext } from "@emulators/core";
+import type {
+  ServicePlugin,
+  Store,
+  WebhookDispatcher,
+  WebhookHeaderContext,
+  TokenMap,
+  AppEnv,
+  RouteContext,
+} from "@emulators/core";
 import { getResendStore } from "./store.js";
 import { generateUuid } from "./helpers.js";
 import { emailRoutes } from "./routes/emails.js";
@@ -23,9 +32,36 @@ export interface ResendSeedConfig {
     last_name?: string;
     audience?: string;
   }>;
+  webhook_targets?: Array<{
+    url: string;
+    signing_secret?: string;
+  }>;
 }
 
-export function seedFromConfig(store: Store, _baseUrl: string, config: ResendSeedConfig): void {
+function resendWebhookHeaders({ body, subscription }: WebhookHeaderContext): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+
+  if (subscription.secret) {
+    const id = generateUuid();
+    const timestamp = Math.floor(Date.now() / 1000);
+    const key = Buffer.from(subscription.secret.replace(/^whsec_/, ""), "base64");
+    const signature = createHmac("sha256", key).update(`${id}.${timestamp}.${body}`).digest("base64");
+    headers["svix-id"] = id;
+    headers["svix-timestamp"] = String(timestamp);
+    headers["svix-signature"] = `v1,${signature}`;
+  }
+
+  return headers;
+}
+
+export function seedFromConfig(
+  store: Store,
+  _baseUrl: string,
+  config: ResendSeedConfig,
+  webhooks?: WebhookDispatcher,
+): void {
   const rs = getResendStore(store);
 
   if (config.domains) {
@@ -98,11 +134,52 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: ResendSee
       });
     }
   }
+
+  if (config.webhook_targets && webhooks) {
+    webhooks.setHeaderFactory(resendWebhookHeaders);
+    const existingUrls = new Set(webhooks.getSubscriptions("resend").map((s) => s.url));
+    for (const target of config.webhook_targets) {
+      if (existingUrls.has(target.url)) continue;
+      webhooks.register({
+        url: target.url,
+        events: ["*"],
+        active: true,
+        secret: target.signing_secret,
+        owner: "resend",
+      });
+    }
+  }
+}
+
+export function materializeResendSeedConfig(config: ResendSeedConfig): {
+  config: ResendSeedConfig;
+  generatedSecrets: Array<{ kind: string; id: string; label: string; value: string }>;
+} {
+  const generatedSecrets: Array<{ kind: string; id: string; label: string; value: string }> = [];
+  const resolved: ResendSeedConfig = { ...config };
+
+  if (resolved.webhook_targets) {
+    resolved.webhook_targets = resolved.webhook_targets.map((target) => {
+      if (target.signing_secret) return target;
+      const secret = `whsec_${randomBytes(24).toString("base64")}`;
+      generatedSecrets.push({
+        kind: "resend.webhook_signing_secret",
+        id: target.url,
+        label: "Resend Webhook Signing Secret",
+        value: secret,
+      });
+      return { ...target, signing_secret: secret };
+    });
+  }
+
+  return { config: resolved, generatedSecrets };
 }
 
 export const resendPlugin: ServicePlugin = {
   name: "resend",
   register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    webhooks.setHeaderFactory(resendWebhookHeaders);
+
     const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
     emailRoutes(ctx);
     domainRoutes(ctx);

--- a/packages/@emulators/sepay/package.json
+++ b/packages/@emulators/sepay/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@emulators/sepay",
+  "version": "0.10.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "homepage": "https://emulate.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/emulate.git",
+    "directory": "packages/@emulators/sepay"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/emulate/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@emulators/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/@emulators/sepay/src/__tests__/sepay.test.ts
+++ b/packages/@emulators/sepay/src/__tests__/sepay.test.ts
@@ -1,0 +1,298 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "@emulators/core";
+import {
+  Store,
+  WebhookDispatcher,
+  authMiddleware,
+  createApiErrorHandler,
+  createErrorHandler,
+  type TokenMap,
+} from "@emulators/core";
+import { sepayPlugin, seedFromConfig, DEFAULT_API_KEY, DEFAULT_WEBHOOK_API_KEY } from "../index.js";
+import { getSepayStore } from "../store.js";
+import { buildVietQrString, crc16 } from "../vietqr.js";
+
+const base = "http://localhost:14000";
+
+interface WebhookRequest {
+  authorization: string | undefined;
+  body: Record<string, unknown>;
+}
+
+function startWebhookTarget(): Promise<{ server: Server; url: string; requests: WebhookRequest[] }> {
+  const requests: WebhookRequest[] = [];
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => (raw += chunk));
+    req.on("end", () => {
+      requests.push({
+        authorization: req.headers.authorization,
+        body: JSON.parse(raw || "{}"),
+      });
+      res.writeHead(200);
+      res.end("OK");
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/webhooks/sepay`, requests });
+    });
+  });
+}
+
+function createTestApp(seedConfig?: Parameters<typeof seedFromConfig>[2]) {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set(DEFAULT_API_KEY, { login: "sepay_admin", id: 1, scopes: [] });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap));
+  sepayPlugin.register(app as never, store, webhooks, base, tokenMap);
+  sepayPlugin.seed?.(store, base);
+  if (seedConfig) seedFromConfig(store, base, seedConfig);
+
+  return { app, store };
+}
+
+function auth(token = DEFAULT_API_KEY): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+describe("SePay plugin", () => {
+  let app: Hono;
+  let store: Store;
+
+  beforeEach(() => {
+    const ctx = createTestApp();
+    app = ctx.app;
+    store = ctx.store;
+  });
+
+  describe("auth", () => {
+    it("rejects missing bearer token", async () => {
+      const res = await app.request(`${base}/userapi/transactions/list`);
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { status: number; error: string };
+      expect(body.error).toBe("Unauthorized");
+    });
+
+    it("rejects invalid api key", async () => {
+      const res = await app.request(`${base}/userapi/transactions/list`, { headers: auth("wrong_key") });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("transactions", () => {
+    it("lists seeded transactions and filters by account_number", async () => {
+      seedFromConfig(store, base, {
+        transactions: [
+          {
+            id: 100001,
+            transactionDate: "2026-01-15 09:30:00",
+            transferType: "in",
+            amount: 250000,
+            code: "ORD1001",
+            content: "ORD1001 thanh toan don hang",
+            referenceNumber: "FT26011509300001",
+          },
+        ],
+      });
+
+      const res = await app.request(`${base}/userapi/transactions/list`, { headers: auth() });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { transactions: Array<Record<string, unknown>> };
+      expect(body.transactions.length).toBeGreaterThanOrEqual(1);
+
+      const filtered = await app.request(`${base}/userapi/transactions/list?account_number=0071000888888`, {
+        headers: auth(),
+      });
+      const filteredBody = (await filtered.json()) as { transactions: Array<{ account_number: string }> };
+      expect(filteredBody.transactions.length).toBeGreaterThan(0);
+      expect(filteredBody.transactions.every((tx) => tx.account_number === "0071000888888")).toBe(true);
+
+      const none = await app.request(`${base}/userapi/transactions/list?account_number=999`, { headers: auth() });
+      const noneBody = (await none.json()) as { transactions: unknown[] };
+      expect(noneBody.transactions).toHaveLength(0);
+    });
+
+    it("filters by reference_number and supports limit/offset", async () => {
+      seedFromConfig(store, base, {
+        transactions: [
+          { id: 1, transferType: "in", amount: 1000, content: "one", referenceNumber: "REF_A" },
+          { id: 2, transferType: "in", amount: 2000, content: "two", referenceNumber: "REF_B" },
+          { id: 3, transferType: "in", amount: 3000, content: "three", referenceNumber: "REF_C" },
+        ],
+      });
+
+      const byRef = await app.request(`${base}/userapi/transactions/list?reference_number=REF_B`, { headers: auth() });
+      const byRefBody = (await byRef.json()) as { transactions: Array<{ id: string; amount_in: string }> };
+      expect(byRefBody.transactions).toHaveLength(1);
+      expect(byRefBody.transactions[0].id).toBe("2");
+      expect(byRefBody.transactions[0].amount_in).toBe("2000.00");
+
+      const paged = await app.request(`${base}/userapi/transactions/list?limit=1&offset=1`, { headers: auth() });
+      const pagedBody = (await paged.json()) as { transactions: Array<{ id: string }> };
+      expect(pagedBody.transactions).toHaveLength(1);
+      expect(pagedBody.transactions[0].id).toBe("2");
+    });
+
+    it("gets a transaction by id and returns 404 for unknown ids", async () => {
+      seedFromConfig(store, base, {
+        transactions: [{ id: 48673, transferType: "in", amount: 19689000, content: "chuyen tien" }],
+      });
+
+      const res = await app.request(`${base}/userapi/transactions/details/48673`, { headers: auth() });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { transaction: { id: string; amount_in: string } };
+      expect(body.transaction.id).toBe("48673");
+      expect(body.transaction.amount_in).toBe("19689000.00");
+
+      const alias = await app.request(`${base}/userapi/transactions/48673`, { headers: auth() });
+      expect(alias.status).toBe(200);
+
+      const missing = await app.request(`${base}/userapi/transactions/details/99999`, { headers: auth() });
+      expect(missing.status).toBe(404);
+    });
+  });
+
+  describe("simulate", () => {
+    let target: Awaited<ReturnType<typeof startWebhookTarget>>;
+
+    beforeEach(async () => {
+      target = await startWebhookTarget();
+    });
+
+    afterEach(async () => {
+      await new Promise<void>((resolve) => target.server.close(() => resolve()));
+    });
+
+    it("creates a transaction and fires signed webhook deliveries to all targets", async () => {
+      seedFromConfig(store, base, {
+        webhook_targets: [{ url: target.url, api_key: "whk_secret_1" }, { url: `${target.url}/second` }],
+      });
+
+      const res = await app.request(`${base}/userapi/simulate/transaction`, {
+        method: "POST",
+        headers: auth(),
+        body: JSON.stringify({
+          gateway: "Vietcombank",
+          accountNumber: "0071000888888",
+          amountIn: 250000,
+          code: "ORD2002",
+          content: "ORD2002 thanh toan don hang",
+          referenceNumber: "FT260115TEST0001",
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { transaction: { id: string; amount_in: string; transfer_type: string } };
+      expect(body.transaction.transfer_type).toBe("in");
+      expect(body.transaction.amount_in).toBe("250000.00");
+
+      expect(target.requests).toHaveLength(2);
+      expect(target.requests[0].authorization).toBe("Bearer whk_secret_1");
+      // target without explicit api_key falls back to the default webhook key
+      expect(target.requests[1].authorization).toBe(`Bearer ${DEFAULT_WEBHOOK_API_KEY}`);
+      const payload = target.requests[0].body;
+      expect(payload.gateway).toBe("Vietcombank");
+      expect(payload.amountIn).toBe(250000);
+      expect(payload.code).toBe("ORD2002");
+      expect(payload.referenceNumber).toBe("FT260115TEST0001");
+
+      const ss = getSepayStore(store);
+      const deliveries = ss.webhookDeliveries.all();
+      expect(deliveries).toHaveLength(2);
+      expect(deliveries.every((d) => d.success && d.status_code === 200)).toBe(true);
+      expect(deliveries.every((d) => d.target_url.startsWith(target.url))).toBe(true);
+
+      const list = await app.request(`${base}/userapi/transactions/list?reference_number=FT260115TEST0001`, {
+        headers: auth(),
+      });
+      const listBody = (await list.json()) as { transactions: unknown[] };
+      expect(listBody.transactions).toHaveLength(1);
+    });
+  });
+
+  describe("reset semantics", () => {
+    it("restores seeded state after reset", async () => {
+      seedFromConfig(store, base, {
+        api_keys: [{ token: "seeded_key", label: "CI Key" }],
+        webhook_targets: [{ url: "http://127.0.0.1:9/webhooks/sepay", api_key: "whk_unreachable" }],
+        transactions: [
+          { id: 555001, transferType: "in", amount: 99000, content: "seeded order", referenceNumber: "SEED_REF" },
+        ],
+      });
+
+      await app.request(`${base}/userapi/simulate/transaction`, {
+        method: "POST",
+        headers: auth(),
+        body: JSON.stringify({ amountIn: 12345, content: "mutation" }),
+      });
+
+      const beforeReset = getSepayStore(store);
+      expect(beforeReset.transactions.count()).toBeGreaterThan(1);
+      expect(beforeReset.webhookDeliveries.count()).toBeGreaterThan(0);
+
+      store.reset();
+      sepayPlugin.seed?.(store, base);
+      seedFromConfig(store, base, {
+        api_keys: [{ token: "seeded_key", label: "CI Key" }],
+        transactions: [
+          { id: 555001, transferType: "in", amount: 99000, content: "seeded order", referenceNumber: "SEED_REF" },
+        ],
+      });
+
+      const ss = getSepayStore(store);
+      expect(ss.webhookDeliveries.count()).toBe(0);
+      expect(ss.apiKeys.findOneBy("token", "seeded_key")).toBeDefined();
+      expect(ss.apiKeys.findOneBy("token", DEFAULT_API_KEY)).toBeDefined();
+      const seeded = ss.transactions.findOneBy("reference_number", "SEED_REF");
+      expect(seeded).toBeDefined();
+      expect(seeded!.amount_in).toBe("99000.00");
+      expect(ss.transactions.findOneBy("transaction_content", "mutation")).toBeUndefined();
+
+      const res = await app.request(`${base}/userapi/transactions/details/555001`, { headers: auth() });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("qr", () => {
+    it("returns a PNG image with correct content type", async () => {
+      const res = await app.request(`${base}/img?acc=0071000888888&bank=970436&amount=250000&des=ORD1001`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("image/png");
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      expect(bytes[0]).toBe(0x89);
+      expect(bytes[1]).toBe(0x50);
+      expect(bytes[2]).toBe(0x4e);
+      expect(bytes[3]).toBe(0x47);
+      const view = new DataView(bytes.buffer);
+      const width = view.getUint32(16);
+      const height = view.getUint32(20);
+      expect(width).toBe(height);
+      expect(width % 8).toBe(0);
+      expect(width).toBeGreaterThan(100);
+    });
+
+    it("rejects missing params", async () => {
+      const res = await app.request(`${base}/img?acc=onlyacc`);
+      expect(res.status).toBe(400);
+    });
+
+    it("builds a VietQR EMVCo payload with valid CRC16", () => {
+      expect(crc16("123456789")).toBe("29B1"); // CRC-16/CCITT-FALSE check value
+      const payload = buildVietQrString({ acc: "0071000888888", bank: "970436", amount: "250000", des: "ORD1001" });
+      expect(payload.startsWith("00020101021238")).toBe(true);
+      expect(payload).toContain("5303704");
+      expect(payload).toContain("5406250000");
+      expect(payload).toContain("5802VN");
+      expect(payload).toContain("QRIBFTTA");
+      expect(/6304[0-9A-F]{4}$/.test(payload)).toBe(true);
+    });
+  });
+});

--- a/packages/@emulators/sepay/src/entities.ts
+++ b/packages/@emulators/sepay/src/entities.ts
@@ -1,0 +1,43 @@
+import type { Entity } from "@emulators/core";
+
+export interface SepayApiKey extends Entity {
+  token: string;
+  label: string;
+}
+
+export interface SepayBankAccount extends Entity {
+  bin: string;
+  account_number: string;
+  name: string;
+}
+
+export interface SepayWebhookTarget extends Entity {
+  url: string;
+  api_key: string;
+}
+
+export type SepayTransferType = "in" | "out";
+
+export interface SepayTransaction extends Entity {
+  sepay_id: string;
+  gateway: string;
+  transaction_date: string;
+  account_number: string;
+  sub_account: string | null;
+  amount_in: string;
+  amount_out: string;
+  accumulated: string;
+  code: string | null;
+  transaction_content: string;
+  reference_number: string | null;
+  transfer_type: SepayTransferType;
+}
+
+export interface SepayWebhookDelivery extends Entity {
+  target_url: string;
+  event: string;
+  request_body: unknown;
+  status_code: number | null;
+  success: boolean;
+  error: string | null;
+}

--- a/packages/@emulators/sepay/src/helpers.ts
+++ b/packages/@emulators/sepay/src/helpers.ts
@@ -1,0 +1,90 @@
+import type { Context, ContentfulStatusCode } from "@emulators/core";
+import { constantTimeSecretEqual } from "@emulators/core";
+import type { SepayTransaction } from "./entities.js";
+import type { SepayStore } from "./store.js";
+
+export function money(value: number | string | null | undefined): string {
+  const num = typeof value === "number" ? value : parseFloat(String(value ?? "0"));
+  return (Number.isFinite(num) ? num : 0).toFixed(2);
+}
+
+export function formatTransaction(tx: SepayTransaction): Record<string, unknown> {
+  return {
+    id: tx.sepay_id,
+    gateway: tx.gateway,
+    bank_brand_name: tx.gateway,
+    account_number: tx.account_number,
+    sub_account: tx.sub_account,
+    transaction_date: tx.transaction_date,
+    transfer_type: tx.transfer_type,
+    amount_in: tx.amount_in,
+    amount_out: tx.amount_out,
+    accumulated: tx.accumulated,
+    code: tx.code,
+    transaction_content: tx.transaction_content,
+    reference_number: tx.reference_number,
+  };
+}
+
+export function toWebhookPayload(tx: SepayTransaction): Record<string, unknown> {
+  return {
+    id: Number(tx.sepay_id) || tx.sepay_id,
+    gateway: tx.gateway,
+    transactionDate: tx.transaction_date,
+    accountNumber: tx.account_number,
+    subAccount: tx.sub_account ?? "",
+    amountIn: parseFloat(tx.amount_in),
+    amountOut: parseFloat(tx.amount_out),
+    accumulated: parseFloat(tx.accumulated),
+    code: tx.code,
+    transactionContent: tx.transaction_content,
+    referenceNumber: tx.reference_number,
+    body: tx.transaction_content,
+  };
+}
+
+export function sepayError(c: Context, status: number, error: string): Response {
+  return c.json({ status, error, messages: { error: true } }, status as ContentfulStatusCode);
+}
+
+export function requireSepayAuth(c: Context, ss: SepayStore): boolean | Response {
+  const header = c.req.header("Authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return sepayError(c, 401, "Unauthorized");
+  const token = header.slice(7).trim();
+  const keys = ss.apiKeys.all();
+  const valid = keys.some((key) => constantTimeSecretEqual(token, key.token));
+  if (!valid) return sepayError(c, 401, "Unauthorized");
+  return true;
+}
+
+export async function dispatchSepayWebhooks(ss: SepayStore, event: string, payload: unknown): Promise<void> {
+  const body = JSON.stringify(payload);
+  for (const target of ss.webhookTargets.all()) {
+    let status: number | null = null;
+    let success = false;
+    let error: string | null = null;
+    try {
+      const response = await fetch(target.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${target.api_key}`,
+        },
+        body,
+        signal: AbortSignal.timeout(10_000),
+      });
+      status = response.status;
+      success = response.ok;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    ss.webhookDeliveries.insert({
+      target_url: target.url,
+      event,
+      request_body: payload,
+      status_code: status,
+      success,
+      error,
+    });
+  }
+}

--- a/packages/@emulators/sepay/src/index.ts
+++ b/packages/@emulators/sepay/src/index.ts
@@ -1,0 +1,148 @@
+import { randomBytes } from "crypto";
+import type { Hono } from "@emulators/core";
+import type { AppEnv, RouteContext, ServicePlugin, Store, TokenMap, WebhookDispatcher } from "@emulators/core";
+import { getSepayStore } from "./store.js";
+import { transactionRoutes } from "./routes/transactions.js";
+import { simulateRoutes } from "./routes/simulate.js";
+import { qrRoutes } from "./routes/qr.js";
+
+export { getSepayStore, type SepayStore } from "./store.js";
+export * from "./entities.js";
+export { buildVietQrString } from "./vietqr.js";
+
+export const DEFAULT_API_KEY = "sepay_test_api_key";
+export const DEFAULT_WEBHOOK_API_KEY = "sepay_test_webhook_key";
+const DEFAULT_BANK_BIN = "970436";
+const DEFAULT_BANK_ACCOUNT = "0071000888888";
+
+export interface SepaySeedConfig {
+  port?: number;
+  api_keys?: Array<{
+    token: string;
+    label?: string;
+  }>;
+  webhook_targets?: Array<{
+    url: string;
+    api_key?: string;
+  }>;
+  bank_accounts?: Array<{
+    bin: string;
+    account_number: string;
+    name: string;
+  }>;
+  transactions?: Array<{
+    id: string | number;
+    gateway?: string;
+    transactionDate?: string;
+    accountNumber?: string;
+    subAccount?: string;
+    transferType: "in" | "out";
+    amount: number | string;
+    accumulated?: number | string;
+    code?: string | null;
+    content: string;
+    referenceNumber?: string | null;
+  }>;
+}
+
+function seedDefaults(store: Store): void {
+  const ss = getSepayStore(store);
+  if (!ss.apiKeys.findOneBy("token", DEFAULT_API_KEY)) {
+    ss.apiKeys.insert({ token: DEFAULT_API_KEY, label: "Local API Key" });
+  }
+  if (!ss.bankAccounts.findOneBy("account_number", DEFAULT_BANK_ACCOUNT)) {
+    ss.bankAccounts.insert({
+      bin: DEFAULT_BANK_BIN,
+      account_number: DEFAULT_BANK_ACCOUNT,
+      name: "NGUYEN VAN A",
+    });
+  }
+}
+
+export function seedFromConfig(store: Store, _baseUrl: string, config: SepaySeedConfig): void {
+  const ss = getSepayStore(store);
+
+  for (const key of config.api_keys ?? []) {
+    if (ss.apiKeys.findOneBy("token", key.token)) continue;
+    ss.apiKeys.insert({ token: key.token, label: key.label ?? "API Key" });
+  }
+
+  for (const target of config.webhook_targets ?? []) {
+    if (ss.webhookTargets.findOneBy("url", target.url)) continue;
+    ss.webhookTargets.insert({ url: target.url, api_key: target.api_key ?? DEFAULT_WEBHOOK_API_KEY });
+  }
+
+  for (const account of config.bank_accounts ?? []) {
+    if (ss.bankAccounts.findOneBy("account_number", account.account_number)) continue;
+    ss.bankAccounts.insert(account);
+  }
+  for (const tx of config.transactions ?? []) {
+    const sepayId = String(tx.id);
+    if (ss.transactions.findOneBy("sepay_id", sepayId)) continue;
+    const rawDate = tx.transactionDate as string | Date | undefined;
+    // YAML parsers turn unquoted timestamps into Date objects
+    const transactionDate =
+      rawDate instanceof Date
+        ? rawDate.toISOString().slice(0, 19).replace("T", " ")
+        : typeof rawDate === "string" && rawDate.length > 0
+          ? rawDate
+          : new Date().toISOString().slice(0, 19).replace("T", " ");
+    ss.transactions.insert({
+      sepay_id: sepayId,
+      gateway: tx.gateway ?? "Vietcombank",
+      transaction_date: transactionDate,
+      account_number: tx.accountNumber ?? ss.bankAccounts.all()[0]?.account_number ?? "",
+      sub_account: tx.subAccount ?? null,
+      amount_in: tx.transferType === "in" ? Number(tx.amount).toFixed(2) : "0.00",
+      amount_out: tx.transferType === "out" ? Number(tx.amount).toFixed(2) : "0.00",
+      accumulated: tx.accumulated !== undefined ? Number(tx.accumulated).toFixed(2) : "0.00",
+      code: tx.code ?? null,
+      transaction_content: tx.content,
+      reference_number: tx.referenceNumber ?? null,
+      transfer_type: tx.transferType,
+    });
+  }
+}
+
+export function materializeSepaySeedConfig(config: SepaySeedConfig): {
+  config: SepaySeedConfig;
+  generatedSecrets: Array<{ kind: string; id: string; label: string; value: string }>;
+} {
+  const generatedSecrets: Array<{ kind: string; id: string; label: string; value: string }> = [];
+  const resolved: SepaySeedConfig = { ...config };
+
+  if (!resolved.api_keys || resolved.api_keys.length === 0) {
+    const token = `sepay_${randomBytes(16).toString("hex")}`;
+    generatedSecrets.push({ kind: "sepay.api_key", id: "api_key", label: "SePay API Key", value: token });
+    resolved.api_keys = [{ token, label: "Generated API Key" }];
+  }
+
+  resolved.webhook_targets = (resolved.webhook_targets ?? []).map((target) => {
+    if (target.api_key) return target;
+    const apiKey = `sepay_whk_${randomBytes(16).toString("hex")}`;
+    generatedSecrets.push({
+      kind: "sepay.webhook_api_key",
+      id: target.url,
+      label: target.url,
+      value: apiKey,
+    });
+    return { ...target, api_key: apiKey };
+  });
+
+  return { config: resolved, generatedSecrets };
+}
+
+export const sepayPlugin: ServicePlugin = {
+  name: "sepay",
+  register(app: Hono<AppEnv>, store: Store, _webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
+    const ctx: RouteContext = { app, store, webhooks: _webhooks, baseUrl, tokenMap };
+    transactionRoutes(ctx);
+    simulateRoutes(ctx);
+    qrRoutes(ctx);
+  },
+  seed(store: Store): void {
+    seedDefaults(store);
+  },
+};
+
+export default sepayPlugin;

--- a/packages/@emulators/sepay/src/png.ts
+++ b/packages/@emulators/sepay/src/png.ts
@@ -1,0 +1,100 @@
+import { encodeQrMatrix } from "./qr.js";
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) crc = CRC_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type: string, data: Uint8Array): Uint8Array {
+  const out = new Uint8Array(12 + data.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, data.length);
+  for (let i = 0; i < 4; i++) out[4 + i] = type.charCodeAt(i);
+  out.set(data, 8);
+  view.setUint32(8 + data.length, crc32(out.subarray(4, 8 + data.length)));
+  return out;
+}
+
+// ponytail: uncompressed deflate (stored blocks); PNG stays tiny at QR sizes
+export function encodePng(width: number, height: number, pixels: Uint8Array): Uint8Array {
+  const stride = width + 1;
+  const raw = new Uint8Array(stride * height);
+  for (let y = 0; y < height; y++) {
+    raw[y * stride] = 0;
+    raw.set(pixels.subarray(y * width, (y + 1) * width), y * stride + 1);
+  }
+
+  const numBlocks = Math.ceil(raw.length / 65535);
+  const idat = new Uint8Array(2 + raw.length + numBlocks * 5 + 4);
+  const view = new DataView(idat.buffer);
+  idat[0] = 0x78;
+  idat[1] = 0x01;
+  let off = 2;
+  for (let i = 0; i < numBlocks; i++) {
+    const start = i * 65535;
+    const len = Math.min(65535, raw.length - start);
+    const last = i === numBlocks - 1 ? 1 : 0;
+    idat[off] = last;
+    view.setUint16(off + 1, len, true);
+    view.setUint16(off + 3, ~len & 0xffff, true);
+    idat.set(raw.subarray(start, start + len), off + 5);
+    off += 5 + len;
+  }
+  view.setUint32(off, adler32(raw));
+
+  const ihdr = new Uint8Array(13);
+  const ihdrView = new DataView(ihdr.buffer);
+  ihdrView.setUint32(0, width);
+  ihdrView.setUint32(4, height);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 0; // grayscale
+
+  const signature = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const parts = [signature, chunk("IHDR", ihdr), chunk("IDAT", idat), chunk("IEND", new Uint8Array(0))];
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const png = new Uint8Array(total);
+  let pos = 0;
+  for (const part of parts) {
+    png.set(part, pos);
+    pos += part.length;
+  }
+  return png;
+}
+
+function adler32(data: Uint8Array): number {
+  let a = 1;
+  let b = 0;
+  for (let i = 0; i < data.length; i++) {
+    a = (a + data[i]) % 65521;
+    b = (b + a) % 65521;
+  }
+  return ((b << 16) | a) >>> 0;
+}
+
+export function renderQrPng(text: string, scale = 8, quietZone = 4): Uint8Array {
+  const modules = encodeQrMatrix(text);
+  const size = modules.length + quietZone * 2;
+  const dim = size * scale;
+  const pixels = new Uint8Array(dim * dim).fill(255);
+  for (let my = 0; my < modules.length; my++) {
+    for (let mx = 0; mx < modules.length; mx++) {
+      if (!modules[my][mx]) continue;
+      for (let dy = 0; dy < scale; dy++) {
+        const row = ((my + quietZone) * scale + dy) * dim + (mx + quietZone) * scale;
+        pixels.fill(0, row, row + scale);
+      }
+    }
+  }
+  return encodePng(dim, dim, pixels);
+}

--- a/packages/@emulators/sepay/src/qr.ts
+++ b/packages/@emulators/sepay/src/qr.ts
@@ -1,0 +1,221 @@
+const ECC_CODEWORDS_PER_BLOCK_M = [-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26];
+const NUM_ERROR_CORRECTION_BLOCKS_M = [-1, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5, 5, 8, 8, 11, 11, 16, 16, 18, 16, 19];
+// ponytail: versions capped at 20 (byte-mode M capacity ~650 chars); extend table if ever needed
+const ALIGNMENT_POSITIONS: number[][] = [
+  [],
+  [6, 18],
+  [6, 22],
+  [6, 26],
+  [6, 30],
+  [6, 34],
+  [6, 22, 38],
+  [6, 24, 42],
+  [6, 26, 46],
+  [6, 28, 50],
+  [6, 30, 54],
+  [6, 32, 58],
+  [6, 34, 62],
+  [6, 26, 46, 66],
+  [6, 26, 48, 70],
+  [6, 26, 50, 74],
+  [6, 30, 54, 78],
+  [6, 30, 56, 82],
+  [6, 30, 58, 86],
+  [6, 34, 62, 90],
+];
+
+function getNumRawDataModules(ver: number): number {
+  let result = (16 * ver + 128) * ver + 64;
+  if (ver >= 2) {
+    const numAlign = Math.floor(ver / 7) + 2;
+    result -= (25 * numAlign - 10) * numAlign - 55;
+    if (ver >= 7) result -= 36;
+  }
+  return result;
+}
+
+function getNumDataCodewords(ver: number): number {
+  return (
+    Math.floor(getNumRawDataModules(ver) / 8) - ECC_CODEWORDS_PER_BLOCK_M[ver] * NUM_ERROR_CORRECTION_BLOCKS_M[ver]
+  );
+}
+
+function reedSolomonComputeDivisor(degree: number): number[] {
+  const result: number[] = new Array<number>(degree).fill(0);
+  result[degree - 1] = 1;
+  let root = 1;
+  for (let i = 0; i < degree; i++) {
+    for (let j = 0; j < result.length; j++) {
+      result[j] = reedSolomonMultiply(result[j], root);
+      if (j + 1 < result.length) result[j] ^= result[j + 1];
+    }
+    root = reedSolomonMultiply(root, 0x02);
+  }
+  return result;
+}
+
+function reedSolomonMultiply(x: number, y: number): number {
+  let z = 0;
+  for (let i = 7; i >= 0; i--) {
+    z = (z << 1) ^ ((z >>> 7) * 0x11d);
+    z ^= ((y >>> i) & 1) * x;
+  }
+  return z & 0xff;
+}
+
+function reedSolomonComputeRemainder(data: number[], divisor: number[]): number[] {
+  const result = divisor.map(() => 0);
+  for (const b of data) {
+    const factor = (b ^ (result.shift() as number)) & 0xff;
+    result.push(0);
+    for (let i = 0; i < divisor.length; i++) result[i] ^= reedSolomonMultiply(divisor[i], factor);
+  }
+  return result;
+}
+
+export function encodeQrMatrix(text: string): boolean[][] {
+  const dataBytes = Array.from(new TextEncoder().encode(text));
+  let version = 1;
+  while (version <= 20) {
+    const charCountBits = version < 10 ? 8 : 16;
+    if (getNumDataCodewords(version) * 8 >= dataBytes.length * 8 + 4 + charCountBits) break;
+    version++;
+  }
+  if (version > 20) throw new Error("QR payload too long");
+
+  const size = version * 4 + 17;
+  const modules: boolean[][] = Array.from({ length: size }, () => new Array<boolean>(size).fill(false));
+  const isFunction: boolean[][] = Array.from({ length: size }, () => new Array<boolean>(size).fill(false));
+
+  const setFunctionModule = (x: number, y: number, isDark: boolean): void => {
+    modules[y][x] = isDark;
+    isFunction[y][x] = true;
+  };
+
+  const drawFinderPattern = (x: number, y: number): void => {
+    for (let dy = -4; dy <= 4; dy++) {
+      for (let dx = -4; dx <= 4; dx++) {
+        const dist = Math.max(Math.abs(dx), Math.abs(dy));
+        const xx = x + dx;
+        const yy = y + dy;
+        if (xx >= 0 && xx < size && yy >= 0 && yy < size) setFunctionModule(xx, yy, dist !== 2 && dist !== 4);
+      }
+    }
+  };
+  drawFinderPattern(3, 3);
+  drawFinderPattern(size - 4, 3);
+  drawFinderPattern(3, size - 4);
+
+  const align = ALIGNMENT_POSITIONS[version - 1];
+  for (let i = 0; i < align.length; i++) {
+    for (let j = 0; j < align.length; j++) {
+      if ((i === 0 && j === 0) || (i === 0 && j === align.length - 1) || (i === align.length - 1 && j === 0)) continue;
+      for (let dy = -2; dy <= 2; dy++) {
+        for (let dx = -2; dx <= 2; dx++) {
+          setFunctionModule(align[j] + dx, align[i] + dy, Math.max(Math.abs(dx), Math.abs(dy)) !== 1);
+        }
+      }
+    }
+  }
+
+  for (let i = 0; i < size; i++) {
+    if (!isFunction[6][i]) setFunctionModule(i, 6, i % 2 === 0);
+    if (!isFunction[i][6]) setFunctionModule(i, 6, i % 2 === 0);
+  }
+
+  const drawFormatBits = (): void => {
+    const formatData = (0 << 3) | 0; // ECC level M, mask 0
+    let rem = formatData;
+    for (let i = 0; i < 10; i++) rem = (rem << 1) ^ ((rem >>> 9) * 0x537);
+    const bits = ((formatData << 10) | rem) ^ 0x5412;
+    const getBit = (x: number, i: number): boolean => ((x >>> i) & 1) !== 0;
+    for (let i = 0; i <= 5; i++) setFunctionModule(8, i, getBit(bits, i));
+    setFunctionModule(8, 7, getBit(bits, 6));
+    setFunctionModule(8, 8, getBit(bits, 7));
+    setFunctionModule(7, 8, getBit(bits, 8));
+    for (let i = 9; i < 15; i++) setFunctionModule(14 - i, 8, getBit(bits, i));
+    for (let i = 0; i < 8; i++) setFunctionModule(size - 1 - i, 8, getBit(bits, i));
+    for (let i = 8; i < 15; i++) setFunctionModule(8, size - 15 + i, getBit(bits, i));
+    setFunctionModule(size - 8, 8, true);
+  };
+  drawFormatBits();
+
+  if (version >= 7) {
+    let vrem = version;
+    for (let i = 0; i < 12; i++) vrem = (vrem << 1) ^ ((vrem >>> 11) & 1 ? 0x1f25 : 0);
+    const bits = (version << 12) | vrem;
+    for (let i = 0; i < 18; i++) {
+      const bit = ((bits >>> i) & 1) !== 0;
+      setFunctionModule(Math.floor(i / 3), (i % 3) + size - 11, bit);
+      setFunctionModule((i % 3) + size - 11, Math.floor(i / 3), bit);
+    }
+  }
+
+  const numBlocks = NUM_ERROR_CORRECTION_BLOCKS_M[version];
+  const eccLen = ECC_CODEWORDS_PER_BLOCK_M[version];
+  const rawCodewords = Math.floor(getNumRawDataModules(version) / 8);
+  const numShortBlocks = numBlocks - (rawCodewords % numBlocks);
+  const shortBlockLen = Math.floor(rawCodewords / numBlocks);
+
+  const bitBuf: number[] = [];
+  const appendBits = (val: number, len: number): void => {
+    for (let i = len - 1; i >= 0; i--) bitBuf.push((val >>> i) & 1);
+  };
+  appendBits(0x4, 4); // byte mode
+  appendBits(dataBytes.length, version < 10 ? 8 : 16);
+  for (const b of dataBytes) appendBits(b, 8);
+  appendBits(0, Math.min(4, getNumDataCodewords(version) * 8 - bitBuf.length));
+  appendBits(0, (8 - (bitBuf.length % 8)) % 8);
+  for (let padByte = 0xec; bitBuf.length < getNumDataCodewords(version) * 8; padByte ^= 0xec ^ 0x11)
+    appendBits(padByte, 8);
+
+  const dataCodewords: number[] = [];
+  for (let i = 0; i < bitBuf.length; i += 8)
+    dataCodewords.push(bitBuf.slice(i, i + 8).reduce((acc, bit) => (acc << 1) | bit, 0));
+
+  const generator = reedSolomonComputeDivisor(eccLen);
+  const dataBlocks: number[][] = [];
+  const eccBlocks: number[][] = [];
+  for (let i = 0, k = 0; i < numBlocks; i++) {
+    const dataLen = shortBlockLen - eccLen + (i < numShortBlocks ? 0 : 1);
+    const block = dataCodewords.slice(k, k + dataLen);
+    k += dataLen;
+    dataBlocks.push(block);
+    eccBlocks.push(reedSolomonComputeRemainder(block, generator));
+  }
+
+  const codewords: number[] = [];
+  const maxDataLen = shortBlockLen - eccLen + 1;
+  for (let i = 0; i < maxDataLen; i++) {
+    for (let j = 0; j < numBlocks; j++) {
+      if (i < dataBlocks[j].length) codewords.push(dataBlocks[j][i]);
+    }
+  }
+  for (let i = 0; i < eccLen; i++) {
+    for (let j = 0; j < numBlocks; j++) codewords.push(eccBlocks[j][i]);
+  }
+
+  let bitIndex = 0;
+  for (let right = size - 1; right >= 1; right -= 2) {
+    if (right === 6) right = 5;
+    for (let vert = 0; vert < size; vert++) {
+      for (let j = 0; j < 2; j++) {
+        const x = right - j;
+        const upward = ((right + 1) & 2) === 0;
+        const y = upward ? size - 1 - vert : vert;
+        if (!isFunction[y][x] && bitIndex < codewords.length * 8) {
+          modules[y][x] = ((codewords[bitIndex >>> 3] >>> (7 - (bitIndex & 7))) & 1) !== 0;
+          bitIndex++;
+        }
+      }
+    }
+  }
+
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      if (!isFunction[y][x] && (x + y) % 2 === 0) modules[y][x] = !modules[y][x];
+    }
+  }
+
+  return modules;
+}

--- a/packages/@emulators/sepay/src/qr.ts
+++ b/packages/@emulators/sepay/src/qr.ts
@@ -120,7 +120,7 @@ export function encodeQrMatrix(text: string): boolean[][] {
 
   for (let i = 0; i < size; i++) {
     if (!isFunction[6][i]) setFunctionModule(i, 6, i % 2 === 0);
-    if (!isFunction[i][6]) setFunctionModule(i, 6, i % 2 === 0);
+    if (!isFunction[i][6]) setFunctionModule(6, i, i % 2 === 0);
   }
 
   const drawFormatBits = (): void => {

--- a/packages/@emulators/sepay/src/routes/qr.ts
+++ b/packages/@emulators/sepay/src/routes/qr.ts
@@ -1,0 +1,24 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { buildVietQrString } from "../vietqr.js";
+import { renderQrPng } from "../png.js";
+
+export function qrRoutes({ app }: RouteContext): void {
+  const handler = (c: Context): Response => {
+    const acc = c.req.query("acc");
+    const bank = c.req.query("bank");
+    if (!acc || !bank) return c.text("Missing required params: acc, bank", 400);
+    const payload = buildVietQrString({
+      acc,
+      bank,
+      amount: c.req.query("amount"),
+      des: c.req.query("des"),
+    });
+    return new Response(new Uint8Array(renderQrPng(payload)), {
+      status: 200,
+      headers: { "Content-Type": "image/png" },
+    });
+  };
+
+  app.get("/img", (c) => handler(c));
+  app.get("/qr/img", (c) => handler(c));
+}

--- a/packages/@emulators/sepay/src/routes/simulate.ts
+++ b/packages/@emulators/sepay/src/routes/simulate.ts
@@ -1,0 +1,71 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { getSepayStore } from "../store.js";
+import {
+  dispatchSepayWebhooks,
+  formatTransaction,
+  money,
+  requireSepayAuth,
+  sepayError,
+  toWebhookPayload,
+} from "../helpers.js";
+import type { SepayTransaction, SepayTransferType } from "../entities.js";
+
+export function simulateRoutes({ app, store }: RouteContext): void {
+  const ss = getSepayStore(store);
+
+  app.post("/userapi/simulate/transaction", async (c: Context): Promise<Response> => {
+    const auth = requireSepayAuth(c, ss);
+    if (auth instanceof Response) return auth;
+
+    let body: Record<string, unknown> = {};
+    try {
+      const parsed = await c.req.json();
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) body = parsed;
+    } catch {
+      return sepayError(c, 400, "Invalid JSON body");
+    }
+
+    const str = (key: string): string | null => {
+      const value = body[key];
+      return typeof value === "string" || typeof value === "number" ? String(value) : null;
+    };
+
+    const amountIn = str("amountIn");
+    const amountOut = str("amountOut");
+    const amount = str("amount");
+    let transferType = (str("transferType") ?? "") as SepayTransferType;
+    if (transferType !== "in" && transferType !== "out") {
+      const inAmount = parseFloat(amountIn ?? amount ?? "0");
+      transferType = parseFloat(amountOut ?? "0") > 0 && !(inAmount > 0) ? "out" : "in";
+    }
+    const resolvedAmountIn = transferType === "in" ? (amountIn ?? amount ?? "0") : "0";
+    const resolvedAmountOut = transferType === "out" ? (amountOut ?? amount ?? "0") : "0";
+
+    const maxExisting = ss.transactions.all().reduce((max, tx) => Math.max(max, Number(tx.sepay_id) || 0), 100000);
+    const id = str("id") ?? String(maxExisting + 1);
+
+    const tx: SepayTransaction = ss.transactions.insert({
+      sepay_id: id,
+      gateway: str("gateway") ?? "Vietcombank",
+      transaction_date: str("transactionDate") ?? new Date().toISOString().slice(0, 19).replace("T", " "),
+      account_number: str("accountNumber") ?? ss.bankAccounts.all()[0]?.account_number ?? "",
+      sub_account: str("subAccount"),
+      amount_in: money(resolvedAmountIn),
+      amount_out: money(resolvedAmountOut),
+      accumulated: money(str("accumulated")),
+      code: str("code"),
+      transaction_content: str("content") ?? str("transactionContent") ?? "",
+      reference_number: str("referenceNumber"),
+      transfer_type: transferType,
+    });
+
+    await dispatchSepayWebhooks(ss, "transaction", toWebhookPayload(tx));
+
+    return c.json({
+      status: 200,
+      error: null,
+      messages: { success: true },
+      transaction: formatTransaction(tx),
+    });
+  });
+}

--- a/packages/@emulators/sepay/src/routes/transactions.ts
+++ b/packages/@emulators/sepay/src/routes/transactions.ts
@@ -1,0 +1,57 @@
+import type { Context, RouteContext } from "@emulators/core";
+import { getSepayStore } from "../store.js";
+import { formatTransaction, requireSepayAuth, sepayError } from "../helpers.js";
+
+export function transactionRoutes({ app, store }: RouteContext): void {
+  const ss = getSepayStore(store);
+
+  app.get("/userapi/transactions/list", (c) => {
+    const auth = requireSepayAuth(c, ss);
+    if (auth instanceof Response) return auth;
+
+    let items = ss.transactions.all();
+    const accountNumber = c.req.query("account_number");
+    if (accountNumber) items = items.filter((tx) => tx.account_number === accountNumber);
+    const reference = c.req.query("reference_number") ?? c.req.query("reference_code");
+    if (reference) items = items.filter((tx) => tx.reference_number === reference);
+    const sinceId = c.req.query("since_id");
+    if (sinceId) items = items.filter((tx) => Number(tx.sepay_id) >= Number(sinceId));
+    const amountIn = c.req.query("amount_in");
+    if (amountIn) items = items.filter((tx) => parseFloat(tx.amount_in) === parseFloat(amountIn));
+    const amountOut = c.req.query("amount_out");
+    if (amountOut) items = items.filter((tx) => parseFloat(tx.amount_out) === parseFloat(amountOut));
+
+    items.sort((a, b) => Number(b.sepay_id) - Number(a.sepay_id));
+
+    const limitRaw = parseInt(c.req.query("limit") ?? "", 10);
+    const limit = Math.min(Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 5000, 5000);
+    const offsetRaw = parseInt(c.req.query("offset") ?? "0", 10);
+    const offset = Number.isFinite(offsetRaw) && offsetRaw > 0 ? offsetRaw : 0;
+    items = items.slice(offset, offset + limit);
+
+    return c.json({
+      status: 200,
+      error: null,
+      messages: { success: true },
+      transactions: items.map(formatTransaction),
+    });
+  });
+
+  const getTransaction = (c: Context): Response => {
+    const auth = requireSepayAuth(c, ss);
+    if (auth instanceof Response) return auth;
+    const id = c.req.param("id");
+    const tx =
+      ss.transactions.findOneBy("sepay_id", id) ?? ss.transactions.findOneBy("sepay_id", String(parseInt(id, 10)));
+    if (!tx) return sepayError(c, 404, "Not found");
+    return c.json({
+      status: 200,
+      error: null,
+      messages: { success: true },
+      transaction: formatTransaction(tx),
+    });
+  };
+
+  app.get("/userapi/transactions/details/:id", (c) => getTransaction(c));
+  app.get("/userapi/transactions/:id", (c) => getTransaction(c));
+}

--- a/packages/@emulators/sepay/src/store.ts
+++ b/packages/@emulators/sepay/src/store.ts
@@ -1,0 +1,26 @@
+import { Store, type Collection } from "@emulators/core";
+import type {
+  SepayApiKey,
+  SepayBankAccount,
+  SepayTransaction,
+  SepayWebhookDelivery,
+  SepayWebhookTarget,
+} from "./entities.js";
+
+export interface SepayStore {
+  apiKeys: Collection<SepayApiKey>;
+  bankAccounts: Collection<SepayBankAccount>;
+  webhookTargets: Collection<SepayWebhookTarget>;
+  transactions: Collection<SepayTransaction>;
+  webhookDeliveries: Collection<SepayWebhookDelivery>;
+}
+
+export function getSepayStore(store: Store): SepayStore {
+  return {
+    apiKeys: store.collection<SepayApiKey>("sepay.api_keys", ["token"]),
+    bankAccounts: store.collection<SepayBankAccount>("sepay.bank_accounts", ["bin", "account_number"]),
+    webhookTargets: store.collection<SepayWebhookTarget>("sepay.webhook_targets", ["url"]),
+    transactions: store.collection<SepayTransaction>("sepay.transactions", ["sepay_id", "account_number"]),
+    webhookDeliveries: store.collection<SepayWebhookDelivery>("sepay.webhook_deliveries", ["target_url"]),
+  };
+}

--- a/packages/@emulators/sepay/src/vietqr.ts
+++ b/packages/@emulators/sepay/src/vietqr.ts
@@ -1,0 +1,35 @@
+export function crc16(data: string): string {
+  let crc = 0xffff;
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data.charCodeAt(i) << 8;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc.toString(16).toUpperCase().padStart(4, "0");
+}
+
+function tlv(id: string, value: string): string {
+  return id + String(value.length).padStart(2, "0") + value;
+}
+
+export interface VietQrInput {
+  acc: string;
+  bank: string;
+  amount?: string | null;
+  des?: string | null;
+}
+
+export function buildVietQrString({ acc, bank, amount, des }: VietQrInput): string {
+  const merchantInfo = tlv("00", "A000000727") + tlv("01", tlv("00", bank) + tlv("01", acc) + tlv("02", "QRIBFTTA"));
+  let payload =
+    tlv("00", "01") +
+    tlv("01", amount ? "12" : "11") +
+    tlv("38", merchantInfo) +
+    tlv("53", "704") +
+    (amount ? tlv("54", String(parseInt(amount, 10))) : "") +
+    tlv("58", "VN");
+  if (des) payload += tlv("62", tlv("08", des));
+  payload += "6304";
+  return payload + crc16(payload);
+}

--- a/packages/@emulators/sepay/tsconfig.json
+++ b/packages/@emulators/sepay/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@emulators/sepay/tsup.config.ts
+++ b/packages/@emulators/sepay/tsup.config.ts
@@ -1,0 +1,19 @@
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineConfig } from "tsup";
+
+const copyFonts = async () => {
+  const src = resolve(__dirname, "../core/src/fonts");
+  const dest = resolve(__dirname, "dist/fonts");
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+};
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: [/^@emulators\/core/],
+  onSuccess: copyFonts,
+});

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -72,6 +72,7 @@
     "@emulators/clerk": "workspace:*",
     "@emulators/linear": "workspace:*",
     "@emulators/twilio": "workspace:*",
+    "@emulators/sepay": "workspace:*",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -432,10 +432,25 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   },
   resend: {
     label: "Resend email API emulator",
-    endpoints: "emails, domains, contacts, API keys, inbox UI",
+    endpoints: "emails, domains, contacts, API keys, inbox UI, webhook deliveries",
     async load() {
       const mod = await import("@emulators/resend");
-      return { plugin: mod.resendPlugin, seedFromConfig: mod.seedFromConfig };
+      return {
+        plugin: mod.resendPlugin,
+        seedFromConfig: mod.seedFromConfig,
+        prepareSeed(config) {
+          const materialized = mod.materializeResendSeedConfig(config);
+          return Promise.resolve({
+            config: materialized.config as Record<string, unknown>,
+            generatedSecrets: materialized.generatedSecrets.map((secret) => ({
+              kind: secret.kind,
+              id: secret.id,
+              label: secret.label,
+              value: secret.value,
+            })),
+          });
+        },
+      };
     },
     defaultFallback() {
       return { login: "re_test_admin", id: 1, scopes: [] };

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -40,6 +40,7 @@ const SERVICE_NAME_LIST = [
   "clerk",
   "linear",
   "twilio",
+  "sepay",
 ] as const;
 export type ServiceName = (typeof SERVICE_NAME_LIST)[number];
 export const SERVICE_NAMES: readonly ServiceName[] = SERVICE_NAME_LIST;
@@ -648,6 +649,58 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
         conversations: {
           services: [{ friendly_name: "Local Conversations" }],
         },
+      },
+    },
+  },
+
+  sepay: {
+    label: "SePay VietQR payment gateway emulator",
+    endpoints: "transactions list/details, webhook deliveries, VietQR image generation, transaction simulator",
+    async load() {
+      const mod = await import("@emulators/sepay");
+      return {
+        plugin: mod.sepayPlugin,
+        seedFromConfig: mod.seedFromConfig,
+        prepareSeed(config) {
+          const materialized = mod.materializeSepaySeedConfig(config);
+          return Promise.resolve({
+            config: materialized.config as Record<string, unknown>,
+            generatedSecrets: materialized.generatedSecrets.map((secret) => ({
+              kind: secret.kind,
+              id: secret.id,
+              label: secret.label,
+              value: secret.value,
+            })),
+          });
+        },
+      };
+    },
+    defaultFallback() {
+      return { login: "sepay_admin", id: 1, scopes: [] };
+    },
+    initConfig: {
+      sepay: {
+        api_keys: [{ token: "sepay_test_api_key", label: "Local API Key" }],
+        webhook_targets: [
+          {
+            url: "http://localhost:3000/api/payments/sepay/webhook",
+            api_key: "sepay_test_webhook_key",
+          },
+        ],
+        bank_accounts: [{ bin: "970436", account_number: "0071000888888", name: "NGUYEN VAN A" }],
+        transactions: [
+          {
+            id: 100001,
+            gateway: "Vietcombank",
+            transactionDate: "2026-01-15 09:30:00",
+            accountNumber: "0071000888888",
+            transferType: "in",
+            amount: 250000,
+            code: "ORD1001",
+            content: "ORD1001 thanh toan don hang",
+            referenceNumber: "FT26011509300001",
+          },
+        ],
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,6 +759,22 @@ importers:
         specifier: ^4.1.0
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
+  packages/@emulators/sepay:
+    dependencies:
+      '@emulators/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/@emulators/slack:
     dependencies:
       '@emulators/core':
@@ -877,6 +893,9 @@ importers:
       '@emulators/resend':
         specifier: workspace:*
         version: link:../@emulators/resend
+      '@emulators/sepay':
+        specifier: workspace:*
+        version: link:../@emulators/sepay
       '@emulators/slack':
         specifier: workspace:*
         version: link:../@emulators/slack
@@ -6269,6 +6288,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/skills/sepay/SKILL.md
+++ b/skills/sepay/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: sepay
+description: Emulated SePay VietQR payment gateway APIs for local development and testing. Use when the user needs to test SePay transaction queries, bank-transfer webhooks, VietQR image generation, or SePay SDK integrations without hitting the real SePay service.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# SePay API Emulator
+
+Stateful emulation of the SePay v1 transaction API (`my.sepay.vn/userapi`), inbound-to-merchant webhook delivery, VietQR PNG generation, and a local bank-transaction simulator.
+
+## Start
+
+```bash
+npx emulate --service sepay
+```
+
+Default URL: `http://localhost:4014` when all services are started, or `http://localhost:4000` when SePay is the only service.
+
+## Defaults
+
+```text
+SEPAY_API_KEY=sepay_test_api_key
+SEPAY_WEBHOOK_API_KEY=sepay_test_webhook_key
+```
+
+A default bank account is seeded: bin `970436`, account number `0071000888888`.
+
+## Auth
+
+All `/userapi/*` routes require `Authorization: Bearer <API_KEY>` matching a seeded API key. Missing or invalid keys return 401. Webhook deliveries carry `Authorization: Bearer <webhook api key>` per target; validate that shared secret in your webhook handler.
+
+## Core Routes
+
+- `GET /userapi/transactions/list` - list transactions (newest first)
+- `GET /userapi/transactions/details/{id}` - get transaction details
+- `POST /userapi/simulate/transaction` - local-only helper to create a transaction and fire webhooks
+- `GET /img?acc=&bank=&amount=&des=` - VietQR PNG (also at `/qr/img`)
+
+## List Filters
+
+`account_number`, `reference_number`, `since_id`, `amount_in`, `amount_out`, `limit` (max 5000), `offset`.
+
+## Webhook Payload
+
+```json
+{
+  "id": 100001,
+  "gateway": "Vietcombank",
+  "transactionDate": "2026-01-15 09:30:00",
+  "accountNumber": "0071000888888",
+  "subAccount": "",
+  "amountIn": 250000,
+  "amountOut": 0,
+  "accumulated": 0,
+  "code": "ORD1001",
+  "transactionContent": "ORD1001 thanh toan don hang",
+  "referenceNumber": "FT26011509300001",
+  "body": "ORD1001 thanh toan don hang"
+}
+```
+
+## Payment Flow Testing
+
+1. Generate a checkout QR with `GET /img?acc=<account>&bank=<bin>&amount=<vnd>&des=<order code>`.
+2. Simulate the customer paying: `POST /userapi/simulate/transaction` with JSON body `{ "accountNumber": "...", "amountIn": 250000, "code": "ORDER123", "content": "..." }`.
+3. The emulator POSTs the webhook payload above to every seeded `webhook_targets[].url` with its per-target bearer key, then records each attempt in the store.
+4. Poll `GET /userapi/transactions/list?reference_number=...` like production code to confirm reconciliation.
+
+Seed config keys: `api_keys` (token + label), `webhook_targets` (url + api_key), `bank_accounts` (bin + account_number + name), `transactions` (camelCase fields). Omitted API keys are generated and reported through `generatedSecrets` when using `--generated-secrets-file`.
+
+## Current Limits
+
+No real bank connections, OAuth 2.0 API v2 endpoints, virtual accounts, bank account listing endpoints, transaction count endpoint, rate limiting, or webhook retry behavior is implemented.


### PR DESCRIPTION
## Summary

Combined PR (was #211 + #212). Adds SePay support and fixes Resend webhook delivery; #212 will be closed as folded in.

### SePay VietQR payment gateway emulator (new `@emulators/sepay`)

Stateful SePay emulator for F&B payment flows (VietQR bank transfers):

- `GET /userapi/transactions/list` (+filters) and `GET /userapi/transactions/:id` — SePay userapi wire format, bearer auth
- `POST /userapi/simulate/transaction` — test helper: inserts a transaction and fans out real-shaped webhooks (`Authorization: Bearer <target key>`) to seeded targets, recording delivery attempts
- `GET /img` / `/qr/img` — VietQR PNG generation (EMVCo TLV + CRC16-CCITT, zero-dep QR + PNG)
- Seed config under `sepay:`: `api_keys`, `webhook_targets`, `bank_accounts`, `transactions`; omitted keys auto-generate via `generatedSecrets`
- Registered in CLI/registry/docs; port 4014; 10 tests (auth, list/filter/pagination, details+404, simulate→webhook via local http target, reset-restores-seeds, PNG route, CRC16 vector)

### Resend webhook delivery (fix)

WebhookDispatcher events were dispatched but nothing was subscribed as `resend`, so no webhook was ever delivered.

- `resend.webhook_targets: [{ url, signing_secret? }]` — registers as owner-`resend` subscriptions (idempotent by URL)
- Svix headers: `svix-id`, `svix-timestamp`, `svix-signature: v1,<base64 HMAC-SHA256>` over `{id}.{timestamp}.{body}`
- Omitted secrets auto-generate as `whsec_<base64>` via new `prepareSeed` hook

## Test plan

- `@emulators/sepay`: 10/10; `@emulators/resend`: 25/25 (23 existing + 2 new with live http target + signature verification)
- `turbo run build test lint type-check --filter='./packages/*'` — 20/20