### PR TITLE
Support Resend idempotency keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ npx emulate start --service github --seed config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact so the command can be retried immediately. A hard termination such as `SIGKILL` can leave a complete published artifact that must be removed manually after confirming no invocation is using it. Only generated secrets are included. Explicitly configured keys are never copied into the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files keep requiring `private_key`.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures and `SIGINT` or `SIGTERM` received during startup remove the invocation-owned artifact so the command can be retried immediately. An uncatchable termination such as `SIGKILL` can leave a complete published artifact that must be removed manually after confirming no invocation is using it. Only generated secrets are included. Explicitly configured keys are never copied into the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files keep requiring `private_key`.
 
 ### Vitest / Jest setup
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ All services start with sensible defaults. No config file needed:
 
 Stripe webhooks configured with a secret include a `Stripe-Signature` header signed over the timestamp and raw request body.
 
+Resend `POST /emails` and `POST /emails/batch` requests accept an `Idempotency-Key` header containing 1 to 256 characters. An equivalent retry within 24 hours replays the original response without capturing another email or dispatching more webhooks. Reusing the key with a changed payload returns `409 invalid_idempotent_request`, while overlapping requests return `409 concurrent_idempotent_requests`. Keys are scoped by API credential and endpoint.
+
 ## CLI
 
 ```bash

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -146,7 +146,7 @@ npx emulate start --service github --seed emulate.config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Explicit keys are excluded. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require an explicit private key.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures and `SIGINT` or `SIGTERM` received during startup remove the invocation-owned artifact. An uncatchable termination such as `SIGKILL` can leave a complete artifact that must be removed manually after confirming no invocation is using it. Explicit keys are excluded. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require an explicit private key.
 
 ## Google Seed Config
 

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -36,7 +36,7 @@ npx emulate start --service github --seed emulate.config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Only generated keys appear in the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`. Direct `seedFromConfig` calls always require it.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures and `SIGINT` or `SIGTERM` received during startup remove the invocation-owned artifact. An uncatchable termination such as `SIGKILL` can leave a complete artifact that must be removed manually after confirming no invocation is using it. Only generated keys appear in the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`. Direct `seedFromConfig` calls always require it.
 
 ## Users
 

--- a/apps/web/app/docs/resend/page.mdx
+++ b/apps/web/app/docs/resend/page.mdx
@@ -10,6 +10,20 @@ Resend email API emulation with email sending, domain management, API keys, audi
 - `GET /emails/:id` — get email
 - `POST /emails/:id/cancel` — cancel scheduled email
 
+### Idempotent sends
+
+Add `Idempotency-Key` to `POST /emails` or `POST /emails/batch` to make retries safe:
+
+```bash
+curl -X POST http://localhost:4000/emails \
+  -H "Authorization: Bearer re_test_key" \
+  -H "Idempotency-Key: welcome-user-42" \
+  -H "Content-Type: application/json" \
+  -d '{"from":"hello@example.com","to":"user@example.com","subject":"Hello"}'
+```
+
+Keys must contain 1 to 256 characters and are scoped by API credential and endpoint. For 24 hours, an equivalent retry returns the exact original response without capturing another email or dispatching more webhooks. A changed payload returns `409 invalid_idempotent_request`; a request that overlaps the original returns `409 concurrent_idempotent_requests`. At expiry, the key can create a new send. Idempotency keys and internal records are not returned by email list or detail routes.
+
 ## Domains
 
 - `POST /domains` — create domain

--- a/packages/@emulators/resend/README.md
+++ b/packages/@emulators/resend/README.md
@@ -13,13 +13,17 @@ npm install @emulators/resend
 ## Endpoints
 
 ### Emails
-- `POST /emails` — send single email
-- `POST /emails/batch` — send up to 100 emails
+
+- `POST /emails` — send single email, with optional `Idempotency-Key` support
+- `POST /emails/batch` — send up to 100 emails, with optional `Idempotency-Key` support
 - `GET /emails` — list sent emails
 - `GET /emails/:id` — get email
 - `POST /emails/:id/cancel` — cancel scheduled email
 
+An idempotency key must contain 1 to 256 characters. Equivalent retries within 24 hours replay the original response without capturing duplicate emails or dispatching duplicate webhooks. A changed payload returns `409 invalid_idempotent_request`, and an overlapping request returns `409 concurrent_idempotent_requests`. Keys are scoped by API credential and endpoint and are never returned by the email APIs.
+
 ### Domains
+
 - `POST /domains` — create domain
 - `GET /domains` — list domains
 - `GET /domains/:id` — get domain
@@ -27,11 +31,13 @@ npm install @emulators/resend
 - `POST /domains/:id/verify` — trigger domain verification
 
 ### API Keys
+
 - `POST /api-keys` — create API key
 - `GET /api-keys` — list API keys
 - `DELETE /api-keys/:id` — delete API key
 
 ### Audiences & Contacts
+
 - `POST /audiences` — create audience
 - `GET /audiences` — list audiences
 - `DELETE /audiences/:id` — delete audience
@@ -40,6 +46,7 @@ npm install @emulators/resend
 - `DELETE /audiences/:audience_id/contacts/:id` — delete contact
 
 ### Inbox
+
 - `GET /inbox` — list captured emails
 - `GET /inbox/:id` — view captured email
 

--- a/packages/@emulators/resend/src/__tests__/resend.test.ts
+++ b/packages/@emulators/resend/src/__tests__/resend.test.ts
@@ -384,22 +384,41 @@ describe("Resend plugin - Idempotency-Key", () => {
       "Content-Type": "application/json",
       "Idempotency-Key": key,
     });
+    const normalizedFallback = await sendJson(app, "/emails", payload, {
+      Authorization: "token re_adapter_token",
+      "Content-Type": "application/json",
+      "Idempotency-Key": key,
+    });
+    const anonymous = await sendJson(app, "/emails", payload, {
+      "Content-Type": "application/json",
+      "Idempotency-Key": key,
+    });
+    const anonymousReplay = await sendJson(app, "/emails", payload, {
+      "Content-Type": "application/json",
+      "Idempotency-Key": key,
+    });
 
-    expect([first.status, batch.status, otherCredential.status]).toEqual([200, 200, 200]);
+    expect([first.status, batch.status, otherCredential.status, normalizedFallback.status, anonymous.status]).toEqual([
+      200, 200, 200, 200, 200,
+    ]);
+    expect(await normalizedFallback.json()).toEqual(await otherCredential.json());
+    expect(await anonymousReplay.json()).toEqual(await anonymous.json());
     const rs = getResendStore(store);
-    expect(rs.emails.count()).toBe(3);
-    expect(rs.idempotencyRecords.count()).toBe(3);
+    expect(rs.emails.count()).toBe(4);
+    expect(rs.idempotencyRecords.count()).toBe(4);
     expect(JSON.stringify(store.snapshot())).not.toContain("re_test_token");
     expect(JSON.stringify(store.snapshot())).not.toContain("re_adapter_token");
   });
 
   it.each([
-    ["empty", ""],
-    ["too long", "x".repeat(257)],
-  ])("rejects a %s key without side effects", async (_name, key) => {
+    ["single request with an empty", "/emails", payload, ""],
+    ["single request with a too long", "/emails", payload, "x".repeat(257)],
+    ["batch request with an empty", "/emails/batch", [payload], ""],
+    ["batch request with a too long", "/emails/batch", [payload], "x".repeat(257)],
+  ])("rejects a %s key without side effects", async (_name, path, body, key) => {
     const { app, store, webhooks } = createTestApp();
     const dispatch = vi.spyOn(webhooks, "dispatch");
-    const response = await sendJson(app, "/emails", payload, {
+    const response = await sendJson(app, path, body, {
       ...authHeaders(),
       "Idempotency-Key": key,
     });
@@ -432,6 +451,11 @@ describe("Resend plugin - Idempotency-Key", () => {
       headers,
       body: "not json",
     });
+    const malformedSingle = await app.request(`${base}/emails`, {
+      method: "POST",
+      headers,
+      body: "not json",
+    });
     const invalid = await sendJson(app, "/emails", { from: payload.from }, headers);
     const oversized = await sendJson(
       app,
@@ -440,7 +464,7 @@ describe("Resend plugin - Idempotency-Key", () => {
       headers,
     );
 
-    expect([malformed.status, invalid.status, oversized.status]).toEqual([422, 422, 422]);
+    expect([malformed.status, malformedSingle.status, invalid.status, oversized.status]).toEqual([422, 422, 422, 422]);
     expect(getResendStore(store).idempotencyRecords.count()).toBe(0);
     const valid = await sendJson(app, "/emails", payload, headers);
     expect(valid.status).toBe(200);
@@ -470,6 +494,7 @@ describe("Resend plugin - Idempotency-Key", () => {
     const firstPromise = sendJson(app, "/emails", payload, headers);
     await started;
     const concurrent = await sendJson(app, "/emails", payload, headers);
+    const concurrentChanged = await sendJson(app, "/emails", { ...payload, subject: "Changed" }, headers);
 
     expect(concurrent.status).toBe(409);
     expect(await concurrent.json()).toEqual({
@@ -477,6 +502,8 @@ describe("Resend plugin - Idempotency-Key", () => {
       name: "concurrent_idempotent_requests",
       message: "There is another request in progress with the same idempotency key.",
     });
+    expect(concurrentChanged.status).toBe(409);
+    expect(((await concurrentChanged.json()) as { name: string }).name).toBe("concurrent_idempotent_requests");
     expect(getResendStore(store).emails.count()).toBe(1);
 
     releaseDispatch();
@@ -484,27 +511,53 @@ describe("Resend plugin - Idempotency-Key", () => {
     expect(first.status).toBe(200);
     const replay = await sendJson(app, "/emails", payload, headers);
     expect(await replay.json()).toEqual(await first.json());
+    const changedAfterCompletion = await sendJson(app, "/emails", { ...payload, subject: "Changed" }, headers);
+    expect(changedAfterCompletion.status).toBe(409);
+    expect(((await changedAfterCompletion.json()) as { name: string }).name).toBe("invalid_idempotent_request");
     expect(getResendStore(store).emails.count()).toBe(1);
   });
 
-  it("replays immediately before 24 hours and permits a fresh send at expiry", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  it.each([
+    ["single", "/emails", payload, 2],
+    ["batch", "/emails/batch", [payload, { ...payload, to: "second@example.com" }], 4],
+  ] as const)(
+    "replays a %s send immediately before 24 hours and permits a fresh send at expiry",
+    async (_name, path, body, emailCount) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      const { app, store } = createTestApp();
+      const headers = { ...authHeaders(), "Idempotency-Key": `ttl-${_name}` };
+      const first = await sendJson(app, path, body, headers);
+      const firstBody = await first.json();
+
+      vi.setSystemTime(new Date("2026-01-01T23:59:59.999Z"));
+      const beforeExpiry = await sendJson(app, path, body, headers);
+      expect(await beforeExpiry.json()).toEqual(firstBody);
+
+      vi.setSystemTime(new Date("2026-01-02T00:00:00.000Z"));
+      const atExpiry = await sendJson(app, path, body, headers);
+      expect(await atExpiry.json()).not.toEqual(firstBody);
+      expect(getResendStore(store).emails.count()).toBe(emailCount);
+      expect(getResendStore(store).idempotencyRecords.count()).toBe(1);
+    },
+  );
+
+  it("includes prototype-named properties in request fingerprints", async () => {
     const { app, store } = createTestApp();
-    const headers = { ...authHeaders(), "Idempotency-Key": "ttl-key" };
-    const first = await sendJson(app, "/emails", payload, headers);
-    const firstBody = (await first.json()) as { id: string };
+    const headers = { ...authHeaders(), "Idempotency-Key": "prototype-property" };
+    const original = JSON.parse(
+      '{"from":"sender@example.com","to":"recipient@example.com","subject":"Idempotent send","custom":{"__proto__":{"value":"original"}}}',
+    ) as Record<string, unknown>;
+    const changed = JSON.parse(
+      '{"from":"sender@example.com","to":"recipient@example.com","subject":"Idempotent send","custom":{"__proto__":{"value":"changed"}}}',
+    ) as Record<string, unknown>;
 
-    vi.setSystemTime(new Date("2026-01-01T23:59:59.999Z"));
-    const beforeExpiry = await sendJson(app, "/emails", payload, headers);
-    expect(await beforeExpiry.json()).toEqual(firstBody);
+    expect((await sendJson(app, "/emails", original, headers)).status).toBe(200);
+    const conflict = await sendJson(app, "/emails", changed, headers);
 
-    vi.setSystemTime(new Date("2026-01-02T00:00:00.000Z"));
-    const atExpiry = await sendJson(app, "/emails", payload, headers);
-    const atExpiryBody = (await atExpiry.json()) as { id: string };
-    expect(atExpiryBody.id).not.toBe(firstBody.id);
-    expect(getResendStore(store).emails.count()).toBe(2);
-    expect(getResendStore(store).idempotencyRecords.count()).toBe(1);
+    expect(conflict.status).toBe(409);
+    expect(((await conflict.json()) as { name: string }).name).toBe("invalid_idempotent_request");
+    expect(getResendStore(store).emails.count()).toBe(1);
   });
 
   it("restores completed records and replays them within their original TTL", async () => {

--- a/packages/@emulators/resend/src/__tests__/resend.test.ts
+++ b/packages/@emulators/resend/src/__tests__/resend.test.ts
@@ -619,6 +619,29 @@ describe("Resend plugin - Idempotency-Key", () => {
     expect(getResendStore(store).emails.count()).toBe(2);
     expect(getResendStore(store).idempotencyRecords.findOneBy("state", "completed")?.state).toBe("completed");
   });
+
+  it("releases a reservation when response serialization fails after execution", async () => {
+    const { app, store } = createTestApp();
+    const headers = { ...authHeaders(), "Idempotency-Key": "retry-after-response-failure" };
+    const circular: Record<string, unknown> = { value: payload.from };
+    circular.self = circular;
+    const originalInsert = getResendStore(store).emails.insert.bind(getResendStore(store).emails);
+    const insert = vi.spyOn(getResendStore(store).emails, "insert").mockImplementation((data) => {
+      const email = originalInsert(data);
+      email.uuid = circular as unknown as string;
+      return email;
+    });
+
+    const failed = await sendJson(app, "/emails", payload, headers);
+    expect(failed.status).toBe(500);
+    expect(getResendStore(store).emails.count()).toBe(0);
+    expect(getResendStore(store).idempotencyRecords.count()).toBe(0);
+
+    insert.mockRestore();
+    const retry = await sendJson(app, "/emails", payload, headers);
+    expect(retry.status).toBe(200);
+    expect(getResendStore(store).emails.count()).toBe(1);
+  });
 });
 
 describe("Resend plugin - Domains", () => {

--- a/packages/@emulators/resend/src/__tests__/resend.test.ts
+++ b/packages/@emulators/resend/src/__tests__/resend.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "@emulators/core";
 import {
   Store,
@@ -12,13 +12,18 @@ import { resendPlugin, seedFromConfig, getResendStore } from "../index.js";
 
 const base = "http://localhost:4000";
 
-function createTestApp() {
-  const store = new Store();
-  const webhooks = new WebhookDispatcher();
+function createTestApp(options: { store?: Store; webhooks?: WebhookDispatcher } = {}) {
+  const store = options.store ?? new Store();
+  const webhooks = options.webhooks ?? new WebhookDispatcher();
   const tokenMap: TokenMap = new Map();
   tokenMap.set("re_test_token", {
     login: "testuser@example.com",
     id: 1,
+    scopes: [],
+  });
+  tokenMap.set("re_other_token", {
+    login: "other@example.com",
+    id: 2,
     scopes: [],
   });
 
@@ -33,6 +38,19 @@ function createTestApp() {
 
 function authHeaders(): Record<string, string> {
   return { Authorization: "Bearer re_test_token", "Content-Type": "application/json" };
+}
+
+function sendJson(
+  app: Hono,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = authHeaders(),
+): Promise<Response> {
+  return app.request(`${base}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
 }
 
 describe("Resend plugin - Emails", () => {
@@ -169,6 +187,384 @@ describe("Resend plugin - Emails", () => {
       headers: authHeaders(),
     });
     expect(res.status).toBe(422);
+  });
+});
+
+describe("Resend plugin - Idempotency-Key", () => {
+  const payload = {
+    from: "sender@example.com",
+    to: "recipient@example.com",
+    subject: "Idempotent send",
+  };
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["single", "/emails", payload, 1],
+    ["batch", "/emails/batch", [payload, { ...payload, to: "second@example.com" }], 2],
+  ] as const)(
+    "replays an equivalent %s response without inserting emails or dispatching webhooks",
+    async (_name, path, body, count) => {
+      const { app, store, webhooks } = createTestApp();
+      const dispatch = vi.spyOn(webhooks, "dispatch");
+      const headers = { ...authHeaders(), "Idempotency-Key": `replay-${_name}` };
+
+      const first = await sendJson(app, path, body, headers);
+      const firstText = await first.text();
+      const webhookCount = dispatch.mock.calls.length;
+      const second = await sendJson(app, path, body, headers);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(await second.text()).toBe(firstText);
+      expect(getResendStore(store).emails.count()).toBe(count);
+      expect(getResendStore(store).idempotencyRecords.count()).toBe(1);
+      expect(dispatch).toHaveBeenCalledTimes(webhookCount);
+    },
+  );
+
+  it("continues creating distinct emails without a key and with different keys", async () => {
+    const { app, store } = createTestApp();
+    const noKeyFirst = await sendJson(app, "/emails", payload);
+    const noKeySecond = await sendJson(app, "/emails", payload);
+    const firstKey = await sendJson(app, "/emails", payload, {
+      ...authHeaders(),
+      "Idempotency-Key": "different-a",
+    });
+    const secondKey = await sendJson(app, "/emails", payload, {
+      ...authHeaders(),
+      "Idempotency-Key": "different-b",
+    });
+
+    const ids = await Promise.all(
+      [noKeyFirst, noKeySecond, firstKey, secondKey].map(
+        async (response) => ((await response.json()) as { id: string }).id,
+      ),
+    );
+    expect(new Set(ids).size).toBe(4);
+    expect(getResendStore(store).emails.count()).toBe(4);
+  });
+
+  it.each([
+    ["from", { from: "changed@example.com" }],
+    ["to", { to: "changed@example.com" }],
+    ["subject", { subject: "Changed" }],
+    ["html", { html: "<p>Changed</p>" }],
+    ["text", { text: "Changed" }],
+    ["cc", { cc: "cc@example.com" }],
+    ["bcc", { bcc: "bcc@example.com" }],
+    ["reply_to", { reply_to: "reply@example.com" }],
+    ["headers", { headers: { "X-Custom": "changed" } }],
+    ["tags", { tags: [{ name: "environment", value: "test" }] }],
+    ["attachments", { attachments: [{ filename: "hello.txt", content: "changed" }] }],
+    ["template", { template: { id: "template-id", variables: { nested: "changed" } } }],
+    ["scheduled_at", { scheduled_at: "2099-01-01T00:00:00Z" }],
+    ["unknown nested field", { custom: { nested: { value: "changed" } } }],
+  ])("returns a payload conflict when %s changes", async (field, override) => {
+    const { app, store, webhooks } = createTestApp();
+    const dispatch = vi.spyOn(webhooks, "dispatch");
+    const headers = { ...authHeaders(), "Idempotency-Key": `conflict-${field}` };
+
+    expect((await sendJson(app, "/emails", payload, headers)).status).toBe(200);
+    const webhookCount = dispatch.mock.calls.length;
+    const conflict = await sendJson(app, "/emails", { ...payload, ...override }, headers);
+
+    expect(conflict.status).toBe(409);
+    expect(await conflict.json()).toEqual({
+      statusCode: 409,
+      name: "invalid_idempotent_request",
+      message:
+        "This idempotency key has been used with this HTTP method and endpoint within the last 24 hours, but the request body was modified and doesn’t match the original request.",
+    });
+    expect(getResendStore(store).emails.count()).toBe(1);
+    expect(dispatch).toHaveBeenCalledTimes(webhookCount);
+  });
+
+  it.each([
+    [
+      "a field in a batch item",
+      [payload, { ...payload, to: "second@example.com", custom: { nested: "original" } }],
+      [payload, { ...payload, to: "second@example.com", custom: { nested: "changed" } }],
+    ],
+    [
+      "batch order",
+      [
+        { ...payload, subject: "First" },
+        { ...payload, subject: "Second" },
+      ],
+      [
+        { ...payload, subject: "Second" },
+        { ...payload, subject: "First" },
+      ],
+    ],
+  ])("returns a payload conflict when %s changes", async (name, original, changed) => {
+    const { app, store, webhooks } = createTestApp();
+    const dispatch = vi.spyOn(webhooks, "dispatch");
+    const headers = { ...authHeaders(), "Idempotency-Key": `batch-conflict-${name}` };
+
+    expect((await sendJson(app, "/emails/batch", original, headers)).status).toBe(200);
+    const emailCount = getResendStore(store).emails.count();
+    const webhookCount = dispatch.mock.calls.length;
+    const conflict = await sendJson(app, "/emails/batch", changed, headers);
+
+    expect(conflict.status).toBe(409);
+    expect(((await conflict.json()) as { name: string }).name).toBe("invalid_idempotent_request");
+    expect(getResendStore(store).emails.count()).toBe(emailCount);
+    expect(dispatch).toHaveBeenCalledTimes(webhookCount);
+  });
+
+  it("treats object ordering, header ordering, address forms, and omitted defaults as equivalent", async () => {
+    const { app, store } = createTestApp();
+    const headers = { ...authHeaders(), "Idempotency-Key": "canonical-equivalence" };
+    const firstPayload = {
+      ...payload,
+      cc: "cc@example.com",
+      bcc: "bcc@example.com",
+      reply_to: "reply@example.com",
+      headers: { "X-Second": "2", "X-First": "1" },
+      custom: { z: 1, a: { second: true, first: false } },
+    };
+    const equivalentPayload = {
+      custom: { a: { first: false, second: true }, z: 1 },
+      headers: { "X-First": "1", "X-Second": "2" },
+      reply_to: ["reply@example.com"],
+      bcc: ["bcc@example.com"],
+      cc: ["cc@example.com"],
+      subject: payload.subject,
+      to: [payload.to],
+      from: payload.from,
+      html: null,
+      text: null,
+      tags: [],
+      scheduled_at: null,
+    };
+
+    const first = await sendJson(app, "/emails", firstPayload, headers);
+    const second = await sendJson(app, "/emails", equivalentPayload, headers);
+
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual(await first.json());
+
+    const defaultHeaders = { ...authHeaders(), "Idempotency-Key": "canonical-defaults" };
+    const omittedDefaults = await sendJson(app, "/emails", payload, defaultHeaders);
+    const explicitDefaults = await sendJson(
+      app,
+      "/emails",
+      {
+        ...payload,
+        to: [payload.to],
+        html: null,
+        text: null,
+        cc: [],
+        bcc: [],
+        reply_to: [],
+        headers: {},
+        tags: [],
+        scheduled_at: null,
+      },
+      defaultHeaders,
+    );
+    expect(await explicitDefaults.json()).toEqual(await omittedDefaults.json());
+    expect(getResendStore(store).emails.count()).toBe(2);
+  });
+
+  it("scopes the same textual key by endpoint and credential without persisting authorization secrets", async () => {
+    const { app, store } = createTestApp();
+    const key = "isolated-key";
+    const first = await sendJson(app, "/emails", payload, { ...authHeaders(), "Idempotency-Key": key });
+    const batch = await sendJson(app, "/emails/batch", [payload], {
+      ...authHeaders(),
+      "Idempotency-Key": key,
+    });
+    const otherCredential = await sendJson(app, "/emails", payload, {
+      Authorization: "Bearer re_adapter_token",
+      "Content-Type": "application/json",
+      "Idempotency-Key": key,
+    });
+
+    expect([first.status, batch.status, otherCredential.status]).toEqual([200, 200, 200]);
+    const rs = getResendStore(store);
+    expect(rs.emails.count()).toBe(3);
+    expect(rs.idempotencyRecords.count()).toBe(3);
+    expect(JSON.stringify(store.snapshot())).not.toContain("re_test_token");
+    expect(JSON.stringify(store.snapshot())).not.toContain("re_adapter_token");
+  });
+
+  it.each([
+    ["empty", ""],
+    ["too long", "x".repeat(257)],
+  ])("rejects a %s key without side effects", async (_name, key) => {
+    const { app, store, webhooks } = createTestApp();
+    const dispatch = vi.spyOn(webhooks, "dispatch");
+    const response = await sendJson(app, "/emails", payload, {
+      ...authHeaders(),
+      "Idempotency-Key": key,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      statusCode: 400,
+      name: "invalid_idempotency_key",
+      message: "Idempotency keys, if present, must have between 1 and 256 characters.",
+    });
+    expect(getResendStore(store).emails.count()).toBe(0);
+    expect(getResendStore(store).idempotencyRecords.count()).toBe(0);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it.each([1, 256])("accepts a %i-character key", async (length) => {
+    const { app } = createTestApp();
+    const headers = { ...authHeaders(), "Idempotency-Key": "x".repeat(length) };
+    const first = await sendJson(app, "/emails", payload, headers);
+    const replay = await sendJson(app, "/emails", payload, headers);
+    expect(first.status).toBe(200);
+    expect(await replay.json()).toEqual(await first.json());
+  });
+
+  it("does not reserve keys for malformed, validation-failing, or oversized requests", async () => {
+    const { app, store } = createTestApp();
+    const headers = { ...authHeaders(), "Idempotency-Key": "reusable-after-validation" };
+    const malformed = await app.request(`${base}/emails/batch`, {
+      method: "POST",
+      headers,
+      body: "not json",
+    });
+    const invalid = await sendJson(app, "/emails", { from: payload.from }, headers);
+    const oversized = await sendJson(
+      app,
+      "/emails/batch",
+      Array.from({ length: 101 }, () => payload),
+      headers,
+    );
+
+    expect([malformed.status, invalid.status, oversized.status]).toEqual([422, 422, 422]);
+    expect(getResendStore(store).idempotencyRecords.count()).toBe(0);
+    const valid = await sendJson(app, "/emails", payload, headers);
+    expect(valid.status).toBe(200);
+    expect(getResendStore(store).emails.count()).toBe(1);
+  });
+
+  it("returns a concurrency conflict while the original request is awaiting webhook dispatch", async () => {
+    const { app, store, webhooks } = createTestApp();
+    let releaseDispatch!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    let dispatchStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      dispatchStarted = resolve;
+    });
+    let callCount = 0;
+    vi.spyOn(webhooks, "dispatch").mockImplementation(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        dispatchStarted();
+        await deferred;
+      }
+    });
+    const headers = { ...authHeaders(), "Idempotency-Key": "concurrent-key" };
+
+    const firstPromise = sendJson(app, "/emails", payload, headers);
+    await started;
+    const concurrent = await sendJson(app, "/emails", payload, headers);
+
+    expect(concurrent.status).toBe(409);
+    expect(await concurrent.json()).toEqual({
+      statusCode: 409,
+      name: "concurrent_idempotent_requests",
+      message: "There is another request in progress with the same idempotency key.",
+    });
+    expect(getResendStore(store).emails.count()).toBe(1);
+
+    releaseDispatch();
+    const first = await firstPromise;
+    expect(first.status).toBe(200);
+    const replay = await sendJson(app, "/emails", payload, headers);
+    expect(await replay.json()).toEqual(await first.json());
+    expect(getResendStore(store).emails.count()).toBe(1);
+  });
+
+  it("replays immediately before 24 hours and permits a fresh send at expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const { app, store } = createTestApp();
+    const headers = { ...authHeaders(), "Idempotency-Key": "ttl-key" };
+    const first = await sendJson(app, "/emails", payload, headers);
+    const firstBody = (await first.json()) as { id: string };
+
+    vi.setSystemTime(new Date("2026-01-01T23:59:59.999Z"));
+    const beforeExpiry = await sendJson(app, "/emails", payload, headers);
+    expect(await beforeExpiry.json()).toEqual(firstBody);
+
+    vi.setSystemTime(new Date("2026-01-02T00:00:00.000Z"));
+    const atExpiry = await sendJson(app, "/emails", payload, headers);
+    const atExpiryBody = (await atExpiry.json()) as { id: string };
+    expect(atExpiryBody.id).not.toBe(firstBody.id);
+    expect(getResendStore(store).emails.count()).toBe(2);
+    expect(getResendStore(store).idempotencyRecords.count()).toBe(1);
+  });
+
+  it("restores completed records and replays them within their original TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+    const firstContext = createTestApp();
+    const headers = { ...authHeaders(), "Idempotency-Key": "snapshot-key" };
+    const first = await sendJson(firstContext.app, "/emails/batch", [payload], headers);
+    const firstBody = await first.json();
+    const snapshot = firstContext.store.snapshot();
+
+    vi.setSystemTime(new Date("2026-02-01T12:00:00.000Z"));
+    const restoredStore = new Store();
+    restoredStore.restore(snapshot);
+    const restoredContext = createTestApp({ store: restoredStore });
+    const dispatch = vi.spyOn(restoredContext.webhooks, "dispatch");
+    const replay = await sendJson(restoredContext.app, "/emails/batch", [payload], headers);
+
+    expect(await replay.json()).toEqual(firstBody);
+    expect(getResendStore(restoredStore).emails.count()).toBe(1);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not expose the key or internal record fields through email APIs", async () => {
+    const { app } = createTestApp();
+    const key = "private-idempotency-key";
+    const send = await sendJson(app, "/emails", payload, { ...authHeaders(), "Idempotency-Key": key });
+    const { id } = (await send.json()) as { id: string };
+    const detail = await app.request(`${base}/emails/${id}`, { headers: authHeaders() });
+    const list = await app.request(`${base}/emails`, { headers: authHeaders() });
+    const detailText = await detail.text();
+    const listText = await list.text();
+
+    for (const text of [detailText, listText]) {
+      expect(text).not.toContain(key);
+      expect(text).not.toContain("lookup_digest");
+      expect(text).not.toContain("request_fingerprint");
+      expect(text).not.toContain("expires_at");
+    }
+  });
+
+  it("rolls back inserted rows and releases the reservation after an unexpected execution failure", async () => {
+    const { app, store, webhooks } = createTestApp();
+    const headers = { ...authHeaders(), "Idempotency-Key": "retry-after-failure" };
+    const dispatch = vi.spyOn(webhooks, "dispatch");
+    dispatch.mockResolvedValueOnce();
+    dispatch.mockResolvedValueOnce();
+    dispatch.mockRejectedValueOnce(new Error("injected failure"));
+    const batch = [payload, { ...payload, to: "second@example.com" }];
+
+    const failed = await sendJson(app, "/emails/batch", batch, headers);
+    expect(failed.status).toBe(500);
+    expect(getResendStore(store).emails.count()).toBe(0);
+    expect(getResendStore(store).idempotencyRecords.count()).toBe(0);
+
+    vi.restoreAllMocks();
+    const retry = await sendJson(app, "/emails/batch", batch, headers);
+    expect(retry.status).toBe(200);
+    expect(getResendStore(store).emails.count()).toBe(2);
+    expect(getResendStore(store).idempotencyRecords.findOneBy("state", "completed")?.state).toBe("completed");
   });
 });
 

--- a/packages/@emulators/resend/src/entities.ts
+++ b/packages/@emulators/resend/src/entities.ts
@@ -17,6 +17,15 @@ export interface ResendEmail extends Entity {
   last_event: string;
 }
 
+export interface ResendIdempotencyRecord extends Entity {
+  lookup_digest: string;
+  request_fingerprint: string;
+  state: "in_progress" | "completed";
+  response_status: number | null;
+  response_body: unknown | null;
+  expires_at: string;
+}
+
 export interface ResendDomain extends Entity {
   uuid: string;
   name: string;

--- a/packages/@emulators/resend/src/idempotency.ts
+++ b/packages/@emulators/resend/src/idempotency.ts
@@ -1,0 +1,155 @@
+import { createHash } from "crypto";
+import type { Collection, Context } from "@emulators/core";
+import type { ResendIdempotencyRecord } from "./entities.js";
+
+export const RESEND_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+
+export const INVALID_IDEMPOTENCY_KEY_MESSAGE = "Idempotency keys, if present, must have between 1 and 256 characters.";
+export const INVALID_IDEMPOTENT_REQUEST_MESSAGE =
+  "This idempotency key has been used with this HTTP method and endpoint within the last 24 hours, but the request body was modified and doesn’t match the original request.";
+export const CONCURRENT_IDEMPOTENT_REQUESTS_MESSAGE =
+  "There is another request in progress with the same idempotency key.";
+
+export type IdempotencyDecision =
+  | { kind: "reserved"; record: ResendIdempotencyRecord }
+  | { kind: "replay"; status: number; body: unknown }
+  | { kind: "payload_conflict" }
+  | { kind: "concurrent" };
+
+export function readIdempotencyKey(c: Context): { present: false } | { present: true; key: string } {
+  if (!c.req.raw.headers.has("Idempotency-Key")) return { present: false };
+  return { present: true, key: c.req.raw.headers.get("Idempotency-Key") ?? "" };
+}
+
+export function isValidIdempotencyKey(key: string): boolean {
+  const length = Array.from(key).length;
+  return length >= 1 && length <= 256;
+}
+
+export function canonicalizeEmailPayload(body: Record<string, unknown>): Record<string, unknown> {
+  const canonical: Record<string, unknown> = { ...body };
+
+  canonical.html = body.html ?? null;
+  canonical.text = body.text ?? null;
+  canonical.cc = canonicalizeAddress(body, "cc", []);
+  canonical.bcc = canonicalizeAddress(body, "bcc", []);
+  canonical.reply_to = canonicalizeAddress(body, "reply_to", []);
+  canonical.headers = body.headers ?? {};
+  canonical.tags = body.tags ?? [];
+  canonical.scheduled_at = body.scheduled_at ?? null;
+
+  if (Object.prototype.hasOwnProperty.call(body, "to")) {
+    canonical.to = canonicalizeAddress(body, "to", body.to);
+  }
+
+  return canonical;
+}
+
+export function requestFingerprint(value: unknown): string {
+  return sha256(stableSerialize(value));
+}
+
+export function idempotencyLookupDigest(c: Context, method: string, endpoint: string, key: string): string {
+  return sha256(JSON.stringify([credentialNamespace(c), method.toUpperCase(), endpoint, key]));
+}
+
+export function reserveIdempotencyRecord(
+  records: Collection<ResendIdempotencyRecord>,
+  lookupDigest: string,
+  fingerprint: string,
+  now = Date.now(),
+): IdempotencyDecision {
+  let existing = records.findOneBy("lookup_digest", lookupDigest);
+  if (existing && Date.parse(existing.expires_at) <= now) {
+    records.delete(existing.id);
+    existing = undefined;
+  }
+
+  if (existing) {
+    if (existing.state === "in_progress") return { kind: "concurrent" };
+    if (existing.request_fingerprint !== fingerprint) return { kind: "payload_conflict" };
+    return {
+      kind: "replay",
+      status: existing.response_status ?? 200,
+      body: existing.response_body,
+    };
+  }
+
+  return {
+    kind: "reserved",
+    record: records.insert({
+      lookup_digest: lookupDigest,
+      request_fingerprint: fingerprint,
+      state: "in_progress",
+      response_status: null,
+      response_body: null,
+      expires_at: new Date(now + RESEND_IDEMPOTENCY_TTL_MS).toISOString(),
+    }),
+  };
+}
+
+export function completeIdempotencyRecord(
+  records: Collection<ResendIdempotencyRecord>,
+  recordId: number,
+  responseStatus: number,
+  responseBody: unknown,
+): void {
+  const record = records.get(recordId);
+  if (!record || record.state !== "in_progress") return;
+  records.update(recordId, {
+    state: "completed",
+    response_status: responseStatus,
+    response_body: responseBody,
+  });
+}
+
+export function releaseIdempotencyRecord(records: Collection<ResendIdempotencyRecord>, recordId: number): void {
+  const record = records.get(recordId);
+  if (record?.state === "in_progress") records.delete(recordId);
+}
+
+export function stableSerialize(value: unknown): string {
+  return JSON.stringify(sortRecursively(value));
+}
+
+function canonicalizeAddress(
+  body: Record<string, unknown>,
+  field: "to" | "cc" | "bcc" | "reply_to",
+  omittedDefault: unknown,
+): unknown {
+  if (!Object.prototype.hasOwnProperty.call(body, field) || body[field] == null) return omittedDefault;
+  const value = body[field];
+  if (typeof value === "string") return value ? [value] : [];
+  if (Array.isArray(value)) return value.map((address) => String(address));
+  return value;
+}
+
+function credentialNamespace(c: Context): string {
+  const authenticatedToken = c.get("authToken");
+  if (typeof authenticatedToken === "string" && authenticatedToken.length > 0) return `token:${authenticatedToken}`;
+
+  const authorization = c.req.header("Authorization")?.trim();
+  if (!authorization) return "anonymous";
+
+  const tokenMatch = authorization.match(/^(?:Bearer|token)\s+(.+)$/i);
+  if (tokenMatch) return `token:${tokenMatch[1].trim()}`;
+
+  const separator = authorization.indexOf(" ");
+  if (separator === -1) return `authorization:${authorization}`;
+  return `authorization:${authorization.slice(0, separator).toLowerCase()} ${authorization.slice(separator + 1).trim()}`;
+}
+
+function sortRecursively(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortRecursively);
+  if (value === null || typeof value !== "object") return value;
+
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = sortRecursively((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/packages/@emulators/resend/src/idempotency.ts
+++ b/packages/@emulators/resend/src/idempotency.ts
@@ -143,7 +143,8 @@ function sortRecursively(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sortRecursively);
   if (value === null || typeof value !== "object") return value;
 
-  const sorted: Record<string, unknown> = {};
+  // A null prototype keeps JSON keys such as "__proto__" as ordinary data.
+  const sorted: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (const key of Object.keys(value).sort()) {
     sorted[key] = sortRecursively((value as Record<string, unknown>)[key]);
   }

--- a/packages/@emulators/resend/src/routes/emails.ts
+++ b/packages/@emulators/resend/src/routes/emails.ts
@@ -1,14 +1,33 @@
-import type { RouteContext } from "@emulators/core";
-import { getResendStore } from "../store.js";
+import type { AppEnv, ContentfulStatusCode, Context, RouteContext } from "@emulators/core";
+import { getResendStore, type ResendStore } from "../store.js";
 import { generateUuid, resendError, resendList, parseResendBody } from "../helpers.js";
 import type { ResendEmail } from "../entities.js";
+import {
+  canonicalizeEmailPayload,
+  completeIdempotencyRecord,
+  CONCURRENT_IDEMPOTENT_REQUESTS_MESSAGE,
+  idempotencyLookupDigest,
+  INVALID_IDEMPOTENCY_KEY_MESSAGE,
+  INVALID_IDEMPOTENT_REQUEST_MESSAGE,
+  isValidIdempotencyKey,
+  readIdempotencyKey,
+  releaseIdempotencyRecord,
+  requestFingerprint,
+  reserveIdempotencyRecord,
+} from "../idempotency.js";
+
+type EmailInput = Record<string, unknown>;
+type IdempotencyStart = { kind: "continue"; recordId: number | null } | { kind: "response"; response: Response };
 
 export function emailRoutes(ctx: RouteContext): void {
   const { app, store, webhooks } = ctx;
   const rs = () => getResendStore(store);
 
   app.post("/emails/batch", async (c) => {
-    let emails: Array<Record<string, unknown>>;
+    const keyError = validateIdempotencyKey(c);
+    if (keyError) return keyError;
+
+    let emails: EmailInput[];
     try {
       const raw = await c.req.json();
       if (!Array.isArray(raw)) {
@@ -23,112 +42,49 @@ export function emailRoutes(ctx: RouteContext): void {
       return resendError(c, 422, "validation_error", "Batch size cannot exceed 100 emails");
     }
 
-    // Validate all emails before inserting any to prevent phantom records
+    // Validate the whole operation before reserving its key or inserting any rows.
     for (const emailData of emails) {
-      if (!emailData.from) return resendError(c, 422, "validation_error", "Missing required field: from");
-      if (!emailData.to) return resendError(c, 422, "validation_error", "Missing required field: to");
-      if (!emailData.subject) return resendError(c, 422, "validation_error", "Missing required field: subject");
+      const validation = validateEmail(c, emailData);
+      if (validation) return validation;
     }
 
-    const results: Array<{ id: string }> = [];
+    const currentStore = rs();
+    const idempotency = beginIdempotency(c, currentStore, "/emails/batch", emails.map(canonicalizeEmailPayload));
+    if (idempotency.kind === "response") return idempotency.response;
 
-    for (const emailData of emails) {
-      const from = emailData.from as string;
-      const to = emailData.to as string | string[];
-      const subject = emailData.subject as string;
-      const toArray = Array.isArray(to) ? to : [to];
-      const uuid = generateUuid();
+    return executeSend(c, currentStore, idempotency.recordId, async (insertedEmailIds) => {
+      const results: Array<{ id: string }> = [];
 
-      const scheduledAt = emailData.scheduled_at as string | undefined;
-      const status = scheduledAt ? ("scheduled" as const) : ("delivered" as const);
-
-      rs().emails.insert({
-        uuid,
-        from,
-        to: toArray,
-        subject,
-        html: (emailData.html as string) ?? null,
-        text: (emailData.text as string) ?? null,
-        cc: normalizeStringArray(emailData.cc),
-        bcc: normalizeStringArray(emailData.bcc),
-        reply_to: normalizeStringArray(emailData.reply_to),
-        headers: (emailData.headers as Record<string, string>) ?? {},
-        tags: (emailData.tags as Array<{ name: string; value: string }>) ?? [],
-        status,
-        scheduled_at: scheduledAt ?? null,
-        last_event: status === "scheduled" ? "email.scheduled" : "email.delivered",
-      });
-
-      if (!scheduledAt) {
-        await webhooks.dispatch(
-          "email.sent",
-          undefined,
-          { type: "email.sent", data: { email_id: uuid, to: toArray, from, subject } },
-          "resend",
-        );
-        await webhooks.dispatch(
-          "email.delivered",
-          undefined,
-          { type: "email.delivered", data: { email_id: uuid, to: toArray, from, subject } },
-          "resend",
-        );
+      for (const emailData of emails) {
+        const email = insertEmail(currentStore, emailData);
+        insertedEmailIds.push(email.id);
+        await dispatchEmailWebhooks(email);
+        results.push({ id: email.uuid });
       }
 
-      results.push({ id: uuid });
-    }
-
-    return c.json({ data: results }, 200);
+      return { data: results };
+    });
   });
 
   app.post("/emails", async (c) => {
+    const keyError = validateIdempotencyKey(c);
+    if (keyError) return keyError;
+
     const body = await parseResendBody(c);
-    const from = body.from as string | undefined;
-    const to = body.to as string | string[] | undefined;
-    const subject = body.subject as string | undefined;
 
-    if (!from) return resendError(c, 422, "validation_error", "Missing required field: from");
-    if (!to) return resendError(c, 422, "validation_error", "Missing required field: to");
-    if (!subject) return resendError(c, 422, "validation_error", "Missing required field: subject");
+    const validation = validateEmail(c, body);
+    if (validation) return validation;
 
-    const toArray = Array.isArray(to) ? to : [to];
-    const uuid = generateUuid();
+    const currentStore = rs();
+    const idempotency = beginIdempotency(c, currentStore, "/emails", canonicalizeEmailPayload(body));
+    if (idempotency.kind === "response") return idempotency.response;
 
-    const scheduledAt = body.scheduled_at as string | undefined;
-    const status = scheduledAt ? ("scheduled" as const) : ("delivered" as const);
-
-    rs().emails.insert({
-      uuid,
-      from,
-      to: toArray,
-      subject,
-      html: (body.html as string) ?? null,
-      text: (body.text as string) ?? null,
-      cc: normalizeStringArray(body.cc),
-      bcc: normalizeStringArray(body.bcc),
-      reply_to: normalizeStringArray(body.reply_to),
-      headers: (body.headers as Record<string, string>) ?? {},
-      tags: (body.tags as Array<{ name: string; value: string }>) ?? [],
-      status,
-      scheduled_at: scheduledAt ?? null,
-      last_event: status === "scheduled" ? "email.scheduled" : "email.delivered",
+    return executeSend(c, currentStore, idempotency.recordId, async (insertedEmailIds) => {
+      const email = insertEmail(currentStore, body);
+      insertedEmailIds.push(email.id);
+      await dispatchEmailWebhooks(email);
+      return { id: email.uuid };
     });
-
-    if (!scheduledAt) {
-      await webhooks.dispatch(
-        "email.sent",
-        undefined,
-        { type: "email.sent", data: { email_id: uuid, to: toArray, from, subject } },
-        "resend",
-      );
-      await webhooks.dispatch(
-        "email.delivered",
-        undefined,
-        { type: "email.delivered", data: { email_id: uuid, to: toArray, from, subject } },
-        "resend",
-      );
-    }
-
-    return c.json({ id: uuid }, 200);
   });
 
   app.get("/emails", (c) => {
@@ -158,6 +114,120 @@ export function emailRoutes(ctx: RouteContext): void {
     });
 
     return c.json({ id: email.uuid, object: "email", canceled: true });
+  });
+
+  async function dispatchEmailWebhooks(email: ResendEmail): Promise<void> {
+    if (email.scheduled_at) return;
+
+    const data = {
+      email_id: email.uuid,
+      to: email.to,
+      from: email.from,
+      subject: email.subject,
+    };
+    await webhooks.dispatch("email.sent", undefined, { type: "email.sent", data }, "resend");
+    await webhooks.dispatch("email.delivered", undefined, { type: "email.delivered", data }, "resend");
+  }
+}
+
+function validateIdempotencyKey(c: Context<AppEnv>): Response | undefined {
+  const header = readIdempotencyKey(c);
+  if (header.present && !isValidIdempotencyKey(header.key)) {
+    return resendError(c, 400, "invalid_idempotency_key", INVALID_IDEMPOTENCY_KEY_MESSAGE);
+  }
+  return undefined;
+}
+
+function validateEmail(c: Context<AppEnv>, emailData: EmailInput): Response | undefined {
+  if (!emailData || typeof emailData !== "object" || Array.isArray(emailData)) {
+    return resendError(c, 422, "validation_error", "Missing required field: from");
+  }
+  if (!emailData.from) return resendError(c, 422, "validation_error", "Missing required field: from");
+  if (!emailData.to) return resendError(c, 422, "validation_error", "Missing required field: to");
+  if (!emailData.subject) return resendError(c, 422, "validation_error", "Missing required field: subject");
+  return undefined;
+}
+
+function beginIdempotency(
+  c: Context<AppEnv>,
+  rs: ResendStore,
+  endpoint: "/emails" | "/emails/batch",
+  canonicalPayload: unknown,
+): IdempotencyStart {
+  const header = readIdempotencyKey(c);
+  if (!header.present) return { kind: "continue", recordId: null };
+
+  const decision = reserveIdempotencyRecord(
+    rs.idempotencyRecords,
+    idempotencyLookupDigest(c, "POST", endpoint, header.key),
+    requestFingerprint(canonicalPayload),
+  );
+
+  if (decision.kind === "replay") {
+    return {
+      kind: "response",
+      response: c.json(decision.body, decision.status as ContentfulStatusCode),
+    };
+  }
+  if (decision.kind === "payload_conflict") {
+    return {
+      kind: "response",
+      response: resendError(c, 409, "invalid_idempotent_request", INVALID_IDEMPOTENT_REQUEST_MESSAGE),
+    };
+  }
+  if (decision.kind === "concurrent") {
+    return {
+      kind: "response",
+      response: resendError(c, 409, "concurrent_idempotent_requests", CONCURRENT_IDEMPOTENT_REQUESTS_MESSAGE),
+    };
+  }
+
+  return { kind: "continue", recordId: decision.record.id };
+}
+
+async function executeSend<T extends Record<string, unknown>>(
+  c: Context<AppEnv>,
+  rs: ResendStore,
+  idempotencyRecordId: number | null,
+  operation: (insertedEmailIds: number[]) => Promise<T>,
+): Promise<Response> {
+  const insertedEmailIds: number[] = [];
+  try {
+    const responseBody = await operation(insertedEmailIds);
+    if (idempotencyRecordId !== null) {
+      completeIdempotencyRecord(rs.idempotencyRecords, idempotencyRecordId, 200, responseBody);
+    }
+    return c.json(responseBody, 200);
+  } catch (error) {
+    for (const emailId of insertedEmailIds.reverse()) rs.emails.delete(emailId);
+    if (idempotencyRecordId !== null) releaseIdempotencyRecord(rs.idempotencyRecords, idempotencyRecordId);
+    throw error;
+  }
+}
+
+function insertEmail(rs: ResendStore, emailData: EmailInput): ResendEmail {
+  const from = emailData.from as string;
+  const to = emailData.to as string | string[];
+  const subject = emailData.subject as string;
+  const toArray = Array.isArray(to) ? to : [to];
+  const scheduledAt = emailData.scheduled_at as string | undefined;
+  const status = scheduledAt ? ("scheduled" as const) : ("delivered" as const);
+
+  return rs.emails.insert({
+    uuid: generateUuid(),
+    from,
+    to: toArray,
+    subject,
+    html: (emailData.html as string) ?? null,
+    text: (emailData.text as string) ?? null,
+    cc: normalizeStringArray(emailData.cc),
+    bcc: normalizeStringArray(emailData.bcc),
+    reply_to: normalizeStringArray(emailData.reply_to),
+    headers: (emailData.headers as Record<string, string>) ?? {},
+    tags: (emailData.tags as Array<{ name: string; value: string }>) ?? [],
+    status,
+    scheduled_at: scheduledAt ?? null,
+    last_event: status === "scheduled" ? "email.scheduled" : "email.delivered",
   });
 }
 

--- a/packages/@emulators/resend/src/routes/emails.ts
+++ b/packages/@emulators/resend/src/routes/emails.ts
@@ -194,10 +194,11 @@ async function executeSend<T extends Record<string, unknown>>(
   const insertedEmailIds: number[] = [];
   try {
     const responseBody = await operation(insertedEmailIds);
+    const response = c.json(responseBody, 200);
     if (idempotencyRecordId !== null) {
       completeIdempotencyRecord(rs.idempotencyRecords, idempotencyRecordId, 200, responseBody);
     }
-    return c.json(responseBody, 200);
+    return response;
   } catch (error) {
     for (const emailId of insertedEmailIds.reverse()) rs.emails.delete(emailId);
     if (idempotencyRecordId !== null) releaseIdempotencyRecord(rs.idempotencyRecords, idempotencyRecordId);

--- a/packages/@emulators/resend/src/store.ts
+++ b/packages/@emulators/resend/src/store.ts
@@ -1,8 +1,16 @@
 import { Store, type Collection } from "@emulators/core";
-import type { ResendEmail, ResendDomain, ResendApiKey, ResendAudience, ResendContact } from "./entities.js";
+import type {
+  ResendEmail,
+  ResendIdempotencyRecord,
+  ResendDomain,
+  ResendApiKey,
+  ResendAudience,
+  ResendContact,
+} from "./entities.js";
 
 export interface ResendStore {
   emails: Collection<ResendEmail>;
+  idempotencyRecords: Collection<ResendIdempotencyRecord>;
   domains: Collection<ResendDomain>;
   apiKeys: Collection<ResendApiKey>;
   audiences: Collection<ResendAudience>;
@@ -12,6 +20,7 @@ export interface ResendStore {
 export function getResendStore(store: Store): ResendStore {
   return {
     emails: store.collection<ResendEmail>("resend.emails", ["uuid"]),
+    idempotencyRecords: store.collection<ResendIdempotencyRecord>("resend.idempotency_records", ["lookup_digest"]),
     domains: store.collection<ResendDomain>("resend.domains", ["uuid", "name"]),
     apiKeys: store.collection<ResendApiKey>("resend.api_keys", ["uuid"]),
     audiences: store.collection<ResendAudience>("resend.audiences", ["uuid"]),

--- a/packages/emulate/src/__tests__/start-generated-secrets-signal.test.ts
+++ b/packages/emulate/src/__tests__/start-generated-secrets-signal.test.ts
@@ -1,0 +1,73 @@
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const portless = vi.hoisted(() => {
+  let markStarted!: () => void;
+  let releaseCheck!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const pending = new Promise<void>((resolve) => {
+    releaseCheck = resolve;
+  });
+
+  return {
+    started,
+    release: () => releaseCheck(),
+    ensurePortless: vi.fn(async () => {
+      markStarted();
+      await pending;
+    }),
+  };
+});
+
+vi.mock("../portless.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../portless.js")>()),
+  ensurePortless: portless.ensurePortless,
+}));
+
+const { startCommand } = await import("../commands/start.js");
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const directory of directories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe("CLI generated secrets startup signals", () => {
+  it("removes the published artifact when termination arrives during Portless setup", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "emulate-start-signal-"));
+    directories.push(directory);
+    const destination = join(directory, "secrets.json");
+    const beforeSigint = process.listeners("SIGINT");
+    const beforeSigterm = process.listeners("SIGTERM");
+    const start = startCommand({
+      port: 15100,
+      service: "vercel",
+      generatedSecretsFile: destination,
+      portless: true,
+    });
+
+    await portless.started;
+    await expect(access(destination)).resolves.toBeUndefined();
+    const shutdown = process.listeners("SIGTERM").find((listener) => !beforeSigterm.includes(listener));
+    const interrupt = process.listeners("SIGINT").find((listener) => !beforeSigint.includes(listener));
+    expect(shutdown).toBeDefined();
+    expect(interrupt).toBe(shutdown);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    shutdown?.("SIGTERM");
+    portless.release();
+    await start;
+
+    expect(exit).toHaveBeenCalledWith(0);
+    await expect(access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(process.listeners("SIGINT")).toEqual(beforeSigint);
+    expect(process.listeners("SIGTERM")).toEqual(beforeSigterm);
+  });
+});

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -442,8 +442,8 @@ export async function startCommand(options: StartOptions): Promise<void> {
     throw error;
   }
 
-  startupShutdown.uninstall();
   installShutdown(registeredAliases, stores, httpServers);
+  startupShutdown.uninstall();
 }
 
 function printBanner(

--- a/packages/emulate/src/commands/start.ts
+++ b/packages/emulate/src/commands/start.ts
@@ -268,6 +268,56 @@ function installShutdown(portlessAliases: PortlessAlias[], stores: Store[], http
   process.once("SIGTERM", shutdown);
 }
 
+interface StartupShutdownGuard {
+  requested(): boolean;
+  finished(): Promise<void>;
+  rollback(): Promise<void>;
+  uninstall(): void;
+}
+
+function installStartupShutdown(
+  portlessAliases: PortlessAlias[],
+  stores: Store[],
+  httpServers: HttpServer[],
+  generatedSecretsFile: PublishedGeneratedSecretsFile,
+): StartupShutdownGuard {
+  let shutdownRequested = false;
+  let rollbackPromise: Promise<void> | undefined;
+  let shutdownPromise: Promise<void> | undefined;
+
+  const rollback = () => {
+    rollbackPromise ??= rollbackStartup(httpServers, stores, portlessAliases, generatedSecretsFile);
+    return rollbackPromise;
+  };
+  const uninstall = () => {
+    process.removeListener("SIGINT", shutdown);
+    process.removeListener("SIGTERM", shutdown);
+  };
+  const shutdown = () => {
+    if (shutdownPromise) return;
+    shutdownRequested = true;
+    console.log(`\n${pc.dim("Shutting down...")}`);
+    shutdownPromise = (async () => {
+      try {
+        await rollback();
+      } finally {
+        uninstall();
+        process.exit(0);
+      }
+    })();
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  return {
+    requested: () => shutdownRequested,
+    finished: () => shutdownPromise ?? Promise.resolve(),
+    rollback,
+    uninstall,
+  };
+}
+
 export async function startCommand(options: StartOptions): Promise<void> {
   const { port: basePort } = options;
 
@@ -351,10 +401,15 @@ export async function startCommand(options: StartOptions): Promise<void> {
     generatedSecrets,
   });
   const registeredAliases: PortlessAlias[] = [];
+  const startupShutdown = installStartupShutdown(registeredAliases, stores, httpServers, publishedSecretsFile);
 
   try {
     if (options.portless) {
       await ensurePortless({ throwOnFailure: true });
+      if (startupShutdown.requested()) {
+        await startupShutdown.finished();
+        return;
+      }
     }
     for (const alias of portlessAliases) {
       registerAlias(alias);
@@ -370,14 +425,24 @@ export async function startCommand(options: StartOptions): Promise<void> {
       const httpServer = serve({ fetch: app.fetch, port });
       httpServers.push(httpServer);
       await waitForServerListening(httpServer);
+      if (startupShutdown.requested()) {
+        await startupShutdown.finished();
+        return;
+      }
     }
 
     printBanner(serviceUrls, tokens, configSource);
   } catch (error) {
-    await rollbackStartup(httpServers, stores, registeredAliases, publishedSecretsFile);
+    await startupShutdown.rollback();
+    if (startupShutdown.requested()) {
+      await startupShutdown.finished();
+      return;
+    }
+    startupShutdown.uninstall();
     throw error;
   }
 
+  startupShutdown.uninstall();
   installShutdown(registeredAliases, stores, httpServers);
 }
 

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -26,6 +26,9 @@ GitHub API coverage:
 
 Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.
+
+Resend API behavior:
+  Idempotency-Key retries on email send endpoints replay successful responses for 24 hours.
 `,
   );
 

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -28,7 +28,10 @@ Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.
 
 Resend API behavior:
-  Idempotency-Key retries on email send endpoints replay successful responses for 24 hours.
+  Idempotency-Key retries on POST /emails and POST /emails/batch replay successes for 24 hours.
+
+Generated secrets:
+  Startup failures and termination signals during startup remove an invocation-owned output file.
 `,
   );
 

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -74,7 +74,7 @@ npx emulate list
 
 The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
 
-The generated-secrets destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Only service-generated values appear in the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows.
+The generated-secrets destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before opening listeners or configuring portless. Handled startup failures and `SIGINT` or `SIGTERM` received during startup remove the invocation-owned artifact. An uncatchable termination such as `SIGKILL` can leave a complete artifact that must be removed manually after confirming no invocation is using it. Only service-generated values appear in the artifact. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows.
 
 The advertised base URL (used in OAuth redirects, webhook URLs, etc.) can be overridden via `--base-url`, the `EMULATE_BASE_URL` env var (supports `{service}` template), or per-service `baseUrl` in the seed config. When running under portless, the `PORTLESS_URL` env var is also detected automatically.
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -60,7 +60,7 @@ npx emulate start --service github --seed emulate.config.yaml \
   --generated-secrets-file .emulate-secrets.json
 ```
 
-The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before any listener or portless alias starts. Handled startup failures remove the invocation-owned artifact. A hard termination can leave a complete artifact that must be removed manually after confirming no invocation is using it. Read `generatedSecrets` from the artifact, then keep the file out of source control. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`.
+The destination must not exist. emulate removes inherited ACLs, verifies effective owner-only access, and publishes complete JSON before any listener or portless alias starts. Handled startup failures and `SIGINT` or `SIGTERM` received during startup remove the invocation-owned artifact. An uncatchable termination such as `SIGKILL` can leave a complete artifact that must be removed manually after confirming no invocation is using it. Read `generatedSecrets` from the artifact, then keep the file out of source control. Linux requires `setfacl` and `getfacl` from the `acl` package. The flag fails closed when access controls cannot be verified and is not supported on Windows. Without `--generated-secrets-file`, CLI seed files still require `private_key`.
 
 ## Auth
 

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: resend
 description: Emulated Resend email API for local development and testing. Use when the user needs to send emails locally, test transactional email flows, implement magic link or verification code auth, inspect sent emails, manage domains/contacts/API keys, or work with the Resend API without sending real emails. Triggers include "Resend API", "emulate Resend", "send email locally", "test email", "magic link", "verification email", "email inbox", "RESEND_BASE_URL", or any task requiring a local email API.
-allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+allowed-tools: Bash(npx emulate:*), Bash(curl:*)
 ---
 
 # Resend Email API Emulator
 
 Fully stateful Resend API emulation. Emails, domains, API keys, audiences, and contacts persist in memory. Sent emails are captured and viewable through the inbox UI or the REST API.
 
-No real emails are sent. Every call to `POST /emails` stores the message locally so you can inspect it programmatically or in the browser.
+No real emails are sent. Every successful unique send is stored locally so you can inspect it programmatically or in the browser. A keyed retry replays the original response without storing another message.
 
 ## Start
 
@@ -132,7 +132,7 @@ resend:
 
 ## Retrieving Sent Emails
 
-This is the key differentiator of the emulator: every email sent via `POST /emails` is stored and queryable.
+This is the key differentiator of the emulator: every successful unique send via `POST /emails` is stored and queryable. Idempotent retries do not add duplicate records.
 
 ### Inbox UI
 
@@ -201,6 +201,26 @@ curl -X POST http://localhost:4000/emails/<id>/cancel \
 ```
 
 Supported fields: `from`, `to`, `subject`, `html`, `text`, `cc`, `bcc`, `reply_to`, `headers`, `tags`, `scheduled_at`.
+
+### Idempotency
+
+`POST /emails` and `POST /emails/batch` accept an `Idempotency-Key` header. The key is scoped by API credential and endpoint, so the same text can be used independently for single and batch sends or by different credentials.
+
+```bash
+# The first request captures the email. An equivalent retry replays its response.
+curl -X POST http://localhost:4000/emails \
+  -H "Authorization: Bearer re_test_key" \
+  -H "Idempotency-Key: welcome-user-42" \
+  -H "Content-Type: application/json" \
+  -d '{"from":"hello@example.com","to":"user@example.com","subject":"Hello","html":"<p>Welcome</p>"}'
+```
+
+- A present key must contain 1 to 256 characters. Invalid keys return `400 invalid_idempotency_key` and do not reserve the key.
+- An equivalent retry within 24 hours returns the exact original status and JSON body without another captured email or webhook.
+- Reusing a key with a changed payload returns `409 invalid_idempotent_request`.
+- A retry while the original request is running returns `409 concurrent_idempotent_requests`. It is safe to retry after the original completes.
+- At or after 24 hours, the key expires and can create a fresh send.
+- Validation failures and failed executions do not reserve the key. Keys and internal idempotency records are not returned by `GET /emails` or `GET /emails/:id`.
 
 ### Domains
 


### PR DESCRIPTION
Resend email retries now match the production API contract, so applications can retry sends locally without creating duplicate captured messages or webhooks.

- Add 24-hour `Idempotency-Key` handling to `POST /emails` and `POST /emails/batch`, replaying the original successful response for equivalent requests.
- Scope keys by API credential and endpoint, normalize equivalent payload forms, validate key length, and return Resend-compatible conflicts for changed or overlapping requests.
- Persist completed records while releasing reservations and rolling back inserted emails when execution fails, allowing safe retries after failures.
- Document the behavior in the README, Resend package and web docs, agent skill, and CLI help.
- Remove invocation-owned generated-secret files when `SIGINT` or `SIGTERM` interrupts CLI startup, keeping startup cleanup behavior consistent with its documentation.