### PR TITLE
feat(github): inspect installation token metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,8 @@ github:
 
 JWT authentication: sign a JWT with `{ iss: "<app_id>" }` using the app's private key (RS256). The emulator verifies the signature and resolves the app.
 
+Inspect secret-free metadata for minted installation tokens at `GET /_emulate/installation-tokens`.
+
 **App webhook delivery**: When events occur on repos where a GitHub App is installed, the emulator mirrors real GitHub behavior:
 - All webhook payloads (including repo and org hooks) include an `installation` field with `{ id, node_id }`.
 - If the app has a `webhook_url`, the emulator delivers the event there with the `installation` field and (if configured) an `X-Hub-Signature-256` header signed with `webhook_secret`.

--- a/apps/web/app/docs/configuration/page.mdx
+++ b/apps/web/app/docs/configuration/page.mdx
@@ -131,6 +131,7 @@ github:
 - `GET /app/installations` - list app installations
 - `GET /app/installations/:id` - get installation
 - `POST /app/installations/:id/access_tokens` - create installation access token
+- `GET /_emulate/installation-tokens` - inspect secret-free metadata for minted installation tokens
 - `GET /repos/:owner/:repo/installation` - find repo installation
 - `GET /orgs/:org/installation` - find org installation
 - `GET /users/:username/installation` - find user installation

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -31,6 +31,12 @@ The generated RSA-2048 PKCS#1 key remains stable across `reset()` calls. Explici
 
 The Next.js and Nuxt adapters also generate omitted keys. Their returned server handlers expose `generatedSecrets()`, and persistence restores the same identity across cold starts. Keep persisted snapshots private because they contain the signing key. Custom persistence backends must implement atomic `initialize()` semantics when generated identities are used.
 
+## Installation token inspection
+
+`GET /_emulate/installation-tokens` lists metadata for GitHub App installation tokens minted by the current emulator state. It includes App, installation, account, permissions, repository access, issuance, expiry, and lifecycle status without exposing token values or token-derived identifiers.
+
+Expiry is informational and does not change authorization behavior. `createEmulator().reset()` clears minted installation-specific authorization and metadata while preserving seeded tokens, generated App keys, and existing fallback-token behavior. Persisted Next.js and Nuxt adapters restore the metadata with their private snapshot.
+
 The CLI can generate omitted keys when you request a private delivery file:
 
 ```bash

--- a/apps/web/app/docs/nextjs/page.mdx
+++ b/apps/web/app/docs/nextjs/page.mdx
@@ -48,6 +48,8 @@ This creates the following routes:
 
 GitHub App seeds may omit `private_key`; retain the handler and call server-only `generatedSecrets()`. Keep persisted generated keys private and implement atomic `initialize`.
 
+Minted GitHub App installation-token metadata is available at `/emulate/github/_emulate/installation-tokens`.
+
 ## Auth.js / NextAuth Configuration
 
 Point your provider at the emulator paths on the same origin:

--- a/apps/web/app/docs/nuxt/page.mdx
+++ b/apps/web/app/docs/nuxt/page.mdx
@@ -48,6 +48,8 @@ This creates these routes:
 
 GitHub App seeds may omit `private_key`; retain the handler and call server-only `generatedSecrets()`. Keep persisted generated keys private and implement atomic `initialize`.
 
+Minted GitHub App installation-token metadata is available at `/emulate/github/_emulate/installation-tokens`.
+
 ## Nuxt Config
 
 Emulator UI pages use bundled fonts. Wrap your Nuxt config so Nitro traces the core package assets into production builds:

--- a/apps/web/app/docs/page.mdx
+++ b/apps/web/app/docs/page.mdx
@@ -97,3 +97,5 @@ You can also use emulate as a library in your tests. See the [Programmatic API](
 ## Framework Integration
 
 Embed emulators directly in your Next.js or Nuxt app so they run on the same origin. See the [Next.js Integration](/docs/nextjs) and [Nuxt Integration](/docs/nuxt) pages for setup instructions.
+
+GitHub App flows expose secret-free installation-token metadata through an emulator-only inspection route. See the [GitHub documentation](/docs/github) for details.

--- a/packages/@emulators/adapter-next/README.md
+++ b/packages/@emulators/adapter-next/README.md
@@ -49,6 +49,8 @@ export const { GET, POST, PUT, PATCH, DELETE } = emulator
 
 GitHub App seeds may omit `private_key`. Read generated keys with the handler's server-only `generatedSecrets()` method. Explicit keys are excluded; persisted snapshots contain generated keys and require a private backend with atomic `initialize`.
 
+Inspect minted installation-token metadata at `/emulate/github/_emulate/installation-tokens`.
+
 ## Auth.js / NextAuth configuration
 
 Point your provider at the emulator paths on the same origin:

--- a/packages/@emulators/adapter-next/src/__tests__/github-app-identity.test.ts
+++ b/packages/@emulators/adapter-next/src/__tests__/github-app-identity.test.ts
@@ -6,7 +6,20 @@ function config(persistence?: TestPersistence, privateKey?: string): EmulateHand
     services: {
       github: {
         emulator: github,
-        seed: { apps: [{ app_id: 123, slug: "embedded", name: "Embedded", private_key: privateKey }] },
+        seed: {
+          users: [{ login: "octocat" }],
+          orgs: [{ login: "acme" }],
+          repos: [{ owner: "acme", name: "private-repo", private: true }],
+          apps: [
+            {
+              app_id: 123,
+              slug: "embedded",
+              name: "Embedded",
+              private_key: privateKey,
+              installations: [{ installation_id: 124, account: "acme" }],
+            },
+          ],
+        },
       },
     },
     persistence,
@@ -26,6 +39,15 @@ githubAppIdentityContract<EmulateHandlerConfig, ReturnType<typeof createEmulateH
         headers: authorization ? { Authorization: authorization } : undefined,
       }),
       { params: Promise.resolve({ path: ["github", "app"] }) },
+    );
+  },
+  request(handler, path, authorization, method = "GET") {
+    return handler[method](
+      new Request(`http://localhost/emulate/github/${path}`, {
+        method,
+        headers: authorization ? { Authorization: authorization } : undefined,
+      }),
+      { params: Promise.resolve({ path: ["github", ...path.split("/")] }) },
     );
   },
 });

--- a/packages/@emulators/adapter-nuxt/README.md
+++ b/packages/@emulators/adapter-nuxt/README.md
@@ -52,6 +52,8 @@ This creates these routes:
 
 GitHub App seeds may omit `private_key`. Read generated keys with the handler's server-only `generatedSecrets()` method. Explicit keys are excluded; persisted snapshots contain generated keys and require a private backend with atomic `initialize`.
 
+Inspect minted installation-token metadata at `/emulate/github/_emulate/installation-tokens`.
+
 ## Nuxt Config
 
 Emulator UI pages use bundled fonts. Wrap your Nuxt config so Nitro traces the core package assets into production builds:

--- a/packages/@emulators/adapter-nuxt/src/__tests__/github-app-identity.test.ts
+++ b/packages/@emulators/adapter-nuxt/src/__tests__/github-app-identity.test.ts
@@ -6,7 +6,20 @@ function config(persistence?: TestPersistence, privateKey?: string): EmulateHand
     services: {
       github: {
         emulator: github,
-        seed: { apps: [{ app_id: 123, slug: "embedded", name: "Embedded", private_key: privateKey }] },
+        seed: {
+          users: [{ login: "octocat" }],
+          orgs: [{ login: "acme" }],
+          repos: [{ owner: "acme", name: "private-repo", private: true }],
+          apps: [
+            {
+              app_id: 123,
+              slug: "embedded",
+              name: "Embedded",
+              private_key: privateKey,
+              installations: [{ installation_id: 124, account: "acme" }],
+            },
+          ],
+        },
       },
     },
     persistence,
@@ -26,6 +39,15 @@ githubAppIdentityContract<EmulateHandlerConfig, ReturnType<typeof createEmulateH
         headers: authorization ? { Authorization: authorization } : undefined,
       }),
       context: { params: { path: "github/app" } },
+    });
+  },
+  request(handler, path, authorization, method = "GET") {
+    return handler({
+      req: new Request(`http://localhost/emulate/github/${path}`, {
+        method,
+        headers: authorization ? { Authorization: authorization } : undefined,
+      }),
+      context: { params: { path: `github/${path}` } },
     });
   },
 });

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -131,6 +131,7 @@ npm install @emulators/github
 - Automatic suite status rollup from check run results
 
 ### Misc
+- `GET /_emulate/installation-tokens` — inspect secret-free GitHub App installation-token metadata
 - `GET /rate_limit` — rate limit status
 - `GET /meta` — server metadata
 - `GET /octocat` — ASCII art

--- a/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
+++ b/packages/@emulators/github/src/__tests__/webhook-installation.test.ts
@@ -479,6 +479,176 @@ describe("GitHub App installation token flow", () => {
     expect(body.permissions).toEqual({ contents: "read" });
     expect(body.repositories).toEqual([expect.objectContaining({ full_name: "octocat/hello-world" })]);
   });
+
+  it("inspects minted token metadata without exposing token values", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-28T12:00:00.000Z"));
+      const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+      const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+      const { app } = createTestApp({
+        users: [{ login: "octocat" }],
+        repos: [{ owner: "octocat", name: "hello-world" }],
+        apps: [
+          {
+            app_id: 800,
+            slug: "token-app",
+            name: "Token App",
+            private_key: privateKeyPem,
+            permissions: { contents: "read", issues: "write" },
+            installations: [
+              {
+                installation_id: 99,
+                account: "octocat",
+                repository_selection: "selected",
+                repositories: ["octocat/hello-world"],
+              },
+            ],
+          },
+        ],
+      });
+
+      const mintResponse = await app.request(`${base}/app/installations/99/access_tokens`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${createAppJwt("800", privateKeyPem)}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ permissions: { contents: "read" } }),
+      });
+      const minted = (await mintResponse.json()) as { token: string };
+
+      const inspectionResponse = await app.request(`${base}/_emulate/installation-tokens`);
+      const inspection = (await inspectionResponse.json()) as {
+        installation_tokens: Array<{
+          permissions: Record<string, string>;
+          repository_ids: number[];
+        }>;
+      };
+
+      expect(inspectionResponse.status).toBe(200);
+      expect(inspection.installation_tokens).toEqual([
+        {
+          app: { id: 800, slug: "token-app", name: "Token App" },
+          installation: { id: 99 },
+          account: expect.objectContaining({ login: "octocat", type: "User" }),
+          permissions: { contents: "read" },
+          repository_selection: "selected",
+          repository_ids: [expect.any(Number)],
+          issued_at: "2026-08-28T12:00:00.000Z",
+          expires_at: "2026-08-28T13:00:00.000Z",
+          status: "active",
+        },
+      ]);
+      expect(JSON.stringify(inspection)).not.toContain(minted.token);
+      expect(JSON.stringify(inspection)).not.toContain(minted.token.slice(0, 12));
+
+      inspection.installation_tokens[0]!.permissions.contents = "write";
+      inspection.installation_tokens[0]!.repository_ids.push(999);
+      expect(await (await app.request(`${base}/_emulate/installation-tokens`)).json()).toEqual({
+        installation_tokens: [
+          expect.objectContaining({
+            permissions: { contents: "read" },
+            repository_ids: [expect.any(Number)],
+          }),
+        ],
+      });
+
+      vi.setSystemTime(new Date("2026-08-28T13:00:00.000Z"));
+      expect(await (await app.request(`${base}/_emulate/installation-tokens`)).json()).toMatchObject({
+        installation_tokens: [{ status: "expired" }],
+      });
+      expect(
+        (
+          await app.request(`${base}/user`, {
+            headers: { Authorization: `Bearer ${minted.token}` },
+          })
+        ).status,
+      ).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not record rejected mints or seeded user tokens", async () => {
+    const { app } = createTestApp();
+    const response = await app.request(`${base}/app/installations/999/access_tokens`, {
+      method: "POST",
+      headers: { Authorization: "Bearer invalid" },
+    });
+
+    expect(response.status).toBe(401);
+    expect(await (await app.request(`${base}/_emulate/installation-tokens`)).json()).toEqual({
+      installation_tokens: [],
+    });
+  });
+
+  it("records exactly one inspection row for each successful mint", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+    const { app } = createTestApp({
+      users: [{ login: "octocat" }],
+      repos: [{ owner: "octocat", name: "hello-world" }],
+      apps: [
+        {
+          app_id: 800,
+          slug: "token-app",
+          name: "Token App",
+          private_key: privateKeyPem,
+          permissions: { contents: "write" },
+          installations: [{ installation_id: 99, account: "octocat" }],
+        },
+      ],
+    });
+    const authorization = `Bearer ${createAppJwt("800", privateKeyPem)}`;
+
+    for (const permission of ["read", "write"]) {
+      const response = await app.request(`${base}/app/installations/99/access_tokens`, {
+        method: "POST",
+        headers: { Authorization: authorization, "Content-Type": "application/json" },
+        body: JSON.stringify({ permissions: { contents: permission } }),
+      });
+      expect(response.status).toBe(201);
+    }
+
+    expect(await (await app.request(`${base}/_emulate/installation-tokens`)).json()).toMatchObject({
+      installation_tokens: [
+        expect.objectContaining({ permissions: { contents: "read" } }),
+        expect.objectContaining({ permissions: { contents: "write" } }),
+      ],
+    });
+  });
+
+  it("does not authorize a token when metadata insertion fails", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+    const { app, store, tokenMap } = createTestApp({
+      users: [{ login: "octocat" }],
+      apps: [
+        {
+          app_id: 800,
+          slug: "token-app",
+          name: "Token App",
+          private_key: privateKeyPem,
+          installations: [{ installation_id: 99, account: "octocat" }],
+        },
+      ],
+    });
+    vi.spyOn(getGitHubStore(store).installationTokenMetadata, "insert").mockImplementationOnce(() => {
+      throw new Error("metadata unavailable");
+    });
+
+    const response = await app.request(`${base}/app/installations/99/access_tokens`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${createAppJwt("800", privateKeyPem)}` },
+    });
+
+    expect(response.status).toBe(500);
+    expect([...tokenMap.keys()].filter((token) => token.startsWith("ghs_"))).toEqual([]);
+    expect(await (await app.request(`${base}/_emulate/installation-tokens`)).json()).toEqual({
+      installation_tokens: [],
+    });
+  });
 });
 
 describe("app webhook_url delivery", () => {

--- a/packages/@emulators/github/src/entities.ts
+++ b/packages/@emulators/github/src/entities.ts
@@ -509,6 +509,21 @@ export interface GitHubAppInstallation extends Entity {
   suspended_at: string | null;
 }
 
+export interface GitHubInstallationTokenMetadata extends Entity {
+  app_id: number;
+  app_slug: string;
+  app_name: string;
+  installation_id: number;
+  account_id: number;
+  account_login: string;
+  account_type: "User" | "Organization";
+  permissions: Record<string, string>;
+  repository_ids: number[];
+  repository_selection: "all" | "selected";
+  issued_at: string;
+  expires_at: string;
+}
+
 export interface GitHubOAuthGrant extends Entity {
   user_id: number;
   oauth_app_id: number;

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -33,6 +33,7 @@ import { rateLimitRoutes } from "./routes/rate-limit.js";
 import { metaRoutes } from "./routes/meta.js";
 import { oauthRoutes } from "./routes/oauth.js";
 import { appsRoutes } from "./routes/apps.js";
+import { installationTokenRoutes } from "./routes/installation-tokens.js";
 import { findOrCreateBlob, findOrCreateCommit, findOrCreateTree } from "./git-helpers.js";
 
 export { getGitHubStore, type GitHubStore } from "./store.js";
@@ -645,6 +646,7 @@ export const githubPlugin: ServicePlugin = {
     metaRoutes(ctx);
     oauthRoutes(ctx);
     appsRoutes(ctx);
+    installationTokenRoutes(ctx);
     contentsRoutes(ctx);
     // Registered last: the catch-all /commits/:ref{.+} route must not shadow
     // /commits/:sha/comments (comments.ts) or /commits/:ref/check-* (checks.ts).

--- a/packages/@emulators/github/src/routes/apps.ts
+++ b/packages/@emulators/github/src/routes/apps.ts
@@ -191,7 +191,23 @@ export function appsRoutes({ app, store, baseUrl, tokenMap }: RouteContext): voi
     }
 
     const token = "ghs_" + randomBytes(20).toString("base64url");
-    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const issuedAt = new Date().toISOString();
+    const expiresAt = new Date(Date.parse(issuedAt) + 60 * 60 * 1000).toISOString();
+
+    getGitHubStore(store).installationTokenMetadata.insert({
+      app_id: authApp.appId,
+      app_slug: authApp.slug,
+      app_name: authApp.name,
+      installation_id: inst.installation_id,
+      account_id: inst.account_id,
+      account_login: inst.account_login,
+      account_type: inst.account_type,
+      permissions: { ...requestedPermissions },
+      repository_ids: [...requestedRepoIds],
+      repository_selection: tokenRepositorySelection,
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+    });
 
     if (tokenMap) {
       tokenMap.set(token, {
@@ -203,8 +219,8 @@ export function appsRoutes({ app, store, baseUrl, tokenMap }: RouteContext): voi
           appId: inst.app_id,
           accountId: inst.account_id,
           accountType: inst.account_type,
-          permissions: requestedPermissions,
-          repositoryIds: requestedRepoIds,
+          permissions: { ...requestedPermissions },
+          repositoryIds: [...requestedRepoIds],
           repositorySelection: tokenRepositorySelection,
         },
       });

--- a/packages/@emulators/github/src/routes/installation-tokens.ts
+++ b/packages/@emulators/github/src/routes/installation-tokens.ts
@@ -1,0 +1,35 @@
+import type { RouteContext } from "@emulators/core";
+import { getGitHubStore } from "../store.js";
+
+export function installationTokenRoutes(ctx: RouteContext): void {
+  const { app, store } = ctx;
+
+  app.get("/_emulate/installation-tokens", (c) => {
+    const now = Date.now();
+    const installationTokens = getGitHubStore(store)
+      .installationTokenMetadata.all()
+      .map((entry) => ({
+        app: {
+          id: entry.app_id,
+          slug: entry.app_slug,
+          name: entry.app_name,
+        },
+        installation: {
+          id: entry.installation_id,
+        },
+        account: {
+          id: entry.account_id,
+          login: entry.account_login,
+          type: entry.account_type,
+        },
+        permissions: { ...entry.permissions },
+        repository_selection: entry.repository_selection,
+        repository_ids: [...entry.repository_ids],
+        issued_at: entry.issued_at,
+        expires_at: entry.expires_at,
+        status: now < Date.parse(entry.expires_at) ? "active" : "expired",
+      }));
+
+    return c.json({ installation_tokens: installationTokens });
+  });
+}

--- a/packages/@emulators/github/src/store.ts
+++ b/packages/@emulators/github/src/store.ts
@@ -34,6 +34,7 @@ import type {
   GitHubOAuthApp,
   GitHubApp,
   GitHubAppInstallation,
+  GitHubInstallationTokenMetadata,
   GitHubOAuthGrant,
 } from "./entities.js";
 
@@ -72,6 +73,7 @@ export interface GitHubStore {
   oauthApps: Collection<GitHubOAuthApp>;
   apps: Collection<GitHubApp>;
   appInstallations: Collection<GitHubAppInstallation>;
+  installationTokenMetadata: Collection<GitHubInstallationTokenMetadata>;
   oauthGrants: Collection<GitHubOAuthGrant>;
 }
 
@@ -111,6 +113,10 @@ export function getGitHubStore(store: Store): GitHubStore {
     oauthApps: store.collection<GitHubOAuthApp>("github.oauth_apps", ["client_id"]),
     apps: store.collection<GitHubApp>("github.apps", ["slug"]),
     appInstallations: store.collection<GitHubAppInstallation>("github.app_installations", [
+      "app_id",
+      "installation_id",
+    ]),
+    installationTokenMetadata: store.collection<GitHubInstallationTokenMetadata>("github.installation_token_metadata", [
       "app_id",
       "installation_id",
     ]),

--- a/packages/emulate/src/__tests__/api.test.ts
+++ b/packages/emulate/src/__tests__/api.test.ts
@@ -84,12 +84,14 @@ describe("createEmulator", () => {
       seed: {
         github: {
           users: [{ login: "octocat" }],
+          orgs: [{ login: "acme" }],
+          repos: [{ owner: "acme", name: "private-repo", private: true }],
           apps: [
             {
               app_id: 900,
               slug: "generated-key-app",
               name: "Generated Key App",
-              installations: [{ installation_id: 901, account: "octocat" }],
+              installations: [{ installation_id: 901, account: "acme" }],
             },
           ],
         },
@@ -108,13 +110,55 @@ describe("createEmulator", () => {
 
     const firstToken = await createInstallationToken(github.url, "900", 901, privateKey);
     expect(firstToken.status).toBe(201);
-    expect(((await firstToken.json()) as { token: string }).token).toMatch(/^ghs_/);
+    const firstTokenValue = ((await firstToken.json()) as { token: string }).token;
+    expect(firstTokenValue).toMatch(/^ghs_/);
+    expect(await (await fetch(`${github.url}/_emulate/installation-tokens`)).json()).toMatchObject({
+      installation_tokens: [expect.objectContaining({ installation: { id: 901 }, status: "active" })],
+    });
+    expect(
+      (
+        await fetch(`${github.url}/repos/acme/private-repo`, {
+          headers: { Authorization: `Bearer ${firstTokenValue}` },
+        })
+      ).status,
+    ).toBe(200);
 
     github.reset();
 
+    expect(await (await fetch(`${github.url}/_emulate/installation-tokens`)).json()).toEqual({
+      installation_tokens: [],
+    });
+    const resetTokenUser = await fetch(`${github.url}/user`, {
+      headers: { Authorization: `Bearer ${firstTokenValue}` },
+    });
+    expect(resetTokenUser.status).toBe(200);
+    expect(await resetTokenUser.json()).toMatchObject({ login: "octocat", type: "User" });
+    expect(
+      (
+        await fetch(`${github.url}/repos/acme/private-repo`, {
+          headers: { Authorization: `Bearer ${firstTokenValue}` },
+        })
+      ).status,
+    ).toBe(403);
+    expect(
+      (
+        await fetch(`${github.url}/user`, {
+          headers: { Authorization: "Bearer test_token_admin" },
+        })
+      ).status,
+    ).toBe(200);
+
     const tokenAfterReset = await createInstallationToken(github.url, "900", 901, privateKey);
     expect(tokenAfterReset.status).toBe(201);
-    expect(((await tokenAfterReset.json()) as { token: string }).token).toMatch(/^ghs_/);
+    const tokenAfterResetValue = ((await tokenAfterReset.json()) as { token: string }).token;
+    expect(tokenAfterResetValue).toMatch(/^ghs_/);
+    expect(
+      (
+        await fetch(`${github.url}/repos/acme/private-repo`, {
+          headers: { Authorization: `Bearer ${tokenAfterResetValue}` },
+        })
+      ).status,
+    ).toBe(200);
     expect(github.generatedSecrets[0]!.value).toBe(privateKey);
 
     await github.close();

--- a/packages/emulate/src/api.ts
+++ b/packages/emulate/src/api.ts
@@ -70,7 +70,13 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
 
   const fallbackUser = entry.defaultFallback(svcSeedConfig);
 
-  const { app, store, webhooks } = createServer(loaded.plugin, { port, baseUrl, tokens, appKeyResolver, fallbackUser });
+  const { app, store, webhooks, tokenMap } = createServer(loaded.plugin, {
+    port,
+    baseUrl,
+    tokens,
+    appKeyResolver,
+    fallbackUser,
+  });
   cachedResolver = loaded.createAppKeyResolver?.(store);
 
   const seed = () => {
@@ -87,6 +93,9 @@ export async function createEmulator(options: EmulatorOptions): Promise<Emulator
     url: baseUrl,
     generatedSecrets,
     reset() {
+      for (const [token, user] of tokenMap) {
+        if (user.installation) tokenMap.delete(token);
+      }
       store.reset();
       seed();
     },

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -23,6 +23,7 @@ Framework adapters:
 
 GitHub API coverage:
   Includes repository contents, raw downloads, commit history, commit details, and ref comparisons.
+  Inspect minted installation-token metadata at GET /_emulate/installation-tokens.
 
 Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.

--- a/skills/emulate/SKILL.md
+++ b/skills/emulate/SKILL.md
@@ -99,6 +99,8 @@ await github.close()
 await vercel.close()
 ```
 
+For GitHub App tests, inspect secret-free minted installation-token metadata at `GET /_emulate/installation-tokens`.
+
 ### Options
 
 | Option | Default | Description |

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -610,7 +610,12 @@ curl -X POST $BASE/app/installations/100/access_tokens \
 # 3. Use the installation token to call API endpoints
 curl $BASE/repos/my-org/org-repo \
   -H "Authorization: Bearer ghs_..."
+
+# Inspect minted installation-token metadata without token values
+curl $BASE/_emulate/installation-tokens
 ```
+
+The inspection route is emulator-specific. It lists App, installation, account, permissions, repository access, issuance, expiry, and lifecycle status without accepting or returning token values or token-derived identifiers. Expiry is informational and does not change authorization behavior.
 
 ### OAuth Flow
 

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -50,6 +50,8 @@ This creates the following routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
+GitHub installation-token metadata is available server-side at `/emulate/github/_emulate/installation-tokens`.
+
 ## Auth.js / NextAuth Configuration
 
 Point your provider at the emulator paths on the same origin:

--- a/skills/nuxt/SKILL.md
+++ b/skills/nuxt/SKILL.md
@@ -50,6 +50,8 @@ This creates these routes:
 - `/emulate/github/**` serves the GitHub emulator
 - `/emulate/google/**` serves the Google emulator
 
+GitHub installation-token metadata is available server-side at `/emulate/github/_emulate/installation-tokens`.
+
 ## Nuxt Config
 
 Emulator UI pages use bundled fonts. Wrap your Nuxt config so Nitro traces the core package assets into production builds:

--- a/tests/contracts/github-app-identity.d.ts
+++ b/tests/contracts/github-app-identity.d.ts
@@ -11,6 +11,7 @@ interface Harness<Config, AdapterHandler extends Handler> {
   config(persistence?: TestPersistence, privateKey?: string): Config;
   createExplicitPrivateKey(): Promise<string>;
   requestApp(handler: AdapterHandler, authorization?: string, method?: "GET" | "POST"): Promise<Response>;
+  request(handler: AdapterHandler, path: string, authorization?: string, method?: "GET" | "POST"): Promise<Response>;
 }
 export function githubAppIdentityContract<Config, AdapterHandler extends Handler>(
   harness: Harness<Config, AdapterHandler>,

--- a/tests/contracts/github-app-identity.js
+++ b/tests/contracts/github-app-identity.js
@@ -213,5 +213,72 @@ export function githubAppIdentityContract(h) {
       expect(serialized).not.toContain(privateKey);
       expect(serialized).not.toContain(Buffer.from(privateKey).toString("base64"));
     });
+    it("persists and restores installation-token inspection metadata", async () => {
+      const persistence = memory();
+      const first = create(persistence);
+      const privateKey = await key(first);
+      const mint = await h.request(
+        first,
+        "app/installations/124/access_tokens",
+        `Bearer ${jwt(privateKey)}`,
+        "POST",
+      );
+      expect(mint.status).toBe(201);
+      const token = (await mint.json()).token;
+
+      expect(await (await h.request(first, "_emulate/installation-tokens")).json()).toMatchObject({
+        installation_tokens: [
+          expect.objectContaining({
+            app: { id: 123, slug: "embedded", name: "Embedded" },
+            installation: { id: 124 },
+            account: expect.objectContaining({ login: "acme", type: "Organization" }),
+            status: "active",
+          }),
+        ],
+      });
+      await vi.waitFor(() => expect(persistence.read()).toContain("github.installation_token_metadata"));
+
+      const second = create(persistence);
+      expect(await (await h.request(second, "_emulate/installation-tokens")).json()).toEqual(
+        await (await h.request(first, "_emulate/installation-tokens")).json(),
+      );
+      expect((await h.request(second, "repos/acme/private-repo", `Bearer ${token}`)).status).toBe(200);
+    });
+    it("restores legacy installation authorization without fabricating inspection metadata", async () => {
+      const persistence = memory();
+      const first = create(persistence);
+      const privateKey = await key(first);
+      const mint = await h.request(
+        first,
+        "app/installations/124/access_tokens",
+        `Bearer ${jwt(privateKey)}`,
+        "POST",
+      );
+      expect(mint.status).toBe(201);
+      const token = (await mint.json()).token;
+      await vi.waitFor(() => expect(persistence.read()).toContain("github.installation_token_metadata"));
+
+      const snapshot = JSON.parse(persistence.read());
+      delete snapshot.store.collections["github:github.installation_token_metadata"];
+      const legacyPersistence = memory(JSON.stringify(snapshot));
+      const restored = create(legacyPersistence);
+
+      expect(await (await h.request(restored, "_emulate/installation-tokens")).json()).toEqual({
+        installation_tokens: [],
+      });
+      expect((await h.request(restored, "repos/acme/private-repo", `Bearer ${token}`)).status).toBe(200);
+
+      const nextMint = await h.request(
+        restored,
+        "app/installations/124/access_tokens",
+        `Bearer ${jwt(privateKey)}`,
+        "POST",
+      );
+      expect(nextMint.status).toBe(201);
+      expect(await (await h.request(restored, "_emulate/installation-tokens")).json()).toMatchObject({
+        installation_tokens: [expect.objectContaining({ installation: { id: 124 }, status: "active" })],
+      });
+      await vi.waitFor(() => expect(legacyPersistence.read()).toContain("github.installation_token_metadata"));
+    });
   });
 }


### PR DESCRIPTION
## Summary

- add an emulator-only endpoint for inspecting secret-free GitHub App installation-token metadata
- clear installation-token metadata and authorization on reset while preserving seeded tokens and generated App identity
- persist metadata across Next.js and Nuxt adapter cold starts
- document the route across the CLI, packages, skills, and docs site

## Testing

- `pnpm build`
- `node scripts/sync-versions.mjs --check`
- `pnpm format:check`
- `pnpm type-check`
- `pnpm lint`
- `pnpm test`
