### PR TITLE
fix(google): enforce OAuth authority in strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,8 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `google.strict_scopes: true` in seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
 
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+
 - `GET /o/oauth2/v2/auth` - authorization endpoint
 - `POST /oauth2/token` - token exchange
 - `GET /oauth2/v2/userinfo` - get user info

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ github:
       auto_init: true
 
 google:
+  strict_scopes: false
   users:
     - email: testuser@example.com
       name: Test User
@@ -778,6 +779,8 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 ## Google OAuth + Gmail, Calendar, and Drive APIs
 
 OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local inbox, calendar, and drive flows.
+
+OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `google.strict_scopes: true` in seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
 
 - `GET /o/oauth2/v2/auth` - authorization endpoint
 - `POST /oauth2/token` - token exchange

--- a/README.md
+++ b/README.md
@@ -782,7 +782,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `google.strict_scopes: true` in seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
 
-Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Drive content updates with `PUT` require `drive` or `drive.file` while metadata updates with `PATCH` also accept `drive.metadata`, Gmail `messages.send` accepts `gmail.send` while `drafts.send` requires `https://mail.google.com/`, `gmail.compose`, or `gmail.modify`, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
 
 - `GET /o/oauth2/v2/auth` - authorization endpoint
 - `POST /oauth2/token` - token exchange

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -2,6 +2,13 @@
 
 OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local inbox, calendar, and drive flows.
 
+OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `google.strict_scopes: true` in seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
+
+```yaml
+google:
+  strict_scopes: true
+```
+
 ## OAuth & OpenID Connect
 
 - `GET /o/oauth2/v2/auth` - authorization endpoint

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -4,6 +4,8 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `google.strict_scopes: true` in seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
 
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+
 ```yaml
 google:
   strict_scopes: true

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -4,7 +4,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `google.strict_scopes: true` in seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
 
-Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Drive content updates with `PUT` require `drive` or `drive.file` while metadata updates with `PATCH` also accept `drive.metadata`, Gmail `messages.send` accepts `gmail.send` while `drafts.send` requires `https://mail.google.com/`, `gmail.compose`, or `gmail.modify`, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
 
 ```yaml
 google:

--- a/emulate.config.example.yaml
+++ b/emulate.config.example.yaml
@@ -78,6 +78,7 @@ vercel:
         - http://localhost:3000/api/auth/callback/vercel
 
 google:
+  strict_scopes: false
   users:
     - email: testuser@gmail.com
       name: Test User

--- a/packages/@emulators/google/README.md
+++ b/packages/@emulators/google/README.md
@@ -79,10 +79,13 @@ npm install @emulators/google
 
 Standard OAuth 2.0 authorization code flow. Configure clients in the seed config.
 
+OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `strict_scopes: true` in the Google seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for Google userinfo, Gmail, Calendar, and Drive. Scope failures use Google's `403` `insufficientPermissions` error envelope. Invalid credentials use `401` `UNAUTHENTICATED`.
+
 ## Seed Configuration
 
 ```yaml
 google:
+  strict_scopes: false
   users:
     - email: testuser@example.com
       name: Test User

--- a/packages/@emulators/google/README.md
+++ b/packages/@emulators/google/README.md
@@ -81,6 +81,8 @@ Standard OAuth 2.0 authorization code flow. Configure clients in the seed config
 
 OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `strict_scopes: true` in the Google seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for Google userinfo, Gmail, Calendar, and Drive. Scope failures use Google's `403` `insufficientPermissions` error envelope. Invalid credentials use `401` `UNAUTHENTICATED`.
 
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+
 ## Seed Configuration
 
 ```yaml

--- a/packages/@emulators/google/README.md
+++ b/packages/@emulators/google/README.md
@@ -81,7 +81,7 @@ Standard OAuth 2.0 authorization code flow. Configure clients in the seed config
 
 OAuth authority checks are relaxed by default so local apps can use simple bearer tokens without completing an OAuth flow. Set `strict_scopes: true` in the Google seed config to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce granted scopes for Google userinfo, Gmail, Calendar, and Drive. Scope failures use Google's `403` `insufficientPermissions` error envelope. Invalid credentials use `401` `UNAUTHENTICATED`.
 
-Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Drive content updates with `PUT` require `drive` or `drive.file` while metadata updates with `PATCH` also accept `drive.metadata`, Gmail `messages.send` accepts `gmail.send` while `drafts.send` requires `https://mail.google.com/`, `gmail.compose`, or `gmail.modify`, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
 
 ## Seed Configuration
 

--- a/packages/@emulators/google/src/__tests__/google.test.ts
+++ b/packages/@emulators/google/src/__tests__/google.test.ts
@@ -14,7 +14,7 @@ import { buildRawMessage } from "../helpers.js";
 
 const base = "http://localhost:4000";
 
-function createTestApp() {
+function createTestApp(options?: { strictScopes?: boolean; useFallback?: boolean }) {
   const store = new Store();
   const webhooks = new WebhookDispatcher();
   const tokenMap: TokenMap = new Map();
@@ -27,10 +27,20 @@ function createTestApp() {
   const app = new Hono();
   app.onError(createApiErrorHandler());
   app.use("*", createErrorHandler());
-  app.use("*", authMiddleware(tokenMap));
+  app.use(
+    "*",
+    authMiddleware(
+      tokenMap,
+      undefined,
+      options?.useFallback
+        ? { login: "testuser@example.com", id: 1, scopes: ["openid", "email", "profile"] }
+        : undefined,
+    ),
+  );
   googlePlugin.register(app as any, store, webhooks, base, tokenMap);
   googlePlugin.seed?.(store, base);
   seedFromConfig(store, base, {
+    ...(options?.strictScopes === undefined ? {} : { strict_scopes: options.strictScopes }),
     users: [
       { email: "testuser@example.com", name: "Test User" },
       { email: "consumer@gmail.com", name: "Consumer User" },
@@ -209,11 +219,138 @@ async function formRequest(app: Hono, path: string, body: Record<string, string>
   });
 }
 
+async function issueGoogleToken(app: Hono, scope: string) {
+  const authorizeRes = await formRequest(app, "/o/oauth2/v2/auth/callback", {
+    email: "testuser@example.com",
+    redirect_uri: "http://localhost:3000/api/auth/callback/google",
+    scope,
+    client_id: "emu_google_client_id",
+  });
+  const code = new URL(authorizeRes.headers.get("Location")!).searchParams.get("code")!;
+  const tokenRes = await formRequest(app, "/oauth2/token", {
+    code,
+    grant_type: "authorization_code",
+    redirect_uri: "http://localhost:3000/api/auth/callback/google",
+    client_id: "emu_google_client_id",
+    client_secret: "emu_google_client_secret",
+  });
+  expect(tokenRes.status).toBe(200);
+  return (await tokenRes.json()) as { access_token: string; refresh_token: string; scope: string };
+}
+
 describe("Google plugin integration", () => {
   let app: Hono;
 
   beforeEach(() => {
     app = createTestApp().app;
+  });
+
+  describe("strict OAuth authority", () => {
+    const routes = ["/drive/v3/files", "/gmail/v1/users/me/messages", "/calendar/v3/calendars/primary/events"];
+
+    it("rejects bearer tokens that Google did not issue", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+
+      for (const route of routes) {
+        const res = await strictApp.request(`${base}${route}`, {
+          headers: { Authorization: "Bearer totally-bogus-token" },
+        });
+        expect(res.status).toBe(401);
+        expect(await res.json()).toMatchObject({
+          error: { code: 401, status: "UNAUTHENTICATED", errors: [{ reason: "authError" }] },
+        });
+      }
+    });
+
+    it("accepts authorization-code tokens with matching service scopes", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const cases = [
+        ["/drive/v3/files", "https://www.googleapis.com/auth/drive"],
+        ["/gmail/v1/users/me/messages", "https://www.googleapis.com/auth/gmail.readonly"],
+        ["/calendar/v3/calendars/primary/events", "https://www.googleapis.com/auth/calendar.readonly"],
+      ] as const;
+
+      for (const [route, scope] of cases) {
+        const token = await issueGoogleToken(strictApp, scope);
+        const res = await strictApp.request(`${base}${route}`, {
+          headers: { Authorization: `Bearer ${token.access_token}` },
+        });
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it("rejects revoked access tokens", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const token = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/drive");
+
+      const before = await strictApp.request(`${base}/drive/v3/files`, {
+        headers: { Authorization: `Bearer ${token.access_token}` },
+      });
+      expect(before.status).toBe(200);
+
+      const revoke = await formRequest(strictApp, "/oauth2/revoke", { token: token.access_token });
+      expect(revoke.status).toBe(200);
+
+      const after = await strictApp.request(`${base}/drive/v3/files`, {
+        headers: { Authorization: `Bearer ${token.access_token}` },
+      });
+      expect(after.status).toBe(401);
+      expect(await after.json()).toMatchObject({ error: { status: "UNAUTHENTICATED" } });
+    });
+
+    it("rejects access tokens without a scope for the requested service", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const token = await issueGoogleToken(strictApp, "openid");
+
+      for (const route of routes) {
+        const res = await strictApp.request(`${base}${route}`, {
+          headers: { Authorization: `Bearer ${token.access_token}` },
+        });
+        expect(res.status).toBe(403);
+        expect(await res.json()).toMatchObject({
+          error: {
+            code: 403,
+            status: "PERMISSION_DENIED",
+            errors: [{ reason: "insufficientPermissions" }],
+          },
+        });
+      }
+    });
+
+    it("rejects refresh tokens presented to resource APIs", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const token = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/drive");
+      const res = await strictApp.request(`${base}/drive/v3/files`, {
+        headers: { Authorization: `Bearer ${token.refresh_token}` },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it.each([undefined, false])("preserves permissive auth when strict_scopes is %s", async (strictScopes) => {
+      const permissiveApp = createTestApp({ strictScopes, useFallback: true }).app;
+
+      for (const route of routes) {
+        const expected = await permissiveApp.request(`${base}${route}`, { headers: authHeaders() });
+        const bogus = await permissiveApp.request(`${base}${route}`, {
+          headers: { Authorization: "Bearer totally-bogus-token" },
+        });
+        expect(bogus.status).toBe(200);
+        expect(await bogus.text()).toBe(await expected.text());
+      }
+
+      const token = await issueGoogleToken(permissiveApp, "openid");
+      const revoke = await formRequest(permissiveApp, "/oauth2/revoke", { token: token.access_token });
+      expect(revoke.status).toBe(200);
+
+      for (const credential of [token.access_token, token.refresh_token]) {
+        const expected = await permissiveApp.request(`${base}/drive/v3/files`, { headers: authHeaders() });
+        const res = await permissiveApp.request(`${base}/drive/v3/files`, {
+          headers: { Authorization: `Bearer ${credential}` },
+        });
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe(await expected.text());
+      }
+    });
   });
 
   it("returns user info for a valid token", async () => {

--- a/packages/@emulators/google/src/__tests__/google.test.ts
+++ b/packages/@emulators/google/src/__tests__/google.test.ts
@@ -219,13 +219,15 @@ async function formRequest(app: Hono, path: string, body: Record<string, string>
   });
 }
 
-async function issueGoogleToken(app: Hono, scope: string) {
-  const authorizeRes = await formRequest(app, "/o/oauth2/v2/auth/callback", {
+async function issueGoogleToken(app: Hono, scope?: string) {
+  const authorizationBody: Record<string, string> = {
     email: "testuser@example.com",
     redirect_uri: "http://localhost:3000/api/auth/callback/google",
-    scope,
     client_id: "emu_google_client_id",
-  });
+  };
+  if (scope !== undefined) authorizationBody.scope = scope;
+
+  const authorizeRes = await formRequest(app, "/o/oauth2/v2/auth/callback", authorizationBody);
   const code = new URL(authorizeRes.headers.get("Location")!).searchParams.get("code")!;
   const tokenRes = await formRequest(app, "/oauth2/token", {
     code,
@@ -277,6 +279,138 @@ describe("Google plugin integration", () => {
         });
         expect(res.status).toBe(200);
       }
+    });
+
+    it("enforces operation-specific Gmail scopes", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const insertScopes = [
+        "https://www.googleapis.com/auth/gmail.insert",
+        "https://www.googleapis.com/auth/gmail.modify",
+      ];
+
+      for (const scope of insertScopes) {
+        const token = await issueGoogleToken(strictApp, scope);
+        const importRes = await jsonRequest(strictApp, "/gmail/v1/users/me/messages/import", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token.access_token}` },
+          body: { from: "sender@example.com", to: "testuser@example.com" },
+        });
+        expect(importRes.status).toBe(200);
+
+        const insertRes = await jsonRequest(strictApp, "/gmail/v1/users/me/messages", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token.access_token}` },
+          body: { from: "sender@example.com", to: "testuser@example.com" },
+        });
+        expect(insertRes.status).toBe(200);
+      }
+
+      for (const path of [
+        "/gmail/v1/users/me/messages/batchDelete",
+        "/gmail/v1/users/me/messages/msg_invoice",
+        "/gmail/v1/users/me/threads/thread_billing",
+      ]) {
+        const token = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/gmail.modify");
+        const res = await jsonRequest(strictApp, path, {
+          method: path.endsWith("batchDelete") ? "POST" : "DELETE",
+          headers: { Authorization: `Bearer ${token.access_token}` },
+          body: path.endsWith("batchDelete") ? { ids: ["msg_invoice"] } : undefined,
+        });
+        expect(res.status).toBe(403);
+      }
+
+      const insertOnlyToken = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/gmail.insert");
+      const batchDeleteRes = await jsonRequest(strictApp, "/gmail/v1/users/me/messages/batchDelete", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${insertOnlyToken.access_token}` },
+        body: { ids: ["msg_invoice"] },
+      });
+      expect(batchDeleteRes.status).toBe(403);
+    });
+
+    it("separates Drive metadata and media access", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+
+      for (const scope of [
+        "https://www.googleapis.com/auth/drive.metadata",
+        "https://www.googleapis.com/auth/drive.metadata.readonly",
+      ]) {
+        const token = await issueGoogleToken(strictApp, scope);
+        const metadataRes = await strictApp.request(`${base}/drive/v3/files/drv_handbook`, {
+          headers: { Authorization: `Bearer ${token.access_token}` },
+        });
+        expect(metadataRes.status).toBe(200);
+
+        const mediaRes = await strictApp.request(`${base}/drive/v3/files/drv_handbook?alt=media`, {
+          headers: { Authorization: `Bearer ${token.access_token}` },
+        });
+        expect(mediaRes.status).toBe(403);
+      }
+
+      const contentToken = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/drive.readonly");
+      const mediaRes = await strictApp.request(`${base}/drive/v3/files/drv_handbook?alt=media`, {
+        headers: { Authorization: `Bearer ${contentToken.access_token}` },
+      });
+      expect(mediaRes.status).toBe(200);
+    });
+
+    it("accepts documented Calendar freebusy and Gmail settings read scopes", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const freeBusyToken = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/calendar.freebusy");
+      const freeBusyRes = await jsonRequest(strictApp, "/calendar/v3/freeBusy", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${freeBusyToken.access_token}` },
+        body: {
+          timeMin: "2025-01-10T11:00:00.000Z",
+          timeMax: "2025-01-10T14:00:00.000Z",
+          items: [{ id: "primary" }],
+        },
+      });
+      expect(freeBusyRes.status).toBe(200);
+
+      for (const scope of [
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.settings.basic",
+      ]) {
+        const token = await issueGoogleToken(strictApp, scope);
+        const settingsRes = await strictApp.request(`${base}/gmail/v1/users/me/settings/sendAs`, {
+          headers: { Authorization: `Bearer ${token.access_token}` },
+        });
+        expect(settingsRes.status).toBe(200);
+      }
+
+      const sharingToken = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/gmail.settings.sharing");
+      const sharingRes = await strictApp.request(`${base}/gmail/v1/users/me/settings/sendAs`, {
+        headers: { Authorization: `Bearer ${sharingToken.access_token}` },
+      });
+      expect(sharingRes.status).toBe(403);
+    });
+
+    it("stores default OAuth scopes when authorization omits scope", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const token = await issueGoogleToken(strictApp);
+      expect(token.scope).toBe("openid email profile");
+
+      const userinfoRes = await strictApp.request(`${base}/oauth2/v2/userinfo`, {
+        headers: { Authorization: `Bearer ${token.access_token}` },
+      });
+      expect(userinfoRes.status).toBe(200);
+
+      const refreshRes = await formRequest(strictApp, "/oauth2/token", {
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+        client_id: "emu_google_client_id",
+        client_secret: "emu_google_client_secret",
+      });
+      expect(refreshRes.status).toBe(200);
+      const refreshed = (await refreshRes.json()) as { access_token: string; scope: string };
+      expect(refreshed.scope).toBe("openid email profile");
+
+      const refreshedUserinfoRes = await strictApp.request(`${base}/oauth2/v2/userinfo`, {
+        headers: { Authorization: `Bearer ${refreshed.access_token}` },
+      });
+      expect(refreshedUserinfoRes.status).toBe(200);
     });
 
     it("rejects revoked access tokens", async () => {

--- a/packages/@emulators/google/src/__tests__/google.test.ts
+++ b/packages/@emulators/google/src/__tests__/google.test.ts
@@ -182,7 +182,7 @@ function createTestApp(options?: { strictScopes?: boolean; useFallback?: boolean
     ],
   });
 
-  return { app };
+  return { app, store };
 }
 
 function authHeaders(extra?: Record<string, string>): Record<string, string> {
@@ -328,6 +328,48 @@ describe("Google plugin integration", () => {
       expect(batchDeleteRes.status).toBe(403);
     });
 
+    it("separates message send and draft send scopes", async () => {
+      const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
+      const sendToken = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/gmail.send");
+
+      const messageSendRes = await jsonRequest(strictApp, "/gmail/v1/users/me/messages/send", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${sendToken.access_token}` },
+        body: { from: "testuser@example.com", to: "partner@example.com", subject: "Sent message" },
+      });
+      expect(messageSendRes.status).toBe(200);
+
+      for (const path of ["/gmail/v1/users/me/drafts/send", "/upload/gmail/v1/users/me/drafts/send"]) {
+        const draftSendRes = await jsonRequest(strictApp, path, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${sendToken.access_token}` },
+          body: { id: "msg_draft" },
+        });
+        expect(draftSendRes.status).toBe(403);
+      }
+
+      const draftToken = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/gmail.compose");
+      const createDraftRes = await jsonRequest(strictApp, "/gmail/v1/users/me/drafts", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${draftToken.access_token}` },
+        body: {
+          message: {
+            from: "testuser@example.com",
+            to: "partner@example.com",
+            subject: "Draft message",
+          },
+        },
+      });
+      expect(createDraftRes.status).toBe(200);
+      const draft = (await createDraftRes.json()) as { id: string };
+      const draftSendRes = await jsonRequest(strictApp, "/gmail/v1/users/me/drafts/send", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${draftToken.access_token}` },
+        body: { id: draft.id },
+      });
+      expect(draftSendRes.status).toBe(200);
+    });
+
     it("separates Drive metadata and media access", async () => {
       const strictApp = createTestApp({ strictScopes: true, useFallback: true }).app;
 
@@ -352,6 +394,82 @@ describe("Google plugin integration", () => {
         headers: { Authorization: `Bearer ${contentToken.access_token}` },
       });
       expect(mediaRes.status).toBe(200);
+
+      const metadataToken = await issueGoogleToken(strictApp, "https://www.googleapis.com/auth/drive.metadata");
+      const putRes = await jsonRequest(strictApp, "/drive/v3/files/drv_handbook", {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${metadataToken.access_token}` },
+        body: {},
+      });
+      expect(putRes.status).toBe(403);
+
+      const patchRes = await jsonRequest(strictApp, "/drive/v3/files/drv_handbook", {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${metadataToken.access_token}` },
+        body: {},
+      });
+      expect(patchRes.status).toBe(200);
+    });
+
+    it("rejects malformed persisted access token records", async () => {
+      const { app: strictApp, store } = createTestApp({ strictScopes: true, useFallback: true });
+      const records: Array<Record<string, unknown>> = [
+        {
+          email: "testuser@example.com",
+          userId: 1,
+          scopes: ["https://www.googleapis.com/auth/drive"],
+          clientId: "emu_google_client_id",
+          expiresAt: Date.now() + 60_000,
+        },
+        {
+          email: "testuser@example.com",
+          userId: 1,
+          scopes: { drive: true },
+          clientId: "emu_google_client_id",
+          expiresAt: Date.now() + 60_000,
+          revoked: false,
+        },
+        {
+          email: "testuser@example.com",
+          userId: Number.POSITIVE_INFINITY,
+          scopes: ["https://www.googleapis.com/auth/drive"],
+          clientId: "emu_google_client_id",
+          expiresAt: Date.now() + 60_000,
+          revoked: false,
+        },
+        {
+          email: "testuser@example.com",
+          userId: 1,
+          scopes: ["https://www.googleapis.com/auth/drive"],
+          clientId: "emu_google_client_id",
+          expiresAt: Number.POSITIVE_INFINITY,
+          revoked: false,
+        },
+        {
+          email: 123,
+          userId: 1,
+          scopes: ["https://www.googleapis.com/auth/drive"],
+          clientId: "emu_google_client_id",
+          expiresAt: Date.now() + 60_000,
+          revoked: false,
+        },
+        {
+          email: "testuser@example.com",
+          userId: 1,
+          scopes: ["https://www.googleapis.com/auth/drive"],
+          clientId: null,
+          expiresAt: Date.now() + 60_000,
+          revoked: false,
+        },
+      ];
+
+      for (const record of records) {
+        store.setData("google.oauth.accessTokens", new Map([["malformed-token", record]]));
+        const res = await strictApp.request(`${base}/drive/v3/files`, {
+          headers: { Authorization: "Bearer malformed-token" },
+        });
+        expect(res.status).toBe(401);
+      }
     });
 
     it("accepts documented Calendar freebusy and Gmail settings read scopes", async () => {

--- a/packages/@emulators/google/src/auth.ts
+++ b/packages/@emulators/google/src/auth.ts
@@ -84,7 +84,7 @@ export function googleStrictAuth(store: Store): MiddlewareHandler {
     }
 
     const record = getGoogleAccessTokens(store).get(token);
-    if (!record || record.revoked || record.expiresAt <= Date.now()) {
+    if (!isValidGoogleAccessTokenRecord(record) || record.expiresAt <= Date.now()) {
       return googleApiError(c, 401, "Request had invalid authentication credentials.", "authError", "UNAUTHENTICATED");
     }
 
@@ -113,9 +113,10 @@ export function driveScopes(c: Context): string[] {
     }
     return [DRIVE, DRIVE_FILE, DRIVE_READONLY, DRIVE_METADATA, DRIVE_METADATA_READONLY];
   }
-  if (c.req.method === "PATCH" || c.req.method === "PUT") {
+  if (c.req.method === "PATCH") {
     return [DRIVE, DRIVE_FILE, DRIVE_METADATA];
   }
+  if (c.req.method === "PUT") return [DRIVE, DRIVE_FILE];
   return [DRIVE, DRIVE_FILE];
 }
 
@@ -130,9 +131,10 @@ export function gmailScopes(c: Context): string[] {
     return method === "GET" ? gmailSettingsReadScopes() : [GMAIL, GMAIL_SETTINGS_SHARING];
   }
   if (method === "DELETE" && /\/(messages|threads)\/[^/]+$/.test(path)) return [GMAIL];
-  if (path.endsWith("/send") || path.includes("/messages/send")) {
+  if (path.includes("/messages/send")) {
     return [GMAIL, GMAIL_MODIFY, GMAIL_COMPOSE, GMAIL_SEND];
   }
+  if (path.includes("/drafts/send")) return [GMAIL, GMAIL_MODIFY, GMAIL_COMPOSE];
   if (path.includes("/drafts")) {
     return method === "GET"
       ? [GMAIL, GMAIL_MODIFY, GMAIL_COMPOSE, GMAIL_READONLY]
@@ -194,6 +196,21 @@ function requiredScopesForRequest(c: Context): string[] | undefined {
 function bearerToken(c: Context): string | undefined {
   const match = /^Bearer\s+(\S+)$/i.exec(c.req.header("Authorization") ?? "");
   return match?.[1];
+}
+
+function isValidGoogleAccessTokenRecord(record: unknown): record is GoogleAccessTokenRecord {
+  if (record === null || typeof record !== "object") return false;
+
+  const candidate = record as Record<string, unknown>;
+  return (
+    typeof candidate.email === "string" &&
+    Number.isFinite(candidate.userId) &&
+    Array.isArray(candidate.scopes) &&
+    candidate.scopes.every((scope) => typeof scope === "string") &&
+    typeof candidate.clientId === "string" &&
+    Number.isFinite(candidate.expiresAt) &&
+    candidate.revoked === false
+  );
 }
 
 function gmailSettingsReadScopes(): string[] {

--- a/packages/@emulators/google/src/auth.ts
+++ b/packages/@emulators/google/src/auth.ts
@@ -28,7 +28,8 @@ const CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events";
 const CALENDAR_EVENTS_READONLY = "https://www.googleapis.com/auth/calendar.events.readonly";
 const CALENDAR_EVENTS_OWNED = "https://www.googleapis.com/auth/calendar.events.owned";
 const CALENDAR_EVENTS_OWNED_READONLY = "https://www.googleapis.com/auth/calendar.events.owned.readonly";
-const CALENDAR_FREEBUSY = "https://www.googleapis.com/auth/calendar.events.freebusy";
+const CALENDAR_EVENTS_FREEBUSY = "https://www.googleapis.com/auth/calendar.events.freebusy";
+const CALENDAR_FREEBUSY = "https://www.googleapis.com/auth/calendar.freebusy";
 
 export interface GoogleAccessTokenRecord {
   email: string;
@@ -107,6 +108,9 @@ export function googleStrictAuth(store: Store): MiddlewareHandler {
 
 export function driveScopes(c: Context): string[] {
   if (c.req.method === "GET") {
+    if (new URL(c.req.url).searchParams.get("alt") === "media") {
+      return [DRIVE, DRIVE_FILE, DRIVE_READONLY];
+    }
     return [DRIVE, DRIVE_FILE, DRIVE_READONLY, DRIVE_METADATA, DRIVE_METADATA_READONLY];
   }
   if (c.req.method === "PATCH" || c.req.method === "PUT") {
@@ -119,10 +123,13 @@ export function gmailScopes(c: Context): string[] {
   const path = new URL(c.req.url).pathname;
   const method = c.req.method;
 
-  if (path.includes("/settings/filters")) return [GMAIL, GMAIL_SETTINGS_BASIC];
-  if (path.includes("/settings/forwardingAddresses") || path.includes("/settings/sendAs")) {
-    return [GMAIL, GMAIL_SETTINGS_BASIC, GMAIL_SETTINGS_SHARING];
+  if (path.includes("/settings/filters")) {
+    return method === "GET" ? gmailSettingsReadScopes() : [GMAIL, GMAIL_SETTINGS_BASIC];
   }
+  if (path.includes("/settings/forwardingAddresses") || path.includes("/settings/sendAs")) {
+    return method === "GET" ? gmailSettingsReadScopes() : [GMAIL, GMAIL_SETTINGS_SHARING];
+  }
+  if (method === "DELETE" && /\/(messages|threads)\/[^/]+$/.test(path)) return [GMAIL];
   if (path.endsWith("/send") || path.includes("/messages/send")) {
     return [GMAIL, GMAIL_MODIFY, GMAIL_COMPOSE, GMAIL_SEND];
   }
@@ -136,8 +143,9 @@ export function gmailScopes(c: Context): string[] {
       ? [GMAIL, GMAIL_MODIFY, GMAIL_READONLY, GMAIL_METADATA, GMAIL_LABELS]
       : [GMAIL, GMAIL_MODIFY, GMAIL_LABELS];
   }
-  if (path.includes("/messages/import") || path.includes("/messages/batchDelete")) {
-    return [GMAIL, GMAIL_INSERT];
+  if (path.endsWith("/messages/batchDelete")) return [GMAIL];
+  if (path.endsWith("/messages/import") || (method === "POST" && path.endsWith("/messages"))) {
+    return [GMAIL, GMAIL_INSERT, GMAIL_MODIFY];
   }
   if (method === "GET") return [GMAIL, GMAIL_MODIFY, GMAIL_READONLY, GMAIL_METADATA];
   return [GMAIL, GMAIL_MODIFY];
@@ -148,7 +156,9 @@ export function calendarScopes(c: Context): string[] {
   if (path.includes("/calendarList")) {
     return [CALENDAR, CALENDAR_READONLY, CALENDAR_LIST, CALENDAR_LIST_READONLY];
   }
-  if (path.endsWith("/freeBusy")) return [CALENDAR, CALENDAR_READONLY, CALENDAR_FREEBUSY];
+  if (path.endsWith("/freeBusy")) {
+    return [CALENDAR, CALENDAR_READONLY, CALENDAR_EVENTS_FREEBUSY, CALENDAR_FREEBUSY];
+  }
   if (c.req.method === "GET") {
     return [
       CALENDAR,
@@ -184,4 +194,8 @@ function requiredScopesForRequest(c: Context): string[] | undefined {
 function bearerToken(c: Context): string | undefined {
   const match = /^Bearer\s+(\S+)$/i.exec(c.req.header("Authorization") ?? "");
   return match?.[1];
+}
+
+function gmailSettingsReadScopes(): string[] {
+  return [GMAIL, GMAIL_MODIFY, GMAIL_READONLY, GMAIL_SETTINGS_BASIC];
 }

--- a/packages/@emulators/google/src/auth.ts
+++ b/packages/@emulators/google/src/auth.ts
@@ -1,0 +1,187 @@
+import type { Context, MiddlewareHandler, Store } from "@emulators/core";
+import { googleApiError } from "./helpers.js";
+
+const ACCESS_TOKENS_KEY = "google.oauth.accessTokens";
+
+const DRIVE = "https://www.googleapis.com/auth/drive";
+const DRIVE_FILE = "https://www.googleapis.com/auth/drive.file";
+const DRIVE_METADATA = "https://www.googleapis.com/auth/drive.metadata";
+const DRIVE_METADATA_READONLY = "https://www.googleapis.com/auth/drive.metadata.readonly";
+const DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly";
+
+const GMAIL = "https://mail.google.com/";
+const GMAIL_COMPOSE = "https://www.googleapis.com/auth/gmail.compose";
+const GMAIL_INSERT = "https://www.googleapis.com/auth/gmail.insert";
+const GMAIL_LABELS = "https://www.googleapis.com/auth/gmail.labels";
+const GMAIL_METADATA = "https://www.googleapis.com/auth/gmail.metadata";
+const GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify";
+const GMAIL_READONLY = "https://www.googleapis.com/auth/gmail.readonly";
+const GMAIL_SEND = "https://www.googleapis.com/auth/gmail.send";
+const GMAIL_SETTINGS_BASIC = "https://www.googleapis.com/auth/gmail.settings.basic";
+const GMAIL_SETTINGS_SHARING = "https://www.googleapis.com/auth/gmail.settings.sharing";
+
+const CALENDAR = "https://www.googleapis.com/auth/calendar";
+const CALENDAR_READONLY = "https://www.googleapis.com/auth/calendar.readonly";
+const CALENDAR_LIST = "https://www.googleapis.com/auth/calendar.calendarlist";
+const CALENDAR_LIST_READONLY = "https://www.googleapis.com/auth/calendar.calendarlist.readonly";
+const CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events";
+const CALENDAR_EVENTS_READONLY = "https://www.googleapis.com/auth/calendar.events.readonly";
+const CALENDAR_EVENTS_OWNED = "https://www.googleapis.com/auth/calendar.events.owned";
+const CALENDAR_EVENTS_OWNED_READONLY = "https://www.googleapis.com/auth/calendar.events.owned.readonly";
+const CALENDAR_FREEBUSY = "https://www.googleapis.com/auth/calendar.events.freebusy";
+
+export interface GoogleAccessTokenRecord {
+  email: string;
+  userId: number;
+  scopes: string[];
+  clientId: string;
+  expiresAt: number;
+  revoked: boolean;
+}
+
+export function getGoogleAccessTokens(store: Store): Map<string, GoogleAccessTokenRecord> {
+  let tokens = store.getData<Map<string, GoogleAccessTokenRecord>>(ACCESS_TOKENS_KEY);
+  if (!tokens) {
+    tokens = new Map();
+    store.setData(ACCESS_TOKENS_KEY, tokens);
+  }
+  return tokens;
+}
+
+export function registerGoogleAccessToken(
+  store: Store,
+  token: string,
+  record: Omit<GoogleAccessTokenRecord, "revoked">,
+): void {
+  getGoogleAccessTokens(store).set(token, { ...record, revoked: false });
+}
+
+export function revokeGoogleAccessToken(store: Store, token: string): boolean {
+  const tokens = getGoogleAccessTokens(store);
+  const record = tokens.get(token);
+  if (!record) return false;
+  tokens.set(token, { ...record, revoked: true });
+  return true;
+}
+
+export function googleStrictAuth(store: Store): MiddlewareHandler {
+  return async (c, next) => {
+    const requiredScopes = requiredScopesForRequest(c);
+    if (!requiredScopes) {
+      await next();
+      return;
+    }
+
+    if (store.getData<boolean>("google.strict_scopes") !== true) {
+      await next();
+      return;
+    }
+
+    const token = bearerToken(c);
+    if (!token) {
+      return googleApiError(c, 401, "Request had invalid authentication credentials.", "authError", "UNAUTHENTICATED");
+    }
+
+    const record = getGoogleAccessTokens(store).get(token);
+    if (!record || record.revoked || record.expiresAt <= Date.now()) {
+      return googleApiError(c, 401, "Request had invalid authentication credentials.", "authError", "UNAUTHENTICATED");
+    }
+
+    c.set("authToken", token);
+    c.set("authScopes", record.scopes);
+    c.set("authUser", { login: record.email, id: record.userId, scopes: record.scopes });
+
+    if (requiredScopes.length > 0 && !record.scopes.some((scope) => requiredScopes.includes(scope))) {
+      return googleApiError(
+        c,
+        403,
+        "Request had insufficient authentication scopes.",
+        "insufficientPermissions",
+        "PERMISSION_DENIED",
+      );
+    }
+
+    await next();
+  };
+}
+
+export function driveScopes(c: Context): string[] {
+  if (c.req.method === "GET") {
+    return [DRIVE, DRIVE_FILE, DRIVE_READONLY, DRIVE_METADATA, DRIVE_METADATA_READONLY];
+  }
+  if (c.req.method === "PATCH" || c.req.method === "PUT") {
+    return [DRIVE, DRIVE_FILE, DRIVE_METADATA];
+  }
+  return [DRIVE, DRIVE_FILE];
+}
+
+export function gmailScopes(c: Context): string[] {
+  const path = new URL(c.req.url).pathname;
+  const method = c.req.method;
+
+  if (path.includes("/settings/filters")) return [GMAIL, GMAIL_SETTINGS_BASIC];
+  if (path.includes("/settings/forwardingAddresses") || path.includes("/settings/sendAs")) {
+    return [GMAIL, GMAIL_SETTINGS_BASIC, GMAIL_SETTINGS_SHARING];
+  }
+  if (path.endsWith("/send") || path.includes("/messages/send")) {
+    return [GMAIL, GMAIL_MODIFY, GMAIL_COMPOSE, GMAIL_SEND];
+  }
+  if (path.includes("/drafts")) {
+    return method === "GET"
+      ? [GMAIL, GMAIL_MODIFY, GMAIL_COMPOSE, GMAIL_READONLY]
+      : [GMAIL, GMAIL_MODIFY, GMAIL_COMPOSE];
+  }
+  if (path.includes("/labels")) {
+    return method === "GET"
+      ? [GMAIL, GMAIL_MODIFY, GMAIL_READONLY, GMAIL_METADATA, GMAIL_LABELS]
+      : [GMAIL, GMAIL_MODIFY, GMAIL_LABELS];
+  }
+  if (path.includes("/messages/import") || path.includes("/messages/batchDelete")) {
+    return [GMAIL, GMAIL_INSERT];
+  }
+  if (method === "GET") return [GMAIL, GMAIL_MODIFY, GMAIL_READONLY, GMAIL_METADATA];
+  return [GMAIL, GMAIL_MODIFY];
+}
+
+export function calendarScopes(c: Context): string[] {
+  const path = new URL(c.req.url).pathname;
+  if (path.includes("/calendarList")) {
+    return [CALENDAR, CALENDAR_READONLY, CALENDAR_LIST, CALENDAR_LIST_READONLY];
+  }
+  if (path.endsWith("/freeBusy")) return [CALENDAR, CALENDAR_READONLY, CALENDAR_FREEBUSY];
+  if (c.req.method === "GET") {
+    return [
+      CALENDAR,
+      CALENDAR_READONLY,
+      CALENDAR_EVENTS,
+      CALENDAR_EVENTS_READONLY,
+      CALENDAR_EVENTS_OWNED,
+      CALENDAR_EVENTS_OWNED_READONLY,
+    ];
+  }
+  return [CALENDAR, CALENDAR_EVENTS, CALENDAR_EVENTS_OWNED];
+}
+
+export function userinfoScopes(): string[] {
+  return [
+    "openid",
+    "email",
+    "profile",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+  ];
+}
+
+function requiredScopesForRequest(c: Context): string[] | undefined {
+  const path = new URL(c.req.url).pathname;
+  if (path === "/oauth2/v2/userinfo") return userinfoScopes();
+  if (path.startsWith("/gmail/") || path.startsWith("/upload/gmail/")) return gmailScopes(c);
+  if (path.startsWith("/calendar/")) return calendarScopes(c);
+  if (path.startsWith("/drive/") || path.startsWith("/upload/drive/")) return driveScopes(c);
+  return undefined;
+}
+
+function bearerToken(c: Context): string | undefined {
+  const match = /^Bearer\s+(\S+)$/i.exec(c.req.header("Authorization") ?? "");
+  return match?.[1];
+}

--- a/packages/@emulators/google/src/helpers.ts
+++ b/packages/@emulators/google/src/helpers.ts
@@ -243,7 +243,7 @@ export function googleApiError(c: Context, code: number, message: string, reason
         status,
       },
     },
-    code as 400 | 401 | 404,
+    code as 400 | 401 | 403 | 404,
   );
 }
 

--- a/packages/@emulators/google/src/index.ts
+++ b/packages/@emulators/google/src/index.ts
@@ -20,6 +20,7 @@ import { oauthRoutes } from "./routes/oauth.js";
 import { settingsRoutes } from "./routes/settings.js";
 import { threadRoutes } from "./routes/threads.js";
 import { getGoogleStore } from "./store.js";
+import { googleStrictAuth } from "./auth.js";
 
 export { getGoogleStore, type GoogleStore } from "./store.js";
 export * from "./entities.js";
@@ -114,6 +115,7 @@ export interface GoogleSeedDriveItem {
 
 export interface GoogleSeedConfig {
   port?: number;
+  strict_scopes?: boolean;
   users?: GoogleSeedUser[];
   oauth_clients?: Array<{
     client_id: string;
@@ -293,6 +295,10 @@ function resolveHd(user: GoogleSeedUser): string | null {
 
 export function seedFromConfig(store: Store, _baseUrl: string, config: GoogleSeedConfig): void {
   const gs = getGoogleStore(store);
+
+  if (config.strict_scopes !== undefined) {
+    store.setData("google.strict_scopes", config.strict_scopes);
+  }
 
   if (config.users) {
     for (const user of config.users) {
@@ -493,6 +499,7 @@ export const googlePlugin: ServicePlugin = {
   name: "google",
   register(app: Hono<AppEnv>, store: Store, webhooks: WebhookDispatcher, baseUrl: string, tokenMap?: TokenMap): void {
     const ctx: RouteContext = { app, store, webhooks, baseUrl, tokenMap };
+    app.use("*", googleStrictAuth(store));
     oauthRoutes(ctx);
     calendarRoutes(ctx);
     driveRoutes(ctx);

--- a/packages/@emulators/google/src/routes/oauth.ts
+++ b/packages/@emulators/google/src/routes/oauth.ts
@@ -18,6 +18,7 @@ import type { GoogleUser } from "../entities.js";
 import { registerGoogleAccessToken, revokeGoogleAccessToken } from "../auth.js";
 
 const JWT_SECRET = new TextEncoder().encode("emulate-google-jwt-secret");
+const DEFAULT_OAUTH_SCOPE = "openid email profile";
 
 type PendingCode = {
   email: string;
@@ -133,7 +134,7 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
   app.get("/o/oauth2/v2/auth", (c) => {
     const client_id = c.req.query("client_id") ?? "";
     const redirect_uri = c.req.query("redirect_uri") ?? "";
-    const scope = c.req.query("scope") ?? "";
+    const scope = normalizeOAuthScope(c.req.query("scope"));
     const state = c.req.query("state") ?? "";
     const nonce = c.req.query("nonce") ?? "";
     const code_challenge = c.req.query("code_challenge") ?? "";
@@ -200,7 +201,7 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
     const body = await c.req.parseBody();
     const email = bodyStr(body.email);
     const redirect_uri = bodyStr(body.redirect_uri);
-    const scope = bodyStr(body.scope);
+    const scope = normalizeOAuthScope(bodyStr(body.scope));
     const state = bodyStr(body.state);
     const client_id = bodyStr(body.client_id);
     const nonce = bodyStr(body.nonce);
@@ -280,7 +281,8 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       }
 
       const accessToken = "google_" + randomBytes(20).toString("base64url");
-      const scopes = record.scope ? record.scope.split(/\s+/).filter(Boolean) : [];
+      const scope = normalizeOAuthScope(record.scope);
+      const scopes = scope.split(/\s+/).filter(Boolean);
 
       if (tokenMap) {
         tokenMap.set(accessToken, { login: user.email, id: user.id, scopes });
@@ -297,7 +299,7 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
         access_token: accessToken,
         token_type: "Bearer",
         expires_in: 3600,
-        scope: record.scope || "openid email profile",
+        scope,
       });
     }
 
@@ -349,7 +351,7 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
 
     const accessToken = "google_" + randomBytes(20).toString("base64url");
     const refreshToken = "google_refresh_" + randomBytes(24).toString("base64url");
-    const scopes = pending.scope ? pending.scope.split(/\s+/).filter(Boolean) : [];
+    const scopes = pending.scope.split(/\s+/).filter(Boolean);
 
     if (tokenMap) {
       tokenMap.set(accessToken, { login: user.email, id: user.id, scopes });
@@ -377,7 +379,7 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       id_token: idToken,
       token_type: "Bearer",
       expires_in: 3600,
-      scope: pending.scope || "openid email profile",
+      scope: pending.scope,
     });
   });
 
@@ -434,4 +436,9 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
 
     return c.body(null, 200);
   });
+}
+
+function normalizeOAuthScope(scope: string | undefined): string {
+  const normalized = scope?.trim() ?? "";
+  return normalized || DEFAULT_OAUTH_SCOPE;
 }

--- a/packages/@emulators/google/src/routes/oauth.ts
+++ b/packages/@emulators/google/src/routes/oauth.ts
@@ -15,6 +15,7 @@ import {
 } from "@emulators/core";
 import { getGoogleStore } from "../store.js";
 import type { GoogleUser } from "../entities.js";
+import { registerGoogleAccessToken, revokeGoogleAccessToken } from "../auth.js";
 
 const JWT_SECRET = new TextEncoder().encode("emulate-google-jwt-secret");
 
@@ -284,6 +285,13 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       if (tokenMap) {
         tokenMap.set(accessToken, { login: user.email, id: user.id, scopes });
       }
+      registerGoogleAccessToken(store, accessToken, {
+        email: user.email,
+        userId: user.id,
+        scopes,
+        clientId: record.clientId,
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      });
 
       return c.json({
         access_token: accessToken,
@@ -346,6 +354,13 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
     if (tokenMap) {
       tokenMap.set(accessToken, { login: user.email, id: user.id, scopes });
     }
+    registerGoogleAccessToken(store, accessToken, {
+      email: user.email,
+      userId: user.id,
+      scopes,
+      clientId: pending.clientId,
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    });
     getRefreshTokens(store).set(refreshToken, {
       email: user.email,
       scope: pending.scope,
@@ -411,9 +426,8 @@ export function oauthRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
       token = params.get("token") ?? "";
     }
 
-    if (token && tokenMap) {
-      tokenMap.delete(token);
-    }
+    if (token && tokenMap) tokenMap.delete(token);
+    if (token) revokeGoogleAccessToken(store, token);
     if (token) {
       getRefreshTokens(store).delete(token);
     }

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -26,6 +26,9 @@ GitHub API coverage:
 
 Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.
+
+Google OAuth authority:
+  Set google.strict_scopes to true in seed config to validate issued tokens, revocation, and API scopes.
 `,
   );
 

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -29,7 +29,7 @@ Webhook signatures:
 
 Google OAuth authority:
   Set google.strict_scopes to true in seed config to validate issued tokens, revocation, and API scopes.
-  Strict mode follows Google's method-level scope requirements, including content access for Drive media and full mail authority for Gmail deletion.
+  Strict mode follows Google's method-level scope requirements, including content access for Drive media, content-write scopes for Drive PUT updates, and full mail authority for Gmail deletion and draft sends.
 `,
   );
 

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -29,6 +29,7 @@ Webhook signatures:
 
 Google OAuth authority:
   Set google.strict_scopes to true in seed config to validate issued tokens, revocation, and API scopes.
+  Strict mode follows Google's method-level scope requirements, including content access for Drive media and full mail authority for Gmail deletion.
 `,
   );
 

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -146,6 +146,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
     },
     initConfig: {
       google: {
+        strict_scopes: false,
         users: [
           {
             email: "testuser@example.com",

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -106,6 +106,8 @@ new GoogleStrategy({
 
 OAuth authority checks are relaxed by default. Set `google.strict_scopes: true` to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce the scopes granted by the authorization flow for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
 
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+
 ```yaml
 google:
   strict_scopes: false

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -106,7 +106,7 @@ new GoogleStrategy({
 
 OAuth authority checks are relaxed by default. Set `google.strict_scopes: true` to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce the scopes granted by the authorization flow for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
 
-Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
+Strict mode follows Google's method-level scope requirements. Drive metadata scopes do not permit `alt=media` downloads, Drive content updates with `PUT` require `drive` or `drive.file` while metadata updates with `PATCH` also accept `drive.metadata`, Gmail `messages.send` accepts `gmail.send` while `drafts.send` requires `https://mail.google.com/`, `gmail.compose`, or `gmail.modify`, Gmail message and thread deletion plus `messages.batchDelete` require `https://mail.google.com/`, and Gmail settings reads accept `gmail.readonly`, `gmail.modify`, or `gmail.settings.basic`.
 
 ```yaml
 google:

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -104,8 +104,11 @@ new GoogleStrategy({
 
 ## Seed Config
 
+OAuth authority checks are relaxed by default. Set `google.strict_scopes: true` to reject unknown, revoked, expired, and refresh tokens on resource APIs and to enforce the scopes granted by the authorization flow for userinfo, Gmail, Calendar, and Drive. Strict mode returns Google-style `401` `UNAUTHENTICATED` errors for invalid credentials and `403` `insufficientPermissions` errors for scope misses.
+
 ```yaml
 google:
+  strict_scopes: false
   users:
     - email: testuser@gmail.com
       name: Test User


### PR DESCRIPTION
## Summary

Fixes #218.

The Google emulator currently treats any nonempty bearer credential as authenticated through the core fallback user. That makes an unknown token, a revoked access token, and a refresh token presented as an access token indistinguishable from a valid credential. Google resource routes also ignore the scopes granted during OAuth.

This adds an opt-in `google.strict_scopes` mode, following the compatibility pattern already used by the Linear and Slack emulators. When enabled, Google now:

- accepts only unexpired access tokens issued by its authorization code or refresh flow
- preserves revoked access-token records and rejects those credentials after `/oauth2/revoke`
- rejects refresh tokens on resource APIs
- checks documented Google scope strings for userinfo, Gmail, Calendar, and Drive routes
- returns the existing Google error envelope with `401` `UNAUTHENTICATED` for invalid credentials and `403` `insufficientPermissions` for scope misses

Strict mode defaults to `false`. Existing users can continue using arbitrary local bearer tokens without completing OAuth, with unchanged response statuses and bodies.

## Reproduction

Use a Google seed with an OAuth client, a user, and at least one Drive item:

```yaml
google:
  users:
    - email: repro@example.com
      name: Repro User
  oauth_clients:
    - client_id: repro-google-client
      client_secret: repro-google-secret
      redirect_uris:
        - http://localhost:9/callback
  drive_items:
    - id: drv_repro_folder
      user_email: repro@example.com
      name: Repro
      mime_type: application/vnd.google-apps.folder
      parent_ids: [root]
```

Start v0.10.0 with `npx emulate@0.10.0 start --service google --port 4700 --seed emulate.config.yaml`, then compare these requests:

1. Call `/drive/v3/files` with `Bearer totally-bogus-token`.
2. Complete the authorization code flow for the Drive scope and call the same route with the issued access token.
3. Revoke that access token through `/oauth2/revoke`, then call Drive with it again.
4. Complete another authorization code flow with only `openid`, then call Drive, Gmail, and Calendar data routes.
5. Present an issued refresh token to a resource route.

On v0.10.0, all five resource credential variants return `200` and expose seeded data. With this change and `google.strict_scopes: true`, the results are:

| Scenario | v0.10.0 | This PR, strict mode |
| --- | --- | --- |
| Unknown bearer token | `200` | `401 UNAUTHENTICATED` |
| Issued token with matching scope | `200` | `200` |
| Revoked access token | `200` | `401 UNAUTHENTICATED` |
| `openid`-only token on Drive, Gmail, or Calendar | `200` | `403 insufficientPermissions` |
| Refresh token on a resource route | `200` | `401 UNAUTHENTICATED` |

## Compatibility

`strict_scopes` is absent or `false` by default. Tests compare response bodies as well as status codes for unknown, revoked, underscoped, and refresh credentials to guard the existing permissive workflow.

The starter config, package README, root README, docs site, Google skill, and CLI help now document the option.

## Tests

- `pnpm test`
- `pnpm type-check`
- `pnpm lint`
- `pnpm build`

## Follow-ups

The Microsoft and GitHub emulators have the same adjacent unknown-bearer fallback gap. They are intentionally out of scope here and can use the same opt-in pattern in separate changes. Consent denial and fault injection are also outside this PR.
