### PR TITLE
Add Google Calendar Discovery metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `GET /oauth2/v2/userinfo` - get user info
 - `GET /.well-known/openid-configuration` - OIDC discovery document
 - `GET /oauth2/v3/certs` - JSON Web Key Set (JWKS)
+- `GET /discovery/v1/apis/calendar/v3/rest` - unauthenticated Calendar v3 Discovery document for the supported operations
 - `GET /gmail/v1/users/:userId/messages` - list messages with `q`, `labelIds`, `maxResults`, and `pageToken`
 - `GET /gmail/v1/users/:userId/messages/:id` - fetch a Gmail-style message payload in `full`, `metadata`, `minimal`, or `raw` formats
 - `GET /gmail/v1/users/:userId/messages/:messageId/attachments/:id` - fetch attachment bodies
@@ -802,6 +803,12 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 - `GET /gmail/v1/users/:userId/settings/forwardingAddresses`, `GET /gmail/v1/users/:userId/settings/sendAs`
 - `GET /calendar/v3/users/:userId/calendarList`, `GET /calendar/v3/calendars/:calendarId/events`, `POST /calendar/v3/calendars/:calendarId/events`, `DELETE /calendar/v3/calendars/:calendarId/events/:eventId`, `POST /calendar/v3/freeBusy`
 - `GET /drive/v3/files`, `GET /drive/v3/files/:fileId`, `POST /drive/v3/files`, `PATCH /drive/v3/files/:fileId`, `PUT /drive/v3/files/:fileId`, `POST /upload/drive/v3/files`
+
+Calendar v3 Discovery is public at `/discovery/v1/apis/calendar/v3/rest`; Calendar data endpoints remain authenticated. Its `rootUrl` and `servicePath` reflect configured and adapter-mounted base URLs, and its `baseUrl` points to the local `/calendar/v3/` service path. For example:
+
+```bash
+curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
+```
 
 ## Slack API
 

--- a/README.md
+++ b/README.md
@@ -810,6 +810,34 @@ Calendar v3 Discovery is public at `/discovery/v1/apis/calendar/v3/rest`; Calend
 curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
 ```
 
+Discovery-based Python clients need the local URI template explicitly. Configure `calendar_local` in the top-level `tokens` seed map for a seeded Google user, then use local credentials and disable discovery caching while developing:
+
+```yaml
+tokens:
+  calendar_local:
+    login: testuser@example.com
+```
+
+```python
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+GOOGLE_EMULATOR_URL = "http://localhost:4002"
+credentials = Credentials(token="calendar_local")
+service = build(
+    "calendar",
+    "v3",
+    credentials=credentials,
+    discoveryServiceUrl=(
+        f"{GOOGLE_EMULATOR_URL}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest"
+    ),
+    cache_discovery=False,
+)
+calendar_list = service.calendarList().list().execute()
+```
+
+`google-api-python-client` otherwise uses Google's discovery sources and production Calendar URL. If discovery caching is enabled, clear the client cache after changing the advertised URL or discovery document.
+
 ## Slack API
 
 Fully stateful Slack Web API emulation with channels, messages, threads, reactions, user profiles, presence, modern file uploads, pins, bookmarks, views, OAuth v2, and incoming webhooks. Chat writes preserve common rich message fields such as `blocks`, `attachments`, `metadata`, formatting flags, unfurl flags, and client message ids. Conversation writes update archive state, names, topics, purposes, membership, DMs, MPIMs, and read cursors. User writes update profile fields, status, custom fields, and deterministic active or away presence. File writes support the current external upload flow with local upload URLs, file share messages, reads, lists, downloads, and deletes. Pin and bookmark writes support channel message pins and link bookmarks. View writes support App Home publishing and modal stacks. Seeded OAuth apps and OAuth installs create bot users and installation records. OAuth exchanges and explicit token seeds create scoped token records. Supported write state changes dispatch Slack `event_callback` payloads to configured webhook URLs.

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -76,6 +76,34 @@ curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
 
 The document's `rootUrl` and `servicePath` reflect the configured advertised base URL, including a mount prefix when using an adapter. Its `baseUrl` points to the local `/calendar/v3/` path so discovery-based clients can build requests against the emulator.
 
+The Python discovery client needs the local discovery URI template explicitly. It does not infer the emulator endpoint from `GOOGLE_EMULATOR_URL` and can otherwise use Google's discovery metadata and production Calendar URL. Give it a local bearer token for a seeded user and disable discovery caching during development:
+
+```yaml
+tokens:
+  calendar_local:
+    login: testuser@example.com
+```
+
+```python
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+GOOGLE_EMULATOR_URL = "http://localhost:4002"
+credentials = Credentials(token="calendar_local")
+service = build(
+    "calendar",
+    "v3",
+    credentials=credentials,
+    discoveryServiceUrl=(
+        f"{GOOGLE_EMULATOR_URL}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest"
+    ),
+    cache_discovery=False,
+)
+calendar_list = service.calendarList().list().execute()
+```
+
+Add `calendar_local` to the top-level `tokens` seed map and map it to the seeded Google user's email. If discovery caching is enabled, clear the client cache after changing the advertised URL or discovery document.
+
 ## Drive
 
 - `GET /drive/v3/files` - list files

--- a/apps/web/app/docs/google/page.mdx
+++ b/apps/web/app/docs/google/page.mdx
@@ -61,11 +61,20 @@ OAuth 2.0, OpenID Connect, and mutable Google Workspace-style surfaces for local
 
 ## Calendar
 
+- `GET /discovery/v1/apis/calendar/v3/rest` - unauthenticated Calendar v3 Discovery document for the supported operations
 - `GET /calendar/v3/users/:userId/calendarList` - list calendars
 - `GET /calendar/v3/calendars/:calendarId/events` - list events
 - `POST /calendar/v3/calendars/:calendarId/events` - create event
 - `DELETE /calendar/v3/calendars/:calendarId/events/:eventId` - delete event
 - `POST /calendar/v3/freeBusy` - query free/busy
+
+The Calendar Discovery route is public, while Calendar data routes require a bearer token. Fetch it locally with:
+
+```bash
+curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
+```
+
+The document's `rootUrl` and `servicePath` reflect the configured advertised base URL, including a mount prefix when using an adapter. Its `baseUrl` points to the local `/calendar/v3/` path so discovery-based clients can build requests against the emulator.
 
 ## Drive
 

--- a/packages/@emulators/google/README.md
+++ b/packages/@emulators/google/README.md
@@ -76,6 +76,34 @@ curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
 
 Its `rootUrl` and `servicePath` reflect the configured advertised base URL, including a mount prefix when Google is embedded through an adapter. Its `baseUrl` is the advertised service base followed by `/calendar/v3/`, so discovery-based clients can use the generated Calendar URLs locally.
 
+The Python discovery client does not infer this endpoint from `GOOGLE_EMULATOR_URL`. Pass the local URI template explicitly, provide local credentials, and disable discovery caching while developing so metadata changes are picked up:
+
+```yaml
+tokens:
+  calendar_local:
+    login: testuser@example.com
+```
+
+```python
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+GOOGLE_EMULATOR_URL = "http://localhost:4002"
+credentials = Credentials(token="calendar_local")
+service = build(
+    "calendar",
+    "v3",
+    credentials=credentials,
+    discoveryServiceUrl=(
+        f"{GOOGLE_EMULATOR_URL}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest"
+    ),
+    cache_discovery=False,
+)
+calendar_list = service.calendarList().list().execute()
+```
+
+Configure `calendar_local` in the top-level `tokens` seed map for the user whose calendars you want to use. If discovery caching is enabled, clear the client cache after changing the advertised URL or discovery document.
+
 ### Drive
 - `GET /drive/v3/files` — list files
 - `GET /drive/v3/files/:fileId` — get file metadata

--- a/packages/@emulators/google/README.md
+++ b/packages/@emulators/google/README.md
@@ -61,11 +61,20 @@ npm install @emulators/google
 - `GET /gmail/v1/users/:userId/settings/sendAs` — list send-as aliases
 
 ### Calendar
+- `GET /discovery/v1/apis/calendar/v3/rest` — unauthenticated Calendar v3 Discovery document for the supported operations
 - `GET /calendar/v3/users/:userId/calendarList` — list calendars
 - `GET /calendar/v3/calendars/:calendarId/events` — list events
 - `POST /calendar/v3/calendars/:calendarId/events` — create event
 - `DELETE /calendar/v3/calendars/:calendarId/events/:eventId` — delete event
 - `POST /calendar/v3/freeBusy` — free/busy query
+
+The Calendar Discovery document is public, while Calendar data endpoints require a bearer token. Request it locally with:
+
+```bash
+curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
+```
+
+Its `rootUrl` and `servicePath` reflect the configured advertised base URL, including a mount prefix when Google is embedded through an adapter. Its `baseUrl` is the advertised service base followed by `/calendar/v3/`, so discovery-based clients can use the generated Calendar URLs locally.
 
 ### Drive
 - `GET /drive/v3/files` — list files

--- a/packages/@emulators/google/src/__tests__/google.test.ts
+++ b/packages/@emulators/google/src/__tests__/google.test.ts
@@ -256,6 +256,12 @@ describe("Google plugin integration", () => {
       id: "calendar:v3",
       name: "calendar",
       version: "v3",
+      revision: "emulate",
+      title: "Calendar API",
+      description: "Manipulates events and other calendar data.",
+      documentationLink: "https://developers.google.com/workspace/calendar/firstapp",
+      ownerDomain: "google.com",
+      ownerName: "Google",
       protocol: "rest",
       rootUrl: `${base}/`,
       servicePath: "calendar/v3/",
@@ -285,6 +291,11 @@ describe("Google plugin integration", () => {
       parameterOrder: ["calendarId"],
       response: { $ref: "Events" },
     });
+    expect(resources.events.methods.list.parameters.calendarId).toMatchObject({
+      location: "path",
+      type: "string",
+      required: true,
+    });
     expect(resources.events.methods.insert).toMatchObject({
       id: "calendar.events.insert",
       path: "calendars/{calendarId}/events",
@@ -292,11 +303,20 @@ describe("Google plugin integration", () => {
       request: { $ref: "Event" },
       response: { $ref: "Event" },
     });
+    expect(resources.events.methods.insert.parameters.calendarId).toMatchObject({
+      location: "path",
+      type: "string",
+      required: true,
+    });
     expect(resources.events.methods.delete).toMatchObject({
       id: "calendar.events.delete",
       path: "calendars/{calendarId}/events/{eventId}",
       httpMethod: "DELETE",
       parameterOrder: ["calendarId", "eventId"],
+    });
+    expect(resources.events.methods.delete.parameters).toEqual({
+      calendarId: expect.objectContaining({ location: "path", type: "string", required: true }),
+      eventId: expect.objectContaining({ location: "path", type: "string", required: true }),
     });
     expect(resources.freebusy.methods.query).toMatchObject({
       id: "calendar.freebusy.query",
@@ -321,6 +341,19 @@ describe("Google plugin integration", () => {
         Events: expect.any(Object),
         FreeBusyRequest: expect.any(Object),
         FreeBusyResponse: expect.any(Object),
+      }),
+    );
+    expect((document.schemas as Record<string, any>).CalendarListEntry.properties).toHaveProperty("timeZone");
+    expect((document.schemas as Record<string, any>).EventDateTime.properties).toEqual(
+      expect.objectContaining({
+        dateTime: expect.any(Object),
+        timeZone: expect.any(Object),
+      }),
+    );
+    expect((document.schemas as Record<string, any>).Event.properties).toEqual(
+      expect.objectContaining({
+        hangoutLink: expect.any(Object),
+        conferenceData: expect.any(Object),
       }),
     );
     expectDiscoveryReferencesToResolve(document);
@@ -354,10 +387,14 @@ describe("Google plugin integration", () => {
       "/api/emulate",
     );
     expect(mountedResponse.status).toBe(200);
-    await expect(mountedResponse.json()).resolves.toMatchObject({
+    const mountedDocument = (await mountedResponse.json()) as DiscoveryDocument;
+    expect(mountedDocument).toMatchObject({
       rootUrl: "https://app.example.test/api/emulate/google/",
       baseUrl: "https://app.example.test/api/emulate/google/calendar/v3/",
     });
+    expect(new URL("users/me/calendarList", mountedDocument.baseUrl as string).href).toBe(
+      "https://app.example.test/api/emulate/google/calendar/v3/users/me/calendarList",
+    );
 
     const mountedCalendarResponse = await runtime.handle(
       new Request("https://app.example.test/api/emulate/google/calendar/v3/users/me/calendarList"),

--- a/packages/@emulators/google/src/__tests__/google.test.ts
+++ b/packages/@emulators/google/src/__tests__/google.test.ts
@@ -6,6 +6,7 @@ import {
   WebhookDispatcher,
   authMiddleware,
   createApiErrorHandler,
+  createAdapterRuntime,
   createErrorHandler,
   type TokenMap,
 } from "@emulators/core";
@@ -14,7 +15,7 @@ import { buildRawMessage } from "../helpers.js";
 
 const base = "http://localhost:4000";
 
-function createTestApp() {
+function createTestApp(advertisedBaseUrl = base) {
   const store = new Store();
   const webhooks = new WebhookDispatcher();
   const tokenMap: TokenMap = new Map();
@@ -28,9 +29,9 @@ function createTestApp() {
   app.onError(createApiErrorHandler());
   app.use("*", createErrorHandler());
   app.use("*", authMiddleware(tokenMap));
-  googlePlugin.register(app as any, store, webhooks, base, tokenMap);
-  googlePlugin.seed?.(store, base);
-  seedFromConfig(store, base, {
+  googlePlugin.register(app as any, store, webhooks, advertisedBaseUrl, tokenMap);
+  googlePlugin.seed?.(store, advertisedBaseUrl);
+  seedFromConfig(store, advertisedBaseUrl, {
     users: [
       { email: "testuser@example.com", name: "Test User" },
       { email: "consumer@gmail.com", name: "Consumer User" },
@@ -179,6 +180,34 @@ function authHeaders(extra?: Record<string, string>): Record<string, string> {
   return { Authorization: "Bearer test-token", ...extra };
 }
 
+type DiscoveryDocument = {
+  [key: string]: unknown;
+};
+
+function expectDiscoveryReferencesToResolve(document: DiscoveryDocument): void {
+  const schemas = document.schemas as Record<string, unknown>;
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+
+    if (!value || typeof value !== "object") return;
+
+    for (const [key, child] of Object.entries(value)) {
+      if (key === "$ref") {
+        expect(typeof child).toBe("string");
+        expect(schemas).toHaveProperty(child as string);
+      } else {
+        visit(child);
+      }
+    }
+  };
+
+  visit(document.resources);
+  visit(schemas);
+}
+
 async function jsonRequest(
   app: Hono,
   path: string,
@@ -214,6 +243,128 @@ describe("Google plugin integration", () => {
 
   beforeEach(() => {
     app = createTestApp().app;
+  });
+
+  it("serves an unauthenticated Calendar Discovery document for the supported methods", async () => {
+    const res = await app.request(`${base}/discovery/v1/apis/calendar/v3/rest`);
+    expect(res.status).toBe(200);
+
+    const document = (await res.json()) as DiscoveryDocument;
+    expect(document).toMatchObject({
+      kind: "discovery#restDescription",
+      discoveryVersion: "v1",
+      id: "calendar:v3",
+      name: "calendar",
+      version: "v3",
+      protocol: "rest",
+      rootUrl: `${base}/`,
+      servicePath: "calendar/v3/",
+      basePath: "/calendar/v3/",
+      baseUrl: `${base}/calendar/v3/`,
+    });
+
+    const unauthenticatedCalendarResponse = await app.request(`${base}/calendar/v3/users/me/calendarList`);
+    expect(unauthenticatedCalendarResponse.status).toBe(401);
+
+    const resources = document.resources as Record<string, any>;
+    expect(Object.keys(resources)).toEqual(["calendarList", "events", "freebusy"]);
+    expect(Object.keys(resources.calendarList.methods)).toEqual(["list"]);
+    expect(Object.keys(resources.events.methods)).toEqual(["list", "insert", "delete"]);
+    expect(Object.keys(resources.freebusy.methods)).toEqual(["query"]);
+
+    expect(resources.calendarList.methods.list).toMatchObject({
+      id: "calendar.calendarList.list",
+      path: "users/me/calendarList",
+      httpMethod: "GET",
+      response: { $ref: "CalendarList" },
+    });
+    expect(resources.events.methods.list).toMatchObject({
+      id: "calendar.events.list",
+      path: "calendars/{calendarId}/events",
+      httpMethod: "GET",
+      parameterOrder: ["calendarId"],
+      response: { $ref: "Events" },
+    });
+    expect(resources.events.methods.insert).toMatchObject({
+      id: "calendar.events.insert",
+      path: "calendars/{calendarId}/events",
+      httpMethod: "POST",
+      request: { $ref: "Event" },
+      response: { $ref: "Event" },
+    });
+    expect(resources.events.methods.delete).toMatchObject({
+      id: "calendar.events.delete",
+      path: "calendars/{calendarId}/events/{eventId}",
+      httpMethod: "DELETE",
+      parameterOrder: ["calendarId", "eventId"],
+    });
+    expect(resources.freebusy.methods.query).toMatchObject({
+      id: "calendar.freebusy.query",
+      path: "freeBusy",
+      httpMethod: "POST",
+      request: { $ref: "FreeBusyRequest" },
+      response: { $ref: "FreeBusyResponse" },
+    });
+
+    const eventListParameters = resources.events.methods.list.parameters as Record<string, unknown>;
+    expect(Object.keys(eventListParameters).sort()).toEqual(
+      ["calendarId", "maxResults", "orderBy", "pageToken", "q", "timeMax", "timeMin"].sort(),
+    );
+    expect(eventListParameters).not.toHaveProperty("singleEvents");
+    expect(eventListParameters).not.toHaveProperty("showDeleted");
+    expect(document.schemas).toEqual(
+      expect.objectContaining({
+        CalendarListEntry: expect.any(Object),
+        CalendarList: expect.any(Object),
+        EventDateTime: expect.any(Object),
+        Event: expect.any(Object),
+        Events: expect.any(Object),
+        FreeBusyRequest: expect.any(Object),
+        FreeBusyResponse: expect.any(Object),
+      }),
+    );
+    expectDiscoveryReferencesToResolve(document);
+  });
+
+  it("advertises configured and adapter-mounted Calendar URLs", async () => {
+    const configuredBase = "https://app.example.test/api/emulate/google///";
+    const configuredApp = createTestApp(configuredBase).app;
+    const configuredResponse = await configuredApp.request(
+      "https://app.example.test/discovery/v1/apis/calendar/v3/rest",
+    );
+    expect(configuredResponse.status).toBe(200);
+    await expect(configuredResponse.json()).resolves.toMatchObject({
+      rootUrl: "https://app.example.test/api/emulate/google/",
+      servicePath: "calendar/v3/",
+      basePath: "/calendar/v3/",
+      baseUrl: "https://app.example.test/api/emulate/google/calendar/v3/",
+    });
+
+    const runtime = createAdapterRuntime(
+      {
+        services: {
+          google: { emulator: { plugin: googlePlugin } },
+        },
+      },
+      (mountPath, service) => `${mountPath}/${service}`,
+    );
+    const mountedResponse = await runtime.handle(
+      new Request("https://app.example.test/api/emulate/google/discovery/v1/apis/calendar/v3/rest"),
+      ["google", "discovery", "v1", "apis", "calendar", "v3", "rest"],
+      "/api/emulate",
+    );
+    expect(mountedResponse.status).toBe(200);
+    await expect(mountedResponse.json()).resolves.toMatchObject({
+      rootUrl: "https://app.example.test/api/emulate/google/",
+      baseUrl: "https://app.example.test/api/emulate/google/calendar/v3/",
+    });
+
+    const mountedCalendarResponse = await runtime.handle(
+      new Request("https://app.example.test/api/emulate/google/calendar/v3/users/me/calendarList"),
+      ["google", "calendar", "v3", "users", "me", "calendarList"],
+      "/api/emulate",
+    );
+    expect(mountedCalendarResponse.status).toBe(401);
   });
 
   it("returns user info for a valid token", async () => {

--- a/packages/@emulators/google/src/routes/calendar-discovery.ts
+++ b/packages/@emulators/google/src/routes/calendar-discovery.ts
@@ -1,0 +1,301 @@
+import type { RouteContext } from "@emulators/core";
+
+const servicePath = "calendar/v3/";
+const basePath = "/calendar/v3/";
+
+export function calendarDiscoveryRoutes({ app, baseUrl }: Pick<RouteContext, "app" | "baseUrl">): void {
+  app.get("/discovery/v1/apis/calendar/v3/rest", () => {
+    const serviceBaseUrl = baseUrl.replace(/\/+$/, "");
+
+    return Response.json({
+      kind: "discovery#restDescription",
+      discoveryVersion: "v1",
+      id: "calendar:v3",
+      name: "calendar",
+      version: "v3",
+      revision: "emulate",
+      title: "Calendar API",
+      description: "Manipulates events and other calendar data.",
+      documentationLink: "https://developers.google.com/workspace/calendar/firstapp",
+      ownerDomain: "google.com",
+      ownerName: "Google",
+      protocol: "rest",
+      baseUrl: `${serviceBaseUrl}/${servicePath}`,
+      basePath,
+      rootUrl: `${serviceBaseUrl}/`,
+      servicePath,
+      batchPath: "batch/calendar/v3",
+      parameters: {
+        alt: { type: "string", location: "query", default: "json", enum: ["json"] },
+        fields: { type: "string", location: "query" },
+        key: { type: "string", location: "query" },
+        oauth_token: { type: "string", location: "query" },
+        prettyPrint: { type: "boolean", location: "query", default: "true" },
+      },
+      resources: {
+        calendarList: {
+          methods: {
+            list: {
+              id: "calendar.calendarList.list",
+              path: "users/me/calendarList",
+              httpMethod: "GET",
+              description: "Returns the calendars on the user's calendar list.",
+              response: { $ref: "CalendarList" },
+            },
+          },
+        },
+        events: {
+          methods: {
+            list: {
+              id: "calendar.events.list",
+              path: "calendars/{calendarId}/events",
+              httpMethod: "GET",
+              description: "Returns events on the specified calendar.",
+              parameterOrder: ["calendarId"],
+              parameters: {
+                calendarId: {
+                  location: "path",
+                  type: "string",
+                  required: true,
+                  description:
+                    "Calendar identifier. Use the primary keyword for the authenticated user's primary calendar.",
+                },
+                timeMin: {
+                  location: "query",
+                  type: "string",
+                  format: "date-time",
+                  description: "Lower bound for an event's end time to filter by.",
+                },
+                timeMax: {
+                  location: "query",
+                  type: "string",
+                  format: "date-time",
+                  description: "Upper bound for an event's start time to filter by.",
+                },
+                maxResults: {
+                  location: "query",
+                  type: "integer",
+                  format: "int32",
+                  description: "Maximum number of events returned on one page.",
+                },
+                pageToken: {
+                  location: "query",
+                  type: "string",
+                  description: "Token specifying which result page to return.",
+                },
+                q: {
+                  location: "query",
+                  type: "string",
+                  description: "Free text search terms for matching events.",
+                },
+                orderBy: {
+                  location: "query",
+                  type: "string",
+                  description: "The order of the events returned in the result.",
+                },
+              },
+              response: { $ref: "Events" },
+            },
+            insert: {
+              id: "calendar.events.insert",
+              path: "calendars/{calendarId}/events",
+              httpMethod: "POST",
+              description: "Creates an event.",
+              parameterOrder: ["calendarId"],
+              parameters: {
+                calendarId: {
+                  location: "path",
+                  type: "string",
+                  required: true,
+                  description:
+                    "Calendar identifier. Use the primary keyword for the authenticated user's primary calendar.",
+                },
+              },
+              request: { $ref: "Event" },
+              response: { $ref: "Event" },
+            },
+            delete: {
+              id: "calendar.events.delete",
+              path: "calendars/{calendarId}/events/{eventId}",
+              httpMethod: "DELETE",
+              description: "Deletes an event.",
+              parameterOrder: ["calendarId", "eventId"],
+              parameters: {
+                calendarId: {
+                  location: "path",
+                  type: "string",
+                  required: true,
+                  description:
+                    "Calendar identifier. Use the primary keyword for the authenticated user's primary calendar.",
+                },
+                eventId: {
+                  location: "path",
+                  type: "string",
+                  required: true,
+                  description: "Event identifier.",
+                },
+              },
+            },
+          },
+        },
+        freebusy: {
+          methods: {
+            query: {
+              id: "calendar.freebusy.query",
+              path: "freeBusy",
+              httpMethod: "POST",
+              description: "Returns free/busy information for a set of calendars.",
+              request: { $ref: "FreeBusyRequest" },
+              response: { $ref: "FreeBusyResponse" },
+            },
+          },
+        },
+      },
+      schemas: {
+        CalendarListEntry: {
+          id: "CalendarListEntry",
+          type: "object",
+          properties: {
+            kind: { type: "string" },
+            etag: { type: "string" },
+            id: { type: "string" },
+            summary: { type: "string" },
+            description: { type: "string" },
+            timeZone: { type: "string" },
+            selected: { type: "boolean" },
+            primary: { type: "boolean" },
+            accessRole: { type: "string" },
+            backgroundColor: { type: "string" },
+            foregroundColor: { type: "string" },
+          },
+        },
+        CalendarList: {
+          id: "CalendarList",
+          type: "object",
+          properties: {
+            kind: { type: "string" },
+            items: { type: "array", items: { $ref: "CalendarListEntry" } },
+            nextPageToken: { type: "string" },
+          },
+        },
+        EventDateTime: {
+          id: "EventDateTime",
+          type: "object",
+          properties: {
+            dateTime: { type: "string", format: "date-time" },
+            date: { type: "string", format: "date" },
+            timeZone: { type: "string" },
+          },
+        },
+        EventAttendee: {
+          id: "EventAttendee",
+          type: "object",
+          properties: {
+            email: { type: "string" },
+            displayName: { type: "string" },
+            responseStatus: { type: "string" },
+            organizer: { type: "boolean" },
+            self: { type: "boolean" },
+          },
+        },
+        EntryPoint: {
+          id: "EntryPoint",
+          type: "object",
+          properties: {
+            entryPointType: { type: "string" },
+            uri: { type: "string" },
+            label: { type: "string" },
+          },
+        },
+        ConferenceData: {
+          id: "ConferenceData",
+          type: "object",
+          properties: {
+            entryPoints: { type: "array", items: { $ref: "EntryPoint" } },
+          },
+        },
+        Event: {
+          id: "Event",
+          type: "object",
+          properties: {
+            kind: { type: "string" },
+            etag: { type: "string" },
+            id: { type: "string" },
+            status: { type: "string" },
+            htmlLink: { type: "string" },
+            hangoutLink: { type: "string" },
+            summary: { type: "string" },
+            description: { type: "string" },
+            location: { type: "string" },
+            created: { type: "string", format: "date-time" },
+            updated: { type: "string", format: "date-time" },
+            start: { $ref: "EventDateTime" },
+            end: { $ref: "EventDateTime" },
+            attendees: { type: "array", items: { $ref: "EventAttendee" } },
+            conferenceData: { $ref: "ConferenceData" },
+            transparency: { type: "string" },
+          },
+        },
+        Events: {
+          id: "Events",
+          type: "object",
+          properties: {
+            kind: { type: "string" },
+            etag: { type: "string" },
+            summary: { type: "string" },
+            description: { type: "string" },
+            timeZone: { type: "string" },
+            accessRole: { type: "string" },
+            items: { type: "array", items: { $ref: "Event" } },
+            nextPageToken: { type: "string" },
+          },
+        },
+        FreeBusyRequestItem: {
+          id: "FreeBusyRequestItem",
+          type: "object",
+          properties: {
+            id: { type: "string" },
+          },
+        },
+        FreeBusyRequest: {
+          id: "FreeBusyRequest",
+          type: "object",
+          properties: {
+            timeMin: { type: "string", format: "date-time" },
+            timeMax: { type: "string", format: "date-time" },
+            timeZone: { type: "string" },
+            items: { type: "array", items: { $ref: "FreeBusyRequestItem" } },
+          },
+        },
+        TimePeriod: {
+          id: "TimePeriod",
+          type: "object",
+          properties: {
+            start: { type: "string", format: "date-time" },
+            end: { type: "string", format: "date-time" },
+          },
+        },
+        FreeBusyCalendar: {
+          id: "FreeBusyCalendar",
+          type: "object",
+          properties: {
+            busy: { type: "array", items: { $ref: "TimePeriod" } },
+          },
+        },
+        FreeBusyResponse: {
+          id: "FreeBusyResponse",
+          type: "object",
+          properties: {
+            kind: { type: "string" },
+            timeMin: { type: "string", format: "date-time" },
+            timeMax: { type: "string", format: "date-time" },
+            calendars: {
+              type: "object",
+              additionalProperties: { $ref: "FreeBusyCalendar" },
+            },
+          },
+        },
+      },
+    });
+  });
+}

--- a/packages/@emulators/google/src/routes/calendar.ts
+++ b/packages/@emulators/google/src/routes/calendar.ts
@@ -11,6 +11,7 @@ import {
   listCalendarsForUser,
 } from "../calendar-helpers.js";
 import { googleApiError } from "../helpers.js";
+import { calendarDiscoveryRoutes } from "./calendar-discovery.js";
 import {
   getRecord,
   getRecordArray,
@@ -21,8 +22,10 @@ import {
 } from "../route-helpers.js";
 import { getGoogleStore } from "../store.js";
 
-export function calendarRoutes({ app, store }: RouteContext): void {
+export function calendarRoutes({ app, store, baseUrl }: RouteContext): void {
   const gs = getGoogleStore(store);
+
+  calendarDiscoveryRoutes({ app, baseUrl });
 
   app.get("/calendar/v3/users/:userId/calendarList", (c) => {
     const authEmail = requireGmailUser(c);

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -31,6 +31,8 @@ Google Calendar Discovery:
   GET /discovery/v1/apis/calendar/v3/rest is public and describes the supported Calendar v3 operations.
   Its rootUrl, servicePath, and baseUrl preserve configured and adapter-mounted service prefixes.
   Example: curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
+  Discovery clients must use .../discovery/v1/apis/{api}/{apiVersion}/rest explicitly.
+  Provide a local bearer token and disable client discovery caching while changing metadata.
 
 Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -27,6 +27,11 @@ GitHub API coverage:
 Linear API coverage:
   Issue queries and mutations include numeric priority and derived priorityLabel fields.
 
+Google Calendar Discovery:
+  GET /discovery/v1/apis/calendar/v3/rest is public and describes the supported Calendar v3 operations.
+  Its rootUrl, servicePath, and baseUrl preserve configured and adapter-mounted service prefixes.
+  Example: curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
+
 Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.
 `,

--- a/packages/emulate/src/registry.ts
+++ b/packages/emulate/src/registry.ts
@@ -135,7 +135,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceEntry> = {
   google: {
     label: "Google OAuth 2.0 / OpenID Connect + Gmail, Calendar, and Drive emulator",
     endpoints:
-      "OAuth authorize, token exchange, userinfo, OIDC discovery, token revocation, Gmail messages/drafts/threads/labels/history/settings, Calendar lists/events/freebusy, Drive files/uploads",
+      "OAuth authorize, token exchange, userinfo, OIDC discovery, Calendar REST discovery, token revocation, Gmail messages/drafts/threads/labels/history/settings, Calendar lists/events/freebusy, Drive files/uploads",
     async load() {
       const mod = await import("@emulators/google");
       return { plugin: mod.googlePlugin, seedFromConfig: mod.seedFromConfig };

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -58,6 +58,34 @@ curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
 
 It describes the supported `calendarList.list`, `events.list`, `events.insert`, `events.delete`, and `freebusy.query` operations. The document's `rootUrl` and `servicePath` reflect the configured advertised base URL, including adapter mount prefixes, and its `baseUrl` points to the local Calendar v3 service path. Calendar data requests still require a bearer token.
 
+Discovery-based clients must be pointed at the local URI template explicitly. `google-api-python-client` otherwise uses Google's discovery sources and production Calendar URL. Use a bearer token mapped to a seeded user and disable discovery caching while developing:
+
+```yaml
+tokens:
+  calendar_local:
+    login: testuser@example.com
+```
+
+```python
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+GOOGLE_EMULATOR_URL = "http://localhost:4002"
+credentials = Credentials(token="calendar_local")
+service = build(
+    "calendar",
+    "v3",
+    credentials=credentials,
+    discoveryServiceUrl=(
+        f"{GOOGLE_EMULATOR_URL}/discovery/v1/apis/{{api}}/{{apiVersion}}/rest"
+    ),
+    cache_discovery=False,
+)
+calendar_list = service.calendarList().list().execute()
+```
+
+Add `calendar_local` to the top-level `tokens` seed map and map it to the seeded Google user's email. If discovery caching is enabled, clear the client cache after changing the advertised URL or discovery document.
+
 ### google-auth-library (Node.js)
 
 ```typescript

--- a/skills/google/SKILL.md
+++ b/skills/google/SKILL.md
@@ -48,6 +48,16 @@ GOOGLE_EMULATOR_URL=http://localhost:4002
 | `https://www.googleapis.com/calendar/v3/...` | `$GOOGLE_EMULATOR_URL/calendar/v3/...` |
 | `https://www.googleapis.com/drive/v3/...` | `$GOOGLE_EMULATOR_URL/drive/v3/...` |
 
+### Calendar Discovery
+
+The Calendar v3 service description is available without authentication:
+
+```bash
+curl http://localhost:4002/discovery/v1/apis/calendar/v3/rest
+```
+
+It describes the supported `calendarList.list`, `events.list`, `events.insert`, `events.delete`, and `freebusy.query` operations. The document's `rootUrl` and `servicePath` reflect the configured advertised base URL, including adapter mount prefixes, and its `baseUrl` points to the local Calendar v3 service path. Calendar data requests still require a bearer token.
+
 ### google-auth-library (Node.js)
 
 ```typescript


### PR DESCRIPTION
## Summary

Add a public Google Calendar v3 Discovery document endpoint for the Calendar operations supported by the emulator: calendar list, event listing and creation or deletion, and free or busy queries.

The document derives its advertised root URL and service URL from the configured service base, preserving adapter mount prefixes so generated client requests target the local emulator while existing Calendar data routes remain authenticated.

Add local discovery-client guidance across the project documentation, Google skill, and CLI help, including seeded bearer token configuration, the explicit local discovery URI template, and discovery cache handling.