### PR TITLE
fix(aws): preserve binary S3 object bodies

### DIFF
--- a/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
+++ b/packages/@emulators/aws/src/__tests__/aws-sdk.e2e.test.ts
@@ -49,6 +49,14 @@ async function streamToString(stream: unknown): Promise<string> {
   return Buffer.concat(chunks).toString();
 }
 
+async function streamToBuffer(stream: unknown): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
 describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
   let emulator: EmulatorHandle;
   let s3: S3Client;
@@ -105,6 +113,22 @@ describe("AWS plugin - real @aws-sdk/client-s3 E2E", () => {
     const head = await s3.send(new HeadObjectCommand({ Bucket: "emulate-default", Key: "e2e/put-get.txt" }));
     expect(head.ContentType).toBe("text/plain");
     expect(head.LastModified).toBeInstanceOf(Date);
+  });
+
+  it("PutObject / GetObject roundtrips binary content byte-for-byte", async () => {
+    const body = Buffer.from([0x00, 0xff, 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: "emulate-default",
+        Key: "e2e/binary.png",
+        Body: body,
+        ContentType: "image/png",
+        ServerSideEncryption: "AES256",
+      }),
+    );
+
+    const get = await s3.send(new GetObjectCommand({ Bucket: "emulate-default", Key: "e2e/binary.png" }));
+    expect(await streamToBuffer(get.Body)).toEqual(body);
   });
 
   it("CopyObject preserves body and returns a parseable response", async () => {

--- a/packages/@emulators/aws/src/entities.ts
+++ b/packages/@emulators/aws/src/entities.ts
@@ -11,7 +11,7 @@ export interface S3Bucket extends Entity {
 export interface S3Object extends Entity {
   bucket_name: string;
   key: string;
-  body: string;
+  body_base64: string;
   content_type: string;
   content_length: number;
   etag: string;

--- a/packages/@emulators/aws/src/helpers.ts
+++ b/packages/@emulators/aws/src/helpers.ts
@@ -23,7 +23,7 @@ export function generateReceiptHandle(): string {
   return randomBytes(48).toString("base64url");
 }
 
-export function md5(content: string): string {
+export function md5(content: string | Buffer): string {
   return createHash("md5").update(content).digest("hex");
 }
 

--- a/packages/@emulators/aws/src/routes/s3.ts
+++ b/packages/@emulators/aws/src/routes/s3.ts
@@ -232,10 +232,10 @@ ${prefixesXml}
     }
 
     // Store the object
-    const fileContent = await file.text();
+    const fileContent = Buffer.from(await file.arrayBuffer());
     const contentType = (body["Content-Type"] as string) ?? file.type ?? "application/octet-stream";
     const etag = md5(fileContent);
-    const contentLength = new TextEncoder().encode(fileContent).byteLength;
+    const contentLength = fileContent.byteLength;
 
     const existing = aws()
       .s3Objects.findBy("bucket_name", bucketName)
@@ -243,7 +243,7 @@ ${prefixesXml}
 
     if (existing) {
       aws().s3Objects.update(existing.id, {
-        body: fileContent,
+        body_base64: fileContent.toString("base64"),
         content_type: contentType,
         content_length: contentLength,
         etag,
@@ -254,7 +254,7 @@ ${prefixesXml}
       aws().s3Objects.insert({
         bucket_name: bucketName,
         key,
-        body: fileContent,
+        body_base64: fileContent.toString("base64"),
         content_type: contentType,
         content_length: contentLength,
         etag,
@@ -316,7 +316,7 @@ ${prefixesXml}
 
       if (existing) {
         aws().s3Objects.update(existing.id, {
-          body: srcObj.body,
+          body_base64: srcObj.body_base64,
           content_type: srcObj.content_type,
           content_length: srcObj.content_length,
           etag,
@@ -327,7 +327,7 @@ ${prefixesXml}
         aws().s3Objects.insert({
           bucket_name: bucketName,
           key,
-          body: srcObj.body,
+          body_base64: srcObj.body_base64,
           content_type: srcObj.content_type,
           content_length: srcObj.content_length,
           etag,
@@ -347,7 +347,7 @@ ${prefixesXml}
       });
     }
 
-    const body = await c.req.text();
+    const body = Buffer.from(await c.req.arrayBuffer());
     const contentType = c.req.header("Content-Type") ?? "application/octet-stream";
     const etag = md5(body);
 
@@ -365,9 +365,9 @@ ${prefixesXml}
 
     if (existing) {
       aws().s3Objects.update(existing.id, {
-        body,
+        body_base64: body.toString("base64"),
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: body.byteLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -376,9 +376,9 @@ ${prefixesXml}
       aws().s3Objects.insert({
         bucket_name: bucketName,
         key,
-        body,
+        body_base64: body.toString("base64"),
         content_type: contentType,
-        content_length: new TextEncoder().encode(body).byteLength,
+        content_length: body.byteLength,
         etag,
         last_modified: new Date().toISOString(),
         metadata,
@@ -415,7 +415,7 @@ ${prefixesXml}
       headers[`x-amz-meta-${k}`] = v;
     }
 
-    return c.text(obj.body, 200, headers);
+    return c.body(Buffer.from(obj.body_base64, "base64"), 200, headers);
   };
 
   const handleHeadObject = (c: S3ObjectContext) => {

--- a/packages/@emulators/core/src/__tests__/http.test.ts
+++ b/packages/@emulators/core/src/__tests__/http.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { Hono, cors } from "../http.js";
 
 describe("internal http layer", () => {
+  it.each([false, true])("preserves HEAD metadata with middleware=%s and no response body", async (middleware) => {
+    const app = new Hono();
+    if (middleware) app.use("*", cors());
+    app.on("HEAD", "/object", (c) => c.text("", 200, { "Content-Length": "123" }));
+    const res = await app.request("/object?partNumber=1", { method: "HEAD" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Length")).toBe("123");
+    expect(res.body).toBeNull();
+  });
+
   it("dispatches middleware and route handlers with params", async () => {
     const app = new Hono();
     const calls: string[] = [];

--- a/packages/@emulators/core/src/http.ts
+++ b/packages/@emulators/core/src/http.ts
@@ -183,12 +183,16 @@ export class Context<E = unknown, P extends string = string> {
   }
 
   finalize(response: Response): Response {
-    if (!hasHeaders(this.responseHeaders)) return response;
+    const isHead = this.req.method === "HEAD";
+    if (!isHead && !hasHeaders(this.responseHeaders)) return response;
     const headers = new Headers(response.headers);
     this.responseHeaders.forEach((value, key) => {
       headers.set(key, value);
     });
-    return new Response(response.body, {
+    // HEAD must carry metadata but no body. A streamed empty body makes Bun
+    // replace Content-Length with chunked encoding, breaking S3 download clients.
+    if (isHead) void response.body?.cancel().catch(() => {});
+    return new Response(isHead ? null : response.body, {
       status: response.status,
       statusText: response.statusText,
       headers,


### PR DESCRIPTION
## Summary

S3 uploads retain their exact bytes, and HEAD responses preserve the object size required by download clients.

- Store object payloads as base64 and read PUT and presigned POST uploads as binary data.
- Finalize HEAD responses with a null body while preserving response and middleware headers. Cancel any discarded response stream.
- Cover binary uploads through the AWS SDK and HEAD metadata with and without middleware.

## Why

S3 object uploads currently pass through `Request.text()` and `Response.text()`. Arbitrary binary objects are therefore decoded as UTF-8 and invalid bytes are replaced, corrupting images and other binary files.

An empty streamed HEAD response also causes Bun to replace Content-Length with chunked encoding. Ruby S3 download clients then lack the object size they need. The shared HTTP-layer fix preserves that metadata without sending a response body.

## Prior work

This builds on and credits https://github.com/vercel-labs/emulate/pull/53 by @zaru, which first identified the binary PUT/GET corruption and proposed base64-backed storage. This version applies that fix to the current S3 route structure, also covers presigned POST uploads and copied objects, names the stored representation `body_base64`, and exercises the behavior through the real AWS SDK with an SSE-S3 request.

## Testing

- AWS suite: 56 passed, including the real SDK binary-object regression.
- Core suite: 78 passed, including HEAD Content-Length and null-body assertions with and without middleware and a `partNumber=1` query.
- Core typecheck passes. These checks ran under Node 24.
- AWS typecheck and lint passed during the original binary-object validation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
