### PR TITLE
fix(okta): honour search and filter expressions on GET /api/v1/groups

### DIFF
--- a/apps/web/app/docs/okta/page.mdx
+++ b/apps/web/app/docs/okta/page.mdx
@@ -34,7 +34,7 @@ Default org server and custom authorization server paths (`/oauth2/:authServerId
 
 ## Groups
 
-- `GET /api/v1/groups` — list groups
+- `GET /api/v1/groups` — list groups (`q`, plus SCIM-style `search` and `filter` such as `profile.name eq "Everyone"`)
 - `POST /api/v1/groups` — create group
 - `GET /api/v1/groups/:groupId` — get group
 - `PUT /api/v1/groups/:groupId` — update group

--- a/packages/@emulators/okta/README.md
+++ b/packages/@emulators/okta/README.md
@@ -42,7 +42,7 @@ Default org server and custom authorization server paths (`/oauth2/:authServerId
 - `POST /api/v1/users/:userId/lifecycle/reactivate` — reactivate
 
 ### Groups
-- `GET /api/v1/groups` — list groups
+- `GET /api/v1/groups` — list groups (`q`, plus SCIM-style `search` and `filter` such as `profile.name eq "Everyone"`)
 - `POST /api/v1/groups` — create group
 - `GET /api/v1/groups/:groupId` — get group
 - `PUT /api/v1/groups/:groupId` — update group

--- a/packages/@emulators/okta/src/__tests__/group-search.test.ts
+++ b/packages/@emulators/okta/src/__tests__/group-search.test.ts
@@ -1,0 +1,115 @@
+import { Hono } from "@emulators/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
+import { oktaPlugin, seedFromConfig } from "../index.js";
+import { filterGroups, parseGroupSearch, InvalidSearchError } from "../search.js";
+import type { OktaGroup } from "../entities.js";
+
+const base = "http://localhost:4000";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("ssws-token", { login: "admin@okta.local", id: 1, scopes: ["okta.*"] });
+
+  const app = new Hono();
+  app.use("*", authMiddleware(tokenMap));
+  oktaPlugin.register(app as any, store, webhooks, base, tokenMap);
+  oktaPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    groups: [
+      { okta_id: "00g_aws", name: "app_aws-e2e", description: "AWS access" },
+      { okta_id: "00g_aws_auto", name: "app_aws-e2e-auto", description: "AWS auto grant" },
+      { okta_id: "00g_twingate", name: "app_twingate-e2e" },
+      { okta_id: "00g_builtin", name: "Built in", type: "BUILT_IN" },
+    ],
+  });
+  return { app, store };
+}
+
+const headers = { Authorization: "SSWS ssws-token" };
+
+async function names(app: Hono, query: string): Promise<{ status: number; names: string[] }> {
+  const res = await app.request(`${base}/api/v1/groups?${query}`, { headers });
+  if (res.status !== 200) return { status: res.status, names: [] };
+  const body = (await res.json()) as Array<{ profile: { name: string } }>;
+  return { status: 200, names: body.map((group) => group.profile.name).sort() };
+}
+
+describe("GET /api/v1/groups search and filter", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("matches an exact profile.name", async () => {
+    const q = new URLSearchParams({ search: 'profile.name eq "app_aws-e2e"' });
+    expect(await names(app, q.toString())).toEqual({ status: 200, names: ["app_aws-e2e"] });
+  });
+
+  it("combines clauses with and", async () => {
+    const q = new URLSearchParams({ search: 'profile.name sw "app_aws" and type eq "OKTA_GROUP"' });
+    expect(await names(app, q.toString())).toEqual({ status: 200, names: ["app_aws-e2e", "app_aws-e2e-auto"] });
+  });
+
+  it("honours filter the same way", async () => {
+    const q = new URLSearchParams({ filter: 'type eq "BUILT_IN"' });
+    const result = await names(app, q.toString());
+    expect(result.status).toBe(200);
+    // The default seed's Everyone group is BUILT_IN too; the OKTA_GROUP ones must be gone.
+    expect(result.names).toContain("Built in");
+    expect(result.names).not.toContain("app_aws-e2e");
+  });
+
+  it("returns an empty page rather than everything when nothing matches", async () => {
+    const q = new URLSearchParams({ search: 'profile.name eq "no-such-group"' });
+    expect(await names(app, q.toString())).toEqual({ status: 200, names: [] });
+  });
+
+  it("still narrows with q alongside search", async () => {
+    const q = new URLSearchParams({ q: "auto", search: 'profile.name sw "app_"' });
+    expect(await names(app, q.toString())).toEqual({ status: 200, names: ["app_aws-e2e-auto"] });
+  });
+
+  it("rejects an expression it cannot evaluate", async () => {
+    const q = new URLSearchParams({ search: 'profile.name gt "a"' });
+    const res = await app.request(`${base}/api/v1/groups?${q}`, { headers });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { errorCode: string };
+    expect(body.errorCode).toBe("E0000031");
+  });
+});
+
+describe("parseGroupSearch", () => {
+  const group = (name: string, description: string | null = null): OktaGroup =>
+    ({
+      id: 1,
+      created_at: "2024-01-01T00:00:00.000Z",
+      updated_at: "2024-01-02T00:00:00.000Z",
+      okta_id: "00g1",
+      type: "OKTA_GROUP",
+      name,
+      description,
+    }) as OktaGroup;
+
+  it("unescapes quoted values and compares case-insensitively", () => {
+    expect(filterGroups([group('Say "hi"')], 'profile.name eq "say \\"HI\\""')).toHaveLength(1);
+  });
+
+  it("supports pr, ne, sw and co", () => {
+    const groups = [group("alpha", "first"), group("beta")];
+    expect(filterGroups(groups, "profile.description pr").map((g) => g.name)).toEqual(["alpha"]);
+    expect(filterGroups(groups, 'profile.name ne "alpha"').map((g) => g.name)).toEqual(["beta"]);
+    expect(filterGroups(groups, 'profile.name sw "al"').map((g) => g.name)).toEqual(["alpha"]);
+    expect(filterGroups(groups, 'profile.name co "et"').map((g) => g.name)).toEqual(["beta"]);
+  });
+
+  it("throws on unknown attributes, operators and missing values", () => {
+    expect(() => parseGroupSearch('profile.email eq "x"')).toThrow(InvalidSearchError);
+    expect(() => parseGroupSearch('profile.name like "x"')).toThrow(InvalidSearchError);
+    expect(() => parseGroupSearch("profile.name eq")).toThrow(InvalidSearchError);
+    expect(() => parseGroupSearch('profile.name eq "a" or type eq "b"')).toThrow(InvalidSearchError);
+  });
+});

--- a/packages/@emulators/okta/src/routes/groups.ts
+++ b/packages/@emulators/okta/src/routes/groups.ts
@@ -10,6 +10,7 @@ import {
   userResponse,
 } from "../route-helpers.js";
 import { getOktaStore } from "../store.js";
+import { InvalidSearchError, filterGroups } from "../search.js";
 
 export function groupRoutes({ app, store, baseUrl, tokenMap }: RouteContext): void {
   const oktaStore = getOktaStore(store);
@@ -22,6 +23,21 @@ export function groupRoutes({ app, store, baseUrl, tokenMap }: RouteContext): vo
     let groups = oktaStore.groups.all();
     if (q) {
       groups = groups.filter((group) => `${group.name} ${group.description ?? ""}`.toLowerCase().includes(q));
+    }
+    // Okta's `search` and `filter` take SCIM-style expressions such as
+    // `profile.name eq "Everyone"`. Both are evaluated here so a lookup by
+    // exact name returns that group rather than the first page of all of them.
+    for (const param of ["search", "filter"] as const) {
+      const expression = c.req.query(param);
+      if (!expression) continue;
+      try {
+        groups = filterGroups(groups, expression);
+      } catch (error) {
+        if (error instanceof InvalidSearchError) {
+          return oktaError(c, 400, "E0000031", "The search filter is invalid", [{ errorSummary: error.message }]);
+        }
+        throw error;
+      }
     }
     const { page, per_page } = parsePagination(c);
     const total = groups.length;

--- a/packages/@emulators/okta/src/search.ts
+++ b/packages/@emulators/okta/src/search.ts
@@ -1,0 +1,107 @@
+import type { OktaGroup } from "./entities.js";
+
+/**
+ * A minimal evaluator for the SCIM-style expressions Okta accepts in the
+ * `search` and `filter` query parameters of the groups list endpoint:
+ *
+ *   profile.name eq "Everyone"
+ *   profile.name sw "app_" and type eq "OKTA_GROUP"
+ *
+ * Supported attributes: id, type, profile.name, profile.description, created,
+ * lastUpdated, lastMembershipUpdated. Supported operators: eq, ne, sw, co, pr.
+ * Clauses combine with `and` only, which is what group lookups by name use.
+ * Anything else is rejected so a client sees Okta's E0000031 instead of an
+ * unfiltered page that looks like a match.
+ */
+
+export class InvalidSearchError extends Error {}
+
+type Clause = { attribute: string; operator: "eq" | "ne" | "sw" | "co" | "pr"; value: string | null };
+
+const ATTRIBUTES = new Set([
+  "id",
+  "type",
+  "profile.name",
+  "profile.description",
+  "created",
+  "lastupdated",
+  "lastmembershipupdated",
+]);
+
+const CLAUSE = /^\s*([A-Za-z.]+)\s+(eq|ne|sw|co|pr)(?:\s+"((?:[^"\\]|\\.)*)")?\s*$/i;
+
+function splitAnd(expression: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quoted = false;
+  for (let i = 0; i < expression.length; i += 1) {
+    const ch = expression[i]!;
+    if (ch === '"' && expression[i - 1] !== "\\") quoted = !quoted;
+    if (!quoted && /\s/.test(ch) && expression.slice(i).match(/^\s+and\s+/i)) {
+      parts.push(current);
+      current = "";
+      i += expression.slice(i).match(/^\s+and\s+/i)![0].length - 1;
+      continue;
+    }
+    current += ch;
+  }
+  parts.push(current);
+  return parts;
+}
+
+export function parseGroupSearch(expression: string): Clause[] {
+  return splitAnd(expression).map((raw) => {
+    const match = raw.match(CLAUSE);
+    if (!match) throw new InvalidSearchError(`Invalid search expression: ${raw.trim()}`);
+    const attribute = match[1]!.toLowerCase();
+    const operator = match[2]!.toLowerCase() as Clause["operator"];
+    const value = match[3] === undefined ? null : match[3].replace(/\\(.)/g, "$1");
+    if (!ATTRIBUTES.has(attribute)) throw new InvalidSearchError(`Unsupported search attribute: ${match[1]}`);
+    if (operator === "pr" && value !== null) throw new InvalidSearchError("pr takes no value");
+    if (operator !== "pr" && value === null) throw new InvalidSearchError(`${operator} needs a quoted value`);
+    return { attribute, operator, value };
+  });
+}
+
+function groupAttribute(group: OktaGroup, attribute: string): string | null {
+  switch (attribute) {
+    case "id":
+      return group.okta_id;
+    case "type":
+      return group.type;
+    case "profile.name":
+      return group.name;
+    case "profile.description":
+      return group.description;
+    case "created":
+      return group.created_at;
+    case "lastupdated":
+    case "lastmembershipupdated":
+      return group.updated_at;
+    default:
+      return null;
+  }
+}
+
+function matches(group: OktaGroup, clause: Clause): boolean {
+  const actual = groupAttribute(group, clause.attribute);
+  if (clause.operator === "pr") return actual !== null && actual !== "";
+  if (actual === null) return clause.operator === "ne";
+  const lhs = actual.toLowerCase();
+  const rhs = clause.value!.toLowerCase();
+  switch (clause.operator) {
+    case "eq":
+      return lhs === rhs;
+    case "ne":
+      return lhs !== rhs;
+    case "sw":
+      return lhs.startsWith(rhs);
+    case "co":
+      return lhs.includes(rhs);
+  }
+}
+
+export function filterGroups(groups: OktaGroup[], expression: string): OktaGroup[] {
+  const clauses = parseGroupSearch(expression);
+  return groups.filter((group) => clauses.every((clause) => matches(group, clause)));
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/groups` only narrowed on `q`. Okta's documented `search` parameter (`profile.name eq "Everyone"`, `profile.name sw "app_" and type eq "OKTA_GROUP"`) and `filter` were ignored, so a client that looks a group up by exact name got the first page of every group back and, if it takes the first result, the wrong group.

This adds a small evaluator (`src/search.ts`) for the SCIM-style expressions Okta accepts on this endpoint:

- attributes: `id`, `type`, `profile.name`, `profile.description`, `created`, `lastUpdated`, `lastMembershipUpdated`
- operators: `eq`, `ne`, `sw`, `co`, `pr`, combined with `and`
- an expression it cannot evaluate returns Okta's `400 E0000031 The search filter is invalid` instead of an unfiltered page

`q` keeps working and composes with `search`/`filter`.

## Why

The Okta SDKs and most hand-written clients find a group by name with `search=profile.name eq "…"`. Against the emulator that call returned everything, which is a silent wrong answer rather than an error.

## Testing

`src/__tests__/group-search.test.ts` covers exact match, `and`, `filter`, the empty result, `q` composition, the 400 path, and the parser's operators and rejections. `pnpm --filter @emulators/okta test`, `type-check` and `lint` pass. Package README and the web docs page mention the parameters.
