### PR TITLE
feat(slack): pinned seed ids and X-OAuth-Scopes on auth.test

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ slack:
     domain: my-workspace
   users:
     - name: developer
+      user_id: U000000010
       real_name: Developer
       email: dev@example.com
       profile:
@@ -301,6 +302,7 @@ slack:
       presence: active
   channels:
     - name: general
+      channel_id: C000000010
       topic: General discussion
     - name: random
       topic: Random stuff

--- a/packages/@emulators/slack/README.md
+++ b/packages/@emulators/slack/README.md
@@ -13,7 +13,7 @@ npm install @emulators/slack
 ## Endpoints
 
 ### Auth & Chat
-- `POST /api/auth.test` — test authentication
+- `POST /api/auth.test` — test authentication (the token's scopes come back in `X-OAuth-Scopes`)
 - `POST /api/chat.postMessage` — post message with text or rich payload fields (supports threads via `thread_ts` and DM user IDs)
 - `POST /api/chat.postEphemeral` — post ephemeral message outside channel history
 - `POST /api/chat.update` — update message text and rich payload fields
@@ -106,6 +106,7 @@ slack:
     domain: my-workspace
   users:
     - name: developer
+      user_id: U000000010
       real_name: Developer
       email: dev@example.com
       profile:
@@ -115,6 +116,7 @@ slack:
       presence: active
   channels:
     - name: general
+      channel_id: C000000010
       topic: General discussion
     - name: random
       topic: Random stuff

--- a/packages/@emulators/slack/src/__tests__/seed-ids.test.ts
+++ b/packages/@emulators/slack/src/__tests__/seed-ids.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { getSlackStore, seedFromConfig } from "../index.js";
+import { createSlackTestApp, slackTestBaseUrl as base } from "./helpers.js";
+
+function seededApp() {
+  const test = createSlackTestApp();
+  seedFromConfig(test.store, base, {
+    users: [
+      { user_id: "U0PINNED01", name: "pinned", real_name: "Pinned User", email: "pinned@example.com" },
+      { name: "generated", email: "generated@example.com" },
+    ],
+    channels: [{ channel_id: "C0PINNED01", name: "pinned-channel" }, { name: "generated-channel" }],
+    tokens: [{ token: "xoxb-pinned", type: "bot", user_id: "U0PINNED01", scopes: ["chat:write", "users:read.email"] }],
+  });
+  return test;
+}
+
+describe("Slack seed: pinned ids", () => {
+  it("keeps the ids a seed pins and still generates the rest", async () => {
+    const { app, store } = seededApp();
+    const ss = getSlackStore(store);
+
+    expect(ss.users.findOneBy("email", "pinned@example.com")?.user_id).toBe("U0PINNED01");
+    expect(ss.users.findOneBy("email", "generated@example.com")?.user_id).toMatch(/^U/);
+    expect(ss.channels.findOneBy("name", "pinned-channel")?.channel_id).toBe("C0PINNED01");
+    expect(ss.channels.findOneBy("name", "generated-channel")?.channel_id).toMatch(/^C/);
+
+    const lookup = await app.request(`${base}/api/users.lookupByEmail`, {
+      method: "POST",
+      headers: { Authorization: "Bearer xoxb-pinned", "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "pinned@example.com" }),
+    });
+    const body = (await lookup.json()) as { ok: boolean; user: { id: string } };
+    expect(body.ok).toBe(true);
+    expect(body.user.id).toBe("U0PINNED01");
+  });
+
+  it("does not seed a second user or channel under an id that already exists", () => {
+    const { store } = seededApp();
+    seedFromConfig(store, base, {
+      users: [{ user_id: "U0PINNED01", name: "someone-else" }],
+      channels: [{ channel_id: "C0PINNED01", name: "another-name" }],
+    });
+    const ss = getSlackStore(store);
+    expect(ss.users.findBy("user_id", "U0PINNED01")).toHaveLength(1);
+    expect(ss.users.all().find((u) => u.name === "someone-else")).toBeUndefined();
+    expect(ss.channels.findBy("channel_id", "C0PINNED01")).toHaveLength(1);
+  });
+
+  it("reports the token's scopes on auth.test the way Slack does", async () => {
+    const { app } = seededApp();
+    const res = await app.request(`${base}/api/auth.test`, {
+      method: "POST",
+      headers: { Authorization: "Bearer xoxb-pinned" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-oauth-scopes")).toBe("chat:write,users:read.email");
+    const body = (await res.json()) as { ok: boolean; user_id: string };
+    expect(body.ok).toBe(true);
+    expect(body.user_id).toBe("U0PINNED01");
+  });
+});

--- a/packages/@emulators/slack/src/index.ts
+++ b/packages/@emulators/slack/src/index.ts
@@ -27,6 +27,7 @@ export interface SlackSeedConfig {
     domain?: string;
   };
   users?: Array<{
+    user_id?: string;
     name: string;
     real_name?: string;
     email?: string;
@@ -35,6 +36,7 @@ export interface SlackSeedConfig {
     presence?: SlackPresence;
   }>;
   channels?: Array<{
+    channel_id?: string;
     name: string;
     topic?: string;
     purpose?: string;
@@ -212,7 +214,10 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: SlackSeed
       const existing = ss.users.all().find((eu) => eu.name === u.name);
       if (existing) continue;
 
-      const userId = generateSlackId("U");
+      // A pinned id lets fixtures and the app under test agree on a user
+      // without a lookup; generated otherwise, as before.
+      const userId = u.user_id?.trim() || generateSlackId("U");
+      if (ss.users.findOneBy("user_id", userId)) continue;
       const email = u.profile?.email ?? u.email ?? `${u.name}@emulate.dev`;
       const realName = u.real_name ?? u.name;
       const profile = normalizeSeedProfile({
@@ -245,13 +250,15 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: SlackSeed
     for (const ch of config.channels) {
       const existing = ss.channels.findOneBy("name", ch.name);
       if (existing) continue;
+      const channelId = ch.channel_id?.trim() || generateSlackId("C");
+      if (ss.channels.findOneBy("channel_id", channelId)) continue;
 
       const creator = ss.users.all()[0]?.user_id ?? "U000000001";
       const now = Math.floor(Date.now() / 1000);
       const isPrivate = ch.is_private ?? false;
 
       ss.channels.insert({
-        channel_id: generateSlackId("C"),
+        channel_id: channelId,
         team_id: teamId,
         name: ch.name,
         is_channel: !isPrivate,

--- a/packages/@emulators/slack/src/routes/auth.ts
+++ b/packages/@emulators/slack/src/routes/auth.ts
@@ -38,6 +38,12 @@ export function authRoutes(ctx: RouteContext): void {
       ? ss().installations.findOneBy("installation_id", tokenRecord.installation_id)
       : undefined;
 
+    // Slack reports the token's granted scopes in a response header rather
+    // than the body; SDKs and setup checks read it to decide what they may call.
+    if (tokenRecord?.scopes.length) {
+      c.header("x-oauth-scopes", tokenRecord.scopes.join(","));
+    }
+
     return slackOk(c, {
       url: `https://${team?.domain ?? "emulate"}.slack.com/`,
       team: team?.name ?? "Emulate",


### PR DESCRIPTION
## Summary

Two small Slack fidelity additions that test suites pointing a real app at the emulator need:

1. **Pinned ids in the seed.** `slack.users[].user_id` and `slack.channels[].channel_id` are now honoured, so a fixture and the application under test can agree on an id without a lookup at start (the mirror channel id an app reads from an env var, the bot user id it pins). Ids are still generated when omitted; a pinned id that already exists is left alone rather than duplicated.
2. **`X-OAuth-Scopes` on `auth.test`.** Slack reports the token's granted scopes in that response header, and SDKs and setup checks read it to decide which methods they may call. The emulator sent no header, so every scope looked missing.

## Testing

`src/__tests__/seed-ids.test.ts` covers pinned vs generated ids, `users.lookupByEmail` resolving the pinned user, duplicate-id protection, and the scopes header. `pnpm --filter @emulators/slack test`, `type-check` and `lint` pass. Seed examples in the package and root READMEs show the new keys.
