### PR TITLE
feat(github): installation tokens administer their account; repository permissions follow GitHub's model

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ github:
   orgs:
     - login: my-org
       name: My Organization
+      # Base permission members hold on org repos (GitHub's default is read).
+      default_repository_permission: none
+      # admin makes the user an organization owner.
+      members:
+        - login: octocat
+          role: admin
   repos:
     - owner: octocat
       name: hello-world

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -141,7 +141,7 @@ npm install @emulators/github
 
 ## Auth
 
-Public repo endpoints work without auth. Private repos and write operations require a valid token. Pagination uses `page`/`per_page` with `Link` headers.
+Public repo endpoints work without auth. Private repos and write operations require a valid token. Repository permissions resolve as on GitHub: organization owners hold admin, members start from the org's base permission (which may be `none`), collaborator and team grants raise it, and `GET /repos/:owner/:repo/collaborators/:username/permission` answers `none` for a user without access. A GitHub App installation token administers the account it is installed on through its permission set: `administration: write` creates repositories and manages collaborators, `members: write` manages organization membership. Pagination uses `page`/`per_page` with `Link` headers.
 
 ## Seed Configuration
 
@@ -154,6 +154,12 @@ github:
   orgs:
     - login: my-org
       name: My Organization
+      # Base permission members hold on org repos (GitHub's default is read).
+      default_repository_permission: none
+      # admin makes the user an organization owner.
+      members:
+        - login: octocat
+          role: admin
   repos:
     - owner: octocat
       name: hello-world

--- a/packages/@emulators/github/src/__tests__/installation-admin.test.ts
+++ b/packages/@emulators/github/src/__tests__/installation-admin.test.ts
@@ -1,0 +1,246 @@
+import { generateKeyPairSync, sign } from "crypto";
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "@emulators/core";
+import { Store, WebhookDispatcher } from "@emulators/core";
+import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
+import { githubPlugin, seedFromConfig, getGitHubStore } from "../index.js";
+
+const base = "http://localhost:4000";
+const APP_ID = 777;
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const APP_PRIVATE_KEY = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("octocat-token", { login: "octocat", id: 1, scopes: ["repo", "admin:org"] });
+  tokenMap.set("hubot-token", { login: "hubot", id: 2, scopes: ["repo"] });
+  tokenMap.set("lurker-token", { login: "lurker", id: 3, scopes: ["repo"] });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use(
+    "*",
+    authMiddleware(tokenMap, (appId) => {
+      const gh = getGitHubStore(store);
+      const ghApp = gh.apps.all().find((a) => a.app_id === appId);
+      if (!ghApp) return null;
+      return { privateKey: ghApp.private_key, slug: ghApp.slug, name: ghApp.name };
+    }),
+  );
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ login: "octocat" }, { login: "hubot" }, { login: "lurker" }],
+    orgs: [
+      {
+        login: "my-org",
+        default_repository_permission: "none",
+        members: [{ login: "octocat", role: "admin" }, { login: "hubot" }],
+      },
+      {
+        login: "open-org",
+        default_repository_permission: "read",
+        members: [{ login: "hubot" }],
+      },
+    ],
+    repos: [
+      { owner: "my-org", name: "private-repo", private: true, collaborators: [{ login: "lurker", permission: "pull" }] },
+      { owner: "my-org", name: "open" },
+      { owner: "open-org", name: "priv", private: true },
+    ],
+    apps: [
+      {
+        app_id: APP_ID,
+        slug: "provisioner",
+        name: "Provisioner",
+        private_key: APP_PRIVATE_KEY,
+        permissions: { administration: "write", members: "write", contents: "read", metadata: "read" },
+        installations: [{ installation_id: 100, account: "my-org", repository_selection: "all" }],
+      },
+    ],
+  });
+  return { app, store };
+}
+
+function headers(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function appJwt(): string {
+  const now = Math.floor(Date.now() / 1000);
+  const unsigned = `${base64UrlJson({ alg: "RS256", typ: "JWT" })}.${base64UrlJson({ iat: now - 60, exp: now + 540, iss: String(APP_ID) })}`;
+  return `${unsigned}.${sign("RSA-SHA256", Buffer.from(unsigned), APP_PRIVATE_KEY).toString("base64url")}`;
+}
+
+async function installationToken(app: Hono, permissions?: Record<string, string>): Promise<string> {
+  const res = await app.request(`${base}/app/installations/100/access_tokens`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${appJwt()}`, "Content-Type": "application/json" },
+    body: permissions ? JSON.stringify({ permissions }) : undefined,
+  });
+  expect(res.status).toBe(201);
+  return ((await res.json()) as { token: string }).token;
+}
+
+async function permissionOf(app: Hono, repo: string, user: string, asToken = "octocat-token") {
+  const res = await app.request(`${base}/repos/${repo}/collaborators/${user}/permission`, {
+    headers: headers(asToken),
+  });
+  if (res.status !== 200) return { status: res.status };
+  const body = (await res.json()) as { permission: string; role_name: string };
+  return { status: 200, permission: body.permission, role_name: body.role_name };
+}
+
+describe("GitHub App installations administer the account they are installed on", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("creates an organization repository with administration: write", async () => {
+    const token = await installationToken(app);
+    const res = await app.request(`${base}/orgs/my-org/repos`, {
+      method: "POST",
+      headers: headers(token),
+      body: JSON.stringify({ name: "service", private: true }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { full_name: string; private: boolean };
+    expect(body.full_name).toBe("my-org/service");
+    expect(body.private).toBe(true);
+  });
+
+  it("is refused without administration: write", async () => {
+    const token = await installationToken(app, { contents: "read", metadata: "read" });
+    const res = await app.request(`${base}/orgs/my-org/repos`, {
+      method: "POST",
+      headers: headers(token),
+      body: JSON.stringify({ name: "nope" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("adds and removes collaborators", async () => {
+    const token = await installationToken(app);
+    const put = await app.request(`${base}/repos/my-org/private-repo/collaborators/hubot`, {
+      method: "PUT",
+      headers: headers(token),
+      body: JSON.stringify({ permission: "push" }),
+    });
+    expect(put.status).toBe(201);
+    expect(await permissionOf(app, "my-org/private-repo", "hubot")).toEqual({
+      status: 200,
+      permission: "write",
+      role_name: "write",
+    });
+
+    const del = await app.request(`${base}/repos/my-org/private-repo/collaborators/hubot`, {
+      method: "DELETE",
+      headers: headers(token),
+    });
+    expect(del.status).toBe(204);
+    expect(await permissionOf(app, "my-org/private-repo", "hubot")).toEqual({
+      status: 200,
+      permission: "none",
+      role_name: "none",
+    });
+  });
+
+  it("manages organization membership with members: write", async () => {
+    const token = await installationToken(app);
+    const put = await app.request(`${base}/orgs/my-org/memberships/lurker`, {
+      method: "PUT",
+      headers: headers(token),
+      body: JSON.stringify({ role: "member" }),
+    });
+    expect(put.status).toBe(200);
+    const get = await app.request(`${base}/orgs/my-org/memberships/lurker`, { headers: headers("octocat-token") });
+    expect(get.status).toBe(200);
+    expect(((await get.json()) as { role: string }).role).toBe("member");
+  });
+});
+
+describe("Repository permissions follow GitHub's model", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("answers for any user: owner admin, member below base permission none, collaborator read, unknown 404", async () => {
+    expect(await permissionOf(app, "my-org/private-repo", "octocat")).toEqual({
+      status: 200,
+      permission: "admin",
+      role_name: "admin",
+    });
+    expect(await permissionOf(app, "my-org/private-repo", "hubot")).toEqual({
+      status: 200,
+      permission: "none",
+      role_name: "none",
+    });
+    expect(await permissionOf(app, "my-org/private-repo", "lurker")).toEqual({
+      status: 200,
+      permission: "read",
+      role_name: "read",
+    });
+    expect(await permissionOf(app, "my-org/private-repo", "nobody")).toEqual({ status: 404 });
+  });
+
+  it("gives members the organization's base permission", async () => {
+    expect(await permissionOf(app, "open-org/priv", "hubot", "hubot-token")).toEqual({
+      status: 200,
+      permission: "read",
+      role_name: "read",
+    });
+    const visible = await app.request(`${base}/repos/open-org/priv`, { headers: headers("hubot-token") });
+    expect(visible.status).toBe(200);
+    const hidden = await app.request(`${base}/repos/my-org/private-repo`, { headers: headers("hubot-token") });
+    expect(hidden.status).toBe(403);
+  });
+
+  it("reads public repositories for everyone", async () => {
+    expect(await permissionOf(app, "my-org/open", "lurker")).toEqual({
+      status: 200,
+      permission: "read",
+      role_name: "read",
+    });
+  });
+
+  it("lets owners, not members, manage collaborators", async () => {
+    const asMember = await app.request(`${base}/repos/my-org/private-repo/collaborators/lurker`, {
+      method: "PUT",
+      headers: headers("hubot-token"),
+      body: JSON.stringify({ permission: "push" }),
+    });
+    expect(asMember.status).toBe(403);
+
+    const asOwner = await app.request(`${base}/repos/my-org/private-repo/collaborators/lurker`, {
+      method: "PUT",
+      headers: headers("octocat-token"),
+      body: JSON.stringify({ permission: "maintain" }),
+    });
+    expect(asOwner.status).toBe(201);
+    expect(await permissionOf(app, "my-org/private-repo", "lurker")).toEqual({
+      status: 200,
+      permission: "write",
+      role_name: "maintain",
+    });
+  });
+
+  it("seeds organization members and their roles", async () => {
+    const members = await app.request(`${base}/orgs/my-org/members`, { headers: headers("octocat-token") });
+    expect(members.status).toBe(200);
+    const logins = ((await members.json()) as Array<{ login: string }>).map((m) => m.login).sort();
+    expect(logins).toEqual(["hubot", "octocat"]);
+    const owner = await app.request(`${base}/orgs/my-org/memberships/octocat`, { headers: headers("octocat-token") });
+    expect(((await owner.json()) as { role: string }).role).toBe("admin");
+  });
+});

--- a/packages/@emulators/github/src/index.ts
+++ b/packages/@emulators/github/src/index.ts
@@ -13,6 +13,7 @@ import { getGitHubStore } from "./store.js";
 import type { GitHubStore } from "./store.js";
 import type { GitHubAppInstallation } from "./entities.js";
 import { generateNodeId } from "./helpers.js";
+import { ensureOrgMembership } from "./route-helpers.js";
 import { usersRoutes } from "./routes/users.js";
 import { reposRoutes } from "./routes/repos.js";
 import { issuesRoutes } from "./routes/issues.js";
@@ -57,6 +58,10 @@ export interface GitHubSeedConfig {
     name?: string;
     description?: string;
     email?: string;
+    /** Base permission every member holds on the org's repos. GitHub's default is read. */
+    default_repository_permission?: "read" | "write" | "admin" | "none";
+    /** Members to seed; `admin` makes the user an organization owner. */
+    members?: Array<{ login: string; role?: "admin" | "member" }>;
   }>;
   tokens?: Record<string, { login: string; scopes?: string[] }>;
   repos?: Array<{
@@ -68,6 +73,8 @@ export interface GitHubSeedConfig {
     topics?: string[];
     default_branch?: string;
     auto_init?: boolean;
+    /** Direct collaborators to seed; `permission` defaults to push. */
+    collaborators?: Array<{ login: string; permission?: "pull" | "triage" | "push" | "maintain" | "admin" }>;
   }>;
   oauth_apps?: Array<{
     client_id: string;
@@ -341,10 +348,15 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
         followers: 0,
         following: 0,
         members_can_create_repositories: true,
-        default_repository_permission: "read",
+        default_repository_permission: o.default_repository_permission ?? "read",
         billing_email: null,
       });
       gh.orgs.update(org.id, { node_id: generateNodeId("Org", org.id) });
+      for (const member of o.members ?? []) {
+        const user = gh.users.findOneBy("login", member.login);
+        if (!user) continue;
+        ensureOrgMembership(gh, gh.orgs.get(org.id)!, user, member.role ?? "member");
+      }
     }
   }
 
@@ -441,6 +453,11 @@ export function seedFromConfig(store: Store, baseUrl: string, config: GitHubSeed
         gh.repos.update(repo.id, { pushed_at: repo.created_at, size: 1 });
       }
 
+      for (const collaborator of r.collaborators ?? []) {
+        const user = gh.users.findOneBy("login", collaborator.login);
+        if (!user) continue;
+        gh.collaborators.insert({ repo_id: repo.id, user_id: user.id, permission: collaborator.permission ?? "push" });
+      }
       if (ownerType === "User") {
         const user = gh.users.findOneBy("login", r.owner);
         if (user && !r.private) {

--- a/packages/@emulators/github/src/route-helpers.ts
+++ b/packages/@emulators/github/src/route-helpers.ts
@@ -1,10 +1,49 @@
 import type { AuthUser } from "@emulators/core";
 import { ApiError, notFound, unauthorized, forbidden } from "@emulators/core";
 import type { GitHubStore } from "./store.js";
-import type { GitHubRepo, GitHubUser } from "./entities.js";
+import type { GitHubOrg, GitHubRepo, GitHubTeam, GitHubUser } from "./entities.js";
 import { generateNodeId } from "./helpers.js";
 
 export { notFound as notFoundResponse };
+
+const MEMBERS_TEAM_SLUG = "members";
+
+/** Effective repository role, in GitHub's `role_name` vocabulary. */
+export type RepoRole = "admin" | "maintain" | "write" | "triage" | "read" | "none";
+
+const ROLE_RANK: Record<RepoRole, number> = { none: 0, read: 1, triage: 2, write: 3, maintain: 4, admin: 5 };
+
+/** Map the permission spellings GitHub uses (collaborator, team, org base) onto a role. */
+export function roleFromPermission(permission: string | null | undefined): RepoRole {
+  switch (permission) {
+    case "admin":
+      return "admin";
+    case "maintain":
+      return "maintain";
+    case "push":
+    case "write":
+      return "write";
+    case "triage":
+      return "triage";
+    case "pull":
+    case "read":
+      return "read";
+    default:
+      return "none";
+  }
+}
+
+/** The legacy `permission` field: admin, write, read or none. */
+export function legacyPermission(role: RepoRole): "admin" | "write" | "read" | "none" {
+  if (role === "admin") return "admin";
+  if (role === "maintain" || role === "write") return "write";
+  if (role === "triage" || role === "read") return "read";
+  return "none";
+}
+
+function higherRole(a: RepoRole, b: RepoRole): RepoRole {
+  return ROLE_RANK[a] >= ROLE_RANK[b] ? a : b;
+}
 
 export function ownerLoginOf(gh: GitHubStore, repo: GitHubRepo): string {
   if (repo.owner_type === "User") {
@@ -22,15 +61,121 @@ export function isOrgMember(gh: GitHubStore, userId: number, orgId: number): boo
   return false;
 }
 
+/**
+ * Organization role of a user: `admin` when they maintain any of the org's
+ * teams (the emulator represents owners as maintainers), `member` when they
+ * belong to one, null when they are not a member. The same reading orgs.ts
+ * gives `GET /orgs/:org/memberships/:username`.
+ */
+export function orgRoleFor(gh: GitHubStore, orgId: number, userId: number): "admin" | "member" | null {
+  let role: "admin" | "member" | null = null;
+  for (const team of gh.teams.findBy("org_id", orgId)) {
+    const membership = gh.teamMembers.findBy("team_id", team.id).find((m) => m.user_id === userId);
+    if (!membership) continue;
+    if (membership.role === "maintainer") return "admin";
+    role = "member";
+  }
+  return role;
+}
+
+/** The implicit `members` team every org membership is recorded in. */
+export function ensureMembersTeam(gh: GitHubStore, org: GitHubOrg): GitHubTeam {
+  const existing = gh.teams.findBy("org_id", org.id).find((t) => t.slug === MEMBERS_TEAM_SLUG);
+  if (existing) return existing;
+  const team = gh.teams.insert({
+    node_id: "pending",
+    name: "Members",
+    slug: MEMBERS_TEAM_SLUG,
+    description: null,
+    privacy: "closed",
+    permission: "pull",
+    org_id: org.id,
+    parent_id: null,
+    members_count: 0,
+    repos_count: 0,
+  });
+  return gh.teams.update(team.id, { node_id: generateNodeId("Team", team.id) }) ?? team;
+}
+
+/** Make `user` an org member, or an owner as maintainer of the members team. Idempotent. */
+export function ensureOrgMembership(gh: GitHubStore, org: GitHubOrg, user: GitHubUser, role: "admin" | "member"): void {
+  const team = ensureMembersTeam(gh, org);
+  const teamRole: "member" | "maintainer" = role === "admin" ? "maintainer" : "member";
+  const existing = gh.teamMembers.findBy("team_id", team.id).find((m) => m.user_id === user.id);
+  if (existing) {
+    if (existing.role !== teamRole) gh.teamMembers.update(existing.id, { role: teamRole });
+  } else {
+    gh.teamMembers.insert({ team_id: team.id, user_id: user.id, role: teamRole });
+  }
+  gh.teams.update(team.id, { members_count: gh.teamMembers.findBy("team_id", team.id).length });
+}
+
+/**
+ * What `user` may do on `repo`, resolved the way GitHub does: the owner of a
+ * user repo and the owners of an organization hold admin; an organization
+ * member starts from the org's base permission (`default_repository_permission`,
+ * which may be `none`); direct collaborator and team grants raise it; anyone
+ * else has no access to a private repo and read on a public one.
+ */
+export function repoRoleFor(gh: GitHubStore, user: GitHubUser, repo: GitHubRepo): RepoRole {
+  if (repo.owner_type === "User") {
+    if (repo.owner_id === user.id) return "admin";
+    const collab = gh.collaborators.findBy("repo_id", repo.id).find((c) => c.user_id === user.id);
+    if (collab) return roleFromPermission(collab.permission);
+    return repo.private ? "none" : "read";
+  }
+
+  const orgRole = orgRoleFor(gh, repo.owner_id, user.id);
+  if (orgRole === "admin") return "admin";
+
+  let role: RepoRole = "none";
+  if (orgRole === "member") {
+    role = roleFromPermission(gh.orgs.get(repo.owner_id)?.default_repository_permission);
+  }
+  const collab = gh.collaborators.findBy("repo_id", repo.id).find((c) => c.user_id === user.id);
+  if (collab) role = higherRole(role, roleFromPermission(collab.permission));
+  for (const membership of gh.teamMembers.findBy("user_id", user.id)) {
+    const team = gh.teams.get(membership.team_id);
+    if (!team || team.org_id !== repo.owner_id || team.slug === MEMBERS_TEAM_SLUG) continue;
+    if (gh.teamRepos.findBy("team_id", team.id).some((link) => link.repo_id === repo.id)) {
+      role = higherRole(role, roleFromPermission(team.permission));
+    }
+  }
+  if (role === "none" && !repo.private) return "read";
+  return role;
+}
+
 export function getActorUser(gh: GitHubStore, authUser: AuthUser): GitHubUser | undefined {
   return gh.users.findOneBy("login", authUser.login);
 }
 
-function installationCanAccessRepo(authUser: AuthUser, repo: GitHubRepo): boolean {
+export function installationCanAccessRepo(authUser: AuthUser, repo: GitHubRepo): boolean {
   const installation = authUser.installation;
   if (!installation) return false;
   if (repo.owner_id !== installation.accountId || repo.owner_type !== installation.accountType) return false;
   return installation.repositorySelection === "all" || installation.repositoryIds.includes(repo.id);
+}
+
+/**
+ * Whether an installation token acts for `owner` with `permission` granted at
+ * write. A GitHub App manages the account it is installed on through its
+ * permission set, not through membership: `administration: write` creates
+ * repositories and manages collaborators there, `members: write` manages
+ * organization membership.
+ */
+export function installationAdministers(
+  authUser: AuthUser | undefined,
+  ownerId: number,
+  ownerType: "User" | "Organization",
+  permission = "administration",
+): boolean {
+  const installation = authUser?.installation;
+  if (!installation) return false;
+  return (
+    installation.accountId === ownerId &&
+    installation.accountType === ownerType &&
+    installation.permissions[permission] === "write"
+  );
 }
 
 function installationActor(gh: GitHubStore, authUser: AuthUser): GitHubUser {
@@ -70,9 +215,7 @@ export function canAccessRepo(gh: GitHubStore, authUser: AuthUser | undefined, r
   if (authUser.installation) return installationCanAccessRepo(authUser, repo);
   const user = getActorUser(gh, authUser);
   if (!user) return false;
-  if (repo.owner_type === "User" && repo.owner_id === user.id) return true;
-  if (repo.owner_type === "Organization" && isOrgMember(gh, user.id, repo.owner_id)) return true;
-  return Boolean(gh.collaborators.findBy("repo_id", repo.id).find((c) => c.user_id === user.id));
+  return repoRoleFor(gh, user, repo) !== "none";
 }
 
 export function assertRepoRead(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): void {
@@ -139,11 +282,10 @@ export function assertAuthenticatedActor(gh: GitHubStore, authUser: AuthUser | u
   return assertAuthenticatedUser(gh, authUser);
 }
 
+/** Admin or maintain on the repo: organization owners, not every member. */
 export function hasRepoAdmin(gh: GitHubStore, user: GitHubUser, repo: GitHubRepo): boolean {
-  if (repo.owner_type === "User" && repo.owner_id === user.id) return true;
-  if (repo.owner_type === "Organization" && isOrgMember(gh, user.id, repo.owner_id)) return true;
-  const collab = gh.collaborators.findBy("repo_id", repo.id).find((c) => c.user_id === user.id);
-  return collab?.permission === "admin" || collab?.permission === "maintain";
+  const role = repoRoleFor(gh, user, repo);
+  return role === "admin" || role === "maintain";
 }
 
 function grantsRepoWrite(permission: string): boolean {
@@ -299,12 +441,46 @@ export function assertBranchUpdateAllowed(
   }
 }
 
+/**
+ * Resolve the actor allowed to administer `repo` (collaborators, protection,
+ * settings): an installation on the owner with `administration: write` and
+ * access to the repo, or a user holding admin or maintain on it.
+ */
 export function assertRepoAdmin(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {
   if (!authUser) throw unauthorized();
+  if (authUser.installation) {
+    if (!installationCanAccessRepo(authUser, repo)) throw forbidden();
+    if (!installationAdministers(authUser, repo.owner_id, repo.owner_type)) throw forbidden();
+    return installationActor(gh, authUser);
+  }
   const user = getActorUser(gh, authUser);
   if (!user) throw unauthorized();
   if (hasRepoAdmin(gh, user, repo)) return user;
   throw forbidden();
+}
+
+/**
+ * Resolve the actor allowed to create a repository owned by `owner`: an
+ * installation on that account with `administration: write`, the user for
+ * their own account, or an organization member for the org.
+ */
+export function assertCanCreateRepoIn(
+  gh: GitHubStore,
+  authUser: AuthUser | undefined,
+  owner: { type: "User" | "Organization"; id: number },
+): GitHubUser {
+  if (!authUser) throw unauthorized();
+  if (authUser.installation) {
+    if (!installationAdministers(authUser, owner.id, owner.type)) throw forbidden();
+    return installationActor(gh, authUser);
+  }
+  const user = assertAuthenticatedUser(gh, authUser);
+  if (owner.type === "User") {
+    if (owner.id !== user.id) throw forbidden();
+    return user;
+  }
+  if (!isOrgMember(gh, user.id, owner.id)) throw forbidden();
+  return user;
 }
 
 export function assertRepoWrite(gh: GitHubStore, authUser: AuthUser | undefined, repo: GitHubRepo): GitHubUser {

--- a/packages/@emulators/github/src/routes/orgs.ts
+++ b/packages/@emulators/github/src/routes/orgs.ts
@@ -13,6 +13,7 @@ import {
   lookupOwner,
   lookupRepo,
 } from "../helpers.js";
+import { installationAdministers } from "../route-helpers.js";
 
 const MEMBERS_TEAM_SLUG = "members";
 
@@ -27,6 +28,17 @@ function requireAuthUser(c: { get: (k: "authUser") => AuthUser | undefined }): A
 }
 
 function requireOrgAdmin(gh: GitHubStore, org: GitHubOrg, auth: AuthUser): void {
+  // A GitHub App installed on the org administers it through its permission
+  // set rather than through membership.
+  if (auth.installation) {
+    if (
+      installationAdministers(auth, org.id, "Organization", "members") ||
+      installationAdministers(auth, org.id, "Organization", "administration")
+    ) {
+      return;
+    }
+    throw forbidden();
+  }
   const user = gh.users.findOneBy("login", auth.login);
   if (!user) throw forbidden();
   const role = orgRoleForUser(gh, org.id, user.id);

--- a/packages/@emulators/github/src/routes/repos.ts
+++ b/packages/@emulators/github/src/routes/repos.ts
@@ -3,11 +3,15 @@ import { ApiError, forbidden, parseJsonBody, parsePagination, setLinkHeader } fr
 import { getGitHubStore } from "../store.js";
 import {
   assertAuthenticatedUser,
+  assertCanCreateRepoIn,
+  assertRepoAdmin,
   assertRepoRead,
   hasRepoAdmin,
   isOrgMember,
+  legacyPermission,
   notFoundResponse,
   ownerLoginOf,
+  repoRoleFor,
 } from "../route-helpers.js";
 import type { GitHubStore } from "../store.js";
 import type { GitHubBranch, GitHubCollaborator, GitHubRef, GitHubRepo, GitHubTag, GitHubUser } from "../entities.js";
@@ -342,14 +346,12 @@ export function reposRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
 
   app.post("/orgs/:org/repos", async (c) => {
     const authUser = c.get("authUser");
-    const user = assertAuthenticatedUser(gh, authUser);
     const orgLogin = c.req.param("org")!;
     const org = gh.orgs.findOneBy("login", orgLogin);
     if (!org) throw notFoundResponse();
 
-    if (!isOrgMember(gh, user.id, org.id)) {
-      throw forbidden();
-    }
+    // A member, or a GitHub App installed on the org with administration: write.
+    const user = assertCanCreateRepoIn(gh, authUser, { type: "Organization", id: org.id });
 
     const body = await parseJsonBody(c);
 
@@ -729,9 +731,7 @@ export function reposRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     const username = c.req.param("username")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const authUser = c.get("authUser");
-    const actor = assertAuthenticatedUser(gh, authUser);
-    if (!hasRepoAdmin(gh, actor, repo)) throw forbidden();
+    assertRepoAdmin(gh, c.get("authUser"), repo);
 
     const target = gh.users.findOneBy("login", username);
     if (!target) throw notFoundResponse();
@@ -759,9 +759,7 @@ export function reposRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     const username = c.req.param("username")!;
     const repo = lookupRepo(gh, owner, repoName);
     if (!repo) throw notFoundResponse();
-    const authUser = c.get("authUser");
-    const actor = assertAuthenticatedUser(gh, authUser);
-    if (!hasRepoAdmin(gh, actor, repo)) throw forbidden();
+    assertRepoAdmin(gh, c.get("authUser"), repo);
 
     const target = gh.users.findOneBy("login", username);
     if (!target) throw notFoundResponse();
@@ -785,39 +783,13 @@ export function reposRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     const target = gh.users.findOneBy("login", username);
     if (!target) throw notFoundResponse();
 
-    if (repo.owner_type === "User" && repo.owner_id === target.id) {
-      return c.json({
-        permission: "admin",
-        role_name: "admin",
-        user: formatUser(target, baseUrl),
-      });
-    }
-
-    if (repo.owner_type === "Organization" && isOrgMember(gh, target.id, repo.owner_id)) {
-      return c.json({
-        permission: "admin",
-        role_name: "admin",
-        user: formatUser(target, baseUrl),
-      });
-    }
-
-    const collab = gh.collaborators.findBy("repo_id", repo.id).find((col) => col.user_id === target.id);
-    if (!collab) throw notFoundResponse();
-
-    const roleName =
-      collab.permission === "admin"
-        ? "admin"
-        : collab.permission === "maintain"
-          ? "maintain"
-          : collab.permission === "push"
-            ? "write"
-            : collab.permission === "triage"
-              ? "triage"
-              : "read";
-
+    // GitHub answers for any user, collaborator or not: `permission` is the
+    // legacy admin/write/read/none scale and `role_name` the precise role. An
+    // org member below the base permission and a stranger both read `none`.
+    const role = repoRoleFor(gh, target, repo);
     return c.json({
-      permission: collab.permission,
-      role_name: roleName,
+      permission: legacyPermission(role),
+      role_name: role,
       user: formatUser(target, baseUrl),
     });
   });


### PR DESCRIPTION
## Summary

Two related fidelity fixes for the GitHub emulator, found while pointing a real GitHub App based provisioning service at it.

**Installation tokens can administer the account they are installed on.** `POST /orgs/:org/repos`, `PUT`/`DELETE /repos/:owner/:repo/collaborators/:username` and `PUT /orgs/:org/memberships/:username` resolved the caller as a user (the installation token's login is the account login, which has no user row) and refused every installation. GitHub Apps manage an account through their permission set, not membership, so now:

- `administration: write` on the installation lets it create repositories in the account and manage collaborators on repositories it can access
- `members: write` lets it manage organization membership
- anything less is 403, as before

**Repository permissions follow GitHub's model.** Every organization member was treated as a repository admin (`isOrgMember` short-circuited `hasRepoAdmin` and `canAccessRepo`). Now, via one `repoRoleFor` resolver:

- organization owners (maintainers of the members team) hold admin
- members start from the org's `default_repository_permission`, which may be `none`
- collaborator and team grants raise the role
- `GET /repos/:owner/:repo/collaborators/:username/permission` answers for any existing user with the legacy `permission` scale (`admin`/`write`/`read`/`none`) and the precise `role_name` (`maintain`, `triage`, ...), returning `none` rather than 404 when the user has no access. 404 stays for an unknown user.

The seed gains `orgs[].default_repository_permission`, `orgs[].members` (with `role: admin` for owners) and `repos[].collaborators`, so these situations can be set up without an admin token at start.

## Testing

`src/__tests__/installation-admin.test.ts` covers installation create/collaborator/membership paths with and without the permission, the permission endpoint across owner, member, collaborator, stranger and unknown user, base-permission visibility, owner-vs-member collaborator management, and the new seed keys. The existing 91 tests pass unchanged. Docs: package README seed example and Auth section, root README seed example.
