### PR TITLE
feat(github): add GET /orgs/:org/repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ Every endpoint below is fully stateful. Creates, updates, and deletes persist in
 - `GET /repos/:owner/:repo` - get repo
 - `GET /repositories/:id` - get repo by numeric ID
 - `POST /user/repos` - create user repo
+- `GET /orgs/:org/repos` - list org repos the caller may see (`type`, `sort`, `direction`)
 - `POST /orgs/:org/repos` - create org repo
 - `PATCH /repos/:owner/:repo` - update repo
 - `DELETE /repos/:owner/:repo` - delete repo (cascades)

--- a/apps/web/app/docs/github/page.mdx
+++ b/apps/web/app/docs/github/page.mdx
@@ -62,6 +62,7 @@ The destination must not exist. emulate removes inherited ACLs, verifies effecti
 - `GET /repos/:owner/:repo` - get repo
 - `GET /repositories/:id` - get repo by numeric ID
 - `POST /user/repos` - create user repo
+- `GET /orgs/:org/repos` - list org repos the caller may see (`type`, `sort`, `direction`)
 - `POST /orgs/:org/repos` - create org repo
 - `PATCH /repos/:owner/:repo` - update repo
 - `DELETE /repos/:owner/:repo` - delete repo (cascades)

--- a/packages/@emulators/github/README.md
+++ b/packages/@emulators/github/README.md
@@ -26,6 +26,7 @@ npm install @emulators/github
 - `GET /repos/:owner/:repo` — get repo
 - `GET /repositories/:id` — get repo by numeric ID
 - `POST /user/repos` — create user repo
+- `GET /orgs/:org/repos` — list org repos the caller may see (`type`, `sort`, `direction`)
 - `POST /orgs/:org/repos` — create org repo
 - `PATCH /repos/:owner/:repo` — update repo
 - `DELETE /repos/:owner/:repo` — delete repo (cascades)

--- a/packages/@emulators/github/src/__tests__/org-repos.test.ts
+++ b/packages/@emulators/github/src/__tests__/org-repos.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "@emulators/core";
+import { Store, WebhookDispatcher } from "@emulators/core";
+import { authMiddleware, createApiErrorHandler, createErrorHandler, type TokenMap } from "@emulators/core";
+import { githubPlugin, seedFromConfig, getGitHubStore } from "../index.js";
+
+const base = "http://localhost:4000";
+
+function createTestApp() {
+  const store = new Store();
+  const webhooks = new WebhookDispatcher();
+  const tokenMap: TokenMap = new Map();
+  tokenMap.set("owner-token", { login: "octocat", id: 1, scopes: ["repo", "admin:org"] });
+  tokenMap.set("stranger-token", { login: "lurker", id: 3, scopes: ["repo"] });
+
+  const app = new Hono();
+  app.onError(createApiErrorHandler());
+  app.use("*", createErrorHandler());
+  app.use("*", authMiddleware(tokenMap));
+  githubPlugin.register(app as any, store, webhooks, base, tokenMap);
+  githubPlugin.seed?.(store, base);
+  seedFromConfig(store, base, {
+    users: [{ login: "octocat" }, { login: "lurker" }],
+    orgs: [{ login: "my-org" }],
+    repos: [
+      { owner: "my-org", name: "public-a" },
+      { owner: "my-org", name: "public-b" },
+      { owner: "my-org", name: "secret", private: true },
+    ],
+  });
+  // octocat is an organization member; lurker is not.
+  const gh = getGitHubStore(store);
+  const org = gh.orgs.findOneBy("login", "my-org")!;
+  const octocat = gh.users.findOneBy("login", "octocat")!;
+  const team = gh.teams.insert({
+    node_id: "T1",
+    name: "Members",
+    slug: "members",
+    description: null,
+    privacy: "closed",
+    permission: "pull",
+    org_id: org.id,
+    parent_id: null,
+    members_count: 1,
+    repos_count: 0,
+  });
+  gh.teamMembers.insert({ team_id: team.id, user_id: octocat.id, role: "maintainer" });
+  return { app, store };
+}
+
+async function names(
+  app: Hono,
+  query: string,
+  token?: string,
+): Promise<{ status: number; names: string[]; link: string | null }> {
+  const res = await app.request(`${base}/orgs/my-org/repos${query}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (res.status !== 200) return { status: res.status, names: [], link: null };
+  const body = (await res.json()) as Array<{ name: string }>;
+  return { status: 200, names: body.map((r) => r.name), link: res.headers.get("Link") };
+}
+
+describe("GET /orgs/:org/repos", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  it("lists only public repositories to anonymous callers and non-members", async () => {
+    expect((await names(app, "?sort=full_name")).names).toEqual(["public-a", "public-b"]);
+    expect((await names(app, "?sort=full_name", "stranger-token")).names).toEqual(["public-a", "public-b"]);
+  });
+
+  it("lists private repositories to members", async () => {
+    expect((await names(app, "?sort=full_name", "owner-token")).names).toEqual(["public-a", "public-b", "secret"]);
+  });
+
+  it("filters by type", async () => {
+    expect((await names(app, "?type=private", "owner-token")).names).toEqual(["secret"]);
+    expect((await names(app, "?type=public&sort=full_name", "owner-token")).names).toEqual(["public-a", "public-b"]);
+    expect((await names(app, "?type=bogus", "owner-token")).status).toBe(422);
+  });
+
+  it("paginates with a Link header", async () => {
+    const first = await names(app, "?sort=full_name&per_page=2&page=1", "owner-token");
+    expect(first.names).toEqual(["public-a", "public-b"]);
+    expect(first.link).toContain('rel="next"');
+    const second = await names(app, "?sort=full_name&per_page=2&page=2", "owner-token");
+    expect(second.names).toEqual(["secret"]);
+  });
+
+  it("returns 404 for an unknown organization", async () => {
+    const res = await app.request(`${base}/orgs/nope/repos`, { headers: { Authorization: "Bearer owner-token" } });
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/@emulators/github/src/routes/repos.ts
+++ b/packages/@emulators/github/src/routes/repos.ts
@@ -4,6 +4,8 @@ import { getGitHubStore } from "../store.js";
 import {
   assertAuthenticatedUser,
   assertRepoRead,
+  canAccessRepo,
+  getActorUser,
   hasRepoAdmin,
   isOrgMember,
   notFoundResponse,
@@ -14,6 +16,7 @@ import type { GitHubBranch, GitHubCollaborator, GitHubRef, GitHubRepo, GitHubTag
 import type { Collection, Entity } from "@emulators/core";
 import { formatRepo, formatUser, generateNodeId, lookupOwner, lookupRepo, timestamp } from "../helpers.js";
 import { findOrCreateBlob, findOrCreateCommit, findOrCreateTree } from "../git-helpers.js";
+import { sortRepos } from "./users.js";
 
 const LICENSE_TEMPLATES: Record<string, { key: string; name: string; spdx_id: string }> = {
   mit: { key: "mit", name: "MIT License", spdx_id: "MIT" },
@@ -338,6 +341,65 @@ export function reposRoutes({ app, store, webhooks, baseUrl }: RouteContext): vo
     );
 
     return c.json(formatRepo(finalRepo, gh, baseUrl), 201);
+  });
+
+  // GET /orgs/:org/repos lists an organization's repositories the caller may
+  // see: public ones for anyone, private ones for members, collaborators and
+  // installations with access, filtered by `type` and sorted like GitHub.
+  app.get("/orgs/:org/repos", (c) => {
+    const org = gh.orgs.findOneBy("login", c.req.param("org")!);
+    if (!org) throw notFoundResponse();
+
+    const typeRaw = (c.req.query("type") ?? "all").toLowerCase();
+    const types = ["all", "public", "private", "forks", "sources", "member"] as const;
+    if (!(types as readonly string[]).includes(typeRaw)) throw new ApiError(422, "Invalid type parameter");
+    const type = typeRaw as (typeof types)[number];
+
+    const sortRaw = (c.req.query("sort") ?? "created").toLowerCase();
+    if (sortRaw !== "created" && sortRaw !== "updated" && sortRaw !== "pushed" && sortRaw !== "full_name") {
+      throw new ApiError(422, "Invalid sort parameter");
+    }
+    const sort = sortRaw as "created" | "updated" | "pushed" | "full_name";
+    const direction =
+      (c.req.query("direction")?.toLowerCase() as "asc" | "desc" | undefined) ??
+      (sort === "full_name" ? "asc" : "desc");
+    if (direction !== "asc" && direction !== "desc") throw new ApiError(422, "Invalid direction parameter");
+
+    const authUser = c.get("authUser");
+    const actor = authUser && !authUser.installation ? getActorUser(gh, authUser) : undefined;
+    let repos = gh.repos
+      .all()
+      .filter((r) => r.owner_type === "Organization" && r.owner_id === org.id)
+      .filter((r) => canAccessRepo(gh, authUser, r));
+    switch (type) {
+      case "public":
+        repos = repos.filter((r) => !r.private);
+        break;
+      case "private":
+        repos = repos.filter((r) => r.private);
+        break;
+      case "forks":
+        repos = repos.filter((r) => r.fork);
+        break;
+      case "sources":
+        repos = repos.filter((r) => !r.fork);
+        break;
+      case "member":
+        repos = actor
+          ? repos.filter((r) => gh.collaborators.findBy("repo_id", r.id).some((col) => col.user_id === actor.id))
+          : [];
+        break;
+      default:
+        break;
+    }
+
+    const { page, per_page } = parsePagination(c);
+    const sorted = sortRepos(repos, sort, direction);
+    const total = sorted.length;
+    const start = (page - 1) * per_page;
+    const items = sorted.slice(start, start + per_page).map((r) => formatRepo(r, gh, baseUrl, actor?.id));
+    setLinkHeader(c, total, page, per_page);
+    return c.json(items);
   });
 
   app.post("/orgs/:org/repos", async (c) => {

--- a/packages/@emulators/github/src/routes/users.ts
+++ b/packages/@emulators/github/src/routes/users.ts
@@ -23,7 +23,7 @@ function listReposForUser(gh: GitHubStore, user: GitHubUser, type: "all" | "owne
   return Array.from(map.values());
 }
 
-function sortRepos(
+export function sortRepos(
   repos: GitHubRepo[],
   sort: "created" | "updated" | "pushed" | "full_name",
   direction: "asc" | "desc",


### PR DESCRIPTION
## Summary

Adds GitHub's [list organization repositories](https://docs.github.com/en/rest/repos/repos#list-organization-repositories) endpoint, `GET /orgs/:org/repos`, which was missing (repositories were reachable one by one and through the user listings, but not through the endpoint clients use to browse an organization).

- Lists the repositories the caller may see: public ones for anyone; private ones for organization members, collaborators and App installations with access, using the existing `canAccessRepo` rules.
- Honours `type` (`all`, `public`, `private`, `forks`, `sources`, `member`), `sort` (`created`, `updated`, `pushed`, `full_name`) and `direction`, with GitHub's defaults (`created` descending; `full_name` ascending), and paginates with `Link` headers via the shared helpers. `sortRepos` from the user listing is reused.

## Testing

`src/__tests__/org-repos.test.ts` covers anonymous vs member visibility, the `type` filter and its 422, pagination, and the 404 for an unknown org. `pnpm --filter @emulators/github test`, `type-check` and `lint` pass. Package README, root README and the web docs page list the route.
