### PR TITLE
feat(vercel): support v7 deployment listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `POST /v13/deployments` - create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` - get deployment (by ID or URL)
 - `GET /v6/deployments` - list deployments (filter by project, target, state)
-- `GET /v7/deployments` - list deployments with commit SHA filtering before pagination, including previews across projects in a team
+- `GET /v7/deployments` - list deployments (filter by project, target, state, commit SHA)
 - `DELETE /v13/deployments/:id` - delete deployment (cascades)
 - `PATCH /v12/deployments/:id/cancel` - cancel building deployment
 - `GET /v2/deployments/:id/aliases` - list deployment aliases

--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `POST /v13/deployments` - create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` - get deployment (by ID or URL)
 - `GET /v6/deployments` - list deployments (filter by project, target, state)
+- `GET /v7/deployments` - list deployments with commit SHA filtering before pagination, including previews across projects in a team
 - `DELETE /v13/deployments/:id` - delete deployment (cascades)
 - `PATCH /v12/deployments/:id/cancel` - cancel building deployment
 - `GET /v2/deployments/:id/aliases` - list deployment aliases

--- a/apps/web/app/docs/vercel/page.mdx
+++ b/apps/web/app/docs/vercel/page.mdx
@@ -28,6 +28,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `POST /v13/deployments` - create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` - get deployment (by ID or URL)
 - `GET /v6/deployments` - list deployments (filter by project, target, state)
+- `GET /v7/deployments` - list deployments with the same filters plus `sha`, applied before cursor pagination; use `teamId` or `slug` to find commit previews across a team's projects
 - `DELETE /v13/deployments/:id` - delete deployment (cascades)
 - `PATCH /v12/deployments/:id/cancel` - cancel building deployment
 - `GET /v2/deployments/:id/aliases` - list deployment aliases

--- a/apps/web/app/docs/vercel/page.mdx
+++ b/apps/web/app/docs/vercel/page.mdx
@@ -28,7 +28,7 @@ Every endpoint below is fully stateful with Vercel-style JSON responses and curs
 - `POST /v13/deployments` - create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` - get deployment (by ID or URL)
 - `GET /v6/deployments` - list deployments (filter by project, target, state)
-- `GET /v7/deployments` - list deployments with the same filters plus `sha`, applied before cursor pagination; use `teamId` or `slug` to find commit previews across a team's projects
+- `GET /v7/deployments` - list deployments (filter by project, target, state, commit SHA)
 - `DELETE /v13/deployments/:id` - delete deployment (cascades)
 - `PATCH /v12/deployments/:id/cancel` - cancel building deployment
 - `GET /v2/deployments/:id/aliases` - list deployment aliases

--- a/packages/@emulators/vercel/README.md
+++ b/packages/@emulators/vercel/README.md
@@ -35,6 +35,7 @@ npm install @emulators/vercel
 - `POST /v13/deployments` — create deployment (auto-transitions to READY)
 - `GET /v13/deployments/:idOrUrl` — get deployment (by ID or URL)
 - `GET /v6/deployments` — list deployments (filter by project, target, state)
+- `GET /v7/deployments` — list deployments (filter by project, target, state, commit SHA)
 - `DELETE /v13/deployments/:id` — delete deployment (cascades)
 - `PATCH /v12/deployments/:id/cancel` — cancel building deployment
 - `GET /v2/deployments/:id/aliases` — list deployment aliases

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Hono } from "@emulators/core";
 import { Store, WebhookDispatcher, authMiddleware, type TokenMap } from "@emulators/core";
-import { vercelPlugin, seedFromConfig } from "../index.js";
+import { vercelPlugin, seedFromConfig, getVercelStore } from "../index.js";
 
 const base = "http://localhost:4000";
+
+type CreatedDeployment = { uid: string; projectId: string };
 
 function createTestApp() {
   const store = new Store();
@@ -28,10 +30,30 @@ function authHeaders(): Record<string, string> {
 
 describe("Vercel plugin integration", () => {
   let app: Hono;
+  let store: Store;
 
   beforeEach(() => {
-    app = createTestApp().app;
+    ({ app, store } = createTestApp());
   });
+
+  async function createDeployment(
+    body: {
+      name: string;
+      meta?: Record<string, string>;
+      gitSource?: { type: string; ref: string; sha: string };
+      target?: string;
+    },
+    teamId?: string,
+  ): Promise<CreatedDeployment> {
+    const query = teamId ? `?teamId=${teamId}` : "";
+    const response = await app.request(`${base}/v13/deployments${query}`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(response.status).toBe(200);
+    return (await response.json()) as CreatedDeployment;
+  }
 
   it("GET /v2/user returns the current user", async () => {
     const res = await app.request(`${base}/v2/user`, { headers: authHeaders() });
@@ -69,5 +91,139 @@ describe("Vercel plugin integration", () => {
     const body = (await res.json()) as { deployments: unknown[]; pagination: unknown };
     expect(Array.isArray(body.deployments)).toBe(true);
     expect(body.pagination).toBeDefined();
+  });
+
+  it.each(["v6", "v7"])("GET /%s/deployments lists account deployments", async (version) => {
+    const deployment = await createDeployment({ name: "website" });
+    const response = await app.request(`${base}/${version}/deployments`, { headers: authHeaders() });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      deployments: [{ uid: deployment.uid, name: "website", projectId: deployment.projectId, meta: {} }],
+      pagination: { count: 1, next: null },
+    });
+  });
+
+  it("GET /v7/deployments requires authentication", async () => {
+    seedFromConfig(store, base, { teams: [{ slug: "first-team" }] });
+    const team = getVercelStore(store).teams.findOneBy("slug", "first-team")!;
+    for (const query of ["", `?teamId=${team.uid}`, `?slug=${team.slug}`]) {
+      const response = await app.request(`${base}/v7/deployments${query}`);
+      expect(response.status).toBe(401);
+    }
+  });
+
+  it.each(["githubCommitSha", "gitlabCommitSha", "bitbucketCommitSha"])(
+    "GET /v7/deployments filters by %s metadata",
+    async (key) => {
+      const matching = await createDeployment({ name: "matching", meta: { [key]: "commit-sha" } });
+      await createDeployment({ name: "other-commit", meta: { [key]: "other-sha" } });
+      await createDeployment({ name: "without-git-metadata" });
+
+      const response = await app.request(`${base}/v7/deployments?sha=commit-sha`, {
+        headers: authHeaders(),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        deployments: [{ uid: matching.uid }],
+        pagination: { count: 1, next: null },
+      });
+    },
+  );
+
+  it("GET /v7/deployments filters by gitSource SHA", async () => {
+    const matching = await createDeployment({
+      name: "matching",
+      gitSource: { type: "github", ref: "main", sha: "commit-sha" },
+    });
+    await createDeployment({
+      name: "other-commit",
+      gitSource: { type: "github", ref: "main", sha: "other-sha" },
+    });
+
+    const response = await app.request(`${base}/v7/deployments?sha=commit-sha`, { headers: authHeaders() });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      deployments: [{ uid: matching.uid }],
+      pagination: { count: 1, next: null },
+    });
+  });
+
+  it.each(["teamId", "slug"])("GET /v7/deployments scopes monorepo previews by %s", async (key) => {
+    seedFromConfig(store, base, { teams: [{ slug: "first-team" }, { slug: "other-team" }] });
+    const vs = getVercelStore(store);
+    const team = vs.teams.findOneBy("slug", "first-team")!;
+    const otherTeam = vs.teams.findOneBy("slug", "other-team")!;
+    const first = await createDeployment({ name: "website", meta: { githubCommitSha: "commit-sha" } }, team.uid);
+    const second = await createDeployment({ name: "api", meta: { githubCommitSha: "commit-sha" } }, team.uid);
+    await createDeployment({ name: "other-team", meta: { githubCommitSha: "commit-sha" } }, otherTeam.uid);
+    await createDeployment({ name: "personal", meta: { githubCommitSha: "commit-sha" } });
+
+    const scope = key === "teamId" ? team.uid : team.slug;
+    const response = await app.request(`${base}/v7/deployments?sha=commit-sha&${key}=${scope}`, {
+      headers: authHeaders(),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { deployments: { uid: string }[] };
+    expect(body.deployments.map((deployment) => deployment.uid).sort()).toEqual([first.uid, second.uid].sort());
+  });
+
+  it("GET /v7/deployments filters SHA before sorting and pagination", async () => {
+    const older = await createDeployment({ name: "older", meta: { githubCommitSha: "commit-sha" } });
+    const newer = await createDeployment({ name: "newer", meta: { githubCommitSha: "commit-sha" } });
+    const unrelated = await createDeployment({ name: "unrelated", meta: { githubCommitSha: "other-sha" } });
+    const vs = getVercelStore(store);
+    for (const [index, deployment] of [older, newer, unrelated].entries()) {
+      const row = vs.deployments.findOneBy("uid", deployment.uid)!;
+      vs.deployments.update(row.id, { created_at: new Date((index + 1) * 1_000).toISOString() });
+    }
+
+    const response = await app.request(`${base}/v7/deployments?sha=commit-sha&limit=1`, {
+      headers: authHeaders(),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      deployments: [{ uid: newer.uid }],
+      pagination: { count: 1, next: 2_000, prev: 2_000 },
+    });
+
+    const earlier = await app.request(`${base}/v7/deployments?sha=commit-sha&since=0&until=1999&limit=1`, {
+      headers: authHeaders(),
+    });
+    expect(earlier.status).toBe(200);
+    expect(await earlier.json()).toMatchObject({
+      deployments: [{ uid: older.uid }],
+      pagination: { count: 1, next: null, prev: 1_000 },
+    });
+  });
+
+  it("GET /v7/deployments combines SHA with existing deployment filters", async () => {
+    const matching = await createDeployment({
+      name: "website",
+      target: "production",
+      meta: { githubCommitSha: "commit-sha" },
+    });
+    await createDeployment({ name: "website", target: "preview", meta: { githubCommitSha: "commit-sha" } });
+    await createDeployment({ name: "api", target: "production", meta: { githubCommitSha: "commit-sha" } });
+
+    const query = new URLSearchParams({
+      sha: "commit-sha",
+      projectId: matching.projectId,
+      app: "website",
+      target: "production",
+      state: "READY",
+    });
+    const response = await app.request(`${base}/v7/deployments?${query}`, { headers: authHeaders() });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      deployments: [{ uid: matching.uid }],
+      pagination: { count: 1, next: null },
+    });
+  });
+
+  it("GET /v7/deployments returns an empty page when the commit has no deployments", async () => {
+    await createDeployment({ name: "other-commit", meta: { githubCommitSha: "other-sha" } });
+    const response = await app.request(`${base}/v7/deployments?sha=missing-sha`, { headers: authHeaders() });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ deployments: [], pagination: { count: 0, next: null, prev: null } });
   });
 });

--- a/packages/@emulators/vercel/src/__tests__/vercel.test.ts
+++ b/packages/@emulators/vercel/src/__tests__/vercel.test.ts
@@ -5,7 +5,7 @@ import { vercelPlugin, seedFromConfig, getVercelStore } from "../index.js";
 
 const base = "http://localhost:4000";
 
-type CreatedDeployment = { uid: string; projectId: string };
+type CreatedDeployment = { uid: string };
 
 function createTestApp() {
   const store = new Store();
@@ -41,7 +41,6 @@ describe("Vercel plugin integration", () => {
       name: string;
       meta?: Record<string, string>;
       gitSource?: { type: string; ref: string; sha: string };
-      target?: string;
     },
     teamId?: string,
   ): Promise<CreatedDeployment> {
@@ -93,16 +92,6 @@ describe("Vercel plugin integration", () => {
     expect(body.pagination).toBeDefined();
   });
 
-  it.each(["v6", "v7"])("GET /%s/deployments lists account deployments", async (version) => {
-    const deployment = await createDeployment({ name: "website" });
-    const response = await app.request(`${base}/${version}/deployments`, { headers: authHeaders() });
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      deployments: [{ uid: deployment.uid, name: "website", projectId: deployment.projectId, meta: {} }],
-      pagination: { count: 1, next: null },
-    });
-  });
-
   it("GET /v7/deployments requires authentication", async () => {
     seedFromConfig(store, base, { teams: [{ slug: "first-team" }] });
     const team = getVercelStore(store).teams.findOneBy("slug", "first-team")!;
@@ -112,54 +101,22 @@ describe("Vercel plugin integration", () => {
     }
   });
 
-  it.each(["githubCommitSha", "gitlabCommitSha", "bitbucketCommitSha"])(
-    "GET /v7/deployments filters by %s metadata",
-    async (key) => {
-      const matching = await createDeployment({ name: "matching", meta: { [key]: "commit-sha" } });
-      await createDeployment({ name: "other-commit", meta: { [key]: "other-sha" } });
-      await createDeployment({ name: "without-git-metadata" });
-
-      const response = await app.request(`${base}/v7/deployments?sha=commit-sha`, {
-        headers: authHeaders(),
-      });
-      expect(response.status).toBe(200);
-      expect(await response.json()).toMatchObject({
-        deployments: [{ uid: matching.uid }],
-        pagination: { count: 1, next: null },
-      });
-    },
-  );
-
-  it("GET /v7/deployments filters by gitSource SHA", async () => {
-    const matching = await createDeployment({
-      name: "matching",
-      gitSource: { type: "github", ref: "main", sha: "commit-sha" },
-    });
-    await createDeployment({
-      name: "other-commit",
-      gitSource: { type: "github", ref: "main", sha: "other-sha" },
-    });
-
-    const response = await app.request(`${base}/v7/deployments?sha=commit-sha`, { headers: authHeaders() });
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      deployments: [{ uid: matching.uid }],
-      pagination: { count: 1, next: null },
-    });
-  });
-
-  it.each(["teamId", "slug"])("GET /v7/deployments scopes monorepo previews by %s", async (key) => {
+  it("GET /v7/deployments finds a team's commit previews across projects", async () => {
     seedFromConfig(store, base, { teams: [{ slug: "first-team" }, { slug: "other-team" }] });
     const vs = getVercelStore(store);
     const team = vs.teams.findOneBy("slug", "first-team")!;
     const otherTeam = vs.teams.findOneBy("slug", "other-team")!;
     const first = await createDeployment({ name: "website", meta: { githubCommitSha: "commit-sha" } }, team.uid);
-    const second = await createDeployment({ name: "api", meta: { githubCommitSha: "commit-sha" } }, team.uid);
+    const second = await createDeployment(
+      { name: "api", gitSource: { type: "github", ref: "main", sha: "commit-sha" } },
+      team.uid,
+    );
+    await createDeployment({ name: "website", meta: { githubCommitSha: "other-sha" } }, team.uid);
+    await createDeployment({ name: "without-git-metadata" }, team.uid);
     await createDeployment({ name: "other-team", meta: { githubCommitSha: "commit-sha" } }, otherTeam.uid);
     await createDeployment({ name: "personal", meta: { githubCommitSha: "commit-sha" } });
 
-    const scope = key === "teamId" ? team.uid : team.slug;
-    const response = await app.request(`${base}/v7/deployments?sha=commit-sha&${key}=${scope}`, {
+    const response = await app.request(`${base}/v7/deployments?sha=commit-sha&teamId=${team.uid}`, {
       headers: authHeaders(),
     });
     expect(response.status).toBe(200);
@@ -194,36 +151,5 @@ describe("Vercel plugin integration", () => {
       deployments: [{ uid: older.uid }],
       pagination: { count: 1, next: null, prev: 1_000 },
     });
-  });
-
-  it("GET /v7/deployments combines SHA with existing deployment filters", async () => {
-    const matching = await createDeployment({
-      name: "website",
-      target: "production",
-      meta: { githubCommitSha: "commit-sha" },
-    });
-    await createDeployment({ name: "website", target: "preview", meta: { githubCommitSha: "commit-sha" } });
-    await createDeployment({ name: "api", target: "production", meta: { githubCommitSha: "commit-sha" } });
-
-    const query = new URLSearchParams({
-      sha: "commit-sha",
-      projectId: matching.projectId,
-      app: "website",
-      target: "production",
-      state: "READY",
-    });
-    const response = await app.request(`${base}/v7/deployments?${query}`, { headers: authHeaders() });
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      deployments: [{ uid: matching.uid }],
-      pagination: { count: 1, next: null },
-    });
-  });
-
-  it("GET /v7/deployments returns an empty page when the commit has no deployments", async () => {
-    await createDeployment({ name: "other-commit", meta: { githubCommitSha: "other-sha" } });
-    const response = await app.request(`${base}/v7/deployments?sha=missing-sha`, { headers: authHeaders() });
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ deployments: [], pagination: { count: 0, next: null, prev: null } });
   });
 });

--- a/packages/@emulators/vercel/src/routes/deployments.ts
+++ b/packages/@emulators/vercel/src/routes/deployments.ts
@@ -532,7 +532,7 @@ export function deploymentsRoutes({ app, store, baseUrl }: RouteContext): void {
     return c.json(formatDeployment(dep, vs, baseUrl));
   });
 
-  app.get("/v6/deployments", (c) => {
+  const listDeployments = (c: Context, shaFilter?: string) => {
     const scope = resolveTeamScope(c, vs);
     if (!scope) {
       return vercelErr(c, 401, "not_authenticated", "Authentication required");
@@ -567,6 +567,16 @@ export function deploymentsRoutes({ app, store, baseUrl }: RouteContext): void {
       list = list.filter((d) => d.state === stateFilter || d.readyState === stateFilter);
     }
 
+    if (shaFilter) {
+      list = list.filter(
+        (d) =>
+          d.gitSource?.sha === shaFilter ||
+          d.meta.githubCommitSha === shaFilter ||
+          d.meta.gitlabCommitSha === shaFilter ||
+          d.meta.bitbucketCommitSha === shaFilter,
+      );
+    }
+
     const pagination = parseCursorPagination(c);
     const { items, pagination: pageMeta } = applyCursorPagination(list, pagination);
 
@@ -574,6 +584,14 @@ export function deploymentsRoutes({ app, store, baseUrl }: RouteContext): void {
       deployments: items.map((d) => formatDeploymentBrief(d, vs)),
       pagination: pageMeta,
     });
+  };
+
+  app.get("/v6/deployments", (c) => listDeployments(c));
+  app.get("/v7/deployments", (c) => {
+    if (!c.get("authUser")) {
+      return vercelErr(c, 401, "not_authenticated", "Authentication required");
+    }
+    return listDeployments(c, c.req.query("sha"));
   });
 
   app.delete("/v13/deployments/:id", (c) => {

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -28,6 +28,9 @@ GitHub API coverage:
 Linear API coverage:
   Issue queries and mutations include numeric priority and derived priorityLabel fields.
 
+Vercel API coverage:
+  GET /v7/deployments lists deployments by commit SHA across a team's projects, with cursor pagination.
+
 Webhook signatures:
   Stripe webhook secrets produce a Stripe-Signature header for raw-body verification.
 `,

--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -259,12 +259,9 @@ curl http://localhost:4000/v13/deployments/dpl_abc123 \
 curl "http://localhost:4000/v6/deployments?projectId=my-app&target=production&limit=10" \
   -H "Authorization: Bearer $TOKEN"
 
-# List deployments for a commit across a team's projects
-curl "http://localhost:4000/v7/deployments?sha=abc123&teamId=team_abc123&limit=100" \
+# List deployments (filter by commit SHA)
+curl "http://localhost:4000/v7/deployments?sha=abc123" \
   -H "Authorization: Bearer $TOKEN"
-
-# V7 also supports the v6 filters. SHA matches gitSource.sha or GitHub, GitLab,
-# and Bitbucket commit metadata before cursor pagination is applied.
 
 # Delete deployment
 curl -X DELETE http://localhost:4000/v13/deployments/dpl_abc123 \

--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -259,6 +259,13 @@ curl http://localhost:4000/v13/deployments/dpl_abc123 \
 curl "http://localhost:4000/v6/deployments?projectId=my-app&target=production&limit=10" \
   -H "Authorization: Bearer $TOKEN"
 
+# List deployments for a commit across a team's projects
+curl "http://localhost:4000/v7/deployments?sha=abc123&teamId=team_abc123&limit=100" \
+  -H "Authorization: Bearer $TOKEN"
+
+# V7 also supports the v6 filters. SHA matches gitSource.sha or GitHub, GitLab,
+# and Bitbucket commit metadata before cursor pagination is applied.
+
 # Delete deployment
 curl -X DELETE http://localhost:4000/v13/deployments/dpl_abc123 \
   -H "Authorization: Bearer $TOKEN"


### PR DESCRIPTION
`GET /v7/deployments` currently returns 404, preventing clients from finding a commit's preview deployments across projects in a team. Add the route using the existing deployment listing logic, with SHA filtering applied before cursor pagination.

Match `gitSource.sha` and GitHub, GitLab, or Bitbucket commit metadata. The new route requires authentication and supports the existing account/team scope, project, target, state, and time filters. Update the README, Vercel skill, docs site, and CLI help.
