### PR TITLE
chore(release): prepare v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 <!-- release:start -->
+## 0.11.1
+
+### Improvements
+
+- **Vercel v7 deployment listing** adds authenticated `GET /v7/deployments` with commit-SHA filtering across projects, team scoping, and pagination (#234)
+
+<!-- release:end -->
+
 ## 0.11.0
 
 ### New Features
@@ -13,8 +21,6 @@
 
 - @ctate
 - @Railly
-
-<!-- release:end -->
 
 ## 0.10.0
 

--- a/packages/@emulators/adapter-next/package.json
+++ b/packages/@emulators/adapter-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-next",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/adapter-nuxt/package.json
+++ b/packages/@emulators/adapter-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/adapter-nuxt",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/apple/package.json
+++ b/packages/@emulators/apple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/apple",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/aws/package.json
+++ b/packages/@emulators/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/aws",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/clerk/package.json
+++ b/packages/@emulators/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/clerk",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/core/package.json
+++ b/packages/@emulators/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/github/package.json
+++ b/packages/@emulators/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/github",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/google/package.json
+++ b/packages/@emulators/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/google",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/linear/package.json
+++ b/packages/@emulators/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/linear",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/microsoft/package.json
+++ b/packages/@emulators/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/microsoft",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/mongoatlas/package.json
+++ b/packages/@emulators/mongoatlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/mongoatlas",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/okta/package.json
+++ b/packages/@emulators/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/okta",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/resend/package.json
+++ b/packages/@emulators/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/resend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/slack/package.json
+++ b/packages/@emulators/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/slack",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/stripe/package.json
+++ b/packages/@emulators/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/stripe",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/twilio/package.json
+++ b/packages/@emulators/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/twilio",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@emulators/vercel/package.json
+++ b/packages/@emulators/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulators/vercel",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulate",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Local drop-in replacement services for CI and no-network sandboxes",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bumps emulate and all @emulators packages to 0.11.1 and adds release notes for authenticated Vercel v7 deployment listing with commit-SHA filtering (#234).

Moves the release markers to the new entry so the release workflow publishes the correct notes.

Validated package version consistency with `node scripts/sync-versions.mjs --check`, whitespace with `git diff --check`, and the changelog release markers.